### PR TITLE
Fix issues in Aux::Timer

### DIFF
--- a/include/networkit/auxiliary/Timer.hpp
+++ b/include/networkit/auxiliary/Timer.hpp
@@ -23,15 +23,9 @@ namespace Aux {
  * A timer for running time measurements.
  */
 class Timer {
-
-protected:
-
-	bool running;			//!< true if timer has been started and not stopped after that
-	my_steady_clock::time_point started;	//!< time at which timer has been started
-	my_steady_clock::time_point stopped;		//!< time at which timer has been stopped
-
 public:
-	Timer();
+	Timer() = default;
+	virtual ~Timer() = default;
 
 	/**
 	 * Start the clock.
@@ -88,7 +82,15 @@ public:
 	/**
 	 *
 	 */
-	virtual std::string elapsedTag();
+	virtual std::string elapsedTag() const;
+
+protected:
+	bool running{false};                   //!< true if timer has been started and not stopped after that
+	my_steady_clock::time_point started;   //!< time at which timer has been started
+	my_steady_clock::time_point stopped;   //!< time at which timer has been stopped
+
+    /// If running returns now, otherwise the stop time
+    my_steady_clock::time_point stopTimeOrNow() const noexcept;
 };
 
 } /* namespace Aux */

--- a/include/networkit/auxiliary/Timer.hpp
+++ b/include/networkit/auxiliary/Timer.hpp
@@ -41,30 +41,30 @@ public:
 	virtual my_steady_clock::time_point stop() noexcept;
 
 	/**
-	 * The number of milliseconds since the current time that the Timer
-	 * object was created.  If stop() was called, it is the number
-	 * of seconds from the instance creation until stop() was called.
+	 * Returns a chrono::duration since the Timer was started.
+	 * If stop() was called, the duration is between the start() and stop()
+	 * calls is returned.
 	 */
 	virtual std::chrono::duration<uint64_t, std::milli> elapsed() const noexcept;
 
 	/**
-	 * The number of milliseconds since the current time that the Timer
-	 * object was created. If stop() was called, it is the number
-	 * of seconds from the instance creation until stop() was called.
+	 * Returns the number of milliseconds since the Timer was started.
+	 * If stop() was called, the duration is between the start() and stop()
+	 * calls is returned.
 	 */
 	virtual uint64_t elapsedMilliseconds() const noexcept;
 
 	/**
-	 * The number of microseconds since the current time that the Timer
-	 * object was created. If stop() was called, it is the number
-	 * of seconds from the instance creation until stop() was called.
+	 * Returns the number of microseconds since the Timer was started.
+	 * If stop() was called, the duration is between the start() and stop()
+	 * calls is returned.
 	 */
 	virtual uint64_t elapsedMicroseconds() const noexcept;
 
 	/**
-	 * The number of nanoseconds since the current time that the Timer
-	 * object was created. If stop() was called, it is the number
-	 * of seconds from the instance creation until stop() was called.
+	 * Returns the number of nanoseconds since the Timer was started.
+	 * If stop() was called, the duration is between the start() and stop()
+	 * calls is returned.
 	 */
 	virtual uint64_t elapsedNanoseconds() const noexcept;
 
@@ -91,6 +91,17 @@ protected:
 	/// If running returns now, otherwise the stop time
 	my_steady_clock::time_point stopTimeOrNow() const noexcept;
 };
+
+/**
+  * A timer for running time measurements.
+  * Same as Timer but automatically starts on construction.
+ */
+class StartedTimer final : public Timer {
+public:
+    StartedTimer() : Timer() {start();}
+    virtual ~StartedTimer() = default;
+};
+
 
 } /* namespace Aux */
 #endif /* TIMER_H_ */

--- a/include/networkit/auxiliary/Timer.hpp
+++ b/include/networkit/auxiliary/Timer.hpp
@@ -26,62 +26,61 @@ public:
 	#endif
 
 	Timer() = default;
-	virtual ~Timer() = default;
 
 	/**
 	 * Start the clock.
 	 * Returns the time at which the instance was started.
 	 */
-	virtual my_steady_clock::time_point start() noexcept;
+	my_steady_clock::time_point start() noexcept;
 
 	/**
 	 * Stops the clock permanently for the instance of the Timer.
 	 * Returns the time at which the instance was stopped.
 	 */
