### PR TITLE
NetworKit::Graph tutorial with Jupyter-Notebook

### DIFF
--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -4704,19 +4704,20 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 cdef class GraphTools:
 	@staticmethod
 	def getCompactedGraph(Graph graph, nodeIdMap):
-		""" Computes a graph with the same structure but with continuous node ids.
+		"""
+		Computes a graph with the same structure but with continuous node ids.
 
-                Parameters
+		Parameters
 		----------
 		graph : networkit.Graph
 			The graph to be compacted.
-                nodeIdMap:
-                        The map providing the information about the node ids.
+		nodeIdMap:
+			The map providing the information about the node ids.
 
-                Returns
+		Returns
 		-------
 		networkit.Graph
-		    The compacted graph
+			The compacted graph
 		"""
 		cdef unordered_map[node,node] cNodeIdMap
 		for key in nodeIdMap:
@@ -4726,15 +4727,15 @@ cdef class GraphTools:
 	@staticmethod
 	def getContinuousNodeIds(Graph graph):
 		"""
-                Computes a map of node ids to continuous node ids.
+		Computes a map of node ids to continuous node ids.
 
-                Parameters
+		Parameters
 		----------
 		graph : networkit.Graph
 			The graph of which the node id map is wanted.
-                Returns
+		Returns
 		-------
-                    Returns the node id map
+			Returns the node id map
 		"""
 		cdef unordered_map[node,node] cResult
 		with nogil:
@@ -4747,16 +4748,16 @@ cdef class GraphTools:
 	@staticmethod
 	def getRandomContinuousNodeIds(Graph graph):
 		"""
-                Computes a map of node ids to continuous, randomly permutated node ids.
+		Computes a map of node ids to continuous, randomly permutated node ids.
 
-                Parameters
+		Parameters
 		----------
 		graph : networkit.Graph
 			The graph of which the node id map is wanted.
 		Returns
 		-------
-                    Returns the node id map
-                """
+			Returns the node id map
+		"""
 		cdef unordered_map[node,node] cResult
 		with nogil:
 			cResult = getRandomContinuousNodeIds(graph._this)

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -4704,8 +4704,19 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 cdef class GraphTools:
 	@staticmethod
 	def getCompactedGraph(Graph graph, nodeIdMap):
-		"""
-			Computes a graph with the same structure but with continuous node ids.
+		""" Computes a graph with the same structure but with continuous node ids.
+
+                Parameters
+		----------
+		graph : networkit.Graph
+			The graph to be compacted.
+                nodeIdMap:
+                        The map providing the information about the node ids.
+
+                Returns
+		-------
+		networkit.Graph
+		    The compacted graph
 		"""
 		cdef unordered_map[node,node] cNodeIdMap
 		for key in nodeIdMap:
@@ -4715,7 +4726,15 @@ cdef class GraphTools:
 	@staticmethod
 	def getContinuousNodeIds(Graph graph):
 		"""
-			Computes a map of node ids to continuous node ids.
+                Computes a map of node ids to continuous node ids.
+
+                Parameters
+		----------
+		graph : networkit.Graph
+			The graph of which the node id map is wanted.
+                Returns
+		-------
+                    Returns the node id map
 		"""
 		cdef unordered_map[node,node] cResult
 		with nogil:
@@ -4728,8 +4747,16 @@ cdef class GraphTools:
 	@staticmethod
 	def getRandomContinuousNodeIds(Graph graph):
 		"""
-			Computes a map of node ids to continuous, randomly permutated node ids.
-		"""
+                Computes a map of node ids to continuous, randomly permutated node ids.
+
+                Parameters
+		----------
+		graph : networkit.Graph
+			The graph of which the node id map is wanted.
+		Returns
+		-------
+                    Returns the node id map
+                """
 		cdef unordered_map[node,node] cResult
 		with nogil:
 			cResult = getRandomContinuousNodeIds(graph._this)

