### PR TITLE
Add support for weights in the NetworkitBinaryGraph format. 

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1004,7 +1004,7 @@ class Graph final {
     * @param v Endpoint of edge.
     * @param weight Optional edge weight.
     */
-    void addPartialEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
+    void addPartialEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight, uint64_t index = 0);
 
     /**
      * Insert an in edge between the nodes @a u and @a v in a directed graph. If the graph is
@@ -1015,7 +1015,7 @@ class Graph final {
      * @param v Endpoint of edge.
      * @param weight Optional edge weight.
      */
-	void addPartialInEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
+	void addPartialInEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight, uint64_t index = 0);
 
     /**
      * Insert an out edge between the nodes @a u and @a v in a directed graph. If the graph is
@@ -1026,7 +1026,7 @@ class Graph final {
      * @param v Endpoint of edge.
      * @param weight Optional edge weight.
      */
-	void addPartialOutEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
+	void addPartialOutEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight, uint64_t index = 0);
 
 
     /**

--- a/include/networkit/io/NetworkitBinaryGraph.hpp
+++ b/include/networkit/io/NetworkitBinaryGraph.hpp
@@ -16,11 +16,11 @@ struct Header {
 };
 
 enum WEIGHT_FORMAT {
-	none = 0,
-	unsignedFormat = 1,
-	signedFormat = 2,
-	doubleFormat = 3,
-	floatFormat = 4
+	NONE = 0,
+	VARINT = 1,
+	SIGNED_VARINT = 2,
+	DOUBLE = 3,
+	FLOAT = 4
 };
 
 static constexpr uint8_t DELETED_BIT = 0x1; // bit 0

--- a/include/networkit/io/NetworkitBinaryGraph.hpp
+++ b/include/networkit/io/NetworkitBinaryGraph.hpp
@@ -1,5 +1,5 @@
-#ifndef NETWORKIT_BINARY_GRAPH_
-#define NETWORKIT_BINARY_GRAPH_
+#ifndef NETWORKIT_BINARY_GRAPH_HPP
+#define NETWORKIT_BINARY_GRAPH_HPP
 
 namespace nkbg {
 struct Header {
@@ -11,19 +11,21 @@ struct Header {
 	uint64_t offsetBaseData;
 	uint64_t offsetAdjLists;
 	uint64_t offsetAdjTranspose;
-	uint64_t offsetWeights;
+	uint64_t offsetWeightLists;
+	uint64_t offsetWeightTranspose;
 };
 
 enum WEIGHT_FORMAT {
-	VARINT = 0,
-	SIGNED_VARINT = 1,
-	DOUBLE = 2,
-	FLOAT = 3
+	none = 0,
+	unsignedFormat = 1,
+	signedFormat = 2,
+	doubleFormat = 3,
+	floatFormat = 4
 };
 
 static constexpr uint8_t DELETED_BIT = 0x1; // bit 0
 static constexpr uint64_t DIR_MASK = 0x1; // bit 0
-static constexpr uint64_t WGHT_MASK = 0x6; //bit 1-2
+static constexpr uint64_t WGHT_MASK = 0xE; //bit 1-3
 static constexpr uint64_t WGHT_SHIFT = 0x1;
 
 }

--- a/include/networkit/io/NetworkitBinaryWriter.hpp
+++ b/include/networkit/io/NetworkitBinaryWriter.hpp
@@ -9,7 +9,6 @@
 
 #include <networkit/graph/Graph.hpp>
 #include <networkit/io/GraphWriter.hpp>
-#include <networkit/io/NetworkitBinaryGraph.hpp>
 
 namespace NetworKit {
 
@@ -30,7 +29,6 @@ enum class NetworkitBinaryWeights {
 class NetworkitBinaryWriter : public GraphWriter {
 
 public:
-
 	NetworkitBinaryWriter(uint64_t chunks = 32, NetworkitBinaryWeights weightsType = NetworkitBinaryWeights::autoDetect);
 
 	void write(const Graph& G, const std::string& path) override;

--- a/include/networkit/io/NetworkitBinaryWriter.hpp
+++ b/include/networkit/io/NetworkitBinaryWriter.hpp
@@ -9,6 +9,7 @@
 
 #include <networkit/graph/Graph.hpp>
 #include <networkit/io/GraphWriter.hpp>
+#include <networkit/io/NetworkitBinaryGraph.hpp>
 
 namespace NetworKit {
 
@@ -17,11 +18,20 @@ namespace NetworKit {
  *
  * Writes a graph in the custom Networkit format documented in cpp/io/NetworkitGraph.md
  */
