### PR TITLE
Support for directed graphs in NetworkitBinaryGraph file format

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -994,17 +994,17 @@ class Graph final {
      * @param weight Optional edge weight.
      */
     void addEdge(node u, node v, edgeweight ew = defaultEdgeWeight);
-    
-	/**
-     * Insert an edge between the nodes @a u and @a v. Unline the addEdge function, this function does not not add any information to v. If the graph is
-     * weighted you can optionally set a weight for this edge. The default
-     * weight is 1.0. Note: Multi-edges are not supported and will NOT be
-     * handled consistently by the graph data structure.
-     * @param u Endpoint of edge.
-     * @param v Endpoint of edge.
-     * @param weight Optional edge weight.
-     */
-	void addPartialEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
+
+    /**
+    * Insert an edge between the nodes @a u and @a v. Unline the addEdge function, this function does not not add any information to v. If the graph is
+    * weighted you can optionally set a weight for this edge. The default
+    * weight is 1.0. Note: Multi-edges are not supported and will NOT be
+    * handled consistently by the graph data structure.
+    * @param u Endpoint of edge.
+    * @param v Endpoint of edge.
+    * @param weight Optional edge weight.
+    */
+    void addPartialEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
 
     /**
      * Insert an in edge between the nodes @a u and @a v in a directed graph. If the graph is

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -57,6 +57,8 @@ struct Edge {
 inline bool operator==(const Edge &e1, const Edge &e2) {
     return e1.u == e2.u && e1.v == e2.v;
 }
+struct Unsafe {};
+static constexpr Unsafe unsafe {};
 } // namespace NetworKit
 
 namespace std {
@@ -683,7 +685,7 @@ class Graph final {
 	 *
 	 * @param u the node memory should be reserved for
 	 * @param size the amount of memory to reserve
-	 * 
+	 *
 	 * This function is thread-safe if called from different
 	 * threads on different nodes.
 	 */
@@ -695,7 +697,7 @@ class Graph final {
 	 * @param u the node memory should be reserved for
 	 * @param inSize the amount of memory to reserve for in edges
 	 * @param outSize the amount of memory to reserve for out edges
-	 * 
+	 *
 	 * This function is thread-safe if called from different
 	 * threads on different nodes.
 	 */
@@ -777,7 +779,14 @@ class Graph final {
      */
     std::string getName() const { return name; }
 
-    /**
+	/**
+	 * Set edge count of the graph to edges.
+	 * @param edges the edge count of a graph
+	 */
+	void setEdgeCount(Unsafe, count edges) { m = edges; }
+    
+	void setNumberOfSelfLoops(Unsafe, count loops) { storedNumberOfSelfLoops = loops; }
+	/**
      * Returns a string representation of the graph.
      * @return A string representation.
      */
@@ -985,6 +994,40 @@ class Graph final {
      * @param weight Optional edge weight.
      */
     void addEdge(node u, node v, edgeweight ew = defaultEdgeWeight);
+    
+	/**
+     * Insert an edge between the nodes @a u and @a v. Unline the addEdge function, this function does not not add any information to v. If the graph is
+     * weighted you can optionally set a weight for this edge. The default
+     * weight is 1.0. Note: Multi-edges are not supported and will NOT be
+     * handled consistently by the graph data structure.
+     * @param u Endpoint of edge.
+     * @param v Endpoint of edge.
+     * @param weight Optional edge weight.
+     */
+	void addPartialEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
+
+    /**
+     * Insert an in edge between the nodes @a u and @a v in a directed graph. If the graph is
+     * weighted you can optionally set a weight for this edge. The default
+     * weight is 1.0. Note: Multi-edges are not supported and will NOT be
+     * handled consistently by the graph data structure.
+     * @param u Endpoint of edge.
+     * @param v Endpoint of edge.
+     * @param weight Optional edge weight.
+     */
+	void addPartialInEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
+
+    /**
+     * Insert an out edge between the nodes @a u and @a v in a directed graph. If the graph is
+     * weighted you can optionally set a weight for this edge. The default
+     * weight is 1.0. Note: Multi-edges are not supported and will NOT be
+     * handled consistently by the graph data structure.
+     * @param u Endpoint of edge.
+     * @param v Endpoint of edge.
+     * @param weight Optional edge weight.
+     */
+	void addPartialOutEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
+
 
     /**
      * Removes the undirected edge {@a u,@a v}.

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -679,15 +679,27 @@ class Graph final {
     Graph &operator=(const Graph &other) = default;
 
 	/**
-	 * Reserves memory in the node's edge containers.
+	 * Reserves memory in the node's edge containers for undirected graphs.
 	 *
-	 * @param u the node memory should be reserved for 
+	 * @param u the node memory should be reserved for
 	 * @param size the amount of memory to reserve
 	 * 
-	 * This function is thread-safe if called from different 
+	 * This function is thread-safe if called from different
 	 * threads on different nodes.
 	 */
 	void preallocateUndirected(node u, size_t size);
+
+	/**
+	 * Reserves memory in the node's edge containers for directed graphs.
+	 *
+	 * @param u the node memory should be reserved for
+	 * @param inSize the amount of memory to reserve for in edges
+	 * @param outSize the amount of memory to reserve for out edges
+	 * 
+	 * This function is thread-safe if called from different
+	 * threads on different nodes.
+	 */
+	void preallocateDirected(node u, size_t outSize, size_t inSize);
 
     /** EDGE IDS **/
 

--- a/include/networkit/io/NetworkitBinaryGraph.hpp
+++ b/include/networkit/io/NetworkitBinaryGraph.hpp
@@ -1,10 +1,11 @@
 #ifndef NETWORKIT_BINARY_GRAPH_
 #define NETWORKIT_BINARY_GRAPH_
 
+namespace nkbg {
 struct Header {
 	char magic[8];
 	uint64_t checksum;
-	uint64_t features; 	
+	uint64_t features;
 	uint64_t nodes;
 	uint64_t chunks;
 	uint64_t offsetBaseData;
@@ -20,11 +21,10 @@ enum WEIGHT_FORMAT {
 	FLOAT = 3
 };
 
-enum MASKS {
-	DIR_MASK = 0x1, // bit 0
-	WGHT_MASK = 0x6, // bit 1-2
-	WGHT_SHIFT = 0x1,
-	DELETED_BIT = 0x1
-};
+static constexpr uint8_t DELETED_BIT = 0x1; // bit 0
+static constexpr uint64_t DIR_MASK = 0x1; // bit 0
+static constexpr uint64_t WGHT_MASK = 0x6; //bit 1-2
+static constexpr uint64_t WGHT_SHIFT = 0x1;
 
+}
 #endif

--- a/include/networkit/io/NetworkitBinaryGraph.hpp
+++ b/include/networkit/io/NetworkitBinaryGraph.hpp
@@ -23,10 +23,8 @@ enum WEIGHT_FORMAT {
 enum MASKS {
 	DIR_MASK = 0x1, // bit 0
 	WGHT_MASK = 0x6, // bit 1-2
-	WGHT_SHIFT = 0x1
+	WGHT_SHIFT = 0x1,
+	DELETED_BIT = 0x1
 };
-
-constexpr auto DELETED_BIT = uint64_t(1) << 52;
-constexpr auto SIZE_MASK = (uint64_t(1) << 52) - 1;
 
 #endif

--- a/include/networkit/io/NetworkitBinaryReader.hpp
+++ b/include/networkit/io/NetworkitBinaryReader.hpp
@@ -6,17 +6,8 @@
 #ifndef NETWORKIT_BINARY_READER_H
 #define NETWORKIT_BINARY_READER_H
 
-#include <networkit/auxiliary/Log.hpp>
-#include <networkit/graph/Graph.hpp>
 #include <networkit/io/GraphReader.hpp>
-#include <networkit/io/NetworkitBinaryGraph.hpp>
-#include <networkit/io/MemoryMappedFile.hpp>
-#include <tlx/math/ffs.hpp>
-
-#include <vector>
-#include <fstream>
-#include <string.h>
-#include <cstring>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
@@ -28,21 +19,21 @@ namespace NetworKit {
 
 class NetworkitBinaryReader : public GraphReader {
 
-public:		
+public:
 	NetworkitBinaryReader() {};
-	
+
 	Graph read(const std::string& path) override; 
 
 private:
 	static size_t decode(const uint8_t* data, uint64_t& result);
-	
+
 	static int64_t decodeZigzag(uint64_t value);
 
 	count nodes;
 	count chunks;
 	bool directed;
 	bool weighted;
-};	
+};
 } /* namespace */
 
 #endif

--- a/include/networkit/io/NetworkitBinaryWriter.hpp
+++ b/include/networkit/io/NetworkitBinaryWriter.hpp
@@ -9,12 +9,6 @@
 
 #include <networkit/graph/Graph.hpp>
 #include <networkit/io/GraphWriter.hpp>
-#include <networkit/auxiliary/Enforce.hpp>
-#include <networkit/io/NetworkitBinaryGraph.hpp>
-#include <tlx/math/clz.hpp>
-
-#include <fstream>
-#include <cstring>
 
 namespace NetworKit {
 
@@ -23,21 +17,21 @@ namespace NetworKit {
  *
  * Writes a graph in the custom Networkit format documented in cpp/io/NetworkitGraph.md
  */
-	
+
 class NetworkitBinaryWriter : public GraphWriter {
-	
+
 public:
 	NetworkitBinaryWriter(uint64_t chunks = 32);
-	
-	void write(const Graph& G, const std::string& path);
-		
+
+	void write(const Graph& G, const std::string& path) override;
+
 private:
 	static size_t encode(uint64_t value, uint8_t* buffer);
 
 	static uint64_t encodeZigzag(int64_t value);
 
 	count nodes;
-	count chunks;	
+	count chunks;
 };
 } /* namespace */
 #endif

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -179,6 +179,19 @@ void Graph::preallocateUndirected(node u, size_t size) {
 	}
 }
 
+void Graph::preallocateDirected(node u, size_t outSize, size_t inSize) {
+	inEdges[u].reserve(inSize);
+	outEdges[u].reserve(outSize);
+
+	if(weighted) {
+		inEdgeWeights[u].reserve(inSize);
+		outEdgeWeights[u].reserve(outSize);
+	}
+	if(edgesIndexed) {
+		inEdgeIds[u].reserve(inSize);
+		outEdgeIds[u].reserve(outSize);
+	}
+}
 /** PRIVATE HELPERS **/
 
 count Graph::getNextGraphId() {

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -170,6 +170,8 @@ Graph::Graph(const Graph &G, bool weighted, bool directed)
 }
 
 void Graph::preallocateUndirected(node u, size_t size) {
+	assert(!directed);
+	assert(exists[u]);
 	outEdges[u].reserve(size);
 	if(weighted) {
 		outEdgeWeights[u].reserve(size);
@@ -180,6 +182,8 @@ void Graph::preallocateUndirected(node u, size_t size) {
 }
 
 void Graph::preallocateDirected(node u, size_t outSize, size_t inSize) {
+	assert(directed);
+	assert(exists[u]);
 	inEdges[u].reserve(inSize);
 	outEdges[u].reserve(outSize);
 

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -688,7 +688,49 @@ void Graph::addEdge(node u, node v, edgeweight ew) {
 	if (u == v) { // count self loop
 		++storedNumberOfSelfLoops;
 	}
-} // namespace NetworKit
+}
+void Graph::addPartialEdge(Unsafe, node u, node v, uint64_t index, edgeweight ew) {
+	assert(u < z);
+	assert(exists[u]);
+	assert(v < z);
+	assert(exists[v]);
+
+	outEdges[u].push_back(v);
+
+	// if edges indexed, give new id
+	if (edgesIndexed) {
+		outEdgeIds[u].push_back(index);
+	}
+	if (weighted) {
+		outEdgeWeights[u].push_back(ew);
+	}
+}
+void Graph::addPartialOutEdge(Unsafe, node u, node v, uint64_t index, edgeweight ew) {
+	assert(u < z);
+	assert(exists[u]);
+	assert(v < z);
+	assert(exists[v]);
+
+	outEdges[u].push_back(v);
+
+	if (weighted) {
+		outEdgeWeights[u].push_back(ew);
+	}
+}
+void Graph::addPartialInEdge(Unsafe, node u, node v, uint64_t index, edgeweight ew) {
+	assert(u < z);
+	assert(exists[u]);
+	assert(v < z);
+	assert(exists[v]);
+
+	inEdges[u].push_back(v);
+	if (edgesIndexed) {
+		inEdgeIds[u].push_back(index);
+	}
+	if (weighted) {
+		inEdgeWeights[u].push_back(ew);
+	}
+}
 
 template <typename T>
 void erase(node u, index idx, std::vector<std::vector<T>> &vec) {

--- a/networkit/cpp/io/NetworkitBinaryGraph.md
+++ b/networkit/cpp/io/NetworkitBinaryGraph.md
@@ -22,7 +22,7 @@ struct Header {
 };
 ```
 - magic: A constant value used to identify the file format version.
-    - The current version is '*nkbg000*' which supports unweighted, undirected graphs.
+    - The current version is '*nkbg001*' which supports unweighted, undirected and directed graphs.
 - checksum: Currently not used
 - features: Contains the graph information bitwise
     - Bit 0 : directed or undirected
@@ -35,23 +35,33 @@ struct Header {
 - chunks: The number of chunks the nodes have been divided in
 - offsetBaseData: Offset of base data in the file 
 - offsetAdjLists: Offset of the adjacency lists in the file
-- offsetTranspose: Currently unused
+- offsetTranspose: Offset of the transposed adjaceny lists in the file
 - offsetWeights: Offset of the weights in the file
 
-All offsets are relative to the beginning of the file.
+All offsets are relative to the beginning of the section.
 
 Base data
 ------------
 ```
-uint64_t sizeSum[nodes]: The sum of sizes of adjacency vertices with indices <= i
+uint64_t nodeFlags[nodes]: Flags storing information about a node
 uint64_t firstVertex[chunks-1]: The index of the first vertex of each chunk excluding the first chunk
 ```
 Adjacency lists
 -----------------
 ```
+uint64_t nrOfEdges: the total number of edges in the block
 uint64_t offset[chunks-1]: Offset of the file where the adjacency list of 
 the firstVertex of each chunk relative to data starts
 varint data [...]: Varint encoded adjaceny lists  
+```
+Transpose lists
+-----------------
+```
+uint64_t nrOfEdges: the total number of edges in the block
+uint64_t offset[chunks-1]: Offset of the file where the tranpose list of 
+the firstVertex of each chunk relative to data starts
+varint data [...]: Varint encoded transpose lists  
+
 ```
 Weights
 --------------------

--- a/networkit/cpp/io/NetworkitBinaryReader.cpp
+++ b/networkit/cpp/io/NetworkitBinaryReader.cpp
@@ -164,7 +164,8 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 	};
 
 	// create graph
-	for(uint64_t c = 0; c < chunks; c++) {
+	#pragma omp parallel for
+	for(omp_index c = 0; c < static_cast<omp_index>(chunks); c++) {
 		constructGraph(c);
 	}
 	G.setNumberOfSelfLoops(unsafe, selfLoops);

--- a/networkit/cpp/io/NetworkitBinaryReader.cpp
+++ b/networkit/cpp/io/NetworkitBinaryReader.cpp
@@ -56,7 +56,7 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 	};
 
 	auto checkHeader = [&] () {
-		if(memcmp("nkbg000", header.magic, 8)) {
+		if(memcmp("nkbg001", header.magic, 8)) {
 			throw std::runtime_error("Reader expected another magic value");
 		} else {
 			directed = (header.features & DIR_MASK);
@@ -75,17 +75,13 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 	Graph G(nodes, weighted, directed);
 
 	// Read base data.
-	std::vector<uint64_t> prefSum;
+	std::vector<uint8_t> nodeFlags;
 	const char *baseIt = mmfile.cbegin() + header.offsetBaseData;
 	for(uint64_t i = 0; i < nodes; i++) {
-		uint64_t sum;
-		memcpy(&sum, baseIt, sizeof(uint64_t));
-		baseIt += sizeof(uint64_t);
-		uint64_t deleted = (sum & DELETED_BIT);
-		if(!deleted) {
-			sum &= SIZE_MASK;
-			prefSum.push_back(sum);
-		} else {
+		uint8_t flag;
+		memcpy(&flag, baseIt, sizeof(uint8_t));
+		baseIt += sizeof(uint8_t);
+		if (!(flag & DELETED_BIT)) {
 			G.removeNode(i);
 		}
 	}
@@ -110,29 +106,25 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 			memcpy(&off, adjIt + (c-1)* sizeof(uint64_t), sizeof(uint64_t));
 		}
 		off += (chunks - 1) * sizeof(uint64_t);
+
+		uint64_t adjListSize;
+		memcpy(&adjListSize, (adjIt + off), sizeof(uint64_t));
+		off += sizeof(uint64_t);
+		DEBUG("adjListSize: ", adjListSize);
 		uint64_t n = firstVert[c+1] - firstVert[c];
 
 		for (uint64_t i = 0; i < n; i++) {
-			uint64_t nbrs;
 			uint64_t curr = vertex+i;
-			if(curr > 0) {
-				nbrs = prefSum[curr] - prefSum[curr-1];
-			} else {
-				nbrs = prefSum[0];
-			}
+			uint64_t nbrs;
+			size_t rd = NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(adjIt + off), nbrs);
+			off += rd;
 			if(!directed) {
 				G.preallocateUndirected(curr, nbrs);
 			}
 			for (uint64_t j = 0; j < nbrs; j++) {
 				uint64_t add;
-				size_t rd = NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(adjIt + off), add);
-				if(!G.isDirected()) {
-					if(add <= curr) {
-						G.addEdge(curr, add);
-					}
-				} else {
-					G.addEdge(curr,add);
-				}
+				rd = NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(adjIt + off), add);
+				G.addEdge(curr, add);
 				off+=rd;
 			}
 		}

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -5,6 +5,11 @@
  */
 
 #include <networkit/io/NetworkitBinaryWriter.hpp>
+#include <networkit/auxiliary/Enforce.hpp>
+#include <networkit/io/NetworkitBinaryGraph.hpp>
+#include <tlx/math/clz.hpp>
+#include <fstream>
+#include <cstring>
 
 namespace NetworKit {
 
@@ -43,13 +48,13 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 	Aux::enforceOpened(outfile);
 
 	uint64_t weightFormat = 0;
-	Header header = {};
+	nkbg::Header header = {};
 	uint64_t adjListSize = 0;
 	uint64_t adjTransposeSize = 0;
 
 	auto setFeatures = [&] () {
-		header.features |= (G.isDirected() & DIR_MASK);
-		header.features |= ((weightFormat << WGHT_SHIFT) & WGHT_MASK);
+		header.features |= (G.isDirected() & nkbg::DIR_MASK);
+		header.features |= ((weightFormat << nkbg::WGHT_SHIFT) & nkbg::WGHT_MASK);
 	};
 
 	auto writeHeader = [&] () {
@@ -130,7 +135,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 	setFeatures();
 	header.nodes = nodes;
 	header.chunks = chunks;
-	header.offsetBaseData = sizeof(Header);
+	header.offsetBaseData = sizeof(nkbg::Header);
 	header.offsetAdjLists = header.offsetBaseData
 			+ nodes * sizeof(uint8_t) // nodeFlags.
 			+ (chunks - 1) * sizeof(uint64_t); // firstVertex.
@@ -147,7 +152,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 	G.forNodes([&] (node u) {
 		uint8_t nodeFlag = 0;
 		if (G.hasNode(u)) {
-			nodeFlag |= DELETED_BIT;
+			nodeFlag |= nkbg::DELETED_BIT;
 		}
 		outfile.write(reinterpret_cast<char*>(&nodeFlag), sizeof(uint8_t));
 	});


### PR DESCRIPTION
1. The file format needed to be changed, as we need to save two prefix sums per directed graphs; one for the in edges and one for the out edges.
2. Directed graphs are now supported
3. We can now read in parallel