### PR TITLE
Resolve issue #364

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1003,6 +1003,8 @@ class Graph final {
     * @param u Endpoint of edge.
     * @param v Endpoint of edge.
     * @param weight Optional edge weight.
+    * @param ew Optional edge weight.
+    * @param index Optional node index.
     */
     void addPartialEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
 
@@ -1013,7 +1015,8 @@ class Graph final {
      * handled consistently by the graph data structure.
      * @param u Endpoint of edge.
      * @param v Endpoint of edge.
-     * @param weight Optional edge weight.
+     * @param ew Optional edge weight.
+     * @param index Optional node index.
      */
 	void addPartialInEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
 
@@ -1024,7 +1027,8 @@ class Graph final {
      * handled consistently by the graph data structure.
      * @param u Endpoint of edge.
      * @param v Endpoint of edge.
-     * @param weight Optional edge weight.
+     * @param ew Optional edge weight.
+     * @param index Optional node index.
      */
 	void addPartialOutEdge(Unsafe, node u, node v, uint64_t index = 0, edgeweight ew = defaultEdgeWeight);
 

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -720,6 +720,10 @@ void Graph::addPartialOutEdge(Unsafe, node u, node v, uint64_t index, edgeweight
 
 	outEdges[u].push_back(v);
 
+	// if edges indexed, give new id
+	if (edgesIndexed) {
+		outEdgeIds[u].push_back(index);
+	}
 	if (weighted) {
 		outEdgeWeights[u].push_back(ew);
 	}
@@ -731,6 +735,7 @@ void Graph::addPartialInEdge(Unsafe, node u, node v, uint64_t index, edgeweight 
 	assert(exists[v]);
 
 	inEdges[u].push_back(v);
+
 	if (edgesIndexed) {
 		inEdgeIds[u].push_back(index);
 	}


### PR DESCRIPTION
This PR adds the following slight modifications to the `Graph` class:
- `Graph::addPartialOutEdge` now uses the passed `index` parameter.
- Add the `index` parameter to the doxygen documents of all `Graph::addPartial*Edge` functions.