+enum class NetworkitBinaryWeights {
+	none,
+	unsignedFormat,
+	signedFormat,
+	doubleFormat,
+	floatFormat,
+	autoDetect
+};
 
 class NetworkitBinaryWriter : public GraphWriter {
 
 public:
-	NetworkitBinaryWriter(uint64_t chunks = 32);
+
+	NetworkitBinaryWriter(uint64_t chunks = 32, NetworkitBinaryWeights weightsType = NetworkitBinaryWeights::autoDetect);
 
 	void write(const Graph& G, const std::string& path) override;
 
@@ -32,6 +42,7 @@ private:
 
 	count nodes;
 	count chunks;
+	NetworkitBinaryWeights weightsType;
 };
 } /* namespace */
 #endif

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -696,7 +696,7 @@ void Graph::addEdge(node u, node v, edgeweight ew) {
 		++storedNumberOfSelfLoops;
 	}
 }
-void Graph::addPartialEdge(Unsafe, node u, node v, uint64_t index, edgeweight ew) {
+void Graph::addPartialEdge(Unsafe, node u, node v, edgeweight ew, uint64_t index) {
 	assert(u < z);
 	assert(exists[u]);
 	assert(v < z);
@@ -712,7 +712,7 @@ void Graph::addPartialEdge(Unsafe, node u, node v, uint64_t index, edgeweight ew
 		outEdgeWeights[u].push_back(ew);
 	}
 }
-void Graph::addPartialOutEdge(Unsafe, node u, node v, uint64_t index, edgeweight ew) {
+void Graph::addPartialOutEdge(Unsafe, node u, node v, edgeweight ew, uint64_t index) {
 	assert(u < z);
 	assert(exists[u]);
 	assert(v < z);
@@ -724,7 +724,7 @@ void Graph::addPartialOutEdge(Unsafe, node u, node v, uint64_t index, edgeweight
 		outEdgeWeights[u].push_back(ew);
 	}
 }
-void Graph::addPartialInEdge(Unsafe, node u, node v, uint64_t index, edgeweight ew) {
+void Graph::addPartialInEdge(Unsafe, node u, node v, edgeweight ew, uint64_t index) {
 	assert(u < z);
 	assert(exists[u]);
 	assert(v < z);

--- a/networkit/cpp/io/NetworkitBinaryGraph.md
+++ b/networkit/cpp/io/NetworkitBinaryGraph.md
@@ -18,11 +18,12 @@ struct Header {
     uint64_t offsetBaseData;
     uint64_t offsetAdjLists;
     uint64_t offsetTranspose;
-	uint64_t offsetWeights;
+    uint64_t offsetWeightLists;
+    uint64_t offsetWeightTranspose;
 };
 ```
 - magic: A constant value used to identify the file format version.
-    - The current version is '*nkbg001*' which supports unweighted, undirected and directed graphs.
+    - The current version is '*nkbg002*' which supports weighted, undirected and directed graphs.
 - checksum: Currently not used
 - features: Contains the graph information bitwise
     - Bit 0 : directed or undirected
@@ -36,7 +37,8 @@ struct Header {
 - offsetBaseData: Offset of base data in the file 
 - offsetAdjLists: Offset of the adjacency lists in the file
 - offsetTranspose: Offset of the transposed adjaceny lists in the file
-- offsetWeights: Offset of the weights in the file
+- offsetWeightLists: Offset of the adjacency weights in the file
+- offsetWeightTranspose: Offset of the transposed adjacency weights in the file
 
 All offsets are relative to the beginning of the section.
 
@@ -63,7 +65,21 @@ the firstVertex of each chunk relative to data starts
 varint data [...]: Varint encoded transpose lists  
 
 ```
-Weights
+Weight lists
 --------------------
-Weights are currently not supported. 
-
+```
+uint64_t offset[chunks-1]: Offset of the file where the weights are
+Depending on the type of weights:
+ - unsigned/signed weights: varint data [...]: Varint encoded weight lists
+ - double weights: double data [...]: Weight lists as doubles
+ - float weights: float data [...]: Weight lists as floats
+```
+Weight transpose
+--------------------
+```
+uint64_t offset[chunks-1]: Offset of the file where the transposed weights are
+Depending on the type of weights:
+ - unsigned/signed weights: varint data [...]: Varint encoded weight lists
+ - double weights: double data [...]: Weight lists as doubles
+ - float weights: float data [...]: Weight lists as floats
+```

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -866,4 +866,24 @@ TEST_F(IOGTest, testNetworkitBinaryWiki) {
 		});
 	});
 }