-	virtual my_steady_clock::time_point stop() noexcept;
+	my_steady_clock::time_point stop() noexcept;
 
 	/**
 	 * Returns a chrono::duration since the Timer was started.
 	 * If stop() was called, the duration is between the start() and stop()
 	 * calls is returned.
 	 */
-	virtual std::chrono::duration<uint64_t, std::milli> elapsed() const noexcept;
+	std::chrono::duration<uint64_t, std::milli> elapsed() const noexcept;
 
 	/**
 	 * Returns the number of milliseconds since the Timer was started.
 	 * If stop() was called, the duration is between the start() and stop()
 	 * calls is returned.
 	 */
-	virtual uint64_t elapsedMilliseconds() const noexcept;
+	uint64_t elapsedMilliseconds() const noexcept;
 
 	/**
 	 * Returns the number of microseconds since the Timer was started.
 	 * If stop() was called, the duration is between the start() and stop()
 	 * calls is returned.
 	 */
-	virtual uint64_t elapsedMicroseconds() const noexcept;
+	uint64_t elapsedMicroseconds() const noexcept;
 
 	/**
 	 * Returns the number of nanoseconds since the Timer was started.
 	 * If stop() was called, the duration is between the start() and stop()
 	 * calls is returned.
 	 */
-	virtual uint64_t elapsedNanoseconds() const noexcept;
+	uint64_t elapsedNanoseconds() const noexcept;
 
 	/**
 	 * Returns the time at which the instance was started.
 	 */
-	virtual my_steady_clock::time_point startTime() const noexcept;
+	my_steady_clock::time_point startTime() const noexcept;
 
 	/**
 	 * Returns the time at which the instance was stopped.
 	 */
-	virtual my_steady_clock::time_point stopTime() const noexcept;
+	my_steady_clock::time_point stopTime() const noexcept;
 
 	/**
 	 * Returns a human-readable representation including the elapsed time and unit.
 	 */
-	virtual std::string elapsedTag() const;
+	std::string elapsedTag() const;
 
 protected:
 	bool running{false};                   //!< true if timer has been started and not stopped after that
@@ -93,16 +92,18 @@ protected:
 };
 
 /**
-  * A timer for running time measurements.
-  * Same as Timer but automatically starts on construction.
+ * A timer for running time measurements.
+ * Same as Timer but automatically starts on construction.
  */
-class StartedTimer final : public Timer {
+class StartedTimer : public Timer {
 public:
-    StartedTimer() : Timer() {start();}
-    virtual ~StartedTimer() = default;
+	StartedTimer() : Timer() {
+		start();
+	}
 };
 
 
 } /* namespace Aux */
+
 #endif /* TIMER_H_ */
 

--- a/include/networkit/auxiliary/Timer.hpp
+++ b/include/networkit/auxiliary/Timer.hpp
@@ -102,6 +102,36 @@ public:
 	}
 };
 
+/**
+ * A timer for running time measurements within a scope.
+ *
+ * Same as Timer but automatically starts on construction and report on destruction.
+ *
+ * @code
+ * {
+ *    Aux::ScopedTimer someName("Algorithm B");
+ *    // some expensive operations
+ *
+ *
+ * } // <- Report time since creation of the timer object to std::cout
+ * @endcode
+ *
+ * @warning Similarly as std::unique_lock the timer needs a name ("someName" in the example)
+ * to exist until the end of the scope. If the time measured seems too short, make you created
+ * a named instances.
+ */
+class ScopedTimer : public StartedTimer {
+public:
+	explicit ScopedTimer(const std::string& label = "") :
+		StartedTimer(),
+		label(label)
+	{}
+
+	~ScopedTimer();
+
+private:
+	std::string label;
+};
 
 } /* namespace Aux */
 

