### PR TITLE
New Graph method: remove multi-edges

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1067,9 +1067,27 @@ class Graph final {
     void removeAllEdges();
 
     /**
+     * Removes edges adjacent to a node according to a specific criterion.
+     *
+     * @param u The node whose adjacent edges shall be removed.
+     * @param condition A function that takes a node as an input and returns a
+     * bool. If true the edge (u, v) is removed.
+     * @param edgesIn Whether in-going or out-going edges shall be removed.
+     * @return count The number of removed edges.
+     */
+    template <typename Condition>
+    count removeAdjacentEdges(node u, Condition condition, bool edgesIn = false);
+
+
+    /**
      * Removes all self-loops in the graph.
      */
     void removeSelfLoops();
+
+    /**
+     * Removes all multi-edges in the graph.
+     */
+    void removeMultiEdges();
 
     /**
      * Changes the edges {@a s1, @a t1} into {@a s1, @a t2} and the edge {@a
@@ -2094,6 +2112,36 @@ template <typename L> void Graph::DFSEdgesFrom(node r, L handle) const {
         });
     } while (!s.empty());
 }
+
+/* EDGE MODIFIERS */
+
+template <typename Condition>
+count Graph::removeAdjacentEdges(node u, Condition condition, bool edgesIn) {
+	count removedEdges = 0;
+	auto &edges_ = outEdges[u];
+	for (index vi = 0; vi < edges_.size();) {
+		if (condition(edges_[vi])) {
+			++removedEdges;
+			edges_[vi] = edges_.back();
+			edges_.pop_back();
+			if (isWeighted()) {
+				auto &weights_ = edgesIn ? inEdgeWeights[u] : outEdgeWeights[u];
+				weights_[vi] = weights_.back();
+				weights_.pop_back();
+			}
+			if (hasEdgeIds()) {
+				auto &edgeIds_ = edgesIn ? inEdgeIds[u] : outEdgeIds[u];
+				edgeIds_[vi] = edgeIds_.back();
+				edgeIds_.pop_back();
+			}
+		} else {
+			++vi;
+		}
+	}
+
+	return removedEdges;
+}
+
 
 } /* namespace NetworKit */
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -784,7 +784,7 @@ class Graph final {
 	 * @param edges the edge count of a graph
 	 */
 	void setEdgeCount(Unsafe, count edges) { m = edges; }
-    
+
 	void setNumberOfSelfLoops(Unsafe, count loops) { storedNumberOfSelfLoops = loops; }
 	/**
      * Returns a string representation of the graph.

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -317,6 +317,7 @@ cdef extern from "<networkit/graph/Graph.hpp>":
 		void removeAllEdges() except +
 		void removeEdgesFromIsolatedSet(vector[node] nodes) except +
 		void removeSelfLoops() except +
+		void removeMultiEdges() except +
 		void swapEdge(node s1, node t1, node s2, node t2) except +
 		void compactEdges() except +
 		void sortEdges() except +
@@ -817,6 +818,11 @@ cdef class Graph:
 		""" Removes all self-loops from the graph.
 		"""
 		self._this.removeSelfLoops()
+
+	def removeMultiEdges(self):
+		""" Removes all multi-edges from the graph.
+		"""
+		self._this.removeMultiEdges()
 
 	def swapEdge(self, node s1, node t1, node s2, node t2):
 		"""

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -2381,5 +2381,26 @@ TEST_P(GraphGTest, testSubgraphFromNodesDirected) {
 
 }
 
+TEST_P(GraphGTest, testRemoveMultiEdges) {
+	Aux::Random::setSeed(42, false);
+	Graph G(this->Ghouse);
+	auto edgeSet = G.edges();
+	const count nMultiEdges = 10;
+	const count m = G.numberOfEdges();
+
+	// Adding multiedges at random
+	for (count i = 0; i < nMultiEdges; ++i) {
+		auto e = G.randomEdge();
+		G.addEdge(e.first, e.second);
+	}
+
+	EXPECT_EQ(G.numberOfEdges(), m + nMultiEdges);
+	G.removeMultiEdges();
+	EXPECT_EQ(G.numberOfEdges(), m);
+	auto edgeSet_ = G.edges();
+
+	for (count i = 0; i < G.numberOfEdges(); ++i)
+		EXPECT_EQ(edgeSet[i], edgeSet_[i]);
+}
 
 } /* namespace NetworKit */

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -3,15 +3,19 @@ import unittest
 import networkit as nk
 
 class TestGraph(unittest.TestCase):
-	def testSubgraphFromNodes(self):
-		# Directed
-		G = nk.Graph(4, True, True)
-
+	def getSmallGraph(self, weighted=False, directed=False):
+		G = nk.Graph(4, weighted, directed)
 		G.addEdge(0, 1, 1.0)
 		G.addEdge(0, 2, 2.0)
 		G.addEdge(3, 1, 4.0)
 		G.addEdge(3, 2, 5.0)
 		G.addEdge(1, 2, 3.0)
+
+		return G
+
+	def testSubgraphFromNodes(self):
+		# Directed
+		G = self.getSmallGraph(True, True)
 
 		res = G.subgraphFromNodes([0])
 		self.assertTrue(res.isWeighted())
@@ -61,6 +65,33 @@ class TestGraph(unittest.TestCase):
 		res = G.subgraphFromNodes(set([0, 1]), True)
 		self.assertEqual(res.numberOfNodes(), 4)
 		self.assertEqual(res.numberOfEdges(), 4)
+
+	def testRemoveMultiEdges(self):
+
+		def addMultiEdges(G, nMultiEdges):
+			for i in range(nMultiEdges):
+				e = G.randomEdge()
+				G.addEdge(e[0], e[1])
+			return G
+
+		def testGraph(G):
+			addMultiEdges(G, nMultiEdges)
+			self.assertEqual(G.numberOfEdges(), m + nMultiEdges)
+			G.removeMultiEdges()
+			self.assertEqual(G.numberOfEdges(), m)
+
+		nMultiEdges = 5
+
+		# Directed
+		G = self.getSmallGraph(True, True)
+		m = G.numberOfEdges()
+		testGraph(G)
+
+		# Undirected
+		G = self.getSmallGraph(True, False)
+		m = G.numberOfEdges()
+		testGraph(G)
+
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This adds a new method that removes all the multi-edges from a NetworKit graph.
The same code is also used to remove all the self-loops, as the previous implementation was using `removeNode` within a `forEdges` loop, which shall not be allowed according to #378.