### PR TITLE
DynBetweenness: Take graph as a const ref

### DIFF
--- a/include/networkit/centrality/DynBetweenness.hpp
+++ b/include/networkit/centrality/DynBetweenness.hpp
@@ -39,7 +39,7 @@ public:
 	 *
 	 * @param G The graph.
 	 */
-	DynBetweenness(Graph& G);
+	DynBetweenness(const Graph &G);
 
   /**
    * Runs static betweenness centrality algorithm on the initial graph.

--- a/networkit/cpp/centrality/DynBetweenness.cpp
+++ b/networkit/cpp/centrality/DynBetweenness.cpp
@@ -30,7 +30,7 @@ namespace NetworKit {
 // };
 
 
-DynBetweenness::DynBetweenness(Graph& G) : Centrality(G),
+DynBetweenness::DynBetweenness(const Graph &G) : Centrality(G),
 distances(G.upperNodeIdBound(), std::vector<edgeweight>(G.upperNodeIdBound())),
 distancesOld(G.upperNodeIdBound(), std::vector<edgeweight>(G.upperNodeIdBound())),
 sigma(G.upperNodeIdBound(), std::vector<edgeweight>(G.upperNodeIdBound())),


### PR DESCRIPTION
As pointed out in https://github.com/kit-parco/networkit/issues/339#issuecomment-503593708 the input graph of `DynBetweenness` is a (non-const) reference, but it should be const.