### PR TITLE
Remove creation of symlinks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ option(NETWORKIT_STATIC "Build static libraries" OFF)
 option(NETWORKIT_MONOLITH "Build single library (and tests is requested; required for shared lib)" ON)
 option(NETWORKIT_NATIVE "Optimize for native architecture (often better performance)" OFF)
 option(NETWORKIT_WARNINGS "Issue more warnings" OFF)
-option(NETWORKIT_INCLUDESYMLINK "Create symlink to cpp directory" ON)
 option(NETWORKIT_FLATINSTALL "Install into a flat directory structure (useful when building a Python package)" OFF)
 set(NETWORKIT_PYTHON "" CACHE STRING "Directory containing Python.h. Implies MONOLITH=TRUE")
 set(NETWORKIT_PYTHON_SOABI "" CACHE STRING "Platform specific file extension. Implies MONOLITH=TRUE")
@@ -156,17 +155,6 @@ else()
 endif()
 
 ################################################################################
-#include symlink
-if(NETWORKIT_INCLUDESYMLINK)
-	if(UNIX)
-		add_custom_target(symlink_include ALL
-				COMMAND ${CMAKE_COMMAND} -E make_directory "include"
-				COMMAND ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}/networkit/cpp" "include/NetworKit")
-	else()
-		message(WARNING "Cannot create symlink on windows machine")
-	endif()
-endif()
-
 # NETWORKIT MODULES
 if(NETWORKIT_BUILD_CORE AND NETWORKIT_MONOLITH)
 	if(NETWORKIT_STATIC)


### PR DESCRIPTION
As discussed in #347, symlinks are not required anymore. Since they're not supported on all platforms anyhow, let's not create them anymore.