### PR TITLE
gtest wrapper: Do not print source location by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,13 +342,13 @@ if (NETWORKIT_BUILD_TESTS)
 
 		add_test(
 			NAME networkit_tests
-			COMMAND networkit_tests -t
+			COMMAND networkit_tests -t --srcloc
 			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 		)
 
 		add_test(
 			NAME networkit_tests_no_assertions
-			COMMAND networkit_tests -r
+			COMMAND networkit_tests -r --srcloc
 			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 		)
 
@@ -416,13 +416,13 @@ function(networkit_add_extra IS_TEST MOD NAME)
 
 				add_test(
 					NAME "${MOD}/${NAME}"
-					COMMAND ${TARGET_NAME} -t
+					COMMAND ${TARGET_NAME} -t --srcloc
 					WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 					)
 
 				add_test(
 					NAME "${MOD}/${NAME}_no_assertions"
-					COMMAND ${TARGET_NAME} -r
+					COMMAND ${TARGET_NAME} -r --srcloc
 					WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 				)
 			endif()

--- a/networkit/cpp/Unittests-X.cpp
+++ b/networkit/cpp/Unittests-X.cpp
@@ -20,7 +20,8 @@
 #include <networkit/auxiliary/Parallelism.hpp>
 
 struct Options {
-    std::string loglevel;
+    std::string loglevel = "ERROR";
+    bool sourceLocation{false};
     unsigned numThreads{0};
 
     bool modeTests{false};
@@ -38,6 +39,7 @@ struct Options {
         
         parser.add_unsigned("threads",     numThreads,     "set the maximum number of threads; 0 (=default) uses OMP default");
         parser.add_string("loglevel",      loglevel,       "set the log level (TRACE|DEBUG|INFO|WARN|ERROR|FATAL)");
+        parser.add_bool("srcloc",          sourceLocation, "print source location of log messages");
 
         if (!parser.process(argc, argv, std::cerr))
             return false;
@@ -62,17 +64,8 @@ int main(int argc, char *argv[]) {
 
     // Configure logging
 #ifndef NOLOGGING
-    if (!options.loglevel.empty()) {
-        Aux::Log::setLogLevel(options.loglevel);
-        if(Aux::Log::getLogLevel() == "INFO"){
-            Aux::Log::Settings::setPrintLocation(false);
-        }else{
-            Aux::Log::Settings::setPrintLocation(true);
-        }
-    } else {
-        Aux::Log::setLogLevel("ERROR");	// with default level
-        Aux::Log::Settings::setPrintLocation(true);
-    }
+    Aux::Log::setLogLevel(options.loglevel);
+    Aux::Log::Settings::setPrintLocation(options.sourceLocation);
     std::cout << "Loglevel: " << Aux::Log::getLogLevel() << "\n";
 #endif
 

--- a/networkit/cpp/Unittests-X.cpp
+++ b/networkit/cpp/Unittests-X.cpp
@@ -67,6 +67,11 @@ int main(int argc, char *argv[]) {
     Aux::Log::setLogLevel(options.loglevel);
     Aux::Log::Settings::setPrintLocation(options.sourceLocation);
     std::cout << "Loglevel: " << Aux::Log::getLogLevel() << "\n";
+#else
+    if (options.loglevel != "ERROR")
+        std::cout << "WARNING: --loglevel is ignored in NOLOGGING builds" << std::endl;
+    if (options.sourceLocation)
+        std::cout << "WARNING: --srcloc is ignored in NOLOGGING builds" << std::endl;
 #endif
 
     // Configure parallelism


### PR DESCRIPTION
Printing the source location of all debugging messages is incredibly annoying when developing code via TDD in NetworKit, leading to very long lines:
```
[...]
[INFO ][/home/avdgrinten/Projects/networkit/networkit/cpp/centrality/GroupCloseness.cpp, 130: virtual void NetworKit::GroupCloseness::run()]: maxD = 3
[INFO ][/home/avdgrinten/Projects/networkit/networkit/cpp/centrality/GroupCloseness.cpp, 176: virtual void NetworKit::GroupCloseness::run()]: Extracted node 7 with prio 0
[INFO ][/home/avdgrinten/Projects/networkit/networkit/cpp/centrality/GroupCloseness.cpp, 176: virtual void NetworKit::GroupCloseness::run()]: Extracted node 2 with prio 0
[INFO ][/home/avdgrinten/Projects/networkit/networkit/cpp/centrality/GroupCloseness.cpp, 192: virtual void NetworKit::GroupCloseness::run()]: New bound for v = 4
[INFO ][/home/avdgrinten/Projects/networkit/networkit/cpp/centrality/GroupCloseness.cpp, 176: virtual void NetworKit::GroupCloseness::run()]: Extracted node 3 with prio 0
[INFO ][/home/avdgrinten/Projects/networkit/networkit/cpp/centrality/GroupCloseness.cpp, 176: virtual void NetworKit::GroupCloseness::run()]: Extracted node 6 with prio 0
[...]
```

This PR includes two patches: First, we disable printing of source locations in the Google Test wrapper by default. At the same time, we introduce a `--srcloc` argument for the wrapper that enables this functionality. In the second commit, we change the CMake command `ctest` to use `--srcloc`.

Note that this change decouples printing of source locations from the `--loglevel`. Hence, our CI builds will now *include* source locations.