### PR TITLE
Added rpath support for setup.py and consequetive cmake build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(NETWORKIT_PYTHON "" CACHE STRING "Directory containing Python.h. Implies MON
 set(NETWORKIT_PYTHON_SOABI "" CACHE STRING "Platform specific file extension. Implies MONOLITH=TRUE")
 set(NETWORKIT_WITH_SANITIZERS "" CACHE STRING "Uses sanitizers during the compilation")
 set(NETWORKIT_RELEASE_LOGGING "AUTO" CACHE STRING "Do not compile log messages at levels TRACE or DEBUG (AUTO|ON|OFF)")
-set(NETWORKIT_RPATH "" CACHE STRING "Build specific rpath references.")
+set(NETWORKIT_PYTHON_RPATH "" CACHE STRING "Build specific rpath references.")
 
 set (NETWORKIT_CXX_STANDARD "11" CACHE STRING "CXX Version to compile with. Currently fixed to 11")
 
@@ -223,13 +223,19 @@ if(NETWORKIT_PYTHON)
 				LINK_FLAGS "${NETWORKIT_LINK_FLAGS}"
 				PREFIX ""
 				OUTPUT_NAME "_NetworKit.${NETWORKIT_PYTHON_SOABI}")
-	# DSOs on Apple OSes use different conventions for RPATH.
-	if(APPLE)
+	# If rpath-content is set explicitly, omit the dynamic binary path
+	if(NETWORKIT_PYTHON_RPATH)
 		set_target_properties(_NetworKit PROPERTIES
-				INSTALL_RPATH "@loader_path;${NETWORKIT_RPATH}")
+			INSTALL_RPATH "${NETWORKIT_PYTHON_RPATH}")
 	else()
-		set_target_properties(_NetworKit PROPERTIES
-				INSTALL_RPATH "$ORIGIN;${NETWORKIT_RPATH}")
+		# DSOs on Apple OSes use different conventions for RPATH.
+		if(APPLE)
+			set_target_properties(_NetworKit PROPERTIES
+				INSTALL_RPATH "@loader_path")
+		else()
+			set_target_properties(_NetworKit PROPERTIES
+				INSTALL_RPATH "$ORIGIN")
+		endif()
 	endif()
 
 	target_link_libraries(_NetworKit PRIVATE tlx OpenMP::OpenMP_CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(NETWORKIT_PYTHON "" CACHE STRING "Directory containing Python.h. Implies MON
 set(NETWORKIT_PYTHON_SOABI "" CACHE STRING "Platform specific file extension. Implies MONOLITH=TRUE")
 set(NETWORKIT_WITH_SANITIZERS "" CACHE STRING "Uses sanitizers during the compilation")
 set(NETWORKIT_RELEASE_LOGGING "AUTO" CACHE STRING "Do not compile log messages at levels TRACE or DEBUG (AUTO|ON|OFF)")
+set(NETWORKIT_RPATH "" CACHE STRING "Build specific rpath references.")
 
 set (NETWORKIT_CXX_STANDARD "11" CACHE STRING "CXX Version to compile with. Currently fixed to 11")
 
@@ -225,10 +226,10 @@ if(NETWORKIT_PYTHON)
 	# DSOs on Apple OSes use different conventions for RPATH.
 	if(APPLE)
 		set_target_properties(_NetworKit PROPERTIES
-				INSTALL_RPATH "@loader_path")
+				INSTALL_RPATH "@loader_path;${NETWORKIT_RPATH}")
 	else()
 		set_target_properties(_NetworKit PROPERTIES
-				INSTALL_RPATH "$ORIGIN")
+				INSTALL_RPATH "$ORIGIN;${NETWORKIT_RPATH}")
 	endif()
 
 	target_link_libraries(_NetworKit PRIVATE tlx OpenMP::OpenMP_CXX)

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ def cythonizeFile(filepath):
 			exit(1)
 		print("_NetworKit.pyx cythonized", flush=True)
 
-def buildNetworKit(install_prefix, externalCore=False, withTests=False, rpath=False):
+def buildNetworKit(install_prefix, externalCore=False, withTests=False, rpath=None):
 	# Cythonize file
 	cythonizeFile("networkit/_NetworKit.pyx")
 	try:
@@ -162,7 +162,7 @@ def buildNetworKit(install_prefix, externalCore=False, withTests=False, rpath=Fa
 		comp_cmd.append("-GNinja")
 	comp_cmd.append(os.getcwd()) #call CMakeLists.txt from networkit root
 	if rpath:
-		comp_cmd.append("-DNETWORKIT_RPATH="+rpath)
+		comp_cmd.append("-DNETWORKIT_PYTHON_RPATH="+rpath)
 	# Run cmake
 	print("initializing NetworKit compilation with: '{0}'".format(" ".join(comp_cmd)), flush=True)
 	if not subprocess.call(comp_cmd, cwd=buildDirectory) == 0:
@@ -218,7 +218,7 @@ class build_ext(Command):
 		self.include_dirs = None
 		self.library_dirs = None
 		self.networkit_external_core = False
-		self.rpath = False
+		self.rpath = None
 
 		self.extensions = None
 		self.package = None


### PR DESCRIPTION
This adds the possibility to add rpath to both setup.py and cmake. Use case: consecutive packages (python -> C++ external-core) in build systems like spack, which make heavy usage of rpath-manipulation. 