### PR TITLE
Update links: 'kit-parco' -> 'networkit'

### DIFF
--- a/docs/DevGuide.rst
+++ b/docs/DevGuide.rst
@@ -22,7 +22,7 @@ publications is available on the
 Contribution Workflow
 ---------------------
 
-The development of the NetworKit project takes place at our `official repository on GitHub <https://github.com/kit-parco/networkit>`__.
+The development of the NetworKit project takes place at our `official repository on GitHub <https://github.com/networkit/networkit>`__.
 
 There are two important branches you need to be aware of:
 
@@ -58,7 +58,7 @@ Since the algorithm you're working on will take some time to implement, you want
 
 ::
 
-   git remote add upstream https://github.com/kit-parco/networkit.git
+   git remote add upstream https://github.com/networkit/networkit.git
 
 Now you can update your fork on a regular basis with changes from the original repository:
 
@@ -120,7 +120,7 @@ Once you finished the development and testing of your new feature, it is time to
 
 This can be done by visiting the **Pull requests page** (https://github.com/[YOUR-USERNAME]/[FORKED-NETWORKIT]/pulls) of your NetworKit fork on GitHub and clicking on the green **New pull request** button at the top right side of the page.
 
-Here the ``base fork`` at the top should point to ``kit-parco/networkit`` and the base should be ``Dev``. The ``head fork`` should point to your fork of networkit and the ``compare`` branch to the right should point to the feature branch (``feature/[my-awesome-feature-name]``) you would like to create the pull request for.
+Here the ``base fork`` at the top should point to ``networkit/networkit`` and the base should be ``Dev``. The ``head fork`` should point to your fork of networkit and the ``compare`` branch to the right should point to the feature branch (``feature/[my-awesome-feature-name]``) you would like to create the pull request for.
 
 Once you've reviewed all changes, click the green **Create pull request** button and your pull request will be created.
 
@@ -167,7 +167,7 @@ In a nutshell, new developers should familiarise themselves with the existing co
 Report bugs
 -----------
 
-Please report any bugs on the `issues page <https://github.com/kit-parco/networkit/issues>`__ of the official NetworKit repository on GitHub.
+Please report any bugs on the `issues page <https://github.com/networkit/networkit/issues>`__ of the official NetworKit repository on GitHub.
 In very urgent cases it might also make sense to write on the `mailing list <https://lists.uni-koeln.de/mailman/listinfo/networkit>`__.
 Please provide a minimal example so that others can reproduce that bug.
 

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -25,4 +25,4 @@ We provide several example notebooks to get started with NetworKit and Jupyter N
 
 .. |userGuide| raw:: html
 
-	<a href="https://github.com/kit-parco/networkit/blob/Dev/notebooks/User-Guide.ipynb" target="_blank">NetworKit User Guide</a>
+	<a href="https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb" target="_blank">NetworKit User Guide</a>

--- a/extrafiles/sphinx-style/_templates/layout.html
+++ b/extrafiles/sphinx-style/_templates/layout.html
@@ -9,7 +9,7 @@
 {# Add github banner (from: https://github.com/blog/273-github-ribbons). #}
 {% block header %}
   {{ super() }}
-  <a href="https://github.com/kit-parco/networkit"
+  <a href="https://github.com/networkit/networkit"
      class="visible-desktop hidden-xs"><img style="position: absolute; width:auto; height: auto; max-width: 200px; top:
      0px; right: 0; border: 0; z-index: 3;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png" alt="Fork me on GitHub"></a>  
 {% endblock %}

--- a/networkit/__init__.py
+++ b/networkit/__init__.py
@@ -20,7 +20,7 @@ and integration into the Python ecosystem of tools for data analysis and
 scientific computation.
 
 
-Usage examples can be found on https://github.com/kit-parco/networkit/blob/Dev/notebooks/User-Guide.ipynb
+Usage examples can be found on https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb
 """
 
 __author__ = "Christian Staudt"


### PR DESCRIPTION
This updates all the links from the previous networkit github address `kit-parco/networkit` to `networkit/networkit`.