### PR TITLE
Refactor/graph writers

### DIFF
--- a/include/networkit/io/DotGraphWriter.hpp
+++ b/include/networkit/io/DotGraphWriter.hpp
@@ -30,7 +30,7 @@ public:
 	 * @param[in]	graph	The graph object
 	 * @param[in]	path	The file path to be written to
 	 */
-	void write(const Graph &G, const std::string &path) const override;
+	void write(const Graph &G, const std::string &path) override;
 
 };
 

--- a/include/networkit/io/DotGraphWriter.hpp
+++ b/include/networkit/io/DotGraphWriter.hpp
@@ -1,12 +1,15 @@
 /*
- * DotGraphWriter.h
+ * DotGraphWriter.hpp
+ *
+ *  Created on: Jun 5, 2013
+ *      Author: forigem
  */
 
 #ifndef DOTGRAPHWRITER_H
 #define DOTGRAPHWRITER_H
 
-#include <fstream>
 #include <networkit/graph/Graph.hpp>
+#include <networkit/io/GraphWriter.hpp>
 
 namespace NetworKit {
 
@@ -15,19 +18,19 @@ namespace NetworKit {
  * @ingroup io
  *
  * This class turns a graph into a very basic GraphViz file as documented in the official manual [1].
- * If a more thorough support is desired, please contact the developers over networkit@ira.uni-karlsruhe.de.
+ * If a more thorough support is desired, please contact the developers: https://github.com/networkit/networkit
  *
- * [1] http://www.graphviz.org/Documentation/dotguide.pdf
- */ 
-class DotGraphWriter {
+ * [1] https://graphviz.gitlab.io/_pages/pdf/dotguide.pdf
+ */
+class DotGraphWriter final : public GraphWriter {
 public:
 	/**
 	 * Write a graph as a GraphViz/file.
-	 * 
+	 *
 	 * @param[in]	graph	The graph object
 	 * @param[in]	path	The file path to be written to
 	 */
-	virtual void write(Graph& graph, std::string path) const;
+	void write(const Graph &G, const std::string &path) const override;
 
 };
 

--- a/include/networkit/io/EdgeListWriter.hpp
+++ b/include/networkit/io/EdgeListWriter.hpp
@@ -37,7 +37,7 @@ public:
 	 * @param[in]	G		the graph
 	 * @param[in]	path	the output file path
 	 */
-	void write(const Graph &G, const std::string &path) const override;
+	void write(const Graph &G, const std::string &path) override;
 
 protected:
 

--- a/include/networkit/io/EdgeListWriter.hpp
+++ b/include/networkit/io/EdgeListWriter.hpp
@@ -1,5 +1,5 @@
 /*
- * EdgeListWriter.h
+ * EdgeListWriter.hpp
  *
  *  Created on: 18.06.2013
  *      Author: cls
@@ -8,11 +8,7 @@
 #ifndef EDGELISTWRITER_H_
 #define EDGELISTWRITER_H_
 
-#include <fstream>
-#include <iostream>
-#include <string>
-
-#include <networkit/io/GraphReader.hpp>
+#include <networkit/io/GraphWriter.hpp>
 
 namespace NetworKit {
 
@@ -23,7 +19,7 @@ namespace NetworKit {
  * the user.
  *
  */
-class EdgeListWriter {
+class EdgeListWriter final : public GraphWriter {
 
 public:
 
@@ -41,7 +37,7 @@ public:
 	 * @param[in]	G		the graph
 	 * @param[in]	path	the output file path
 	 */
-	void write(const Graph& G, std::string path);
+	void write(const Graph &G, const std::string &path) const override;
 
 protected:
 

--- a/include/networkit/io/GMLGraphWriter.hpp
+++ b/include/networkit/io/GMLGraphWriter.hpp
@@ -29,7 +29,7 @@ public:
 	 * @param[in]	G		Graph of type NetworKit with 2D coordinates.
 	 * @param[in]	path	Path to file.
 	 */
-	void write(const Graph &G, const std::string &path) const override;
+	void write(const Graph &G, const std::string &path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/GMLGraphWriter.hpp
+++ b/include/networkit/io/GMLGraphWriter.hpp
@@ -1,5 +1,5 @@
 /*
- * METISGraphWriter.h
+ * GMLGraphWriter.hpp
  *
  *  Created on: 30.01.2013
  *      Author: Christian Staudt (christian.staudt@kit.edu)
@@ -7,8 +7,6 @@
 
 #ifndef GMLGRAPHWRITER_H_
 #define GMLGRAPHWRITER_H_
-
-#include <fstream>
 
 #include <networkit/io/GraphWriter.hpp>
 
@@ -20,7 +18,7 @@ namespace NetworKit {
  *
  * [1] http://svn.bigcat.unimaas.nl/pvplugins/GML/trunk/docs/gml-technical-report.pdf
  */
-class GMLGraphWriter: public GraphWriter {
+class GMLGraphWriter final: public GraphWriter {
 public:
 	/** Default constructor */
 	GMLGraphWriter() = default;
@@ -31,7 +29,7 @@ public:
 	 * @param[in]	G		Graph of type NetworKit with 2D coordinates.
 	 * @param[in]	path	Path to file.
 	 */
-	virtual void write(const Graph& G, const std::string& path) override;
+	void write(const Graph &G, const std::string &path) const override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/GraphToolBinaryWriter.hpp
+++ b/include/networkit/io/GraphToolBinaryWriter.hpp
@@ -29,22 +29,22 @@ public:
 	 *
 	 * @param[in]	path	input file path
 	 */
-	void write(const Graph &G, const std::string &path) const override;
+	void write(const Graph &G, const std::string &path) override;
 
 protected:
 	bool littleEndianness;
 
 private:
-	void writeAdjacencies(std::ofstream &file, const Graph &G) const;
+	void writeAdjacencies(std::ofstream &file, const Graph &G);
 
-	uint8_t getAdjacencyWidth(uint64_t n) const;
+	uint8_t getAdjacencyWidth(uint64_t n) ;
 
-	void writeComment(std::ofstream &file) const;
+	void writeComment(std::ofstream &file);
 
-	void writeHeader(std::ofstream &file) const;
+	void writeHeader(std::ofstream &file);
 
 	template<typename Type>
-	void writeType(std::ofstream& file, int width, Type val) const {
+	void writeType(std::ofstream& file, int width, Type val) {
 		//DEBUG("writing ",val, "with width ", width, " to file");
 		uint8_t* bytes = new uint8_t[width];
 		if (this->littleEndianness) {

--- a/include/networkit/io/GraphToolBinaryWriter.hpp
+++ b/include/networkit/io/GraphToolBinaryWriter.hpp
@@ -1,5 +1,5 @@
 /*
- * GraphToolBinaryWriter.h
+ * GraphToolBinaryWriter.hpp
  *
  *  Created on: 02.12.14
  *      Author: Maximilian Vogel
@@ -8,11 +8,7 @@
 #ifndef GRAPHTOOLBINARYWRITER_H_
 #define GRAPHTOOLBINARYWRITER_H_
 
-#include <fstream>
-#include <iostream>
-#include <string>
 #include <unordered_map>
-
 
 #include <networkit/io/GraphWriter.hpp>
 
@@ -22,7 +18,7 @@ namespace NetworKit {
  * Writes graphs to files in the binary format defined by graph-tool[1].
  * [1]: http://graph-tool.skewed.de/static/doc/gt_format.html
  */
-class GraphToolBinaryWriter: public GraphWriter {
+class GraphToolBinaryWriter final: public GraphWriter {
 
 public:
 
@@ -33,23 +29,22 @@ public:
 	 *
 	 * @param[in]	path	input file path
 	 */
-	void write(const Graph& G, const std::string& path);
+	void write(const Graph &G, const std::string &path) const override;
 
 protected:
 	bool littleEndianness;
 
-
 private:
-	void writeAdjacencies(std::ofstream& file, const Graph& G);
+	void writeAdjacencies(std::ofstream &file, const Graph &G) const;
 
-	uint8_t getAdjacencyWidth(uint64_t n);
+	uint8_t getAdjacencyWidth(uint64_t n) const;
 
-	void writeComment(std::ofstream& file);
+	void writeComment(std::ofstream &file) const;
 
-	void writeHeader(std::ofstream& file);
+	void writeHeader(std::ofstream &file) const;
 
 	template<typename Type>
-	void writeType(std::ofstream& file, int width, Type val) {
+	void writeType(std::ofstream& file, int width, Type val) const {
 		//DEBUG("writing ",val, "with width ", width, " to file");
 		uint8_t* bytes = new uint8_t[width];
 		if (this->littleEndianness) {
@@ -59,7 +54,7 @@ private:
 		} else {
 			for (int i = 0; i < width; ++i) {
 				bytes[i] = (val >> ((width-1-i)*8)) & 0xFF;
-			}		
+			}
 		}
 		file.write((char*)bytes,width);
 		delete[] bytes;

--- a/include/networkit/io/GraphWriter.hpp
+++ b/include/networkit/io/GraphWriter.hpp
@@ -20,7 +20,7 @@ class GraphWriter {
 public:
 	virtual ~GraphWriter() = default;
 
-	virtual void write(const Graph &G, const std::string &path) const = 0;
+	virtual void write(const Graph &G, const std::string &path) = 0;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/GraphWriter.hpp
+++ b/include/networkit/io/GraphWriter.hpp
@@ -10,8 +10,6 @@
 
 #include <networkit/graph/Graph.hpp>
 
-#include <fstream>
-
 namespace NetworKit {
 
 /**
@@ -22,7 +20,7 @@ class GraphWriter {
 public:
 	virtual ~GraphWriter() = default;
 
-	virtual void write(const Graph& G, const std::string& path) = 0;
+	virtual void write(const Graph &G, const std::string &path) const = 0;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/METISGraphWriter.hpp
+++ b/include/networkit/io/METISGraphWriter.hpp
@@ -1,5 +1,5 @@
 /*
- * METISGraphWriter.h
+ * METISGraphWriter.hpp
  *
  *  Created on: 30.01.2013
  *      Author: Christian Staudt (christian.staudt@kit.edu)
@@ -8,8 +8,6 @@
 #ifndef METISGRAPHWRITER_H_
 #define METISGRAPHWRITER_H_
 
-#include <fstream>
-
 #include <networkit/io/GraphWriter.hpp>
 
 namespace NetworKit {
@@ -17,15 +15,15 @@ namespace NetworKit {
 /**
  * @ingroup io
  */
-class METISGraphWriter: public GraphWriter {
+class METISGraphWriter final : public GraphWriter {
 
 public:
 
 	METISGraphWriter() = default;
 
-	virtual void write(const Graph& G, const std::string& path) override;
+	void write(const Graph &G, const std::string &path) override;
 
-	virtual void write(const Graph& G, bool weighted, std::string path);
+	void write(const Graph &G, bool weighted, const std::string &path);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/NetworkitBinaryWriter.hpp
+++ b/include/networkit/io/NetworkitBinaryWriter.hpp
@@ -1,7 +1,7 @@
 /*
- * NetworkitBinaryWriter.h
+ * NetworkitBinaryWriter.hpp
  *
- *@author Charmaine Ndolo <charmaine.ndolo@b-tu.de>
+ * @author Charmaine Ndolo <charmaine.ndolo@b-tu.de>
  */
 
 #ifndef NETWORKIT_BINARY_WRITER_H
@@ -26,19 +26,18 @@ enum class NetworkitBinaryWeights {
 	autoDetect
 };
 
-class NetworkitBinaryWriter : public GraphWriter {
+class NetworkitBinaryWriter final : public GraphWriter {
 
 public:
 	NetworkitBinaryWriter(uint64_t chunks = 32, NetworkitBinaryWeights weightsType = NetworkitBinaryWeights::autoDetect);
 
-	void write(const Graph& G, const std::string& path) override;
+	void write(const Graph &G, const std::string &path) const override;
 
 private:
 	static size_t encode(uint64_t value, uint8_t* buffer);
 
 	static uint64_t encodeZigzag(int64_t value);
 
-	count nodes;
 	count chunks;
 	NetworkitBinaryWeights weightsType;
 };

--- a/include/networkit/io/NetworkitBinaryWriter.hpp
+++ b/include/networkit/io/NetworkitBinaryWriter.hpp
@@ -31,7 +31,7 @@ class NetworkitBinaryWriter final : public GraphWriter {
 public:
 	NetworkitBinaryWriter(uint64_t chunks = 32, NetworkitBinaryWeights weightsType = NetworkitBinaryWeights::autoDetect);
 
-	void write(const Graph &G, const std::string &path) const override;
+	void write(const Graph &G, const std::string &path) override;
 
 private:
 	static size_t encode(uint64_t value, uint8_t* buffer);

--- a/include/networkit/io/SNAPGraphWriter.hpp
+++ b/include/networkit/io/SNAPGraphWriter.hpp
@@ -47,7 +47,7 @@ public:
 
 	SNAPGraphWriter() = default;
 
-	void write(const Graph &G, const std::string &path) const override;
+	void write(const Graph &G, const std::string &path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/SNAPGraphWriter.hpp
+++ b/include/networkit/io/SNAPGraphWriter.hpp
@@ -1,5 +1,5 @@
 /*
- * SNAPGraphWriter.h
+ * SNAPGraphWriter.hpp
  *
  *  Created on: 24.09.2013
  *      Author: cls
@@ -41,16 +41,13 @@ namespace NetworKit {
  *
  * The problem line is followed by a listing on exactly m edges. The format
  * is <u v w> for a weighted graph, and <u v> for an unweighted graph.
- *
- * Good job
  */
-class SNAPGraphWriter: public GraphWriter {
+class SNAPGraphWriter final : public GraphWriter {
 public:
+
 	SNAPGraphWriter() = default;
-	virtual void write(const Graph& G, const std::string& path) override;
 
-private:
-
+	void write(const Graph &G, const std::string &path) const override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/ThrillGraphBinaryWriter.hpp
+++ b/include/networkit/io/ThrillGraphBinaryWriter.hpp
@@ -19,7 +19,7 @@ public:
 	 * @param[in] G The graph to write.
 	 * @param[in] path The path where to write the graph.
 	 */
-	void write(const Graph &G, const std::string &path) const override;
+	void write(const Graph &G, const std::string &path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/ThrillGraphBinaryWriter.hpp
+++ b/include/networkit/io/ThrillGraphBinaryWriter.hpp
@@ -1,5 +1,5 @@
 /*
- * ThrillGraphBinaryWriter.h
+ * ThrillGraphBinaryWriter.hpp
  *
  * @author Michael Hamann <michael.hamann@kit.edu>
  */
@@ -11,15 +11,15 @@
 
 namespace NetworKit {
 
-class ThrillGraphBinaryWriter : public GraphWriter {
+class ThrillGraphBinaryWriter final : public GraphWriter {
 public:
 	/**
 	 * Write the given graph into a binary file at the given path.
-	 * 
+	 *
 	 * @param[in] G The graph to write.
 	 * @param[in] path The path where to write the graph.
 	 */
-	virtual void write(const Graph& G, const std::string& path);
+	void write(const Graph &G, const std::string &path) const override;
 };
 
 } /* namespace NetworKit */

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -3248,6 +3248,48 @@ cdef class GraphReader:
 			result = move(self._this.read(cpath)) # extra move in order to avoid copying the internal variable that is used by Cython
 		return Graph(0).setThis(result)
 
+cdef extern from "<networkit/io/GraphWriter.hpp>":
+
+	cdef cppclass _GraphWriter "NetworKit::GraphWriter":
+		_GraphWriter() nogil except +
+		void write(_Graph G, string path) nogil except +
+
+cdef class GraphWriter:
+	"""
+	Abstract base class for graph writers
+	"""
+
+	cdef _GraphWriter *_this
+
+	def __init__(self, *args, **kwargs):
+		if type(self) == GraphWriter:
+			raise RuntimeError("Error, you may not use GraphReader directly, use a sub-class instead")
+
+	def __cinit__(self, *args, **kwargs):
+		self._this = NULL
+
+	def __dealloc__(self):
+		if self._this != NULL:
+			del self._this
+		self._this = NULL
+
+	def write(self, Graph G not None, path):
+		"""
+		Write the graph to a file.
+
+		Parameters
+		----------
+		G     : networkit.Graph
+			The graph to write
+		paths : str
+			The output path
+		"""
+		assert path != None
+		cdef string c_path = stdstring(path)
+		with nogil:
+			self._this.write(G._this, c_path)
+		return self
+
 cdef extern from "<networkit/io/METISGraphReader.hpp>":
 
 	cdef cppclass _METISGraphReader "NetworKit::METISGraphReader" (_GraphReader):
@@ -3260,6 +3302,26 @@ cdef class METISGraphReader(GraphReader):
 	"""
 	def __cinit__(self):
 		self._this = new _METISGraphReader()
+
+cdef extern from "<networkit/io/NetworkitBinaryReader.hpp>":
+	cdef cppclass _NetworkitBinaryReader "NetworKit::NetworkitBinaryReader" (_GraphReader):
+		_NetworkitBinaryReader() except +
+
+cdef class NetworkitBinaryReader(GraphReader):
+	"""
+	Reads a graph written in the custom Networkit format documented in cpp/io/NetworkitGraph.md
+	"""
+
+	def __cinit__(self):
+		self._this = new _NetworkitBinaryReader()
+
+cdef extern from "<networkit/io/NetworkitBinaryWriter.hpp>":
+	cdef cppclass _NetworkitBinaryWriter "NetworKit::NetworkitBinaryWriter" (_GraphWriter):
+		_NetworkitBinaryWriter() except +
+
+cdef class NetworkitBinaryWriter(GraphWriter):
+	def __cinit__(self):
+		self._this = new _NetworkitBinaryWriter()
 
 cdef extern from "<networkit/io/GraphToolBinaryReader.hpp>":
 
@@ -3322,32 +3384,17 @@ cdef class ThrillGraphBinaryReader(GraphReader):
 
 cdef extern from "<networkit/io/ThrillGraphBinaryWriter.hpp>":
 
-	cdef cppclass _ThrillGraphBinaryWriter "NetworKit::ThrillGraphBinaryWriter":
-		void write(_Graph G, string path) nogil except +
+	cdef cppclass _ThrillGraphBinaryWriter "NetworKit::ThrillGraphBinaryWriter" (_GraphWriter):
+		_ThrillGraphBinaryWriter() except +
 
-cdef class ThrillGraphBinaryWriter:
+cdef class ThrillGraphBinaryWriter(GraphWriter):
 	"""
 	Writes a graph format consisting of a serialized DIA of vector<uint32_t> from Thrill.
 	Edges are written only in one direction.
 	"""
 
-	cdef _ThrillGraphBinaryWriter _this
-
-	def write(self, Graph G not None, path):
-		"""
-		Write the graph to a binary file.
-
-		Parameters
-		----------
-		G     : networkit.Graph
-			The graph to write
-		paths : str
-			The output path
-		"""
-		cdef string c_path = stdstring(path)
-		with nogil:
-			self._this.write(G._this, c_path)
-		return self
+	def __cinit__(self):
+		self._this = new _ThrillGraphBinaryWriter()
 
 cdef extern from "<networkit/io/EdgeListReader.hpp>":
 
@@ -3443,86 +3490,59 @@ cdef class GMLGraphReader(GraphReader):
 
 cdef extern from "<networkit/io/METISGraphWriter.hpp>":
 
-	cdef cppclass _METISGraphWriter "NetworKit::METISGraphWriter":
+	cdef cppclass _METISGraphWriter "NetworKit::METISGraphWriter" (_GraphWriter):
 		_METISGraphWriter() except +
-		void write(_Graph G, string path) nogil except +
 
 
-cdef class METISGraphWriter:
+cdef class METISGraphWriter(GraphWriter):
 	""" Writes graphs in the METIS format"""
-	cdef _METISGraphWriter _this
 
-	def write(self, Graph G not None, path):
-		 # string needs to be converted to bytes, which are coerced to std::string
-		cdef string cpath = stdstring(path)
-		with nogil:
-			self._this.write(G._this, cpath)
+	def __cinit__(self):
+		self._this = new _METISGraphWriter()
 
 cdef extern from "<networkit/io/GraphToolBinaryWriter.hpp>":
 
-	cdef cppclass _GraphToolBinaryWriter "NetworKit::GraphToolBinaryWriter":
+	cdef cppclass _GraphToolBinaryWriter "NetworKit::GraphToolBinaryWriter" (_GraphWriter):
 		_GraphToolBinaryWriter() except +
-		void write(_Graph G, string path) nogil except +
 
 
-cdef class GraphToolBinaryWriter:
+cdef class GraphToolBinaryWriter(GraphWriter):
 	""" Reads the binary file format defined by graph-tool[1].
 		[1]: http://graph-tool.skewed.de/static/doc/gt_format.html
 	"""
-	cdef _GraphToolBinaryWriter _this
-
-	def write(self, Graph G not None, path):
-		 # string needs to be converted to bytes, which are coerced to std::string
-		cdef string cpath = stdstring(path)
-		with nogil:
-			self._this.write(G._this, cpath)
-
+	def __cinit__(self):
+		self._this = new _GraphToolBinaryWriter()
 
 cdef extern from "<networkit/io/DotGraphWriter.hpp>":
 
-	cdef cppclass _DotGraphWriter "NetworKit::DotGraphWriter":
+	cdef cppclass _DotGraphWriter "NetworKit::DotGraphWriter" (_GraphWriter):
 		_DotGraphWriter() except +
-		void write(_Graph G, string path) nogil except +
 
-
-cdef class DotGraphWriter:
+cdef class DotGraphWriter(GraphWriter):
 	""" Writes graphs in the .dot/GraphViz format"""
-	cdef _DotGraphWriter _this
-
-	def write(self, Graph G not None, path):
-		 # string needs to be converted to bytes, which are coerced to std::string
-		cdef string cpath = stdstring(path)
-		with nogil:
-			self._this.write(G._this, cpath)
-
+	def __cinit__(self):
+		self._this = new _DotGraphWriter()
 
 cdef extern from "<networkit/io/GMLGraphWriter.hpp>":
 
-	cdef cppclass _GMLGraphWriter "NetworKit::GMLGraphWriter":
+	cdef cppclass _GMLGraphWriter "NetworKit::GMLGraphWriter" (_GraphWriter):
 		_GMLGraphWriter() except +
-		void write(_Graph G, string path) nogil except +
 
 
-cdef class GMLGraphWriter:
+cdef class GMLGraphWriter(GraphWriter):
 	""" Writes a graph and its coordinates as a GML file.[1]
 		[1] http://svn.bigcat.unimaas.nl/pvplugins/GML/trunk/docs/gml-technical-report.pdf """
-	cdef _GMLGraphWriter _this
 
-	def write(self, Graph G not None, path):
-		 # string needs to be converted to bytes, which are coerced to std::string
-		cdef string cpath = stdstring(path)
-		with nogil:
-			self._this.write(G._this, cpath)
-
+	def __cinit__(self):
+		self._this = new _GMLGraphWriter()
 
 cdef extern from "<networkit/io/EdgeListWriter.hpp>":
 
-	cdef cppclass _EdgeListWriter "NetworKit::EdgeListWriter":
+	cdef cppclass _EdgeListWriter "NetworKit::EdgeListWriter" (_GraphWriter):
 		_EdgeListWriter() except +
 		_EdgeListWriter(char separator, node firstNode, bool_t bothDirections) except +
-		void write(_Graph G, string path) nogil except +
 
-cdef class EdgeListWriter:
+cdef class EdgeListWriter(GraphWriter):
 	""" Writes graphs in various edge list formats.
 
 	Parameters
@@ -3535,17 +3555,9 @@ cdef class EdgeListWriter:
 		If undirected edges shall be written in both directions, i.e., as symmetric directed graph (default: false)
 	"""
 
-	cdef _EdgeListWriter _this
-
 	def __cinit__(self, separator, firstNode, bool_t bothDirections = False):
 		cdef char sep = stdstring(separator)[0]
-		self._this = _EdgeListWriter(sep, firstNode, bothDirections)
-
-	def write(self, Graph G not None, path):
-		cdef string cpath = stdstring(path)
-		with nogil:
-			self._this.write(G._this, cpath)
-
+		self._this = new _EdgeListWriter(sep, firstNode, bothDirections)
 
 
 cdef extern from "<networkit/io/LineFileReader.hpp>":
@@ -3564,22 +3576,16 @@ cdef class LineFileReader:
 
 
 cdef extern from "<networkit/io/SNAPGraphWriter.hpp>":
-
-	cdef cppclass _SNAPGraphWriter "NetworKit::SNAPGraphWriter":
+	cdef cppclass _SNAPGraphWriter "NetworKit::SNAPGraphWriter" (_GraphWriter):
 		_SNAPGraphWriter() except +
-		void write(_Graph G, string path) nogil except +
 
-cdef class SNAPGraphWriter:
+cdef class SNAPGraphWriter(GraphWriter):
 	""" Writes graphs in a format suitable for the Georgia Tech SNAP software [1]
 		[1]: http://snap-graph.sourceforge.net/
 	"""
-	cdef _SNAPGraphWriter _this
 
-	def write(self, Graph G, path):
-		cdef string cpath = stdstring(path)
-		with nogil:
-			self._this.write(G._this, cpath)
-
+	def __cinit__(self):
+		self._this = new _SNAPGraphWriter()
 
 cdef extern from "<networkit/io/SNAPGraphReader.hpp>":
 

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -3327,7 +3327,7 @@ cdef extern from "<networkit/io/ThrillGraphBinaryWriter.hpp>":
 
 cdef class ThrillGraphBinaryWriter:
 	"""
-	Writes a graph format consisting of a serialized DIA of vector<uint32_t> from thrill.
+	Writes a graph format consisting of a serialized DIA of vector<uint32_t> from Thrill.
 	Edges are written only in one direction.
 	"""
 

--- a/networkit/cpp/io/DotGraphWriter.cpp
+++ b/networkit/cpp/io/DotGraphWriter.cpp
@@ -11,7 +11,7 @@
 
 namespace NetworKit {
 
-void DotGraphWriter::write(const Graph &G, const std::string &path) const {
+void DotGraphWriter::write(const Graph &G, const std::string &path) {
 	std::ofstream file{path};
 
 	file << "graph {\n";

--- a/networkit/cpp/io/DotGraphWriter.cpp
+++ b/networkit/cpp/io/DotGraphWriter.cpp
@@ -5,15 +5,17 @@
  *      Author: forigem
  */
 
+#include <fstream>
+
 #include <networkit/io/DotGraphWriter.hpp>
 
 namespace NetworKit {
 
-void DotGraphWriter::write(Graph& graph, std::string path) const {
+void DotGraphWriter::write(const Graph &G, const std::string &path) const {
 	std::ofstream file{path};
-	
+
 	file << "graph {\n";
-	graph.forEdges([&](node u, node v){
+	G.forEdges([&](node u, node v){
 		file << u << " -- " << v << ";\n";
 	});
 	file << "}\n";

--- a/networkit/cpp/io/EdgeListWriter.cpp
+++ b/networkit/cpp/io/EdgeListWriter.cpp
@@ -5,18 +5,17 @@
  *      Author: cls
  */
 
-#include <networkit/io/EdgeListWriter.hpp>
-#include <networkit/auxiliary/Log.hpp>
-
-#include <sstream>
+#include <fstream>
 
 #include <networkit/auxiliary/Enforce.hpp>
+#include <networkit/auxiliary/Log.hpp>
+#include <networkit/io/EdgeListWriter.hpp>
 
 namespace NetworKit {
 
 EdgeListWriter::EdgeListWriter(char separator, node firstNode, bool bothDirections) : separator(separator), firstNode(firstNode), bothDirections(bothDirections) {}
 
-void EdgeListWriter::write(const Graph& G, std::string path) {
+void EdgeListWriter::write(const Graph &G, const std::string &path) const {
 	std::ofstream file(path);
 	Aux::enforceOpened(file);
 

--- a/networkit/cpp/io/EdgeListWriter.cpp
+++ b/networkit/cpp/io/EdgeListWriter.cpp
@@ -15,7 +15,7 @@ namespace NetworKit {
 
 EdgeListWriter::EdgeListWriter(char separator, node firstNode, bool bothDirections) : separator(separator), firstNode(firstNode), bothDirections(bothDirections) {}
 
-void EdgeListWriter::write(const Graph &G, const std::string &path) const {
+void EdgeListWriter::write(const Graph &G, const std::string &path) {
 	std::ofstream file(path);
 	Aux::enforceOpened(file);
 

--- a/networkit/cpp/io/GMLGraphWriter.cpp
+++ b/networkit/cpp/io/GMLGraphWriter.cpp
@@ -12,7 +12,7 @@
 
 namespace NetworKit {
 
-void GMLGraphWriter::write(const Graph &G, const std::string &path) const {
+void GMLGraphWriter::write(const Graph &G, const std::string &path) {
 	std::ofstream file(path);
 	Aux::enforceOpened(file);
 

--- a/networkit/cpp/io/GMLGraphWriter.cpp
+++ b/networkit/cpp/io/GMLGraphWriter.cpp
@@ -5,26 +5,28 @@
  *      Author: Stefan Bertsch
  */
 
-#include <networkit/io/GMLGraphWriter.hpp>
+#include <fstream>
+
 #include <networkit/auxiliary/Enforce.hpp>
+#include <networkit/io/GMLGraphWriter.hpp>
 
 namespace NetworKit {
 
-void GMLGraphWriter::write(const Graph& G, const std::string& path) {
+void GMLGraphWriter::write(const Graph &G, const std::string &path) const {
 	std::ofstream file(path);
 	Aux::enforceOpened(file);
-	
+
 	file << "graph [\n";
 	if (G.isDirected()) {
 		file << "  directed 1\n";
 	}
-	
+
 	G.forNodes([&](node u) {
 		file << "  node [\n";
 		file << "    id " << u << "\n";
                 file << "  ]\n";
 	});
-		
+
 	G.forEdges([&](node u, node v) {
 			file << "  edge [\n";
 			file << "    source "<< u << "\n";

--- a/networkit/cpp/io/GraphToolBinaryWriter.cpp
+++ b/networkit/cpp/io/GraphToolBinaryWriter.cpp
@@ -5,17 +5,17 @@
  *      Author: Maximilian Vogel
  */
 
-#include <networkit/io/GraphToolBinaryWriter.hpp>
-#include <networkit/auxiliary/Log.hpp>
-#include <networkit/graph/GraphTools.hpp>
-#include <sstream>
+#include <fstream>
 
+#include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Enforce.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/io/GraphToolBinaryWriter.hpp>
 
 namespace NetworKit {
 GraphToolBinaryWriter::GraphToolBinaryWriter(bool littleEndianness) : littleEndianness(littleEndianness) {}
 
-void GraphToolBinaryWriter::write(const Graph& G, const std::string& path) {
+void GraphToolBinaryWriter::write(const Graph &G, const std::string &path) const {
 	std::ofstream file(path, std::ios::binary | std::ios::out);
 	Aux::enforceOpened(file);
 	writeHeader(file);
@@ -32,7 +32,7 @@ void GraphToolBinaryWriter::write(const Graph& G, const std::string& path) {
 	file.close();
 }
 
-uint8_t GraphToolBinaryWriter::getAdjacencyWidth(uint64_t n) {
+uint8_t GraphToolBinaryWriter::getAdjacencyWidth(uint64_t n) const {
 	if (n < (uint64_t)1 << 8) {
 		return 1;
 	} else if (n < (uint64_t)1 << 16) {
@@ -44,13 +44,13 @@ uint8_t GraphToolBinaryWriter::getAdjacencyWidth(uint64_t n) {
 	} // error handling?
 }
 
-void GraphToolBinaryWriter::writeHeader(std::ofstream& file) {
+void GraphToolBinaryWriter::writeHeader(std::ofstream &file) const {
 	uint8_t header[8] = {0xe2, 0x9b, 0xbe, 0x20, 0x67, 0x74, 0x01, 0x00};
 	header[7] |= (uint8_t) !this->littleEndianness;
 	file.write((char*)header,8);
 }
 
-void GraphToolBinaryWriter::writeComment(std::ofstream& file) {
+void GraphToolBinaryWriter::writeComment(std::ofstream &file) const {
 	std::string s = "";
 	uint64_t size = (uint64_t)s.size();
 	writeType<uint64_t>(file,8,size);
@@ -59,7 +59,7 @@ void GraphToolBinaryWriter::writeComment(std::ofstream& file) {
 	}
 }
 
-void GraphToolBinaryWriter::writeAdjacencies(std::ofstream& file, const Graph& G) {
+void GraphToolBinaryWriter::writeAdjacencies(std::ofstream &file, const Graph &G) const {
 	// value of numNodes determines the size of the unsigned integer type storing the node ids
 	int width = (int)getAdjacencyWidth(G.numberOfNodes());
 	//DEBUG("width is: ", width);
@@ -81,7 +81,7 @@ void GraphToolBinaryWriter::writeAdjacencies(std::ofstream& file, const Graph& G
 				for(auto v : adjacencies) {
 					writeType<uint64_t>(file,width,v);
 				}
-			});			
+			});
 		} else {
 			// iterate over each node
 			G.forNodes([&](node u){
@@ -92,7 +92,7 @@ void GraphToolBinaryWriter::writeAdjacencies(std::ofstream& file, const Graph& G
 				G.forNeighborsOf(u,[&](node v){
 					writeType<uint64_t>(file,width,v);
 				});
-			});						
+			});
 		}
 	} else {
 		auto nodeIdMap = GraphTools::getContinuousNodeIds(G);
@@ -104,7 +104,7 @@ void GraphToolBinaryWriter::writeAdjacencies(std::ofstream& file, const Graph& G
 				G.forNeighborsOf(u,[&](node v){
 					if (v <= u)
 						adjacencies.push_back(v);
-				});		
+				});
 				// write number of adjacencies to the file
 				count deg = adjacencies.size();
 				writeType<uint64_t>(file,8,deg);
@@ -112,7 +112,7 @@ void GraphToolBinaryWriter::writeAdjacencies(std::ofstream& file, const Graph& G
 				for(auto& v : adjacencies) {
 					writeType<uint64_t>(file,width,nodeIdMap[v]);
 				}
-			});			
+			});
 		} else {
 			// iterate over each node
 			G.forNodes([&](node u){
@@ -123,11 +123,8 @@ void GraphToolBinaryWriter::writeAdjacencies(std::ofstream& file, const Graph& G
 				G.forNeighborsOf(u,[&](node v){
 					writeType<uint64_t>(file,width,nodeIdMap[v]);
 				});
-			});						
+			});
 		}
 	}
-
-
 }
-
-}
+} // namespace NetworKit

--- a/networkit/cpp/io/GraphToolBinaryWriter.cpp
+++ b/networkit/cpp/io/GraphToolBinaryWriter.cpp
@@ -15,7 +15,7 @@
 namespace NetworKit {
 GraphToolBinaryWriter::GraphToolBinaryWriter(bool littleEndianness) : littleEndianness(littleEndianness) {}
 
-void GraphToolBinaryWriter::write(const Graph &G, const std::string &path) const {
+void GraphToolBinaryWriter::write(const Graph &G, const std::string &path) {
 	std::ofstream file(path, std::ios::binary | std::ios::out);
 	Aux::enforceOpened(file);
 	writeHeader(file);
@@ -32,7 +32,7 @@ void GraphToolBinaryWriter::write(const Graph &G, const std::string &path) const
 	file.close();
 }
 
-uint8_t GraphToolBinaryWriter::getAdjacencyWidth(uint64_t n) const {
+uint8_t GraphToolBinaryWriter::getAdjacencyWidth(uint64_t n) {
 	if (n < (uint64_t)1 << 8) {
 		return 1;
 	} else if (n < (uint64_t)1 << 16) {
@@ -44,13 +44,13 @@ uint8_t GraphToolBinaryWriter::getAdjacencyWidth(uint64_t n) const {
 	} // error handling?
 }
 
-void GraphToolBinaryWriter::writeHeader(std::ofstream &file) const {
+void GraphToolBinaryWriter::writeHeader(std::ofstream &file) {
 	uint8_t header[8] = {0xe2, 0x9b, 0xbe, 0x20, 0x67, 0x74, 0x01, 0x00};
 	header[7] |= (uint8_t) !this->littleEndianness;
 	file.write((char*)header,8);
 }
 
-void GraphToolBinaryWriter::writeComment(std::ofstream &file) const {
+void GraphToolBinaryWriter::writeComment(std::ofstream &file) {
 	std::string s = "";
 	uint64_t size = (uint64_t)s.size();
 	writeType<uint64_t>(file,8,size);
@@ -59,7 +59,7 @@ void GraphToolBinaryWriter::writeComment(std::ofstream &file) const {
 	}
 }
 
-void GraphToolBinaryWriter::writeAdjacencies(std::ofstream &file, const Graph &G) const {
+void GraphToolBinaryWriter::writeAdjacencies(std::ofstream &file, const Graph &G) {
 	// value of numNodes determines the size of the unsigned integer type storing the node ids
 	int width = (int)getAdjacencyWidth(G.numberOfNodes());
 	//DEBUG("width is: ", width);

--- a/networkit/cpp/io/METISGraphWriter.cpp
+++ b/networkit/cpp/io/METISGraphWriter.cpp
@@ -13,11 +13,11 @@
 
 namespace NetworKit {
 
-void METISGraphWriter::write(const Graph &G, const std::string &path) const {
+void METISGraphWriter::write(const Graph &G, const std::string &path) {
 	this->write(G, G.isWeighted(), path);
 }
 
-void METISGraphWriter::write(const Graph &G, bool weighted, const std::string &path) const {
+void METISGraphWriter::write(const Graph &G, bool weighted, const std::string &path) {
 	if (G.isDirected()) {
 		throw std::invalid_argument{"METIS does not support directed graphs"};
 	}

--- a/networkit/cpp/io/METISGraphWriter.cpp
+++ b/networkit/cpp/io/METISGraphWriter.cpp
@@ -5,17 +5,19 @@
  *      Author: Christian Staudt (christian.staudt@kit.edu)
  */
 
-#include <networkit/io/METISGraphWriter.hpp>
-#include <networkit/graph/GraphTools.hpp>
+#include <fstream>
 
 #include <networkit/auxiliary/Enforce.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/io/METISGraphWriter.hpp>
 
 namespace NetworKit {
 
-void METISGraphWriter::write(const Graph& G, const std::string& path) {
+void METISGraphWriter::write(const Graph &G, const std::string &path) const {
 	this->write(G, G.isWeighted(), path);
 }
-void METISGraphWriter::write(const Graph& G, bool weighted, std::string path) {
+
+void METISGraphWriter::write(const Graph &G, bool weighted, const std::string &path) const {
 	if (G.isDirected()) {
 		throw std::invalid_argument{"METIS does not support directed graphs"};
 	}

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -1,15 +1,17 @@
 /*
  * NetworkitBinaryWriter.cpp
  *
- *@author Charmaine Ndolo <charmaine.ndolo@b-tu.de>
+ * @author Charmaine Ndolo <charmaine.ndolo@b-tu.de>
  */
 
-#include <networkit/io/NetworkitBinaryWriter.hpp>
-#include <networkit/io/NetworkitBinaryGraph.hpp>
-#include <networkit/auxiliary/Enforce.hpp>
-#include <tlx/math/clz.hpp>
-#include <fstream>
 #include <cstring>
+#include <fstream>
+
+#include <networkit/auxiliary/Enforce.hpp>
+#include <networkit/io/NetworkitBinaryGraph.hpp>
+#include <networkit/io/NetworkitBinaryWriter.hpp>
+
+#include <tlx/math/clz.hpp>
 
 namespace NetworKit {
 
@@ -42,7 +44,7 @@ uint64_t NetworkitBinaryWriter::encodeZigzag(int64_t value) {
 	return (value << 1) ^ (value >> 31);
 }
 
-void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
+void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) const {
 
 	std::ofstream outfile(path, std::ios::binary);
 	Aux::enforceOpened(outfile);
@@ -54,8 +56,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 		bool fitsIntoInt64 = true;
 		bool fitsIntoFloat = true;
 		G.forNodes([&](node n) {
-			G.forNeighborsOf(n,[&](node v, edgeweight w) {
-				int64_t weight = w*10;
+			G.forNeighborsOf(n,[&](node, edgeweight w) {
 				if(w < 0)
 					isUnsigned = false;
 				if(w != static_cast<int64_t>(w))
@@ -149,9 +150,10 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 		}
 	};
 
-	nodes = G.numberOfNodes();
-	if (nodes < chunks) {
-		chunks = nodes;
+	count nNodes = G.numberOfNodes();
+	count nChunks = chunks;
+	if (nNodes < chunks) {
+		nChunks = nNodes;
 		INFO("reducing chunks to ", chunks, " chunks");
 	}
 
@@ -159,11 +161,11 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 	std::vector<uint64_t> firstInChunk;
 	firstInChunk.push_back(0);
 	uint64_t firstNode = 0;
-	for(uint64_t c = 1; c < chunks; c++) {
-		firstNode += (nodes/chunks);
+	for(uint64_t c = 1; c < nChunks; c++) {
+		firstNode += (nNodes/nChunks);
 		firstInChunk.push_back(firstNode);
 	}
-	firstInChunk.push_back(nodes);
+	firstInChunk.push_back(nNodes);
 
 	// Compute encoded size of arrays and store in vector.
 	uint64_t adjSize = 0;
@@ -206,7 +208,6 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 			uint64_t outNbrs = 0;
 			uint64_t inNbrs = 0;
 			uint8_t tmp [10];
-			uint64_t weight;
 			if(!G.isDirected()){
 				G.forNeighborsOf(n,[&](node v, edgeweight w) {
 					if(v <= n) {
@@ -248,14 +249,14 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 	strncpy(header.magic,"nkbg002",8);
 	header.checksum = 0;
 	setFeatures();
-	header.nodes = nodes;
-	header.chunks = chunks;
+	header.nodes = nNodes;
+	header.chunks = nChunks;
 	header.offsetBaseData = sizeof(nkbg::Header);
 	header.offsetAdjLists = header.offsetBaseData
-			+ nodes * sizeof(uint8_t) // nodeFlags.
-			+ (chunks - 1) * sizeof(uint64_t); // firstVertex.
+			+ nNodes * sizeof(uint8_t) // nodeFlags.
+			+ (nChunks - 1) * sizeof(uint64_t); // firstVertex.
 	header.offsetAdjTranspose = header.offsetAdjLists
-			+ (chunks -1) * sizeof(uint64_t) // adjOffsets
+			+ (nChunks - 1) * sizeof(uint64_t) // adjOffsets
 			+ sizeof(uint64_t) // adjListSize
 			+ adjOffsets.back(); // Size of data
 	if(weightFormat != nkbg::WEIGHT_FORMAT::NONE) {
@@ -281,12 +282,12 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 	});
 
 	assert(!firstInChunk[0]);
-	for (uint64_t c = 1; c < chunks; c++) {
+	for (uint64_t c = 1; c < nChunks; c++) {
 		outfile.write(reinterpret_cast<char*>(&firstInChunk[c]), sizeof(uint64_t));
 	}
 
 	// Write adjacency data.
-	for (uint64_t c = 1; c < chunks; c++) {
+	for (uint64_t c = 1; c < nChunks; c++) {
 		outfile.write(reinterpret_cast<char*>(&adjOffsets[c-1]), sizeof(uint64_t));
 	}
 	// Write size of list
@@ -310,7 +311,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 	});
 
 	// Write transpose data.
-	for (uint64_t c = 1; c < chunks; c++) {
+	for (uint64_t c = 1; c < nChunks; c++) {
 		outfile.write(reinterpret_cast<char*>(&transpOffsets[c-1]), sizeof(uint64_t));
 	}
 	// Write size of transpose list.
@@ -340,9 +341,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 		outfile.write(reinterpret_cast<char*>(&adjWghtOffsets[c-1]), sizeof(uint64_t));
 	}
 	G.forNodes([&](node u) {
-		uint8_t tmp [10];
 		G.forNeighborsOf(u,[&](node v,edgeweight w){
-			uint64_t weightSize;
 			if(!G.isDirected()) {
 				if(v <= u) {
 					writeWeightsToFile(w);
@@ -358,7 +357,6 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 		outfile.write(reinterpret_cast<char*>(&transpWghtOffsets[c-1]), sizeof(uint64_t));
 	}
 	G.forNodes([&](node u) {
-		uint8_t tmp [10];
 		if(!G.isDirected()) {
 			G.forNeighborsOf(u,[&](node v, edgeweight w){
 				if(v >= u) {
@@ -366,7 +364,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 				}
 			});
 		} else {
-			G.forInNeighborsOf(u,[&](node v, edgeweight w){
+			G.forInNeighborsOf(u, [&](node, edgeweight w){
 				writeWeightsToFile(w);
 			});
 		}

--- a/networkit/cpp/io/SNAPGraphWriter.cpp
+++ b/networkit/cpp/io/SNAPGraphWriter.cpp
@@ -5,12 +5,14 @@
  *      Author: cls
  */
 
-#include <networkit/io/SNAPGraphWriter.hpp>
+#include <fstream>
+
 #include <networkit/auxiliary/Enforce.hpp>
+#include <networkit/io/SNAPGraphWriter.hpp>
 
 namespace NetworKit {
 
-void SNAPGraphWriter::write(const Graph& G, const std::string& path) {
+void SNAPGraphWriter::write(const Graph &G, const std::string &path) const {
     std::ofstream file(path);
     Aux::enforceOpened(file);
 

--- a/networkit/cpp/io/SNAPGraphWriter.cpp
+++ b/networkit/cpp/io/SNAPGraphWriter.cpp
@@ -12,7 +12,7 @@
 
 namespace NetworKit {
 
-void SNAPGraphWriter::write(const Graph &G, const std::string &path) const {
+void SNAPGraphWriter::write(const Graph &G, const std::string &path) {
     std::ofstream file(path);
     Aux::enforceOpened(file);
 

--- a/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
@@ -10,7 +10,7 @@
 
 namespace NetworKit {
 
-void ThrillGraphBinaryWriter::write(const Graph &G, const std::string &path) const {
+void ThrillGraphBinaryWriter::write(const Graph &G, const std::string &path) {
 	if (G.upperNodeIdBound() > std::numeric_limits<uint32_t>::max()) {
 		throw std::runtime_error("Thrill binary graphs only support graphs with up to 2^32-1 nodes.");
 	}

--- a/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
@@ -1,10 +1,20 @@
+/*
+ * ThrillGraphBinaryWriter.hpp
+ *
+ * @author Michael Hamann <michael.hamann@kit.edu>
+ */
+
+#include <fstream>
+
 #include <networkit/io/ThrillGraphBinaryWriter.hpp>
 
-void NetworKit::ThrillGraphBinaryWriter::write( const NetworKit::Graph &G, const std::string &path ) {
+namespace NetworKit {
+
+void ThrillGraphBinaryWriter::write(const Graph &G, const std::string &path) const {
 	if (G.upperNodeIdBound() > std::numeric_limits<uint32_t>::max()) {
 		throw std::runtime_error("Thrill binary graphs only support graphs with up to 2^32-1 nodes.");
 	}
-	
+
 	std::ofstream out_stream(path, std::ios::trunc | std::ios::binary);
 
 	std::vector<uint32_t> neighbors;
@@ -44,3 +54,4 @@ void NetworKit::ThrillGraphBinaryWriter::write( const NetworKit::Graph &G, const
 
 	out_stream.close();
 }
+} // namespace NetworKit

--- a/networkit/graphio.py
+++ b/networkit/graphio.py
@@ -4,7 +4,7 @@ from _NetworKit import (METISGraphReader, METISGraphWriter, DotGraphWriter, Edge
 						GraphToolBinaryReader, DGSStreamParser, GraphUpdater, SNAPEdgeListPartitionReader, \
 						SNAPGraphReader, EdgeListReader, CoverReader, CoverWriter, EdgeListCoverReader, \
 						KONECTGraphReader, GMLGraphReader, MultipleEdgesHandling, ThrillGraphBinaryReader, \
-						ThrillGraphBinaryWriter)
+						ThrillGraphBinaryWriter, NetworkitBinaryReader, NetworkitBinaryWriter)
 from _NetworKit import Graph as __Graph
 # local imports
 from .GraphMLIO import GraphMLReader, GraphMLWriter


### PR DESCRIPTION
All classes that write graphs inherit from `GraphWriter`. Exposed `NetworkitBinaryReader/Writer` to Python, together with the `GraphWriter` hierarchy.