--- a/notebooks/GraphNotebook.ipynb
+++ b/notebooks/GraphNotebook.ipynb
@@ -4,7 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook we will cover the most important things on the `Networkit::Graph`, the central class in in Networkit, to get you started. The first step is to import Networkit."
+    "# NetworKit Graph Tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook we will cover the most important things on the `Networkit.Graph`, the central class in in Networkit, to get you started. The first step is to import NetworKit."
    ]
   },
   {
@@ -20,7 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We start by creating the core object, `Networkit::Graph`. The `Graph` class constructor expects the `number of nodes` as an unsigned integer, a Boolean value stating if the graph is weighted or not followed by another Boolean value stating the directedness of the graph. The latter two are set to false by default. If the graph is unweighted, all edge weights are set to `1.0`."
+    "We start by creating the core object, a `Networkit.Graph`. The [networkit.Graph](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=graph#networkit.Graph) constructor expects the `number of nodes` as an unsigned integer, a Boolean value stating if the graph is weighted or not followed by another Boolean value stating the directedness of the graph. The latter two are set to false by default. If the graph is unweighted, all edge weights are set to `1.0`."
    ]
   },
   {
@@ -38,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`G` has 5 nodes, but no edges yet. Using the `addEdges(u,v)` method, we can add edges between the nodes."
+    "`G` has 5 nodes, but no edges yet. Using the [addEdge(node u, node v)](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=addedge#networkit.graph.Graph.addEdge) method, we can add edges between the nodes."
    ]
   },
   {
@@ -92,7 +99,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the method `overview(G)`, we can take a look at the graph we have created so far."
+    "Using the method [overview(G)](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=overview#networkit.overview), we can take a look at the graph we have created so far."
    ]
   },
   {
@@ -108,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have created a graph we can start to play around with it. Say we want to remove the node with the node ID 2, so the third node, from `G`, we can easily do so using `Graph::removeNode(node u)`. "
+    "Now that we have created a graph we can start to play around with it. Say we want to remove the node with the node ID 2, so the third node, from `G`, we can easily do so using [Graph.removeNode(node u)](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=remove%20node#networkit.graph.Graph.removeNode). "
    ]
   },
   {
@@ -127,14 +134,14 @@
    "outputs": [],
    "source": [
     "#Check if it's really gone\n",
-    "print (G.hasNode(2))"
+    "print(G.hasNode(2))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The node has been remove from the graph, however, the node IDs are not adjusted to the match the new number of nodes. Hence, if we want to restore the node we previously removed from G, we can do so using Graph::restoreNode(node u) using the original node ID."
+    "The node has been remove from the graph, however, the node IDs are not adjusted to the match the new number of nodes. Hence, if we want to restore the node we previously removed from G, we can do so using [Graph.restoreNode(node u)](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=restore#networkit.graph.Graph.restoreNode) using the original node ID."
    ]
   },
   {
@@ -153,7 +160,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In case, you permanently want to delete a node, and remap the node IDs so as to have continues IDs, Networkit provides functions from the `GraphTools` module that do just that."
+    "In case, you permanently want to delete a node, and remap the node IDs so as to have continues IDs, Networkit provides functions from the [GraphTools](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=graph%20tools#networkit.graph.GraphTools) module that do just that."
    ]
   },
   {
@@ -169,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Networkit provides a few special itertors that enable iterating over all nodes or edges in a simple manner. These iterators accept callback functions that are passed to the iterators as parameters. More information can be found in the Networkit documentation [here](https://networkit.github.io/dev-docs/python_api/graph.html). Let's start by using the `forNodes` iterator. It expects a callback function which accepts one parameter, i.e., a node. Firstly, we define such a function."
+    "Networkit provides a few special itertors that enable iterating over all nodes or edges in a simple manner. These iterators accept callback functions that are passed to the iterators as parameters. More information can be found in the Networkit documentation [here](https://networkit.github.io/dev-docs/python_api/graph.html). Let's start by using the [forNodes](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=fornodes#networkit.graph.Graph.forNodes) iterator. It expects a callback function which accepts one parameter, i.e., a node. Firstly, we define such a function."
    ]
   },
   {
@@ -221,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now call the `G.forEdges()` iterator, and pass `edgeFunc` to it."
+    "We can now call the [forEdges](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=foredges#networkit.graph.Graph.forEdges) iterator, and pass `edgeFunc` to it."
    ]
   },
   {
@@ -238,14 +245,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Although we did not add any indexes to our edges, our edges all have indexes of 0. This is because Networkit by default indexes all edges with 0. "
+    "Although we did not add any indexes to our edges, our edges all have indexes of 0. This is because Networkit by default indexes all edges with 0. However, sometimes it makes sense to have indexed edges. If you decide to index the edges of your graph after creating it, you can use the [Graph.indexEdges(bool force = False)](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=indexedges#networkit.graph.Graph.indexEdges) method. The `force` parameter forces re-indexing of edges if they had already been indexed."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sometimes you also need to iterate over specific edges, for example all nodes' edges. This calls for nested iterations. Using an ordinary for loop and the `forEdgesOf` iterator we can do so."
+    "Since we did not index the edges of our graph initially, we can use the default value. Indexing the edges of `G` can then be done as simply as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.indexEdges()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sometimes you also need to iterate over specific edges, for example all nodes' edges. This calls for nested iterations. Using an ordinary for loop and the [forEdgesOf](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=foredges#networkit.graph.Graph.forEdges) iterator we can do so."
    ]
   },
   {
@@ -262,7 +285,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note, in an undirected graph, like we have here, the `forEdgesOf` iterator returns all edges of a node. When dealing with a directed graph only the out edges are returned. The rest of the edges can be accessed using the `forInEdgesOf` iterator."
+    "Note, in an undirected graph, like we have here, the [forEdgesOf](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=foredgesof#networkit.Graph.forEdgesOf) iterator returns all edges of a node. When dealing with a directed graph only the out edges are returned. The rest of the edges can be accessed using the [forInEdgesOf](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=forinedges#networkit.Graph.forInEdgesOf) iterator."
    ]
   }
  ],