+TEST_F(IOGTest, NetworkitBinaryAutoDetect) {
+
+	Graph G(10, true, false);
+	int64_t weight = -1;
+	for(count n = 0; n < G.numberOfNodes(); n++) {
+		if(n != G.numberOfNodes()-1)
+			G.addEdge(n, n+1, weight++);
+	}
+	NetworkitBinaryWriter writer(32, NetworkitBinaryWeights::autoDetect);
+	writer.write(G, "../output/binary_auto");
+
+	NetworkitBinaryReader reader;
+	Graph G2 = reader.read("../output/binary_auto");
+	G.forNodes([&](node u){
+		G.forEdgesOf(u, [&](node v) {
+			ASSERT_TRUE(G2.hasEdge(u,v));
+			ASSERT_EQ(G.weight(u,v), G2.weight(u,v));
+		});
+	});
+}
 } /* namespace NetworKit */

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -866,7 +866,8 @@ TEST_F(IOGTest, testNetworkitBinaryWiki) {
 		});
 	});
 }
-TEST_F(IOGTest, NetworkitBinaryAutoDetect) {
+
+TEST_F(IOGTest, testNetworkitBinarySignedWeights) {
 
 	Graph G(10, true, false);
 	int64_t weight = -1;
@@ -875,10 +876,31 @@ TEST_F(IOGTest, NetworkitBinaryAutoDetect) {
 			G.addEdge(n, n+1, weight++);
 	}
 	NetworkitBinaryWriter writer(32, NetworkitBinaryWeights::autoDetect);
-	writer.write(G, "../output/binary_auto");
+	writer.write(G, "output/binarySigned");
 
 	NetworkitBinaryReader reader;
-	Graph G2 = reader.read("../output/binary_auto");
+	Graph G2 = reader.read("output/binarySigned");
+	G.forNodes([&](node u){
+		G.forEdgesOf(u, [&](node v) {
+			ASSERT_TRUE(G2.hasEdge(u,v));
+			ASSERT_EQ(G.weight(u,v), G2.weight(u,v));
+		});
+	});
+}
+
+TEST_F(IOGTest, testNetworkitBinaryFloatWeights) {
+
+	Graph G(10, true, false);
+	float weight = 987.654f;
+	for(count n = 0; n < G.numberOfNodes(); n++) {
+		if(n != G.numberOfNodes()-1)
+			G.addEdge(n, n+1, weight++);
+	}
+	NetworkitBinaryWriter writer(32, NetworkitBinaryWeights::autoDetect);
+	writer.write(G, "output/binaryFloats");
+
+	NetworkitBinaryReader reader;
+	Graph G2 = reader.read("output/binaryFloats");
 	G.forNodes([&](node u){
 		G.forEdgesOf(u, [&](node v) {
 			ASSERT_TRUE(G2.hasEdge(u,v));


### PR DESCRIPTION
This PR adds support for weights in the NetworkitBinaryGraph format. 

Unsigned, signed, float and double weights are supported, and can be passed to the writer as a constructor parameter. If none is passed, the writer tries to detect the type of the weights.

The `addPartial*Edge` functions of the graph were slightly modified too i.e., the order of the function parameters `uint64_t index = 0, edgeweight ew = defaultEdgeWeight` was exchanged. This was necessary because the NetworkitBinaryGraph format does not support indexes, and therefore, the default `index` value should be used.