### PR TITLE
Add InGroup annotations to generators

### DIFF
--- a/include/networkit/generators/EdgeSwitchingMarkovChainGenerator.hpp
+++ b/include/networkit/generators/EdgeSwitchingMarkovChainGenerator.hpp
@@ -6,6 +6,7 @@
 namespace NetworKit {
 
 /**
+ * @ingroup generators
  * Graph generator for generating a random simple graph with exactly the given degree sequence based on the Edge-Switching Markov-Chain method.
  *
  * This implementation is based on the paper

--- a/include/networkit/generators/HyperbolicGenerator.hpp
+++ b/include/networkit/generators/HyperbolicGenerator.hpp
@@ -18,6 +18,9 @@
 
 namespace NetworKit {
 
+/**
+ * @ingroup generators
+ */
 class HyperbolicGenerator: public StaticGraphGenerator {
 	friend class DynamicHyperbolicGenerator;
 public:

--- a/include/networkit/generators/LFRGenerator.hpp
+++ b/include/networkit/generators/LFRGenerator.hpp
@@ -9,6 +9,7 @@
 namespace NetworKit {
 
 /**
+ * @ingroup generators
  * The LFR clustered graph generator as introduced by Andrea Lancichinetti, Santo Fortunato, and Filippo Radicchi.
  *
  * The community assignment follows the algorithm described in

--- a/include/networkit/generators/PubWebGenerator.hpp
+++ b/include/networkit/generators/PubWebGenerator.hpp
@@ -16,6 +16,7 @@
 
 namespace NetworKit {
 
+// TODO: Clean this up.
 const int MAX_RAND_VAL = 1000;
 const float MAX_DENSE_AREA_RADIUS = 0.2f;
 const float MIN_MAX_DENSE_AREA_FACTOR = 5.0f;

--- a/include/networkit/generators/RegularRingLatticeGenerator.hpp
+++ b/include/networkit/generators/RegularRingLatticeGenerator.hpp
@@ -12,7 +12,9 @@
 
 namespace NetworKit {
 
-
+/**
+ * @ingroup generators
+ */
 class RegularRingLatticeGenerator: public StaticGraphGenerator {
 
 public:

--- a/include/networkit/generators/StaticDegreeSequenceGenerator.hpp
+++ b/include/networkit/generators/StaticDegreeSequenceGenerator.hpp
@@ -12,6 +12,7 @@
 
 namespace NetworKit {
 
+// TODO: Clean this up.
 const short NO = 0;
 const short YES = 1;
 const short UNKNOWN = 2;

--- a/include/networkit/generators/StochasticBlockmodel.hpp
+++ b/include/networkit/generators/StochasticBlockmodel.hpp
@@ -13,6 +13,9 @@
 namespace NetworKit {
 
 
+/**
+ * @ingroup generators
+ */
 class StochasticBlockmodel: public StaticGraphGenerator {
 
 public:

--- a/include/networkit/generators/WattsStrogatzGenerator.hpp
+++ b/include/networkit/generators/WattsStrogatzGenerator.hpp
@@ -13,6 +13,9 @@
 namespace NetworKit {
 
 
+/**
+ * @ingroup generators
+ */
 class WattsStrogatzGenerator: public StaticGraphGenerator {
 
 public:


### PR DESCRIPTION
The `@ingroup` attribute was missing for a number of generators. Hence they were not listed in the documentation in the Generator module.

I also added two ToDo requesting code clean up out-of-scope for this PR.