--- a/notebooks/GraphNotebook.ipynb
+++ b/notebooks/GraphNotebook.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook we will cover the most important things on the `Networkit::Graph`, the central class in in Networkit, to get you started. The first step is to import Networkit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import networkit as nk"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start by creating the core object, `Networkit::Graph`. The `Graph` class constructor expects the `number of nodes` as an unsigned integer, a Boolean value stating if the graph is weighted or not followed by another Boolean value stating the directedness of the graph. The latter two are set to false by default. If the graph is unweighted, all edge weights are set to `1.0`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G = nk.Graph(5)\n",
+    "print(G.numberOfNodes())\n",
+    "print(G.numberOfEdges())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`G` has 5 nodes, but no edges yet. Using the `addEdges(u,v)` method, we can add edges between the nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.addEdge(1,3)\n",
+    "G.addEdge(2,4)\n",
+    "G.addEdge(1,2)\n",
+    "G.addEdge(3,4)\n",
+    "G.addEdge(2,3)\n",
+    "G.addEdge(4,0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Node IDs in NetworKit are integer indices that start at 0 through to `G.upperNodeIdBound()`-1. Hence, `G.addEdge(*,5)` is an illegal operation in NetworKit. The same goes for edge IDs. If we need to, for example, add an edge betwen node 0 and node 5, we first need to add a sixth node to the graph using `G.addNode()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.addNode()\n",
+    "print(G.numberOfNodes())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hereafter, we can add the new edge."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.addEdge(0,5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the method `overview(G)`, we can take a look at the graph we have created so far."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nk.overview(G)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have created a graph we can start to play around with it. Say we want to remove the node with the node ID 2, so the third node, from `G`, we can easily do so using `Graph::removeNode(node u)`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.removeNode(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Check if it's really gone\n",
+    "print (G.hasNode(2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The node has been remove from the graph, however, the node IDs are not adjusted to the match the new number of nodes. Hence, if we want to restore the node we previously removed from G, we can do so using Graph::restoreNode(node u) using the original node ID."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#restore node with ID 2\n",
+    "G.restoreNode(2)\n",
+    "#Check if it is back in G\n",
+    "print(G.hasNode(2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In case, you permanently want to delete a node, and remap the node IDs so as to have continues IDs, Networkit provides functions from the `GraphTools` module that do just that."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "newGraph = nk.graph.GraphTools.getCompactedGraph(G, nk.graph.GraphTools.getContinuousNodeIds(G))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Networkit provides a few special itertors that enable iterating over all nodes or edges in a simple manner. These iterators accept callback functions that are passed to the iterators as parameters. More information can be found in the Networkit documentation [here](https://networkit.github.io/dev-docs/python_api/graph.html). Let's start by using the `forNodes` iterator. It expects a callback function which accepts one parameter, i.e., a node. Firstly, we define such a function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def nodeFunc(u):\n",
+    "    print(\"Node id\", u)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then pass `nodeFunc` to the iterator. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.forNodes(nodeFunc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we now want to iterate over all the edges of `G`, and print the edge information, we can do so as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First define callback function\n",
+    "# To iterate over edges it must accept 4 parameters\n",
+    "def edgeFunc(u, v, weight, edgeId):\n",
+    "    print(\"Edge from {} to {} has weight {} and id {}\".format(u, v, weight, edgeId))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now call the `G.forEdges()` iterator, and pass `edgeFunc` to it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using iterator with callback function\n",
+    "G.forEdges(edgeFunc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Although we did not add any indexes to our edges, our edges all have indexes of 0. This is because Networkit by default indexes all edges with 0. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sometimes you also need to iterate over specific edges, for example all nodes' edges. This calls for nested iterations. Using an ordinary for loop and the `forEdgesOf` iterator we can do so."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range ((G.upperNodeIdBound())-1):\n",
+    "    G.forEdgesOf(i, edgeFunc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, in an undirected graph, like we have here, the `forEdgesOf` iterator returns all edges of a node. When dealing with a directed graph only the out edges are returned. The rest of the edges can be accessed using the `forInEdgesOf` iterator."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a new Jupyter-notebook for the `NetworKit::Graph` class. The notebook addresses
- creating a graph,
- modifying the graph and,
- the node/edge the iterators.

While at it, I also added some documention to the GraphTools module functions I came accross.