--- a/include/networkit/auxiliary/Timer.hpp
+++ b/include/networkit/auxiliary/Timer.hpp
@@ -13,17 +13,17 @@
 
 namespace Aux {
 
-#ifdef __MIC__
-#define my_steady_clock std::chrono::monotonic_clock
-#else
-#define my_steady_clock std::chrono::steady_clock
-#endif
-
 /**
  * A timer for running time measurements.
  */
 class Timer {
 public:
+	#ifdef __MIC__
+		using my_steady_clock = std::chrono::monotonic_clock;
+	#else
+		using my_steady_clock = std::chrono::steady_clock;
+	#endif
+
 	Timer() = default;
 	virtual ~Timer() = default;
 

--- a/include/networkit/auxiliary/Timer.hpp
+++ b/include/networkit/auxiliary/Timer.hpp
@@ -9,7 +9,8 @@
 #define TIMER_H_
 
 #include <chrono>
-#include <sstream>
+#include <cstdint>
+#include <string>
 
 namespace Aux {
 
@@ -31,56 +32,54 @@ public:
 	 * Start the clock.
 	 * Returns the time at which the instance was started.
 	 */
-	virtual my_steady_clock::time_point start();
+	virtual my_steady_clock::time_point start() noexcept;
 
 	/**
 	 * Stops the clock permanently for the instance of the Timer.
 	 * Returns the time at which the instance was stopped.
 	 */
-	virtual my_steady_clock::time_point stop();
+	virtual my_steady_clock::time_point stop() noexcept;
 
 	/**
 	 * The number of milliseconds since the current time that the Timer
 	 * object was created.  If stop() was called, it is the number
 	 * of seconds from the instance creation until stop() was called.
 	 */
-	virtual std::chrono::duration<uint64_t, std::milli> elapsed() const;
+	virtual std::chrono::duration<uint64_t, std::milli> elapsed() const noexcept;
 
 	/**
 	 * The number of milliseconds since the current time that the Timer
 	 * object was created. If stop() was called, it is the number
 	 * of seconds from the instance creation until stop() was called.
 	 */
-	virtual uint64_t elapsedMilliseconds() const;
+	virtual uint64_t elapsedMilliseconds() const noexcept;
 
 	/**
 	 * The number of microseconds since the current time that the Timer
 	 * object was created. If stop() was called, it is the number
 	 * of seconds from the instance creation until stop() was called.
 	 */
-	virtual uint64_t elapsedMicroseconds();
+	virtual uint64_t elapsedMicroseconds() const noexcept;
 
 	/**
 	 * The number of nanoseconds since the current time that the Timer
 	 * object was created. If stop() was called, it is the number
 	 * of seconds from the instance creation until stop() was called.
 	 */
-	virtual uint64_t elapsedNanoseconds();
+	virtual uint64_t elapsedNanoseconds() const noexcept;
 
 	/**
 	 * Returns the time at which the instance was started.
 	 */
-	virtual my_steady_clock::time_point startTime();
+	virtual my_steady_clock::time_point startTime() const noexcept;
 
 	/**
 	 * Returns the time at which the instance was stopped.
-	 *
 	 */
-	virtual my_steady_clock::time_point stopTime();
-
+	virtual my_steady_clock::time_point stopTime() const noexcept;
 
 	/**
-	 *
+	 * Returns a human-readable representation including the elapsed time and unit.
 	 */
 	virtual std::string elapsedTag() const;
 
@@ -89,9 +88,10 @@ protected:
 	my_steady_clock::time_point started;   //!< time at which timer has been started
 	my_steady_clock::time_point stopped;   //!< time at which timer has been stopped
 
-    /// If running returns now, otherwise the stop time
-    my_steady_clock::time_point stopTimeOrNow() const noexcept;
+	/// If running returns now, otherwise the stop time
+	my_steady_clock::time_point stopTimeOrNow() const noexcept;
 };
 
 } /* namespace Aux */
 #endif /* TIMER_H_ */
+

--- a/networkit/cpp/auxiliary/Log.cpp
+++ b/networkit/cpp/auxiliary/Log.cpp
@@ -2,8 +2,10 @@
 #include <chrono>
 #include <ctime>
 #include <fstream>
+#include <iostream>
 #include <iomanip>
 #include <ios>
+#include <mutex>
 
 #include <networkit/auxiliary/Log.hpp>
 
@@ -106,6 +108,8 @@ void printLogLevel(std::ostream &stream, LogLevel p) {
 			stream << "[DEBUG]"; break;
 		case LogLevel::trace:
 			stream << "[TRACE]"; break;
+        default:
+            break;
 	}
 }
 

--- a/networkit/cpp/auxiliary/Timer.cpp
+++ b/networkit/cpp/auxiliary/Timer.cpp
@@ -5,55 +5,56 @@
  *      Author: Christian Staudt (christian.staudt@kit.edu)
  */
 
