### PR TITLE
Refactor betweenness

### DIFF
--- a/include/networkit/centrality/Betweenness.hpp
+++ b/include/networkit/centrality/Betweenness.hpp
@@ -1,5 +1,5 @@
 /*
- * Betweenness.h
+ * Betweenness.hpp
  *
  *  Created on: 19.02.2014
  *      Author: cls, ebergamini
@@ -15,7 +15,7 @@ namespace NetworKit {
 /**
  * @ingroup centrality
  */
-class Betweenness: public Centrality {
+class Betweenness final: public Centrality {
 public:
 	/**
 	 * Constructs the Betweenness class for the given Graph @a G. If the betweenness scores should be normalized,

--- a/networkit/cpp/centrality/Betweenness.cpp
+++ b/networkit/cpp/centrality/Betweenness.cpp
@@ -5,25 +5,19 @@
  *      Author: cls, ebergamini
  */
 
-#include <stack>
-#include <queue>
 #include <memory>
 #include <omp.h>
 
-
 #include <networkit/centrality/Betweenness.hpp>
-#include <networkit/auxiliary/PrioQueue.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/SignalHandling.hpp>
-#include <networkit/distance/SSSP.hpp>
 #include <networkit/distance/Dijkstra.hpp>
 #include <networkit/distance/BFS.hpp>
 
 namespace NetworKit {
 
-Betweenness::Betweenness(const Graph& G, bool normalized, bool computeEdgeCentrality) : Centrality(G, normalized, computeEdgeCentrality) {
-
-}
+Betweenness::Betweenness(const Graph& G, bool normalized, bool computeEdgeCentrality) :
+	Centrality(G, normalized, computeEdgeCentrality) {}
 
 void Betweenness::run() {
 	Aux::SignalHandler handler;


### PR DESCRIPTION
As already done with `Closeness` and `APSP`, this improves the memory efficiency of `Betweenness` by allocating the necessary memory once per each thread.