### PR TITLE
Python wrapper for the C++ NeighborRange iterator

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -444,7 +444,7 @@ class Graph final {
     auto callBFSHandle(F &f, node u, count) const -> decltype(f(u)) {
         return f(u);
     }
-
+public:
     /**
      * Class to iterate over the in/out neighbors of a node.
      */
@@ -453,25 +453,30 @@ class Graph final {
       public:
         // The value type of the neighbors (i.e. nodes). Returned by
         // operator*().
-        typedef node value_type;
+        using value_type = node;
 
         // Reference to the value_type, required by STL.
-        typedef value_type &reference;
+        using reference = value_type &;
 
         // Pointer to the value_type, required by STL.
-        typedef value_type *pointer;
+        using pointer = value_type *;
 
         // STL iterator category.
-        typedef std::forward_iterator_tag iterator_category;
+        using iterator_category = std::forward_iterator_tag;
 
         // Signed integer type of the result of subtracting two pointers,
         // required by STL.
-        typedef ptrdiff_t difference_type;
+        using difference_type = ptrdiff_t;
 
         // Own type.
-        typedef NeighborIterator self;
+        using self = NeighborIterator;
 
         NeighborIterator(std::vector<node>::const_iterator nodesIter) : nIter(nodesIter) {}
+
+        /**
+         * @brief WARNING: This contructor is required for Python and should not be used as the iterator is not initialised.
+         */
+        NeighborIterator() {}
 
         NeighborIterator operator++() {
             auto prev = *this;
@@ -518,23 +523,23 @@ class Graph final {
       public:
         // The value type of the neighbors (i.e. nodes). Returned by
         // operator*().
-        typedef std::pair<node, edgeweight> value_type;
+        using value_type = std::pair<node, edgeweight>;
 
         // Reference to the value_type, required by STL.
-        typedef value_type &reference;
+        using reference = value_type &;
 
         // Pointer to the value_type, required by STL.
-        typedef value_type *pointer;
+        using pointer = value_type *;
 
         // STL iterator category.
-        typedef std::forward_iterator_tag iterator_category;
+        using iterator_category = std::forward_iterator_tag;
 
         // Signed integer type of the result of subtracting two pointers,
         // required by STL.
-        typedef ptrdiff_t difference_type;
+        using difference_type = ptrdiff_t;
 
         // Own type.
-        typedef NeighborWeightIterator self;
+        using self = NeighborWeightIterator;
 
         NeighborWeightIterator(
             std::vector<node>::const_iterator nodesIter,
@@ -590,25 +595,34 @@ class Graph final {
      */
     template <bool InEdges = false> class NeighborRange {
       public:
-        NeighborRange(const Graph &G, node u) : G(G), u(u){};
+        NeighborRange(const Graph &G, node u) : G(&G), u(u){
+			assert(G.hasNode(u));
+        };
+
+        NeighborRange() : G(nullptr) {};
 
         NeighborIterator begin() const {
+            assert(G != nullptr);
             if (InEdges)
-                return NeighborIterator(G.inEdges[u].begin());
-            return NeighborIterator(G.outEdges[u].begin());
+                return NeighborIterator(G->inEdges[u].begin());
+            return NeighborIterator(G->outEdges[u].begin());
         }
 
         NeighborIterator end() const {
+            assert(G != nullptr);
             if (InEdges)
-                return NeighborIterator(G.inEdges[u].end());
-            return NeighborIterator(G.outEdges[u].end());
+                return NeighborIterator(G->inEdges[u].end());
+            return NeighborIterator(G->outEdges[u].end());
         }
 
       private:
-        const Graph &G;
-        const node u;
+        const Graph *G;
+        node u;
     };
 
+    using OutNeighborRange = NeighborRange<false>;
+
+    using InNeighborRange = NeighborRange<true>;
     /**
      * Wrapper class to iterate over a range of the neighbors of a node
      * including the edge weights within a for loop.
@@ -640,7 +654,6 @@ class Graph final {
         const node u;
     };
 
-  public:
     /**
      * Create a graph of @a n nodes. The graph has assignable edge weights if @a
      * weighted is set to <code>true</code>. If @a weighted is set to

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -163,5 +163,62 @@ class TestGraph(unittest.TestCase):
 		self.assertEqual(GWeighted.numberOfEdges(),     GTrans.numberOfEdges())
 
 
+	def testIterator(self):
+		# Undirected
+		G = nk.Graph(4, False, False)
+
+		G.addEdge(0, 1)
+		G.addEdge(0, 2)
+		G.addEdge(1, 2)
+		G.addEdge(3, 1)
+		G.addEdge(3, 2)
+
+		def nbrFunc(u, v, weight, edgeId):
+			forEdgesNbrs.append(v)
+
+		# Iterate through neighbours of node using iterNeighbors
+		def nodeIter(node):
+			nodeList = []
+			nbrs = G.iterNeighbors(node)
+			try:
+				while nbrs is not None:
+					nodeList.append(next(nbrs))
+			except StopIteration:
+				pass
+			return nodeList
+
+		for node in range(G.upperNodeIdBound()):
+			forEdgesNbrs = []
+			G.forEdgesOf(node, nbrFunc)
+			nodeNbrs = nodeIter(node)
+			self.assertEqual(sorted(forEdgesNbrs), sorted(nodeNbrs))
+
+		# Directed
+		G = nk.Graph(4, False, True)
+
+		G.addEdge(0, 1)
+		G.addEdge(0, 2)
+		G.addEdge(3, 1)
+		G.addEdge(3, 2)
+		G.addEdge(1, 2)
+
+		# Iterate through neighbours of node using iterNeighbors
+		def nodeInIter(node):
+			nodeList = []
+			nbrs = G.iterInNeighbors(node)
+			try:
+				while nbrs is not None:
+					nodeList.append(next(nbrs))
+					print(nodeList)
+			except StopIteration:
+				pass
+			return nodeList
+
+		for node in range(G.upperNodeIdBound()):
+			forEdgesNbrs = []
+			G.forInEdgesOf(node, nbrFunc)
+			nodeInNbrs = nodeInIter(node)
+			self.assertEqual(sorted(forEdgesNbrs), sorted(nodeInNbrs))
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
The `NeighborRange` iterator is wrapped, and we introduce an equivalent iterator in Python - `iterNeighbors(node u)`. Currently, it is only available for undirected, unweighted graphs.

The current iterators, `forEdges*` or `forNodes*`, require a callback function and are not necessarily intuitive to use for all users. The `iterNeighbors(node u)` iterator is simple to use and pythonic .

Let me briefly explain the changes made in `Graph.hpp`.
 - Addition of a default no parameter constructor: Cython needed a default contructor.
 - `Const node u` -> `node u`: When using the new default constructor, it should be possible to assign a value to `node u` later. This is not possible is `node u` is declared as `const`.
 - `Graph& -> Graph*`: Again, this is because of the new constructor.
 - NeighborIterator from `private` to `public`: This was necessary in order to access the NeighborIterator from Cython.
