### PR TITLE
Refactor/group-betweenness

### DIFF
--- a/include/networkit/centrality/ApproxGroupBetweenness.hpp
+++ b/include/networkit/centrality/ApproxGroupBetweenness.hpp
@@ -1,5 +1,5 @@
 /*
- * ApproxGroupBetweenness.h
+ * ApproxGroupBetweenness.hpp
  *
  *  Created on: 13.03.2018
  *      Author: Marvin Pogoda
@@ -7,12 +7,15 @@
 #ifndef APPROXGROUPBETWEENNESS_H_
 #define APPROXGROUPBETWEENNESS_H_
 
+#include <omp.h>
+
 #include <networkit/base/Algorithm.hpp>
+#include <networkit/distance/BFS.hpp>
 #include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
-class ApproxGroupBetweenness : public Algorithm {
+class ApproxGroupBetweenness final : public Algorithm {
 
 public:
 	/** Constructs the ApproxGroupBetweenness class for a given undirected graph
@@ -33,7 +36,13 @@ public:
 	 * Returns a vector of nodes containing the set of nodes with approximated
 	 * maximum group betweenness.
 	 */
-	std::vector<node> groupMaxBetweenness();
+	std::vector<node> groupMaxBetweenness() const;
+
+	/**
+	 * Returns the score of the given set.
+	 */
+	double scoreOfGroup(const std::vector<node> &S,
+	                    const bool normalized = false) const;
 
 protected:
 	const Graph &G;
@@ -41,16 +50,76 @@ protected:
 	std::vector<node> maxGroup;
 	const count groupSize;
 	const double epsilon;
-	bool hasSortedGroup;
 };
 
-inline std::vector<node> ApproxGroupBetweenness::groupMaxBetweenness() {
+inline std::vector<node> ApproxGroupBetweenness::groupMaxBetweenness() const {
 	assureFinished();
-	if (!hasSortedGroup) {
-		std::sort(maxGroup.begin(), maxGroup.end());
-		hasSortedGroup = true;
-	}
 	return maxGroup;
+}
+
+inline double
+ApproxGroupBetweenness::scoreOfGroup(const std::vector<node> &S,
+                                     const bool normalized) const {
+	if (S.empty())
+		throw std::runtime_error("Error: input group is empty");
+
+	count z = G.upperNodeIdBound();
+	std::vector<bool> inGroup(z);
+	for (node u : S) {
+		if (!G.hasNode(u))
+			throw std::runtime_error("Error, input group contains nodes not in the graph");
+		if (inGroup[u])
+			WARN("Input group contains duplicate nodes!");
+		inGroup[u] = true;
+	}
+
+	std::vector<double> scorePerThread(omp_get_max_threads());
+	std::vector<std::vector<double>> deps(omp_get_max_threads(), std::vector<double>(n));
+	std::vector<BFS> bfss(omp_get_max_threads(), BFS(G, 0, true, true));
+
+	auto computeDeps = [&](node source) {
+
+		auto &dep = deps[omp_get_thread_num()];
+		std::fill(dep.begin(), dep.end(), 0);
+
+		BFS &bfs = bfss[omp_get_thread_num()];
+		bfs.setSource(source);
+		bfs.run();
+
+		double weight;
+		auto sortedNodes = bfs.getNodesSortedByDistance();
+		for (auto it = sortedNodes.rbegin(); it != sortedNodes.rend(); ++it) {
+			node target = *it;
+			for (node pred : bfs.getPredecessors(target)) {
+				(bfs.numberOfPaths(pred) / bfs.numberOfPaths(target)).ToDouble(weight);
+				if (inGroup[pred]) {
+					if (pred != source) {
+						scorePerThread[omp_get_thread_num()] += dep[pred] + weight * (1 + dep[target]);
+					}
+				}
+				else {
+					dep[pred] += weight * (1 + dep[target]);
+				}
+			}
+		}
+	};
+
+	G.balancedParallelForNodes(computeDeps);
+
+	double result = 0;
+	for (double curScore : scorePerThread)
+			result += curScore;
+
+	if (normalized) {
+		double nPairs = (z - S.size()) * (z - S.size() - 1);
+		if (nPairs <= 0)
+			return 0;
+		if (!G.isDirected())
+			nPairs /= 2;
+		result /= nPairs;
+	}
+
+	return result;
 }
 
 } /* namespace NetworKit */

