### PR TITLE
Modernize Globals.hpp

### DIFF
--- a/include/networkit/Globals.hpp
+++ b/include/networkit/Globals.hpp
@@ -9,7 +9,6 @@
 #define GLOBALS_H_
 
 #include <cstdint>
-#include <cmath>
 #include <limits>
 
 #include <networkit/ext/ttmath/ttmath.hpp>

--- a/include/networkit/Globals.hpp
+++ b/include/networkit/Globals.hpp
@@ -14,34 +14,29 @@
 
 #include <networkit/ext/ttmath/ttmath.hpp>
 
-
 namespace NetworKit {
-	/** Typedefs **/
-	typedef uint64_t index; // more expressive name for an index into an array
-#ifdef _MSC_VER	
-	typedef int64_t omp_index;
-#else
-	typedef index omp_index;
-#endif
-	typedef uint64_t count; // more expressive name for an integer quantity
-	typedef ttmath::Big<TTMATH_BITS(64),TTMATH_BITS(64)> bigfloat;	// big floating point number
-	typedef index node; // node indices are 0-based
-	typedef double edgeweight; // edge weight type
-	typedef index edgeid;	// edge id
+    using index = uint64_t; ///< more expressive name for an index into an array
 
-	/** Constants **/
-	constexpr index none = std::numeric_limits<index>::max(); // value for not existing nodes/edges
-	constexpr edgeweight defaultEdgeWeight = 1.0;
-	constexpr edgeweight nullWeight = 0.0;
+    /// Should be used in OpenMP parallel for-loops and is associated with unsigned semantics.
+    /// On MSVC it falls back to being signed, as MSVC does not support unsigned parallel fors.
+#ifdef _MSC_VER
+    using omp_index = int64_t;
+#else
+    using omp_index = index;
+#endif
+
+    using count      = uint64_t; ///< more expressive name for an integer quantity
+    using node       = index;    ///< node indices are 0-based
+    using edgeweight = double;   ///< edge weight type
+    using edgeid     = index;	 ///< edge id
+    using bigfloat = ttmath::Big<TTMATH_BITS(64),TTMATH_BITS(64)>;	///< big floating point number
+
+    constexpr index none = std::numeric_limits<index>::max(); ///< value for not existing nodes/edges
+    constexpr edgeweight defaultEdgeWeight = 1.0;
+    constexpr edgeweight nullWeight = 0.0;
+
+    constexpr double PI = 3.141592653589793238462643383279502884197169399375105820974944592307816406286;
+
 }
-
-#ifdef __INTEL_COMPILER
-constexpr double PI = 3.141592653589793238462643383279502884197169399375105820974944592307816406286;
-#else
-const double PI = 2.0*std::acos(0);
-#endif
-
-// CODE STYLE GUIDELINES: Do not rely on global variables for algorithm parametrization.
-
 
 #endif /* GLOBALS_H_ */

--- a/include/networkit/algebraic/MatrixTools.hpp
+++ b/include/networkit/algebraic/MatrixTools.hpp
@@ -8,8 +8,10 @@
 #ifndef NETWORKIT_CPP_ALGEBRAIC_MATRIXTOOLS_H_
 #define NETWORKIT_CPP_ALGEBRAIC_MATRIXTOOLS_H_
 
-#include <networkit/graph/Graph.hpp>
 #include <atomic>
+#include <cmath>
+
+#include <networkit/graph/Graph.hpp>
 
 namespace MatrixTools {
 

--- a/include/networkit/algebraic/Vector.hpp
+++ b/include/networkit/algebraic/Vector.hpp
@@ -8,10 +8,13 @@
 #ifndef VECTOR_H_
 #define VECTOR_H_
 
+#include <cassert>
+#include <cmath>
 #include <vector>
+
 #include <networkit/Globals.hpp>
 #include <networkit/algebraic/AlgebraicGlobals.hpp>
-#include <cassert>
+
 
 namespace NetworKit {
 

--- a/include/networkit/algebraic/algorithms/AlgebraicSpanningEdgeCentrality.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicSpanningEdgeCentrality.hpp
@@ -8,6 +8,8 @@
 #ifndef NETWORKIT_CPP_ALGEBRAIC_ALGORITHMS_ALGEBRAICSPANNINGEDGECENTRALITY_H_
 #define NETWORKIT_CPP_ALGEBRAIC_ALGORITHMS_ALGEBRAICSPANNINGEDGECENTRALITY_H_
 
+#include <cmath>
+
 #include <networkit/centrality/Centrality.hpp>
 #include <networkit/numerics/LAMG/Lamg.hpp>
 

--- a/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
+++ b/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
@@ -13,6 +13,8 @@
 #include <networkit/algebraic/CSRMatrix.hpp>
 
 #include <limits>
+#include <cmath>
+#include <vector>
 
 namespace NetworKit {
 

--- a/include/networkit/numerics/LAMG/SolverLamg.hpp
+++ b/include/networkit/numerics/LAMG/SolverLamg.hpp
@@ -8,6 +8,9 @@
 #ifndef SOLVERLAMG_H_
 #define SOLVERLAMG_H_
 
+#include <cmath>
+#include <vector>
+
 #include <networkit/numerics/LAMG/LevelHierarchy.hpp>
 #include <networkit/numerics/Smoother.hpp>
 #include <networkit/algebraic/DenseMatrix.hpp>

--- a/include/networkit/viz/Octree.hpp
+++ b/include/networkit/viz/Octree.hpp
@@ -8,6 +8,7 @@
 #ifndef NETWORKIT_CPP_VIZ_OCTREE_H_
 #define NETWORKIT_CPP_VIZ_OCTREE_H_
 
+#include <cmath>
 #include <vector>
 
 #include <networkit/viz/Point.hpp>

--- a/networkit/cpp/viz/MaxentStress.cpp
+++ b/networkit/cpp/viz/MaxentStress.cpp
@@ -16,6 +16,7 @@
 #include <networkit/numerics/Preconditioner/DiagonalPreconditioner.hpp>
 #include <networkit/numerics/Preconditioner/IdentityPreconditioner.hpp>
 
+#include <cmath>
 #include <queue>
 
 namespace NetworKit {


### PR DESCRIPTION
This PR does the following:
- Move `PI` from global namespace into `NetworKit`
- Remove case distinction for the definition of `PI` and always use constant
- Use "using" rather than "typedef"
- Define constexpr debug to be used rather than `NDEBUG`. It also has the advantage that we can shadowing to selectively put module into debug mode.
- Remove now unused `#include <cmath>` from Globals and add it to headers where it's actually used.