+#include <sstream>
+
 #include <networkit/auxiliary/Timer.hpp>
 
 namespace Aux {
 
-Timer::my_steady_clock::time_point Timer::start() {
+Timer::my_steady_clock::time_point Timer::start() noexcept {
 	started = my_steady_clock::now();
 	running = true;
 	return started;
 }
 
-Timer::my_steady_clock::time_point Timer::stop() {
+Timer::my_steady_clock::time_point Timer::stop() noexcept {
 	stopped = my_steady_clock::now();
 	running = false;
 	return stopped;
 }
 
-std::chrono::duration<uint64_t, std::milli> Timer::elapsed() const {
-	if (running) {
-		return std::chrono::duration_cast<std::chrono::duration<uint64_t, std::milli>>(std::chrono::steady_clock::now() - this->started);
-	}
-	std::chrono::duration<uint64_t, std::milli> elapsed = std::chrono::duration_cast<std::chrono::duration<uint64_t, std::milli>>(this->stopped - this->started);
-	return elapsed;
+std::chrono::duration<uint64_t, std::milli> Timer::elapsed() const noexcept {
+	return std::chrono::duration_cast<std::chrono::duration<uint64_t, std::milli> >(stopTimeOrNow() - started);
 }
 
-Timer::my_steady_clock::time_point Timer::startTime() {
+Timer::my_steady_clock::time_point Timer::startTime() const noexcept {
 	return started;
 }
 
-Timer::my_steady_clock::time_point Timer::stopTime() {
+Timer::my_steady_clock::time_point Timer::stopTime() const noexcept {
 	return stopped;
 }
 
-uint64_t Timer::elapsedMilliseconds() {
+uint64_t Timer::elapsedMilliseconds() const noexcept {
 	return elapsed().count();
 }
 
-uint64_t Timer::elapsedMicroseconds() {
-	return std::chrono::duration_cast<std::chrono::duration<uint64_t, std::micro>>(this->stopped - this->started).count();
+uint64_t Timer::elapsedMicroseconds() const noexcept {
+	return std::chrono::duration_cast<std::chrono::duration<uint64_t, std::micro>>(stopTimeOrNow() - started).count();
 }
 
-uint64_t Timer::elapsedNanoseconds() {
-	return std::chrono::duration_cast<std::chrono::duration<uint64_t, std::nano>>(this->stopped - this->started).count();
+uint64_t Timer::elapsedNanoseconds() const noexcept {
+	return std::chrono::duration_cast<std::chrono::duration<uint64_t, std::nano>>(stopTimeOrNow() - started).count();
 }
 
-std::string Timer::elapsedTag() {
+std::string Timer::elapsedTag() const {
 	std::stringstream s;
 	s << "(" << elapsedMilliseconds() << " ms) ";
 	return s.str();
 }
 
+Timer::my_steady_clock::time_point Timer::stopTimeOrNow() const noexcept {
+    return running ? std::chrono::steady_clock::now() : stopped;
+}
 
 } /* namespace Aux */

--- a/networkit/cpp/auxiliary/Timer.cpp
+++ b/networkit/cpp/auxiliary/Timer.cpp
@@ -5,6 +5,7 @@
  *      Author: Christian Staudt (christian.staudt@kit.edu)
  */
 
+#include <iostream>
 #include <sstream>
 
 #include <networkit/auxiliary/Timer.hpp>
@@ -55,6 +56,18 @@ std::string Timer::elapsedTag() const {
 
 Timer::my_steady_clock::time_point Timer::stopTimeOrNow() const noexcept {
     return running ? std::chrono::steady_clock::now() : stopped;
+}
+
+ScopedTimer::~ScopedTimer() {
+	std::stringstream ss;
+	ss << "Timer ";
+
+	if (!label.empty())
+		ss << '"' << label << "\" ";
+
+	ss << "ran for " << (elapsedMicroseconds() * 1e-3) << " ms";
+
+	std::cout << ss.str() << std::endl; // we really want to flush here!
 }
 
 } /* namespace Aux */

--- a/networkit/cpp/auxiliary/Timer.cpp
+++ b/networkit/cpp/auxiliary/Timer.cpp
@@ -9,9 +9,6 @@
 
 namespace Aux {
 
-Timer::Timer() : running(false) {
-}
-
 my_steady_clock::time_point Timer::start() {
 	this->started = my_steady_clock::now();
 	running = true;

--- a/networkit/cpp/auxiliary/Timer.cpp
+++ b/networkit/cpp/auxiliary/Timer.cpp
@@ -55,10 +55,23 @@ std::string Timer::elapsedTag() const {
 }
 
 Timer::my_steady_clock::time_point Timer::stopTimeOrNow() const noexcept {
-    return running ? std::chrono::steady_clock::now() : stopped;
+	return running ? std::chrono::steady_clock::now() : stopped;
 }
 
-ScopedTimer::~ScopedTimer() {
+LoggingTimer::LoggingTimer(const std::string &label, Aux::Log::LogLevel level)
+	: level(level)
+{
+	if (!Aux::Log::isLogLevelEnabled(level))
+		return;
+
+	this->label = label;
+	start();
+}
+
+LoggingTimer::~LoggingTimer() {
+	if (!running)
+		return;
+
 	std::stringstream ss;
 	ss << "Timer ";
 
@@ -67,7 +80,7 @@ ScopedTimer::~ScopedTimer() {
 
 	ss << "ran for " << (elapsedMicroseconds() * 1e-3) << " ms";
 
-	std::cout << ss.str() << std::endl; // we really want to flush here!
+	LOG_AT(level, ss.str());
 }
 
 } /* namespace Aux */

--- a/networkit/cpp/auxiliary/Timer.cpp
+++ b/networkit/cpp/auxiliary/Timer.cpp
@@ -9,16 +9,16 @@
 
 namespace Aux {
 
-my_steady_clock::time_point Timer::start() {
-	this->started = my_steady_clock::now();
+Timer::my_steady_clock::time_point Timer::start() {
+	started = my_steady_clock::now();
 	running = true;
-	return this->started;
+	return started;
 }
 
-my_steady_clock::time_point Timer::stop() {
-	this->stopped = my_steady_clock::now();
+Timer::my_steady_clock::time_point Timer::stop() {
+	stopped = my_steady_clock::now();
 	running = false;
-	return this->stopped;
+	return stopped;
 }
 
 std::chrono::duration<uint64_t, std::milli> Timer::elapsed() const {
@@ -29,16 +29,16 @@ std::chrono::duration<uint64_t, std::milli> Timer::elapsed() const {
 	return elapsed;
 }
 
-my_steady_clock::time_point Timer::startTime() {
-	return this->started;
+Timer::my_steady_clock::time_point Timer::startTime() {
+	return started;
 }
 
-my_steady_clock::time_point Timer::stopTime() {
-	return this->stopped;
+Timer::my_steady_clock::time_point Timer::stopTime() {
+	return stopped;
 }
 
-uint64_t Timer::elapsedMilliseconds() const {
-	return this->elapsed().count();
+uint64_t Timer::elapsedMilliseconds() {
+	return elapsed().count();
 }
 
 uint64_t Timer::elapsedMicroseconds() {
@@ -51,7 +51,7 @@ uint64_t Timer::elapsedNanoseconds() {
 
 std::string Timer::elapsedTag() {
 	std::stringstream s;
-	s << "(" << this->elapsed().count() << " ms) ";
+	s << "(" << elapsedMilliseconds() << " ms) ";
 	return s.str();
 }
 

--- a/networkit/cpp/auxiliary/test/AuxGTest.cpp
+++ b/networkit/cpp/auxiliary/test/AuxGTest.cpp
@@ -35,6 +35,33 @@ namespace NetworKit {
 
 class AuxGTest: public testing::Test{};
 
+TEST_F(AuxGTest, testTimer) {
+    Aux::StartedTimer timer;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    const auto ms = timer.elapsedMilliseconds();
+    const auto us = timer.elapsedMicroseconds();
+    const auto ns = timer.elapsedNanoseconds();
+
+    ASSERT_GE(ms, 5);
+    ASSERT_GE(us, 5000);
+    ASSERT_GE(ns, 5000000);
+
+    timer.stop();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    const auto ms2 = timer.elapsedMilliseconds();
+    const auto us2 = timer.elapsedMicroseconds();
+    const auto ns2 = timer.elapsedNanoseconds();
+
+    ASSERT_GE(ms2, 5);
+    ASSERT_GE(us2, 5000);
+    ASSERT_GE(ns2, 5000000);
+
+    ASSERT_LE(ms2, us2 / 1000 + 1);
+    ASSERT_LE(us2, ns2 / 1000 + 1);
+}
+
 TEST_F(AuxGTest, produceRandomIntegers) {
 	Aux::Random::setSeed(1, false);
 #ifndef NETWORKIT_RELEASE_LOGGING

--- a/networkit/cpp/auxiliary/test/AuxGTest.cpp
+++ b/networkit/cpp/auxiliary/test/AuxGTest.cpp
@@ -36,30 +36,32 @@ namespace NetworKit {
 class AuxGTest: public testing::Test{};
 
 TEST_F(AuxGTest, testTimer) {
-    Aux::StartedTimer timer;
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    const auto ms = timer.elapsedMilliseconds();
-    const auto us = timer.elapsedMicroseconds();
-    const auto ns = timer.elapsedNanoseconds();
+	Aux::LoggingTimer ltimer("LogginTimer", Aux::Log::LogLevel::trace); // only enabled if test is execut with raised loglevel
 
-    ASSERT_GE(ms, 5);
-    ASSERT_GE(us, 5000);
-    ASSERT_GE(ns, 5000000);
+	Aux::StartedTimer timer;
+	std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	const auto ms = timer.elapsedMilliseconds();
+	const auto us = timer.elapsedMicroseconds();
+	const auto ns = timer.elapsedNanoseconds();
 
-    timer.stop();
+	ASSERT_GE(ms, 5);
+	ASSERT_GE(us, 5000);
+	ASSERT_GE(ns, 5000000);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	timer.stop();
 
-    const auto ms2 = timer.elapsedMilliseconds();
-    const auto us2 = timer.elapsedMicroseconds();
-    const auto ns2 = timer.elapsedNanoseconds();
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-    ASSERT_GE(ms2, 5);
-    ASSERT_GE(us2, 5000);
-    ASSERT_GE(ns2, 5000000);
+	const auto ms2 = timer.elapsedMilliseconds();
+	const auto us2 = timer.elapsedMicroseconds();
+	const auto ns2 = timer.elapsedNanoseconds();
 
-    ASSERT_LE(ms2, us2 / 1000 + 1);
-    ASSERT_LE(us2, ns2 / 1000 + 1);
+	ASSERT_GE(ms2, 5);
+	ASSERT_GE(us2, 5000);
+	ASSERT_GE(ns2, 5000000);
+
+	ASSERT_LE(ms2, us2 / 1000 + 1);
+	ASSERT_LE(us2, ns2 / 1000 + 1);
 }
 
 TEST_F(AuxGTest, produceRandomIntegers) {

--- a/networkit/cpp/distance/test/DistanceGTest.cpp
+++ b/networkit/cpp/distance/test/DistanceGTest.cpp
@@ -98,9 +98,9 @@ TEST_F(DistanceGTest, testBidirectionalDijkstra) {
 
 		if (path.size()) {
 			EXPECT_TRUE(G.hasEdge(source, path.front()));
-			for (int i = 0; i < path.size() - 1; ++i)
+			for (size_t i = 0; i < path.size() - 1; ++i)
 				EXPECT_TRUE(G.hasEdge(path[i], path[i + 1]));
-				EXPECT_TRUE(G.hasEdge(path.back(), target));
+			EXPECT_TRUE(G.hasEdge(path.back(), target));
 		} else
 			EXPECT_TRUE(G.hasEdge(source, target));
 	};


### PR DESCRIPTION
Clang rightfully complained about `Aux::Timer` not having a virtual destructor.While fixing this, I spotted a number of additional issues, justifying a PR on its own.

This PR includes:
- A virtual destructor for Timer
- Most of Timer's methods are now `const` and `nothrow` (where applicable)
- A unit test for Timer
- A bug fix for `elapsedMicroseconds()` and `elapsedNanoseconds()`: The documentation stated that `elapsed*()` methods returned the time elapsed since the start and now (if Timer is still running) or
between start and stop if the Timer was stopped. `elapsed()` and `elapsedMilliseconds()` behaved that way, while `elapsedMicroseconds()` and `elapsedNanoseconds()` only considered the latter case.
- Timer defined the macro `my_steady_clock`. While this should have been a `using` declaration not polluting global namespace.
- Add `StartedTimer` which is identical to `Timer` but does automatically call `start()` on construction.

Remarks:
- I do not see a reason to have virtual members in Timer and suggest to drop that (AFAICS its not used in NetworKit itself). But there might be external users. So I did not do it yet.
- I do know why code for MIC uses `std::chrono::monotonic_clock`
- To choice of returning a `std::chrono::duration` in integer milliseconds seems strange; but we cannot really change that now.