### PR TITLE
Fix number of parameters in Graph/neighbors

### DIFF
--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -925,7 +925,7 @@ cdef class Graph:
 	 		List of neighbors of `u`.
 		"""
 		neighborList = []
-		self.forEdgesOf(u, lambda v : neighborList.append(v))
+		self.forEdgesOf(u, lambda u, v, w, eid : neighborList.append(v))
 		return neighborList
 
 	def inNeighbors(self, u):

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -92,6 +92,34 @@ class TestGraph(unittest.TestCase):
 		m = G.numberOfEdges()
 		testGraph(G)
 
+	def testNeighbors(self):
+		# Directed
+		G = nk.Graph(4, False, True)
+
+		G.addEdge(0, 1)
+		G.addEdge(0, 2)
+		G.addEdge(3, 1)
+		G.addEdge(3, 2)
+		G.addEdge(1, 2)
+
+		self.assertEqual(sorted(G.neighbors(0)), [1, 2])
+		self.assertEqual(sorted(G.neighbors(1)), [2])
+		self.assertEqual(sorted(G.neighbors(2)), [])
+		self.assertEqual(sorted(G.neighbors(3)), [1, 2])
+
+		# Undirected
+		G = nk.Graph(4, False, False)
+
+		G.addEdge(0, 1)
+		G.addEdge(0, 2)
+		G.addEdge(3, 1)
+		G.addEdge(3, 2)
+		G.addEdge(1, 2)
+
+		self.assertEqual(sorted(G.neighbors(0)), [1, 2])
+		self.assertEqual(sorted(G.neighbors(1)), [0, 2, 3])
+		self.assertEqual(sorted(G.neighbors(2)), [0, 1, 3])
+		self.assertEqual(sorted(G.neighbors(3)), [1, 2])
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This fixes a bug in the `Graph.neighbors()` method. The current implementation returns the error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "networkit/_NetworKit.pyx", line 922, in networkit._NetworKit.Graph.neighbors
    self.forEdgesOf(u, lambda v : neighborList.append(v))
  File "networkit/_NetworKit.pyx", line 1019, in networkit._NetworKit.Graph.forEdgesOf
    self._this.forEdgesOf[EdgeCallBackWrapper](u, dereference(wrapper))
RuntimeError: An Exception occurred, aborting execution of iterator: lambda() takes exactly one argument (4 given)
```
because the lambda does not have enough parameters (1 instead of 4), and cannot be used by external users.