--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -143,6 +143,15 @@ public:
     }
 
     /**
+     * Sets a new target.
+     */
+    void setTarget(node newTarget) {
+        if (!G.hasNode(newTarget))
+            throw std::runtime_error("Error: node not in the graph.");
+        target = newTarget;
+    }
+
+    /**
      * Returns the sum of distances from the source node node to the reached
      * nodes.
      */

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1347,6 +1347,8 @@ cdef extern from "<networkit/distance/SSSP.hpp>":
 		set[vector[node]] getPaths(node t, bool_t forward) except +
 		vector[node] getNodesSortedByDistance(bool_t moveOut) except +
 		double _numberOfPaths(node t) except +
+		void setSource(node s) except +
+		void setTarget(node t) except +
 
 cdef class SSSP(Algorithm):
 	""" Base class for single source shortest path algorithms. """
@@ -1430,6 +1432,28 @@ cdef class SSSP(Algorithm):
 
 	def numberOfPaths(self, t):
 		return (<_SSSP*>(self._this))._numberOfPaths(t)
+
+	def setSource(self, s not None):
+		"""
+		Sets a new source node.
+
+		Parameters
+		----------
+		s : node
+			New source node.
+		"""
+		(<_SSSP*>(self._this)).setSource(s)
+
+	def setTarget(self, t not None):
+		"""
+		Sets a new target node.
+
+		Parameters
+		----------
+		t : node
+			New target node.
+		"""
+		(<_SSSP*>(self._this)).setTarget(t)
 
 
 cdef extern from "<networkit/distance/DynSSSP.hpp>":

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1362,7 +1362,7 @@ cdef class SSSP(Algorithm):
 	def getDistances(self, moveOut):
 		"""
 		DEPRECATED
-		Returns a vector of weighted distances from the source node, i.e. the
+		Returns a list of weighted distances from the source node, i.e. the
  	 	length of the shortest path from the source node to any other node.
 
  	 	Returns
@@ -1374,24 +1374,19 @@ cdef class SSSP(Algorithm):
 
 	def getDistances(self):
 		"""
-		Returns a vector of weighted distances from the source node, i.e. the
+		Returns a list of weighted distances from the source node, i.e. the
 		length of the shortest path from the source node to any other node.
 
 		Returns
 		-------
-		vector
-		The weighted distances from the source node to any other node in the graph.
+		list
+			The weighted distances from the source node to any other node in the graph.
 		"""
 		return (<_SSSP*>(self._this)).getDistances()
 
 	def distance(self, t):
-		return (<_SSSP*>(self._this)).distance(t)
-
-	def getPredecessors(self, t):
-		return (<_SSSP*>(self._this)).getPredecessors(t)
-
-	def getPath(self, t, forward=True):
-		""" Returns a shortest path from source to `t` and an empty path if source and `t` are not connected.
+		"""
+		Returns the distance from the source node to @a t.
 
 		Parameters
 		----------
@@ -1400,12 +1395,64 @@ cdef class SSSP(Algorithm):
 
 		Returns
 		-------
-		vector
-			A shortest path from source to `t or an empty path.
+		double
+			Distance from the source node to @a t.
+		"""
+		return (<_SSSP*>(self._this)).distance(t)
+
+	def getPredecessors(self, t):
+		"""
+		Returns the predecessor nodes of @a t on all shortest paths from source
+		to @a t.
+		Parameters
+		----------
+		t : node
+			Target node.
+
+		Returns
+		-------
+		list
+			The predecessors of @a t on all shortest paths from source to @a t.
+		"""
+		return (<_SSSP*>(self._this)).getPredecessors(t)
+
+	def getPath(self, t, forward=True):
+		"""
+		Returns a shortest path from source to @a t and an empty path if source and @a t
+		are not connected.
+
+		Parameters
+		----------
+		t : node
+			Target node.
+		forward : bool
+			If @c true (default) the path is directed from source to @a t, otherwise the path
+			is reversed.
+
+		Returns
+		-------
+		list
+			A shortest path from source to @a t or an empty path.
 		"""
 		return (<_SSSP*>(self._this)).getPath(t, forward)
 
 	def getPaths(self, t, forward=True):
+		"""
+		Returns all shortest paths from source to @a t and an empty set if source
+		and @a t are not connected.
+
+		Parameters
+		----------
+		t : node
+			Target node.
+		forward : bool
+			If @c true (default) the path is directed from source to
+			@a t, otherwise the path is reversed.
+
+		Returns
+		-------
+			All shortest paths from source node to target node @a t.
+		"""
 		cdef set[vector[node]] paths = (<_SSSP*>(self._this)).getPaths(t, forward)
 		result = []
 		for elem in paths:
@@ -1413,7 +1460,7 @@ cdef class SSSP(Algorithm):
 		return result
 
 	def getNodesSortedByDistance(self, moveOut=True):
