### PR TITLE
Refactor: top-closeness

### DIFF
--- a/include/networkit/centrality/TopCloseness.hpp
+++ b/include/networkit/centrality/TopCloseness.hpp
@@ -8,7 +8,10 @@
 #ifndef NETWORKIT_CENTRALITY_TOP_CLOSENESS_HPP_
 #define NETWORKIT_CENTRALITY_TOP_CLOSENESS_HPP_
 
+#include <memory>
+
 #include <networkit/base/Algorithm.hpp>
+#include <networkit/components/StronglyConnectedComponents.hpp>
 #include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
@@ -86,7 +89,8 @@ private:
   std::vector<double> farness;
   std::vector<count> reachL;
   std::vector<count> reachU;
-  std::vector<index> component;
+
+  std::unique_ptr<StronglyConnectedComponents> sccsPtr;
 
   void init();
   double BFScut(node v, double x, std::vector<bool> &visited, std::vector<count> &distances,

--- a/include/networkit/centrality/TopCloseness.hpp
+++ b/include/networkit/centrality/TopCloseness.hpp
@@ -16,7 +16,7 @@ namespace NetworKit {
 /**
  * @ingroup centrality
  */
-class TopCloseness : public Algorithm {
+class TopCloseness final : public Algorithm {
 public:
   /**
    * Finds the top k nodes with highest closeness centrality faster than
@@ -46,7 +46,7 @@ public:
   /**
    * Computes top-k closeness on the graph passed in the constructor.
    */
-  void run();
+  void run() override;
 
   /**
    * Returns a list with the k nodes with highest closeness.
@@ -70,28 +70,23 @@ public:
    */
   std::vector<edgeweight> topkScoresList(bool includeTrail = false);
 
-protected:
-  Graph G;
+private:
+  const Graph &G;
   count n;
   count k;
   bool first_heu, sec_heu;
   std::vector<node> topk;
-  count visEdges = 0;
-  count n_op = 0;
-  count trail = 0;
-  double maxFarness = -1.f;
-  count nMaxFarness = 0;
-  std::vector<std::vector<node>> levels;
-  std::vector<count> nodesPerLev;
-  count nLevs = 0;
+  count visEdges;
+  count n_op;
+  count trail;
+  double maxFarness = -1.0;
+  count nMaxFarness;
+  std::vector<std::vector<count>> nodesPerLevs, sumLevels;
   std::vector<edgeweight> topkScores;
-  std::vector<count> maxlevel;
-  std::vector<count> maxlevelSize;
-  std::vector<std::vector<count>> subtree;
   std::vector<double> farness;
   std::vector<count> reachL;
   std::vector<count> reachU;
-  std::vector<count> component;
+  std::vector<index> component;
 
   void init();
   double BFScut(node v, double x, bool *visited, count *distances, node *pred,
@@ -122,6 +117,7 @@ inline std::vector<edgeweight> TopCloseness::topkScoresList(bool includeTrail) {
     std::vector<double> topkScoresNoTrail(begin, begin + k);
     return topkScoresNoTrail;
   }
+
   return topkScores;
 }
 

--- a/include/networkit/centrality/TopCloseness.hpp
+++ b/include/networkit/centrality/TopCloseness.hpp
@@ -89,10 +89,10 @@ private:
   std::vector<index> component;
 
   void init();
-  double BFScut(node v, double x, bool *visited, count *distances, node *pred,
-                count *visEdges);
+  double BFScut(node v, double x, std::vector<bool> &visited, std::vector<count> &distances,
+                std::vector<node> &pred, count &visEdges);
   void computelBound1(std::vector<double> &S);
-  void BFSbound(node x, std::vector<double> &S, count *visEdges,
+  void BFSbound(node x, std::vector<double> &S, count &visEdges,
                 const std::vector<bool> &toAnalyze);
   void computeReachable();
   void computeReachableNodesUndir();

--- a/include/networkit/centrality/TopCloseness.hpp
+++ b/include/networkit/centrality/TopCloseness.hpp
@@ -1,9 +1,11 @@
 /*
- * TopCloseness.h
+ * TopCloseness.hpp
  *
  *  Created on: 03.10.2014
  *      Author: ebergamini, michele borassi
  */
+
+// networkit-format
 
 #ifndef NETWORKIT_CENTRALITY_TOP_CLOSENESS_HPP_
 #define NETWORKIT_CENTRALITY_TOP_CLOSENESS_HPP_
@@ -21,127 +23,124 @@ namespace NetworKit {
  */
 class TopCloseness final : public Algorithm {
 public:
-  /**
-   * Finds the top k nodes with highest closeness centrality faster than
-   * computing it for all nodes, based on "Computing Top-k Closeness Centrality
-   * Faster in Unweighted Graphs", Bergamini et al., ALENEX16. The algorithms is
-   * based on two independent heuristics, described in the referenced paper. We
-   * recommend to use first_heu = true and second_heu = false for complex
-   * networks and first_heu = true and second_heu = true for street networks or
-   * networks with large diameters. Notice that the worst case running time of
-   * the algorithm is O(nm), where n is the number of nodes and m is the number
-   * of edges. However, for most networks the empirical running time is O(m).
-   *
-   * @param G An unweighted graph.
-   * @param k Number of nodes with highest closeness that have to be found. For
-   * example, if k = 10, the top 10 nodes with highest closeness will be
-   * computed.
-   * @param first_heu If true, the neighborhood-based lower bound is computed
-   * and nodes are sorted according to it. If false, nodes are simply sorted by
-   * degree.
-   * @param sec_heu If true, the BFSbound is re-computed at each iteration. If
-   * false, BFScut is used.
-   * @
-   */
-  TopCloseness(const Graph &G, count k = 1, bool first_heu = true,
-               bool sec_heu = true);
+    /**
+     * Finds the top k nodes with highest closeness centrality faster than
+     * computing it for all nodes, based on "Computing Top-k Closeness Centrality
+     * Faster in Unweighted Graphs", Bergamini et al., ALENEX16. The algorithms is
+     * based on two independent heuristics, described in the referenced paper. We
+     * recommend to use first_heu = true and second_heu = false for complex
+     * networks and first_heu = true and second_heu = true for street networks or
+     * networks with large diameters. Notice that the worst case running time of
+     * the algorithm is O(nm), where n is the number of nodes and m is the number
+     * of edges. However, for most networks the empirical running time is O(m).
+     *
+     * @param G An unweighted graph.
+     * @param k Number of nodes with highest closeness that have to be found. For
+     * example, if k = 10, the top 10 nodes with highest closeness will be
+     * computed.
+     * @param first_heu If true, the neighborhood-based lower bound is computed
+     * and nodes are sorted according to it. If false, nodes are simply sorted by
+     * degree.
+     * @param sec_heu If true, the BFSbound is re-computed at each iteration. If
+     * false, BFScut is used.
+     * @
+     */
+    TopCloseness(const Graph &G, count k = 1, bool first_heu = true, bool sec_heu = true);
 
-  /**
-   * Computes top-k closeness on the graph passed in the constructor.
-   */
-  void run() override;
+    /**
+     * Computes top-k closeness on the graph passed in the constructor.
+     */
+    void run() override;
 
-  /**
-   * Returns a list with the k nodes with highest closeness.
-   * WARNING: closeness centrality of some nodes below the top-k could be equal
-   * to the k-th closeness, we call them trail. Set the parameter includeTrail
-   * to true to also include those nodes but consider that the resulting vector
-   * could be longer than k.
-   *
-   * @param includeTrail Whether or not to include trail nodes.
-   */
-  std::vector<node> topkNodesList(bool includeTrail = false);
+    /**
+     * Returns a list with the k nodes with highest closeness.
+     * WARNING: closeness centrality of some nodes below the top-k could be equal
+     * to the k-th closeness, we call them trail. Set the parameter includeTrail
+     * to true to also include those nodes but consider that the resulting vector
+     * could be longer than k.
+     *
+     * @param includeTrail Whether or not to include trail nodes.
+     */
+    std::vector<node> topkNodesList(bool includeTrail = false);
 
-  /**
-   * Returns a list with the scores of the k nodes with highest closeness
-   * WARNING: closeness centrality of some nodes below the top-k could be equal
-   * to the k-th closeness, we call them trail. Set the parameter includeTrail
-   * to true to also include those centrality values but consider that the
-   * resulting vector could be longer than k.
-   *
-   * @param includeTrail Whether or not to include trail centrality value.
-   */
-  std::vector<edgeweight> topkScoresList(bool includeTrail = false);
+    /**
+     * Returns a list with the scores of the k nodes with highest closeness
+     * WARNING: closeness centrality of some nodes below the top-k could be equal
+     * to the k-th closeness, we call them trail. Set the parameter includeTrail
+     * to true to also include those centrality values but consider that the
+     * resulting vector could be longer than k.
+     *
+     * @param includeTrail Whether or not to include trail centrality value.
+     */
+    std::vector<edgeweight> topkScoresList(bool includeTrail = false);
 
 private:
-  const Graph &G;
-  count n;
-  count k;
-  bool first_heu, sec_heu;
-  std::vector<node> topk;
-  count visEdges;
-  count n_op;
-  count trail;
-  double maxFarness = -1.0;
-  count nMaxFarness;
-  std::vector<std::vector<count>> nodesPerLevs, sumLevels;
-  std::vector<edgeweight> topkScores;
-  std::vector<double> farness;
-  std::vector<count> reachL;
-  std::vector<count> reachU;
+    const Graph &G;
+    count n;
+    count k;
+    bool first_heu, sec_heu;
+    std::vector<node> topk;
+    count visEdges;
+    count n_op;
+    count trail;
+    double maxFarness = -1.0;
+    count nMaxFarness;
+    std::vector<std::vector<count>> nodesPerLevs, sumLevels;
+    std::vector<edgeweight> topkScores;
+    std::vector<double> farness;
+    std::vector<count> reachL;
+    std::vector<count> reachU;
 
-  std::unique_ptr<StronglyConnectedComponents> sccsPtr;
+    std::unique_ptr<StronglyConnectedComponents> sccsPtr;
 
-  void init();
-  double BFScut(node v, double x, std::vector<bool> &visited, std::vector<count> &distances,
-                std::vector<node> &pred, count &visEdges);
-  void computelBound1(std::vector<double> &S);
-  void BFSbound(node x, std::vector<double> &S, count &visEdges,
-                const std::vector<bool> &toAnalyze);
-  void computeReachable();
-  void computeReachableNodesUndir();
-  void computeReachableNodesDir();
+    void init();
+    double BFScut(node v, double x, std::vector<bool> &visited, std::vector<count> &distances,
+                  std::vector<node> &pred, count &visEdges);
+    void computelBound1(std::vector<double> &S);
+    void BFSbound(node x, std::vector<double> &S, count &visEdges,
+                  const std::vector<bool> &toAnalyze);
+    void computeReachable();
+    void computeReachableNodesUndir();
+    void computeReachableNodesDir();
 
-  // Returns the node with highest farness
-  struct LargerFarness {
-  public:
-    LargerFarness(const std::vector<double> &v_) : v(v_) {}
-    bool operator()(node x, node y) const { return v[x] > v[y]; }
+    // Returns the node with highest farness
+    struct LargerFarness {
+        LargerFarness(const std::vector<double> &v_) : v(v_) {}
+        bool operator()(node x, node y) const noexcept { return v[x] > v[y]; }
 
-  private:
-    const std::vector<double> &v;
-  };
+    private:
+        const std::vector<double> &v;
+    };
 
-  struct SmallerFarness {
-  public:
-      SmallerFarness(const std::vector<double> &v_) : v(v_) {}
-      bool operator()(node x, node y) const { return v[x] < v[y]; }
+    struct SmallerFarness {
+        SmallerFarness(const std::vector<double> &v_) : v(v_) {}
+        bool operator()(node x, node y) const noexcept { return v[x] < v[y]; }
 
-  private:
-      const std::vector<double> &v;
-  };
+    private:
+        const std::vector<double> &v;
+    };
 };
 
 inline std::vector<node> TopCloseness::topkNodesList(bool includeTrail) {
-  assureFinished();
-  if (!includeTrail) {
-    auto begin = topk.begin();
-    std::vector<node> topkNoTrail(begin, begin + k);
-    return topkNoTrail;
-  }
+    assureFinished();
+    if (!includeTrail) {
+        auto begin = topk.begin();
+        std::vector<node> topkNoTrail(begin, begin + k);
+        return topkNoTrail;
+    }
 
-  return topk;
+    return topk;
 }
 
 inline std::vector<edgeweight> TopCloseness::topkScoresList(bool includeTrail) {
-  assureFinished();
-  if (!includeTrail) {
-    auto begin = topkScores.begin();
-    std::vector<double> topkScoresNoTrail(begin, begin + k);
-    return topkScoresNoTrail;
-  }
+    assureFinished();
+    if (!includeTrail) {
+        auto begin = topkScores.begin();
+        std::vector<double> topkScoresNoTrail(begin, begin + k);
+        return topkScoresNoTrail;
+    }
 
-  return topkScores;
+    return topkScores;
 }
 
 } /* namespace NetworKit */

--- a/include/networkit/centrality/TopCloseness.hpp
+++ b/include/networkit/centrality/TopCloseness.hpp
@@ -7,7 +7,7 @@
 
 #ifndef NETWORKIT_CENTRALITY_TOP_CLOSENESS_HPP_
 #define NETWORKIT_CENTRALITY_TOP_CLOSENESS_HPP_
-#include <networkit/auxiliary/PrioQueue.hpp>
+
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
 
@@ -97,6 +97,25 @@ private:
   void computeReachable();
   void computeReachableNodesUndir();
   void computeReachableNodesDir();
+
+  // Returns the node with highest farness
+  struct LargerFarness {
+  public:
+    LargerFarness(const std::vector<double> &v_) : v(v_) {}
+    bool operator()(node x, node y) const { return v[x] > v[y]; }
+
+  private:
+    const std::vector<double> &v;
+  };
+
+  struct SmallerFarness {
+  public:
+      SmallerFarness(const std::vector<double> &v_) : v(v_) {}
+      bool operator()(node x, node y) const { return v[x] < v[y]; }
+
+  private:
+      const std::vector<double> &v;
+  };
 };
 
 inline std::vector<node> TopCloseness::topkNodesList(bool includeTrail) {

--- a/include/networkit/centrality/TopCloseness.hpp
+++ b/include/networkit/centrality/TopCloseness.hpp
@@ -88,8 +88,7 @@ private:
     std::vector<std::vector<count>> nodesPerLevs, sumLevels;
     std::vector<edgeweight> topkScores;
     std::vector<double> farness;
-    std::vector<count> reachL;
-    std::vector<count> reachU;
+    std::shared_ptr<std::vector<count>> reachLPtr, reachUPtr;
 
     std::unique_ptr<StronglyConnectedComponents> sccsPtr;
 

--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -1,632 +1,623 @@
 /*
  * TopCloseness.cpp
  *
- *  Created on: 12.13.2016
- *      Author: nemes
+ *  Created on: 03.10.2014
+ *      Author: ebergamini, michele borassi
  */
+
+// networkit-format
 
 #include <omp.h>
 #include <queue>
 #include <stack>
 
 #include <networkit/auxiliary/Log.hpp>
-#include <networkit/components/ConnectedComponents.hpp>
 #include <networkit/centrality/TopCloseness.hpp>
+#include <networkit/components/ConnectedComponents.hpp>
 #include <networkit/graph/BFS.hpp>
 
-#include <tlx/container/d_ary_heap.hpp>
 #include <tlx/container/d_ary_addressable_int_heap.hpp>
+#include <tlx/container/d_ary_heap.hpp>
 
 namespace NetworKit {
 
-TopCloseness::TopCloseness(const Graph &G, count k, bool first_heu,
-                           bool sec_heu)
+TopCloseness::TopCloseness(const Graph &G, count k, bool first_heu, bool sec_heu)
     : G(G), k(k), first_heu(first_heu), sec_heu(sec_heu) {}
 
 void TopCloseness::init() {
-  n = G.upperNodeIdBound();
-  trail = 0;
-  visEdges = 0;
-  n_op = 0;
-  maxFarness = 0.0;
-  nMaxFarness = 0;
-  topk.clear();
-  topk.resize(k);
-  topkScores.clear();
-  topkScores.resize(k);
-  DEBUG("Number of nodes: ", n);
-  DEBUG("k = ", k);
-  farness.clear();
-  farness.resize(n, 0);
-  if (sec_heu) {
-      nodesPerLevs.resize(omp_get_max_threads(), std::vector<count>(n));
-      sumLevels.resize(omp_get_max_threads(), std::vector<count>(n));
-  }
-  computeReachable();
-  DEBUG("Done INIT");
+    n = G.upperNodeIdBound();
+    trail = 0;
+    visEdges = 0;
+    n_op = 0;
+    maxFarness = 0.0;
+    nMaxFarness = 0;
+    topk.clear();
+    topk.resize(k);
+    topkScores.clear();
+    topkScores.resize(k);
+    DEBUG("Number of nodes: ", n);
+    DEBUG("k = ", k);
+    farness.clear();
+    farness.resize(n, 0);
+    if (sec_heu) {
+        nodesPerLevs.resize(omp_get_max_threads(), std::vector<count>(n));
+        sumLevels.resize(omp_get_max_threads(), std::vector<count>(n));
+    }
+    computeReachable();
+    DEBUG("Done INIT");
 }
 
 void TopCloseness::computeReachable() {
-  if (G.isDirected()) {
-    sccsPtr = std::unique_ptr<StronglyConnectedComponents>(new StronglyConnectedComponents(G));
-    computeReachableNodesDir();
-  } else {
-    computeReachableNodesUndir();
-  }
+    if (G.isDirected()) {
+        sccsPtr = std::unique_ptr<StronglyConnectedComponents>(new StronglyConnectedComponents(G));
+        computeReachableNodesDir();
+    } else {
+        computeReachableNodesUndir();
+    }
 }
 
 void TopCloseness::computeReachableNodesDir() {
-  reachL = std::vector<count>(n);
-  reachU = std::vector<count>(n);
-  DEBUG("Before running SCCs");
-  auto &sccs = *(sccsPtr.get());
-  sccs.run();
+    reachL = std::vector<count>(n);
+    reachU = std::vector<count>(n);
+    DEBUG("Before running SCCs");
+    auto &sccs = *(sccsPtr.get());
+    sccs.run();
 
-  count N = sccs.numberOfComponents();
-  DEBUG("Number of components: ", N);
-  std::vector<count> reachL_scc(N, 0);
-  std::vector<count> reachU_scc(N, 0);
-  std::vector<count> reachU_without_max_scc(N, 0);
-  std::vector<bool> reach_from_max_scc(N, false);
-  std::vector<bool> reaches_max_scc(N, false);
-  std::vector<std::vector<count>> sccs_vec(N, std::vector<count>());
-  Graph sccGraph(N, false, true);
-  std::vector<bool> found(N, false);
-  count maxSizeCC = 0;
+    count N = sccs.numberOfComponents();
+    DEBUG("Number of components: ", N);
+    std::vector<count> reachL_scc(N, 0);
+    std::vector<count> reachU_scc(N, 0);
+    std::vector<count> reachU_without_max_scc(N, 0);
+    std::vector<bool> reach_from_max_scc(N, false);
+    std::vector<bool> reaches_max_scc(N, false);
+    std::vector<std::vector<count>> sccs_vec(N, std::vector<count>());
+    Graph sccGraph(N, false, true);
+    std::vector<bool> found(N, false);
+    count maxSizeCC = 0;
 
-  // We compute the vector sccs_vec, where each component contains the list of
-  // its nodes
-  for (count v = 0; v < n; v++) {
-    sccs_vec[sccs.componentOfNode(v) - 1].push_back(v);
-  }
+    // We compute the vector sccs_vec, where each component contains the list of
+    // its nodes
+    for (count v = 0; v < n; v++) {
+        sccs_vec[sccs.componentOfNode(v) - 1].push_back(v);
+    }
 
-  // We compute the SCC graph and store it in sccGraph
-  for (count V = 0; V < N; V++) {
-    for (count v : sccs_vec[V]) {
-      G.forNeighborsOf(v, [&](node w) {
-        count W = sccs.componentOfNode(w) - 1;
+    // We compute the SCC graph and store it in sccGraph
+    for (count V = 0; V < N; V++) {
+        for (count v : sccs_vec[V]) {
+            G.forNeighborsOf(v, [&](node w) {
+                count W = sccs.componentOfNode(w) - 1;
 
-        if (W != V && !found[W]) {
-          found[W] = true;
-          sccGraph.addEdge(V, W);
+                if (W != V && !found[W]) {
+                    found[W] = true;
+                    sccGraph.addEdge(V, W);
+                }
+            });
         }
-      });
-    }
-    sccGraph.forNeighborsOf(V, [&](node W) { found[W] = false; });
-    if (sccGraph.degreeOut(V) > sccGraph.degreeOut(maxSizeCC)) {
-      maxSizeCC = V;
-    }
-  }
-
-  // BFS from the biggest SCC.
-  std::queue<count> Q;
-  Q.push(maxSizeCC);
-  reach_from_max_scc[maxSizeCC] = true;
-  while (!Q.empty()) {
-    count V = Q.front();
-    Q.pop();
-    reachL_scc[maxSizeCC] += sccs_vec[V].size();
-    sccGraph.forNeighborsOf(V, [&](node W) {
-      if (!reach_from_max_scc[W]) {
-        reach_from_max_scc[W] = true;
-        Q.push(W);
-      }
-    });
-  }
-  reachU_scc[maxSizeCC] = reachL_scc[maxSizeCC];
-  reaches_max_scc[maxSizeCC] = true;
-
-  // so far only the largest SCC has reach_U and reach_L > 0
-
-  // Dynamic programming to compute number of reachable vertices
-  for (count V = 0; V < N; V++) {
-    if (V == maxSizeCC) {
-      continue;
-    }
-    sccGraph.forNeighborsOf(V, [&](node W) {
-      reachL_scc[V] = std::max(reachL_scc[V], reachL_scc[W]);
-      if (!reach_from_max_scc[W]) {
-        reachU_without_max_scc[V] += reachU_without_max_scc[W];
-      }
-      reachU_scc[V] += reachU_scc[W];
-      reachU_scc[V] = std::min(reachU_scc[V], n);
-      reaches_max_scc[V] = reaches_max_scc[V] || reaches_max_scc[W];
-    });
-
-    if (reaches_max_scc[V]) {
-      reachU_scc[V] = reachU_without_max_scc[V] + reachU_scc[V];
-    }
-    reachL_scc[V] += sccs_vec[V].size();
-    reachU_scc[V] += sccs_vec[V].size();
-    reachU_scc[V] = std::min(reachU_scc[V], n);
-  }
-
-  for (count v = 0; v < n; v++) {
-    reachL[v] = reachL_scc[sccs.componentOfNode(v) - 1];
-    reachU[v] = reachU_scc[sccs.componentOfNode(v) - 1];
-    if (false) { // MICHELE: used to check if the bounds are correct
-      count r = 0;
-      Traversal::BFSfrom(G, v, [&](node, count) { r++; });
-
-      if (reachL[v] > r || reachU[v] < r) {
-        DEBUG("BIG MISTAKE! ", reachL[v], " ", r, " ", reachU[v]);
-        while (true) {
+        sccGraph.forNeighborsOf(V, [&](node W) { found[W] = false; });
+        if (sccGraph.degreeOut(V) > sccGraph.degreeOut(maxSizeCC)) {
+            maxSizeCC = V;
         }
-      }
     }
-  }
+
+    // BFS from the biggest SCC.
+    std::queue<count> Q;
+    Q.push(maxSizeCC);
+    reach_from_max_scc[maxSizeCC] = true;
+    while (!Q.empty()) {
+        count V = Q.front();
+        Q.pop();
+        reachL_scc[maxSizeCC] += sccs_vec[V].size();
+        sccGraph.forNeighborsOf(V, [&](node W) {
+            if (!reach_from_max_scc[W]) {
+                reach_from_max_scc[W] = true;
+                Q.push(W);
+            }
+        });
+    }
+    reachU_scc[maxSizeCC] = reachL_scc[maxSizeCC];
+    reaches_max_scc[maxSizeCC] = true;
+
+    // so far only the largest SCC has reach_U and reach_L > 0
+
+    // Dynamic programming to compute number of reachable vertices
+    for (count V = 0; V < N; V++) {
+        if (V == maxSizeCC) {
+            continue;
+        }
+        sccGraph.forNeighborsOf(V, [&](node W) {
+            reachL_scc[V] = std::max(reachL_scc[V], reachL_scc[W]);
+            if (!reach_from_max_scc[W]) {
+                reachU_without_max_scc[V] += reachU_without_max_scc[W];
+            }
+            reachU_scc[V] += reachU_scc[W];
+            reachU_scc[V] = std::min(reachU_scc[V], n);
+            reaches_max_scc[V] = reaches_max_scc[V] || reaches_max_scc[W];
+        });
+
+        if (reaches_max_scc[V]) {
+            reachU_scc[V] = reachU_without_max_scc[V] + reachU_scc[V];
+        }
+        reachL_scc[V] += sccs_vec[V].size();
+        reachU_scc[V] += sccs_vec[V].size();
+        reachU_scc[V] = std::min(reachU_scc[V], n);
+    }
+
+    for (count v = 0; v < n; v++) {
+        reachL[v] = reachL_scc[sccs.componentOfNode(v) - 1];
+        reachU[v] = reachU_scc[sccs.componentOfNode(v) - 1];
+        if (false) { // MICHELE: used to check if the bounds are correct
+            count r = 0;
+            Traversal::BFSfrom(G, v, [&](node, count) { r++; });
+
+            if (reachL[v] > r || reachU[v] < r) {
+                DEBUG("BIG MISTAKE! ", reachL[v], " ", r, " ", reachU[v]);
+                while (true) {
+                }
+            }
+        }
+    }
 }
 
 void TopCloseness::computeReachableNodesUndir() {
-  reachL = std::vector<count>(n);
+    reachL = std::vector<count>(n);
 
-  ConnectedComponents comps(G);
-  comps.run();
-  std::map<index, count> sizes = comps.getComponentSizes();
-  G.forNodes([&](node v) {
-    index cv = comps.componentOfNode(v);
-    reachL[v] = sizes[cv];
-  });
-  reachU = reachL;
+    ConnectedComponents comps(G);
+    comps.run();
+    std::map<index, count> sizes = comps.getComponentSizes();
+    G.forNodes([&](node v) {
+        index cv = comps.componentOfNode(v);
+        reachL[v] = sizes[cv];
+    });
+    reachU = reachL;
 }
 
 void TopCloseness::computelBound1(std::vector<double> &S) {
-  std::vector<count> neighbors(n, 0);
-  std::vector<count> N(n, 0);
-  std::vector<count> neighbors_new(n, 0);
-  std::vector<count> neighbors_old(n, 0);
-  std::vector<double> sumDist(n, 0);
-  std::vector<bool> finished(n, false);
+    std::vector<count> neighbors(n, 0);
+    std::vector<count> N(n, 0);
+    std::vector<count> neighbors_new(n, 0);
+    std::vector<count> neighbors_old(n, 0);
+    std::vector<double> sumDist(n, 0);
+    std::vector<bool> finished(n, false);
 
-  count n_finished = 0;
+    count n_finished = 0;
 
-  G.forNodes([&](node u) {
-    S[u] = std::numeric_limits<double>::max();
-    if (G.degreeOut(u) == 0) {
-      finished[u] = true;
-      n_finished++;
-    }
-    neighbors[u] = G.degreeOut(u);
-    sumDist[u] = neighbors[u];
-    N[u] = neighbors[u] +
-           1; // we also count the node itself in the number of visited nodes
-  });
-  count level = 2;
-  DEBUG("computing first lbound");
-
-  while (n_finished < n) {
-    DEBUG("First bound. Finished: ", n_finished, " of ", n, ".");
     G.forNodes([&](node u) {
-      if (!finished[u]) {
-        n_op += G.degreeOut(u);
-        neighbors_new[u] = 0;
-        G.forNeighborsOf(u, [&](node v) { neighbors_new[u] += neighbors[v]; });
-        if (!G.isDirected()) {
-          if (level == 2) {
-            neighbors_new[u] -= G.degreeOut(u);
-          } else {
-            if (neighbors_new[u] < (G.degreeOut(u) - 1) * neighbors_old[u]) {
-              DEBUG("BIG MISTAKE");
-              while (true) {
-              }
-            }
-            neighbors_new[u] -= (G.degreeOut(u) - 1) * neighbors_old[u];
-          }
-        }
-
-        count n_old = N[u];
-        N[u] += neighbors_new[u];
-        sumDist[u] += level * neighbors_new[u];
-
-        if (N[u] >= reachL[u]) {
-          if (n_old < reachL[u]) {
-            // We have to consider the case in which the number of reachable
-            // vertices is reachL.
-            S[u] = (sumDist[u] - level * (N[u] - reachL[u])) * (n - 1) /
-                   (reachL[u] - 1) / (reachL[u] - 1);
-          }
-          if (neighbors_new[u] == 0) {
-            reachU[u] = N[u];
-          }
-          if (N[u] >= reachU[u]) {
-            // We have to consider the case in which the number of reachable
-            // vertices is reachU.
-            S[u] =
-                std::min(S[u], (sumDist[u] - level * (N[u] - reachU[u])) *
-                                   (n - 1) / (reachU[u] - 1) / (reachU[u] - 1));
+        S[u] = std::numeric_limits<double>::max();
+        if (G.degreeOut(u) == 0) {
             finished[u] = true;
             n_finished++;
-
-            if (N[u] < reachL[u] && neighbors_new[u] == 0) {
-              DEBUG("BIG MISTAKE!!!", reachL[u]);
-            }
-
-          } else { // reachL < N < reachU
-            // We have to consider the case in which the number of reachable is
-            // N[u].
-            S[u] =
-                std::min(S[u], sumDist[u] * (n - 1) / (N[u] - 1) / (N[u] - 1));
-          }
         }
-      }
+        neighbors[u] = G.degreeOut(u);
+        sumDist[u] = neighbors[u];
+        N[u] = neighbors[u] + 1; // we also count the node itself in the number of visited nodes
     });
-    G.forNodes([&](node u) {
-      // We update neighbors.
-      neighbors_old[u] = neighbors[u];
-      neighbors[u] = neighbors_new[u];
-    });
-    level++;
-  }
-  DEBUG("Visited edges (first lbound): ", n_op);
+    count level = 2;
+    DEBUG("computing first lbound");
+
+    while (n_finished < n) {
+        DEBUG("First bound. Finished: ", n_finished, " of ", n, ".");
+        G.forNodes([&](node u) {
+            if (!finished[u]) {
+                n_op += G.degreeOut(u);
+                neighbors_new[u] = 0;
+                G.forNeighborsOf(u, [&](node v) { neighbors_new[u] += neighbors[v]; });
+                if (!G.isDirected()) {
+                    if (level == 2) {
+                        neighbors_new[u] -= G.degreeOut(u);
+                    } else {
+                        if (neighbors_new[u] < (G.degreeOut(u) - 1) * neighbors_old[u]) {
+                            DEBUG("BIG MISTAKE");
+                            while (true) {
+                            }
+                        }
+                        neighbors_new[u] -= (G.degreeOut(u) - 1) * neighbors_old[u];
+                    }
+                }
+
+                count n_old = N[u];
+                N[u] += neighbors_new[u];
+                sumDist[u] += level * neighbors_new[u];
+
+                if (N[u] >= reachL[u]) {
+                    if (n_old < reachL[u]) {
+                        // We have to consider the case in which the number of reachable
+                        // vertices is reachL.
+                        S[u] = (sumDist[u] - level * (N[u] - reachL[u])) * (n - 1) / (reachL[u] - 1)
+                               / (reachL[u] - 1);
+                    }
+                    if (neighbors_new[u] == 0) {
+                        reachU[u] = N[u];
+                    }
+                    if (N[u] >= reachU[u]) {
+                        // We have to consider the case in which the number of reachable
+                        // vertices is reachU.
+                        S[u] = std::min(S[u], (sumDist[u] - level * (N[u] - reachU[u])) * (n - 1)
+                                                  / (reachU[u] - 1) / (reachU[u] - 1));
+                        finished[u] = true;
+                        n_finished++;
+
+                        if (N[u] < reachL[u] && neighbors_new[u] == 0) {
+                            DEBUG("BIG MISTAKE!!!", reachL[u]);
+                        }
+
+                    } else { // reachL < N < reachU
+                        // We have to consider the case in which the number of reachable is
+                        // N[u].
+                        S[u] = std::min(S[u], sumDist[u] * (n - 1) / (N[u] - 1) / (N[u] - 1));
+                    }
+                }
+            }
+        });
+        G.forNodes([&](node u) {
+            // We update neighbors.
+            neighbors_old[u] = neighbors[u];
+            neighbors[u] = neighbors_new[u];
+        });
+        level++;
+    }
+    DEBUG("Visited edges (first lbound): ", n_op);
 }
 
 void TopCloseness::BFSbound(node x, std::vector<double> &S2, count &visEdges,
                             const std::vector<bool> &toAnalyze) {
-  auto &sccs = *(sccsPtr.get());
-  count r = 0;
-  std::vector<std::vector<node>> levels(n);
-  // nodesPerLev[i] contains the number of nodes in level i
-  std::vector<count> &nodesPerLev = nodesPerLevs[omp_get_thread_num()];
-  std::fill(nodesPerLev.begin(), nodesPerLev.end(), 0);
-  // sumLevs[i] contains the sum of the nodes in levels j <= i
-  std::vector<count> &sumLevs = sumLevels[omp_get_thread_num()];
-  std::fill(sumLevs.begin(), sumLevs.end(), 0);
-  count nLevs = 0;
-  double sum_dist = 0;
-  Traversal::BFSfrom(G, x, [&](node u, count dist) {
-    sum_dist += dist;
-    r++;
-    if (dist > nLevs) {
-      sumLevs[nLevs] += nodesPerLev[nLevs];
-      sumLevs[nLevs + 1] = sumLevs[nLevs];
-      nLevs++;
-      levels[nLevs].clear();
-    }
-    levels[nLevs].push_back(u);
-    nodesPerLev[nLevs]++;
-  });
-  sumLevs[nLevs] += nodesPerLev[nLevs];
-  if (G.isDirected()) {
-    visEdges += G.numberOfEdges();
-  } else {
-    visEdges += 2 * G.numberOfEdges();
-  }
-  S2[x] = sum_dist * (n - 1.0) / (r - 1.0) / (r - 1.0);
-  // we compute the bound for the first level
-  count closeNodes = 0, farNodes = 0;
-  for (count j = 0; j <= nLevs; j++) {
-    if (std::abs(static_cast<long long>(j) - 1LL) <= 1) {
-      closeNodes += nodesPerLev[j];
+    auto &sccs = *(sccsPtr.get());
+    count r = 0;
+    std::vector<std::vector<node>> levels(n);
+    // nodesPerLev[i] contains the number of nodes in level i
+    std::vector<count> &nodesPerLev = nodesPerLevs[omp_get_thread_num()];
+    std::fill(nodesPerLev.begin(), nodesPerLev.end(), 0);
+    // sumLevs[i] contains the sum of the nodes in levels j <= i
+    std::vector<count> &sumLevs = sumLevels[omp_get_thread_num()];
+    std::fill(sumLevs.begin(), sumLevs.end(), 0);
+    count nLevs = 0;
+    double sum_dist = 0;
+    Traversal::BFSfrom(G, x, [&](node u, count dist) {
+        sum_dist += dist;
+        r++;
+        if (dist > nLevs) {
+            sumLevs[nLevs] += nodesPerLev[nLevs];
+            sumLevs[nLevs + 1] = sumLevs[nLevs];
+            nLevs++;
+            levels[nLevs].clear();
+        }
+        levels[nLevs].push_back(u);
+        nodesPerLev[nLevs]++;
+    });
+    sumLevs[nLevs] += nodesPerLev[nLevs];
+    if (G.isDirected()) {
+        visEdges += G.numberOfEdges();
     } else {
-      farNodes += nodesPerLev[j] * std::abs(1LL - static_cast<long long>(j));
+        visEdges += 2 * G.numberOfEdges();
     }
-  }
+    S2[x] = sum_dist * (n - 1.0) / (r - 1.0) / (r - 1.0);
+    // we compute the bound for the first level
+    count closeNodes = 0, farNodes = 0;
+    for (count j = 0; j <= nLevs; j++) {
+        if (std::abs(static_cast<long long>(j) - 1LL) <= 1) {
+            closeNodes += nodesPerLev[j];
+        } else {
+            farNodes += nodesPerLev[j] * std::abs(1LL - static_cast<long long>(j));
+        }
+    }
 
-  edgeweight level_bound = 2.0 * closeNodes + static_cast<double>(farNodes);
-  for (count j = 0; j < levels[1].size(); j++) {
-    node w = levels[1][j];
-    // we subtract 2 not to count the node itself
-    double bound = (level_bound - 2 - G.degree(w)) * (n - 1.0) /
-                   (reachU[w] - 1.0) / (reachU[w] - 1.0);
-    if (toAnalyze[w] && bound > S2[w] &&
-        (!G.isDirected() || sccs.componentOfNode(w) == sccs.componentOfNode(x))) {
-      S2[w] = bound;
+    edgeweight level_bound = 2.0 * closeNodes + static_cast<double>(farNodes);
+    for (count j = 0; j < levels[1].size(); j++) {
+        node w = levels[1][j];
+        // we subtract 2 not to count the node itself
+        double bound =
+            (level_bound - 2 - G.degree(w)) * (n - 1.0) / (reachU[w] - 1.0) / (reachU[w] - 1.0);
+        if (toAnalyze[w] && bound > S2[w]
+            && (!G.isDirected() || sccs.componentOfNode(w) == sccs.componentOfNode(x))) {
+            S2[w] = bound;
+        }
     }
-  }
-  // DEBUG("level_bound = ", level_bound);
-  // now we compute it for the other levels
-  for (omp_index i = 2; i <= static_cast<omp_index>(nLevs); i++) {
-    if (!G.isDirected() && i > 2) {
-      level_bound += sumLevs[i - 3];
+    // DEBUG("level_bound = ", level_bound);
+    // now we compute it for the other levels
+    for (omp_index i = 2; i <= static_cast<omp_index>(nLevs); i++) {
+        if (!G.isDirected() && i > 2) {
+            level_bound += sumLevs[i - 3];
+        }
+        if (i < nLevs) {
+            level_bound -= (sumLevs[nLevs] - sumLevs[i + 1]);
+        }
+        for (count j = 0; j < levels[i].size(); j++) {
+            node w = levels[i][j];
+            double bound =
+                (level_bound - 2 - G.degree(w)) * (n - 1.0) / (reachU[w] - 1.0) / (reachU[w] - 1.0);
+            if (toAnalyze[w] && bound > S2[w]
+                && (!G.isDirected() || sccs.componentOfNode(w) == sccs.componentOfNode(x))) {
+                // TODO MICHELE: as before.
+                S2[w] = bound;
+            }
+        }
     }
-    if (i < nLevs) {
-      level_bound -= (sumLevs[nLevs] - sumLevs[i + 1]);
-    }
-    for (count j = 0; j < levels[i].size(); j++) {
-      node w = levels[i][j];
-      double bound = (level_bound - 2 - G.degree(w)) * (n - 1.0) /
-                     (reachU[w] - 1.0) / (reachU[w] - 1.0);
-      if (toAnalyze[w] && bound > S2[w] &&
-          (!G.isDirected() || sccs.componentOfNode(w) == sccs.componentOfNode(x))) {
-        // TODO MICHELE: as before.
-        S2[w] = bound;
-      }
-    }
-  }
 }
 
-double TopCloseness::BFScut(node v, double x, std::vector<bool> &visited, std::vector<count> &distances,
-                            std::vector<node> &pred, count &visEdges) {
-  count d = 0, f = 0, nd = 1;
-  double rL = reachL[v], rU = reachU[v];
-  std::queue<node> Q1;
-  std::queue<node> to_reset;
-  count sum_dist = 0;
-  double ftildeL = 0, ftildeU = 0, gamma = G.degreeOut(v);
-  double farnessV = 0;
+double TopCloseness::BFScut(node v, double x, std::vector<bool> &visited,
+                            std::vector<count> &distances, std::vector<node> &pred,
+                            count &visEdges) {
+    count d = 0, f = 0, nd = 1;
+    double rL = reachL[v], rU = reachU[v];
+    std::queue<node> Q1;
+    std::queue<node> to_reset;
+    count sum_dist = 0;
+    double ftildeL = 0, ftildeU = 0, gamma = G.degreeOut(v);
+    double farnessV = 0;
 
-  // MICHELE: variable visited is not local, otherwise the allocation would be
-  // too expensive.
-  visited[v] = true;
-  distances[v] = 0;
-  Q1.push(v);
-  to_reset.push(v);
+    // MICHELE: variable visited is not local, otherwise the allocation would be
+    // too expensive.
+    visited[v] = true;
+    distances[v] = 0;
+    Q1.push(v);
+    to_reset.push(v);
 
-  while (!Q1.empty()) {
-    node u = Q1.front();
-    Q1.pop();
+    while (!Q1.empty()) {
+        node u = Q1.front();
+        Q1.pop();
 
-    sum_dist += distances[u];
-    if (distances[u] > d) { // Need to update bounds!
-      d++;
-      ftildeL =
-          (f + (d + 2) * (rL - nd) - gamma) * (n - 1) / (rL - 1.0) / (rL - 1.0);
-      ftildeU =
-          (f + (d + 2) * (rU - nd) - gamma) * (n - 1) / (rU - 1.0) / (rU - 1.0);
-      if (std::min(ftildeL, ftildeU) >= x) {
-        farnessV = std::min(ftildeL, ftildeU);
-        break;
-      }
-      gamma = 0;
-    }
-    bool cont = true;
-    G.forNeighborsOf(u, [&](node w) {
-      if (cont) {
-        ++visEdges;
-        if (!visited[w]) {
-          distances[w] = distances[u] + 1;
-          Q1.push(w);
-          to_reset.push(w);
-          visited[w] = true;
-          f += distances[w];
-          if (!G.isDirected())
-            gamma += (G.degree(w) - 1); // notice: only because it's undirected
-          else
-            gamma += G.degreeOut(w);
-          nd++;
-          pred[w] = u;
-        } else {
-          if (G.isDirected() || pred[u] != w) {
-            ftildeL += (n - 1) / (rL - 1.0) / (rL - 1.0);
-            ftildeU += (n - 1) / (rU - 1.0) / (rU - 1.0);
-            if (std::min(ftildeL, ftildeU) > x) {
-              cont = false;
+        sum_dist += distances[u];
+        if (distances[u] > d) { // Need to update bounds!
+            d++;
+            ftildeL = (f + (d + 2) * (rL - nd) - gamma) * (n - 1) / (rL - 1.0) / (rL - 1.0);
+            ftildeU = (f + (d + 2) * (rU - nd) - gamma) * (n - 1) / (rU - 1.0) / (rU - 1.0);
+            if (std::min(ftildeL, ftildeU) >= x) {
+                farnessV = std::min(ftildeL, ftildeU);
+                break;
             }
-          }
+            gamma = 0;
         }
-      }
-    });
-    if (std::min(ftildeL, ftildeU) > x) {
-      farnessV = std::min(ftildeL, ftildeU);
-      break;
+        bool cont = true;
+        G.forNeighborsOf(u, [&](node w) {
+            if (cont) {
+                ++visEdges;
+                if (!visited[w]) {
+                    distances[w] = distances[u] + 1;
+                    Q1.push(w);
+                    to_reset.push(w);
+                    visited[w] = true;
+                    f += distances[w];
+                    if (!G.isDirected())
+                        gamma += (G.degree(w) - 1); // notice: only because it's undirected
+                    else
+                        gamma += G.degreeOut(w);
+                    nd++;
+                    pred[w] = u;
+                } else {
+                    if (G.isDirected() || pred[u] != w) {
+                        ftildeL += (n - 1) / (rL - 1.0) / (rL - 1.0);
+                        ftildeU += (n - 1) / (rU - 1.0) / (rU - 1.0);
+                        if (std::min(ftildeL, ftildeU) > x) {
+                            cont = false;
+                        }
+                    }
+                }
+            }
+        });
+        if (std::min(ftildeL, ftildeU) > x) {
+            farnessV = std::min(ftildeL, ftildeU);
+            break;
+        }
     }
-  }
-  while (!to_reset.empty()) { // MICHELE: need to reset variable visited.
-                              // Variables pred and distances
-    // do not need to be updated.
-    node u = to_reset.front();
-    to_reset.pop();
-    visited[u] = false;
-  }
-  if (farnessV < x) {
-    farnessV = sum_dist * (n - 1) / (nd - 1.0) / (nd - 1.0);
-  }
-  return farnessV;
+    while (!to_reset.empty()) { // MICHELE: need to reset variable visited.
+                                // Variables pred and distances
+        // do not need to be updated.
+        node u = to_reset.front();
+        to_reset.pop();
+        visited[u] = false;
+    }
+    if (farnessV < x) {
+        farnessV = sum_dist * (n - 1) / (nd - 1.0) / (nd - 1.0);
+    }
+    return farnessV;
 }
 
 void TopCloseness::run() {
-  init();
-  tlx::d_ary_heap<node, 2, LargerFarness> top{farness};
-  top.reserve(k);
-  std::vector<bool> toAnalyze(n, true);
-  omp_lock_t lock;
-  omp_init_lock(&lock);
+    init();
+    tlx::d_ary_heap<node, 2, LargerFarness> top{farness};
+    top.reserve(k);
+    std::vector<bool> toAnalyze(n, true);
+    omp_lock_t lock;
+    omp_init_lock(&lock);
 
-  std::vector<double> S(n);
-  // first lower bound on s
-  if (first_heu) {
-    DEBUG("Computing Neighborhood-based lower bound");
-    computelBound1(S);
-  }
-
-  DEBUG("Initializing queue");
-  G.forNodes([&](node u) {
-    if (G.degreeOut(u) == 0) {
-      farness[u] = std::numeric_limits<double>::max();
-    } else if (first_heu) {
-      farness[u] = S[u];
-    } else {
-      farness[u] = -(static_cast<double>(G.degreeOut(u)));
-    }
-  });
-  tlx::d_ary_addressable_int_heap<node, 2, SmallerFarness> Q{farness};
-  auto nodes = G.nodes();
-  Q.build_heap(std::move(nodes));
-  DEBUG("Done filling the queue");
-
-  std::vector<std::vector<bool>> visitedVec;
-  std::vector<std::vector<count>> distVec;
-  std::vector<std::vector<node>> predVec;
-
-  if (!sec_heu) {
-      visitedVec.resize(omp_get_max_threads(), std::vector<bool>(n));
-      distVec.resize(omp_get_max_threads(), std::vector<count>(n));
-      predVec.resize(omp_get_max_threads(), std::vector<node>(n));
-  }
-
-  double kth = std::numeric_limits<double>::max(); // like in Crescenzi
-#pragma omp parallel                               // Shared variables:
-  // cc: synchronized write, read leads to a positive race condition;
-  // Q: fully synchronized;
-  // top: fully synchronized;
-  // toAnalyze: fully synchronized;
-  // visEdges: one variable for each thread, summed at the end;
-  {
-    count visEdges = 0;
-#ifndef NETWORKIT_RELEASE_LOGGING
-    count iters = 0;
-#endif
-    double farnessS;
-
-    if (omp_get_thread_num() == 0) {
-      DEBUG("Number of threads: ", omp_get_num_threads());
+    std::vector<double> S(n);
+    // first lower bound on s
+    if (first_heu) {
+        DEBUG("Computing Neighborhood-based lower bound");
+        computelBound1(S);
     }
 
-    while (!Q.empty()) {
-      DEBUG("To be analyzed: ", Q.size());
-      omp_set_lock(&lock);
-      if (Q.empty()) { // The size of Q might have changed.
-        omp_unset_lock(&lock);
-        break;
-      }
-      // Access to Q must be synchronized
-      node s = Q.extract_top();
-      toAnalyze[s] = false;
-      omp_unset_lock(&lock);
-
-      if (G.degreeOut(s) == 0 || farness[s] > kth) {
-        break;
-      }
-      DEBUG("Iteration ", ++iters, " of thread ", omp_get_thread_num());
-
-      DEBUG("    Extracted node ", s, " with priority ", farness[s], ".");
-      if (G.degreeOut(s) == 0) {
-
-        omp_set_lock(&lock);
-        toAnalyze[s] = false;
-        farness[s] = std::numeric_limits<double>::max();
-        omp_unset_lock(&lock);
-
-      } else if (sec_heu) {
-        // MICHELE: we use BFSbound to bound the centrality of all nodes.
-        DEBUG("    Running BFSbound.");
-        BFSbound(s, S, visEdges, toAnalyze);
-        omp_set_lock(&lock);
-        farness[s] = S[s];
-        omp_unset_lock(&lock);
-        count imp = 0;
-        for (count v = 0; v < n; v++) {
-          if (farness[v] < S[v] &&
-              toAnalyze[v]) { // This part must be syncrhonized.
-            omp_set_lock(&lock);
-            if (farness[v] < S[v] &&
-                toAnalyze[v]) { // Have to check again, because the variables
-                                // might have changed
-              imp++;
-              farness[v] = S[v];
-              Q.update(v);
-            }
-            omp_unset_lock(&lock);
-          }
+    DEBUG("Initializing queue");
+    G.forNodes([&](node u) {
+        if (G.degreeOut(u) == 0) {
+            farness[u] = std::numeric_limits<double>::max();
+        } else if (first_heu) {
+            farness[u] = S[u];
+        } else {
+            farness[u] = -(static_cast<double>(G.degreeOut(u)));
         }
-        DEBUG("    We have improved ", imp, " bounds.");
-      } else {
-        // MICHELE: we use BFScut to bound the centrality of s.
-        DEBUG("    Running BFScut with x=", kth, " (degree:", G.degreeOut(s),
-              ").");
-        auto &visited = visitedVec[omp_get_thread_num()];
-        std::fill(visited.begin(), visited.end(), false);
-        auto &distances = distVec[omp_get_thread_num()];
-        auto &pred = predVec[omp_get_thread_num()];
-        farnessS = BFScut(s, kth, visited, distances, pred, visEdges);
-        DEBUG("    Visited edges: ", visEdges, ".");
-        omp_set_lock(&lock);
-        farness[s] = farnessS;
-        omp_unset_lock(&lock);
-      }
+    });
+    tlx::d_ary_addressable_int_heap<node, 2, SmallerFarness> Q{farness};
+    auto nodes = G.nodes();
+    Q.build_heap(std::move(nodes));
+    DEBUG("Done filling the queue");
 
-      // If necessary, we update kth.
-      omp_set_lock(&lock);
-      if (farness[s] <= kth) {
-        DEBUG("    The closeness of s is ", 1.0 / farness[s], ".");
-        top.push(s);
-        if (top.size() > k) {
-          ++trail;
-          if (farness[s] < kth) {
-            if (nMaxFarness == trail) {
-              // Purging trail
-              do {
-                top.extract_top();
-              } while (top.size() > k);
+    std::vector<std::vector<bool>> visitedVec;
+    std::vector<std::vector<count>> distVec;
+    std::vector<std::vector<node>> predVec;
 
-              trail = 0;
-              nMaxFarness = 1;
-              if (k > 1) {
-                node last = top.extract_top();
-                maxFarness = farness[last];
-                std::stack<node> tmp;
-                tmp.push(last);
+    if (!sec_heu) {
+        visitedVec.resize(omp_get_max_threads(), std::vector<bool>(n));
+        distVec.resize(omp_get_max_threads(), std::vector<count>(n));
+        predVec.resize(omp_get_max_threads(), std::vector<node>(n));
+    }
 
-                while (!top.empty() && farness[last] == farness[top.top()]) {
-                    tmp.push(top.extract_top());
+    double kth = std::numeric_limits<double>::max(); // like in Crescenzi
+#pragma omp parallel                                 // Shared variables:
+    // cc: synchronized write, read leads to a positive race condition;
+    // Q: fully synchronized;
+    // top: fully synchronized;
+    // toAnalyze: fully synchronized;
+    // visEdges: one variable for each thread, summed at the end;
+    {
+        count visEdges = 0;
+#ifndef NETWORKIT_RELEASE_LOGGING
+        count iters = 0;
+#endif
+        double farnessS;
+
+        if (omp_get_thread_num() == 0) {
+            DEBUG("Number of threads: ", omp_get_num_threads());
+        }
+
+        while (!Q.empty()) {
+            DEBUG("To be analyzed: ", Q.size());
+            omp_set_lock(&lock);
+            if (Q.empty()) { // The size of Q might have changed.
+                omp_unset_lock(&lock);
+                break;
+            }
+            // Access to Q must be synchronized
+            node s = Q.extract_top();
+            toAnalyze[s] = false;
+            omp_unset_lock(&lock);
+
+            if (G.degreeOut(s) == 0 || farness[s] > kth) {
+                break;
+            }
+            DEBUG("Iteration ", ++iters, " of thread ", omp_get_thread_num());
+
+            DEBUG("    Extracted node ", s, " with priority ", farness[s], ".");
+            if (G.degreeOut(s) == 0) {
+
+                omp_set_lock(&lock);
+                toAnalyze[s] = false;
+                farness[s] = std::numeric_limits<double>::max();
+                omp_unset_lock(&lock);
+
+            } else if (sec_heu) {
+                // MICHELE: we use BFSbound to bound the centrality of all nodes.
+                DEBUG("    Running BFSbound.");
+                BFSbound(s, S, visEdges, toAnalyze);
+                omp_set_lock(&lock);
+                farness[s] = S[s];
+                omp_unset_lock(&lock);
+                count imp = 0;
+                for (count v = 0; v < n; v++) {
+                    if (farness[v] < S[v] && toAnalyze[v]) { // This part must be syncrhonized.
+                        omp_set_lock(&lock);
+                        if (farness[v] < S[v] && toAnalyze[v]) { // Have to check again, because the
+                                                                 // variables might have changed
+                            imp++;
+                            farness[v] = S[v];
+                            Q.update(v);
+                        }
+                        omp_unset_lock(&lock);
+                    }
+                }
+                DEBUG("    We have improved ", imp, " bounds.");
+            } else {
+                // MICHELE: we use BFScut to bound the centrality of s.
+                DEBUG("    Running BFScut with x=", kth, " (degree:", G.degreeOut(s), ").");
+                auto &visited = visitedVec[omp_get_thread_num()];
+                std::fill(visited.begin(), visited.end(), false);
+                auto &distances = distVec[omp_get_thread_num()];
+                auto &pred = predVec[omp_get_thread_num()];
+                farnessS = BFScut(s, kth, visited, distances, pred, visEdges);
+                DEBUG("    Visited edges: ", visEdges, ".");
+                omp_set_lock(&lock);
+                farness[s] = farnessS;
+                omp_unset_lock(&lock);
+            }
+
+            // If necessary, we update kth.
+            omp_set_lock(&lock);
+            if (farness[s] <= kth) {
+                DEBUG("    The closeness of s is ", 1.0 / farness[s], ".");
+                top.push(s);
+                if (top.size() > k) {
+                    ++trail;
+                    if (farness[s] < kth) {
+                        if (nMaxFarness == trail) {
+                            // Purging trail
+                            do {
+                                top.extract_top();
+                            } while (top.size() > k);
+
+                            trail = 0;
+                            nMaxFarness = 1;
+                            if (k > 1) {
+                                node last = top.extract_top();
+                                maxFarness = farness[last];
+                                std::stack<node> tmp;
+                                tmp.push(last);
+
+                                while (!top.empty() && farness[last] == farness[top.top()]) {
+                                    tmp.push(top.extract_top());
+                                    ++nMaxFarness;
+                                }
+
+                                while (!tmp.empty()) {
+                                    top.push(tmp.top());
+                                    tmp.pop();
+                                }
+                            }
+                        }
+                    } else { // Same farness as kth
+                        ++nMaxFarness;
+                    }
+                } else if (farness[s] > maxFarness) {
+                    maxFarness = farness[s];
+                    nMaxFarness = 1;
+                } else if (farness[s] == maxFarness) {
                     ++nMaxFarness;
                 }
-
-                while (!tmp.empty()) {
-                    top.push(tmp.top());
-                    tmp.pop();
-                }
-              }
+            } else {
+                DEBUG("    Not in the top-k.");
             }
-          } else { // Same farness as kth
-            ++nMaxFarness;
-          }
-        } else if (farness[s] > maxFarness) {
-          maxFarness = farness[s];
-          nMaxFarness = 1;
-        } else if (farness[s] == maxFarness) {
-          ++nMaxFarness;
+
+            // We load the new value of kth.
+            if (top.size() >= k) {
+                kth = farness[top.top()];
+                if (nMaxFarness == 1) {
+                    maxFarness = kth;
+                }
+            }
+            omp_unset_lock(&lock);
         }
-      } else {
-        DEBUG("    Not in the top-k.");
-      }
+        DEBUG("Number of iterations of thread ", omp_get_thread_num(), ": ", iters, " out of ", n);
+        omp_set_lock(&lock);
+        this->visEdges += visEdges;
+        omp_unset_lock(&lock);
+    }
 
-      // We load the new value of kth.
-      if (top.size() >= k) {
-        kth = farness[top.top()];
-        if (nMaxFarness == 1) {
-          maxFarness = kth;
+    if (trail) {
+        topk.resize(k + trail);
+        topkScores.resize(k + trail);
+    }
+
+    for (count i = top.size(); i; --i) {
+        node elem = top.extract_top();
+        topk[i - 1] = elem;
+        topkScores[i - 1] = 1.0 / farness[elem];
+    }
+    for (count j = 0; j < k + trail; j++) {
+        DEBUG(j + 1, "-th node with max closeness: ", topk[j], ", its closeness: ", topkScores[j]);
+    }
+
+    // Ascending order of nodes ids with same closeness
+    for (count i = 0; i < topk.size() - 1; ++i) {
+        count toSort = 1;
+        while ((i + toSort) < topk.size() && topkScores[i] == topkScores[i + toSort]) {
+            ++toSort;
         }
-      }
-      omp_unset_lock(&lock);
+        if (toSort > 1) {
+            auto begin = topk.begin() + i;
+            std::sort(begin, begin + toSort);
+            i += toSort - 1;
+        }
     }
-    DEBUG("Number of iterations of thread ", omp_get_thread_num(), ": ", iters,
-          " out of ", n);
-    omp_set_lock(&lock);
-    this->visEdges += visEdges;
-    omp_unset_lock(&lock);
-  }
 
-  if (trail) {
-    topk.resize(k + trail);
-    topkScores.resize(k + trail);
-  }
-
-  for (count i = top.size(); i; --i) {
-    node elem = top.extract_top();
-    topk[i - 1] = elem;
-    topkScores[i - 1] = 1.0 / farness[elem];
-  }
-  for (count j = 0; j < k + trail; j++) {
-    DEBUG(j + 1, "-th node with max closeness: ", topk[j],
-          ", its closeness: ", topkScores[j]);
-  }
-
-  // Ascending order of nodes ids with same closeness
-  for (count i = 0; i < topk.size() - 1; ++i) {
-    count toSort = 1;
-    while ((i + toSort) < topk.size() &&
-           topkScores[i] == topkScores[i + toSort]) {
-      ++toSort;
-    }
-    if (toSort > 1) {
-      auto begin = topk.begin() + i;
-      std::sort(begin, begin + toSort);
-      i += toSort - 1;
-    }
-  }
-
-  hasRun = true;
+    hasRun = true;
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -545,36 +545,27 @@ void TopCloseness::run() {
           ++trail;
           if (farness[s] < kth) {
             if (nMaxFarness == trail) {
-              // Purging trial
-              while (top.size() > k) {
+              // Purging trail
+              do {
                 top.extract_top();
-              }
+              } while (top.size() > k);
+
               trail = 0;
               nMaxFarness = 1;
               if (k > 1) {
-                  std::stack<node> tmp;
                 node last = top.extract_top();
-                node next = top.extract_top();
                 maxFarness = farness[last];
+                std::stack<node> tmp;
+                tmp.push(last);
 
-                if (farness[last] == farness[next]) {
-                  tmp.push(last);
-                  while (farness[last] == farness[next] && !top.empty()) {
-                    tmp.push(next);
+                while (!top.empty() && farness[last] == farness[top.top()]) {
+                    tmp.push(top.extract_top());
                     ++nMaxFarness;
-                    next = top.extract_top();
-                  }
-                  if (farness[next] != farness[last]) {
-                    top.push(next);
-                  }
+                }
 
-                  while (!tmp.empty()) {
+                while (!tmp.empty()) {
                     top.push(tmp.top());
                     tmp.pop();
-                  }
-                } else {
-                  top.push(next);
-                  top.push(last);
                 }
               }
             }

--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -437,7 +437,10 @@ void TopCloseness::run() {
         }
     });
     tlx::d_ary_addressable_int_heap<node, 2, SmallerFarness> Q{farness};
-    auto nodes = G.nodes();
+
+    std::vector<node> nodes;
+    nodes.reserve(G.numberOfNodes());
+    G.forNodes([&](const node u) { nodes.emplace_back(u); });
     Q.build_heap(std::move(nodes));
     DEBUG("Done filling the queue");
 

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -46,6 +46,47 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(CL.ranking(), CLL.ranking())
 
 
+	def test_centrality_TopCloseness(self):
+		CC = centrality.Closeness(self.L, True, centrality.ClosenessVariant.Generalized)
+		CC.run()
+		k = 5
+		TC1 = centrality.TopCloseness(self.L, k, True, True)
+		TC1.run()
+		TC2 = centrality.TopCloseness(self.L, k, True, False)
+		TC2.run()
+		TC3 = centrality.TopCloseness(self.L, k, False, True)
+		TC3.run()
+		TC4 = centrality.TopCloseness(self.L, k, False, False)
+		TC4.run()
+
+		# Test if top nodes and scores lists have the same length
+		def test_topk_lists(with_trail):
+			if not with_trail:
+				self.assertEqual(len(TC1.topkNodesList()), k)
+				self.assertEqual(len(TC2.topkNodesList()), k)
+				self.assertEqual(len(TC3.topkNodesList()), k)
+				self.assertEqual(len(TC4.topkNodesList()), k)
+			self.assertEqual(len(TC1.topkNodesList(with_trail)), len(TC1.topkScoresList(with_trail)))
+			self.assertEqual(len(TC2.topkNodesList(with_trail)), len(TC2.topkScoresList(with_trail)))
+			self.assertEqual(len(TC3.topkNodesList(with_trail)), len(TC3.topkScoresList(with_trail)))
+			self.assertEqual(len(TC4.topkNodesList(with_trail)), len(TC4.topkScoresList(with_trail)))
+
+		# Test if the ranking is correct
+		def test_topk_ranking(with_trail):
+			def zip_ranking(nodes, scores):
+				return [(node, score) for node, score in zip(nodes, scores)]
+			length = len(TC1.topkNodesList(with_trail))
+			self.assertEqual(CC.ranking()[:length], zip_ranking(TC1.topkNodesList(), TC1.topkScoresList()))
+			self.assertEqual(CC.ranking()[:length], zip_ranking(TC2.topkNodesList(), TC2.topkScoresList()))
+			self.assertEqual(CC.ranking()[:length], zip_ranking(TC3.topkNodesList(), TC3.topkScoresList()))
+			self.assertEqual(CC.ranking()[:length], zip_ranking(TC4.topkNodesList(), TC4.topkScoresList()))
+
+		test_topk_lists(False)
+		test_topk_lists(True)
+		test_topk_ranking(False)
+		test_topk_ranking(True)
+
+
 	def test_centrality_CoreDecomposition(self):
 		CL = centrality.CoreDecomposition(self.L)
 		CL.run()


### PR DESCRIPTION
This brings some improvements to `TopCloseness`:

- Instead of `Aux::PrioQueue`s (i.e., rb-trees), now it uses heaps.
- Update tlx to use `build_heap`: this allows to build `Q` in `O(n)` instead of `O(n*logn)`
- When `sec_heu` is set to `false`, the algorithm does not allocate `O(n)` memory at every iteration, but pre-allocates it beforehand.
- Uses a `unique_ptr<StronglyConnectedComponents>`  to avoid copying the `components` vector. This saves `O(n)` memory.
- Tracking of "trailing" nodes is simpler and more efficient.
- Simpler GTests.