### PR TITLE
Travis: same build for sanitizers and coverage 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,17 +110,7 @@ matrix:
           update: true
 
     # Test with sanitizers.
-    - name: "Linux, gcc 5.4: Core build, sanitizers"
-      compiler: gcc
-      os: linux
-      dist: xenial
-      script:
-        - mkdir debug_test && cd "$_"
-        - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_WITH_SANITIZERS=leak ..
-        - make -j2
-        - ctest -V
-
-    - name: "Linux, gcc 5: Coverage"
+    - name: "Linux, GCC 5: Core build, sanitizers, coverage"
       compiler: gcc
       os: linux
       dist: xenial
@@ -134,7 +124,7 @@ matrix:
         - pip3 install --upgrade pip
         - pip3 install setuptools cpp-coveralls
         - mkdir build && cd "$_"
-        - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_COVERAGE=ON ..
+        - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_WITH_SANITIZERS=leak -DNETWORKIT_COVERAGE=ON ..
         - make -j2
         - ctest -V
       after_success:


### PR DESCRIPTION
Both sanitizers and coverage need the default gcc version to work. Instead of having two different builds for the same compiler, it could make sense having a single build for both.