-		""" Returns a vector of nodes ordered in increasing distance from the source.
+		""" Returns a list of nodes ordered in increasing distance from the source.
 
 		For this functionality to be available, storeNodesSortedByDistance has to be set to true in the constructor.
 		There are no guarantees regarding the ordering of two nodes with the same distance to the source.
@@ -1425,12 +1472,25 @@ cdef class SSSP(Algorithm):
 
 		Returns
 		-------
-		vector
+		list
 			Nodes ordered in increasing distance from the source.
 		"""
 		return (<_SSSP*>(self._this)).getNodesSortedByDistance(moveOut)
 
 	def numberOfPaths(self, t):
+		"""
+		Returns the number of paths from the source node to @a t.
+
+		Parameters
+		----------
+		t : node
+			Target node.
+
+		Returns
+		-------
+		int
+			The number of paths from the source node to @a t.
+		"""
 		return (<_SSSP*>(self._this))._numberOfPaths(t)
 
 	def setSource(self, s not None):

--- a/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
@@ -5,14 +5,14 @@
  *      Author: Marvin Pogoda
  */
 
-#include <networkit/centrality/ApproxGroupBetweenness.hpp>
-#include <networkit/auxiliary/BucketPQ.hpp>
-#include <networkit/auxiliary/Random.hpp>
-#include <networkit/distance/BFS.hpp>
-#include <networkit/distance/SSSP.hpp>
-
 #include <math.h>
 #include <omp.h>
+
+#include <networkit/auxiliary/BucketPQ.hpp>
+#include <networkit/auxiliary/Random.hpp>
+#include <networkit/centrality/ApproxGroupBetweenness.hpp>
+#include <networkit/distance/BFS.hpp>
+#include <networkit/distance/SSSP.hpp>
 
 namespace NetworKit {
 
@@ -27,7 +27,7 @@ ApproxGroupBetweenness::ApproxGroupBetweenness(const Graph &G,
 		throw std::runtime_error(
 		    "Error: the group size must be between 1 and n-1.");
 	}
-	if (epsilon <= 0.f) {
+	if (epsilon <= 0) {
 		throw std::runtime_error("Error: epsilon must be greater than 0.");
 	}
 	hasRun = false;
@@ -41,8 +41,6 @@ void ApproxGroupBetweenness::run() {
 	count samples = groupSize * log(n) / (epsilon * epsilon);
 	std::vector<std::vector<count>> hyperEdgesPerSample(samples);
 	Aux::BucketPQ nodeDegrees(bucketInitializer, -samples, 1);
-
-	hasSortedGroup = false;
 
 #pragma omp parallel for
 	for (omp_index l = 0; l < static_cast<omp_index>(samples); ++l) {

--- a/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
@@ -41,6 +41,7 @@ void ApproxGroupBetweenness::run() {
 	count samples = groupSize * log(n) / (epsilon * epsilon);
 	std::vector<std::vector<count>> hyperEdgesPerSample(samples);
 	Aux::BucketPQ nodeDegrees(bucketInitializer, -samples, 1);
+	std::vector<BFS> bfss(omp_get_max_threads(), BFS(G, 0, true, true));
 
 #pragma omp parallel for
 	for (omp_index l = 0; l < static_cast<omp_index>(samples); ++l) {
@@ -49,7 +50,10 @@ void ApproxGroupBetweenness::run() {
 		do {
 			t = G.randomNode();
 		} while (s == t);
-		BFS bfs(G, s, true, true, t);
+
+		BFS &bfs = bfss[omp_get_thread_num()];
+		bfs.setSource(s);
+		bfs.setTarget(t);
 		bfs.run();
 		std::set<std::vector<node>> shortestPaths = bfs.getPaths(t);
 

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1479,6 +1479,7 @@ TEST_F(CentralityGTest, testGroupBetweennessScore) {
     G.addEdge(5, 6);
     G.addEdge(6, 7);
 
+    BFS bfs(G, 0, true, false);
     // Naively computes the group betweenness of a group of nodes S
     auto naiveGB = [&](const std::vector<node> &S) -> double {
         double score = 0;
@@ -1487,7 +1488,7 @@ TEST_F(CentralityGTest, testGroupBetweennessScore) {
         for (node u : S)
             inGroup[u] = true;
         for (node source = 0; source < n; ++source) {
-            BFS bfs(G, source, true, false);
+            bfs.setSource(source);
             bfs.run();
             for (node target = 0; target < n; ++target) {
                 if (target == source)
@@ -1529,7 +1530,9 @@ TEST_F(CentralityGTest, testGroupBetweennessScore) {
                         break;
                 }
             }
-            EXPECT_EQ(gb.scoreOfGroup(group), naiveGB(group));
+            double computedScore = gb.scoreOfGroup(group);
+            double naiveScore = naiveGB(group);
+            EXPECT_NEAR(computedScore, naiveScore, 1e-6);
         } while (std::next_permutation(inGroup.begin(), inGroup.end()));
     }
 }

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1457,11 +1457,89 @@ TEST_F(CentralityGTest, testGroupDegreeDirected) {
               gdIncludeGroup.scoreOfGroup(gdIncludeGroup.groupMaxDegree()));
 }
 
+TEST_F(CentralityGTest, testGroupBetweennessScore) {
+/** 0           5
+ *  | \       / |
+ *  1 - 3 - 4 - 6
+ *  | /       \ |
+ *  2           7
+ */
+    Graph G(8, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+    G.addEdge(0, 3);
+    G.addEdge(1, 3);
+    G.addEdge(2, 3);
+
+    G.addEdge(3, 4);
+
+    G.addEdge(4, 5);
+    G.addEdge(4, 6);
+    G.addEdge(4, 7);
+    G.addEdge(5, 6);
+    G.addEdge(6, 7);
+
+    // Naively computes the group betweenness of a group of nodes S
+    auto naiveGB = [&](const std::vector<node> &S) -> double {
+        double score = 0;
+        count n = G.upperNodeIdBound();
+        std::vector<bool> inGroup(n);
+        for (node u : S)
+            inGroup[u] = true;
+        for (node source = 0; source < n; ++source) {
+            BFS bfs(G, source, true, false);
+            bfs.run();
+            for (node target = 0; target < n; ++target) {
+                if (target == source)
+                    continue;
+
+                auto paths = bfs.getPaths(target);
+                if (paths.empty())
+                    continue;
+                double curScore = 0;
+                for (auto &path : paths) {
+                    for (node u : path) {
+                        if (u != source && u != target && inGroup[u]) {
+                            curScore += 1;
+                            break;
+                        }
+                    }
+                }
+
+                score += curScore / static_cast<double>(paths.size());
+            }
+        }
+
+        return score;
+    };
+
+    ApproxGroupBetweenness gb(G, 2, 0.1);
+    count z = G.numberOfNodes();
+    for (count k = 1; k <= z; ++k) {
+        std::vector<bool> inGroup(z);
+        for (index i = 0; i < k; ++i)
+            inGroup[z - i - 1] = true;
+        do {
+            std::vector<node> group;
+            group.reserve(k);
+            for (node u = 0; u < z; ++u) {
+                if (inGroup[u]) {
+                    group.push_back(u);
+                    if (group.size() == k)
+                        break;
+                }
+            }
+            EXPECT_EQ(gb.scoreOfGroup(group), naiveGB(group));
+        } while (std::next_permutation(inGroup.begin(), inGroup.end()));
+    }
+}
+
 TEST_F(CentralityGTest, runTestApproxGroupBetweennessSmallGraph) {
 
     Aux::Random::setSeed(42, false);
 
-    Graph g(8, false, false);
+    count n = 8;
+    Graph g(n, false, false);
 
     g.addEdge(0, 2);
     g.addEdge(1, 2);
@@ -1473,8 +1551,30 @@ TEST_F(CentralityGTest, runTestApproxGroupBetweennessSmallGraph) {
     g.addEdge(5, 7);
     g.addEdge(0, 5);
 
-    ApproxGroupBetweenness gb(g, 2, 0.1);
+    count k = 2;
+    double eps = 0.1;
+    ApproxGroupBetweenness gb(g, k, eps);
     gb.run();
+
+    double maxScore = 0;
+    std::vector<bool> inGroup(n);
+    for (index i = 0; i < k; ++i)
+        inGroup[n - i - 1] = true;
+    do {
+        std::vector<node> group;
+        group.reserve(k);
+        for (node u = 0; u < n; ++u) {
+            if (inGroup[u]) {
+                group.push_back(u);
+                if (group.size() == k)
+                    break;
+            }
+        }
+
+        maxScore = std::max(maxScore, gb.scoreOfGroup(group));
+    } while (std::next_permutation(inGroup.begin(), inGroup.end()));
+
+    EXPECT_TRUE(gb.scoreOfGroup(gb.groupMaxBetweenness()) >= maxScore * eps);
 }
 
 TEST_F(CentralityGTest, testGroupCloseness) {


### PR DESCRIPTION
This brings a new abstract base class `GroupCentralityScore` for all the algorithms computing an exact group centrality score of a given group of nodes. It also includes a new algorithm to compute the group betweenness score.