### PR TITLE
Fix self loop bug in NetworkitBinaryGraph

### DIFF
--- a/networkit/cpp/io/NetworkitBinaryReader.cpp
+++ b/networkit/cpp/io/NetworkitBinaryReader.cpp
@@ -230,12 +230,11 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 						break;
 				}
 				if(!directed) {
-					G.addPartialEdge(unsafe, curr, add, weight);
+					if(curr != add) {
+						G.addPartialEdge(unsafe, curr, add, weight);
+					}
 				} else {
 					G.addPartialInEdge(unsafe, curr, add, weight);
-				}
-				if(curr == add) {
-					selfLoops.fetch_add(1, std::memory_order_relaxed);
 				}
 			}
 		}

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -213,7 +213,8 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string& path) {
 						outNbrs++;
 						adjSize += encode(v, tmp);
 						adjWeightSize += computeWeightsOffsets(w);
-					} else if (v >= n) {
+					}
+					if (v >= n) {
 						inNbrs++;
 						transpSize += encode(v, tmp);
 						transpWeightSize += computeWeightsOffsets(w);

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -908,4 +908,34 @@ TEST_F(IOGTest, testNetworkitBinaryFloatWeights) {
 		});
 	});
 }
+
+TEST_F(IOGTest, testNetworkitBinaryUndirectedSelfLoops) {
+
+	Graph G(5, false, false);
+	G.addEdge(0,0);
+	G.addEdge(1,1);
+	G.addEdge(2,2);
+	G.addEdge(3,3);
+	G.addEdge(4,4);
+	NetworkitBinaryWriter writer;
+	writer.write(G, "output/loops");
+	NetworkitBinaryReader reader;
+	Graph G2 = reader.read("output/loops");
+	ASSERT_EQ(G.numberOfSelfLoops(), G2.numberOfSelfLoops());
+}
+
+TEST_F(IOGTest, testNetworkitBinaryDirectedSelfLoops) {
+
+	Graph G(5, false, true);
+	G.addEdge(0,0);
+	G.addEdge(1,1);
+	G.addEdge(2,2);
+	G.addEdge(3,3);
+	G.addEdge(4,4);
+	NetworkitBinaryWriter writer;
+	writer.write(G, "output/loops");
+	NetworkitBinaryReader reader;
+	Graph G2 = reader.read("output/loops");
+	ASSERT_EQ(G.numberOfSelfLoops(), G2.numberOfSelfLoops());
+}
 } /* namespace NetworKit */


### PR DESCRIPTION
This PR fixes a bug in the NetworkitBinaryGraph format in which self loops where counted twice, instead of once, thus falsifying the number of self loops in graphs with self loops. This PR also includes tests for graphs with self loops.