### PR TITLE
Fix Graph::randomEdges and Accelerate Graph::randomEdge

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1118,8 +1118,8 @@ class Graph final {
      * Returns a random edge. By default a random node u is chosen and then
      * some random neighbor v. So the probability of choosing (u, v) highly
      * depends on the degree of u. Setting uniformDistribution to true, will
-     * give you a real uniform distributed edge, but will be very slow. So
-     * only use uniformDistribution for single calls outside of any loops.
+     * give you a real uniform distributed edge, but will be slower.
+     * Exp. time complexity: O(1) for uniformDistribution = false, O(n) otherwise.
      */
     std::pair<node, node> randomEdge(bool uniformDistribution = false) const;
 

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -987,7 +987,7 @@ std::vector<std::pair<node, node>> Graph::randomEdges(count nr) const {
 	}
 	std::vector<std::pair<node, node>> edges;
 
-	std::default_random_engine gen{std::random_device{}()};
+	auto& gen = Aux::Random::getURNG();
 	std::vector<count> outDeg(upperNodeIdBound());
 	for (count i = 0; i < upperNodeIdBound(); ++i) {
 		outDeg[i] = outEdges[i].size();

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -919,16 +919,65 @@ std::pair<node, node> Graph::randomEdge(bool uniformDistribution) const {
 	}
 
 	if (uniformDistribution) {
-		return randomEdges(1)[0];
+		/*
+		 * The simple idea here is to interpret all neighborhoods next to each other, resulting
+		 * in a virtual vector of size m. Then we draw a random index and return the edge.
+		 * For undirected edges, the vector has size 2m; but the idea remains. There is one minor
+		 * complication for undirected edges with self-loops: each edge {u,v} with u != v is stored
+		 * twice (once in the neighborhood of u, once in v) but a loop (u, u) is only stored once.
+		 * To equalize the probabilities we reject edges {u,v} with u > v and try again. This leads
+		 * to less than two expected trails in and is only done for undirected graphs with self-loops.
+		 */
+
+		while (true) {
+			const auto upper = directed
+				? numberOfEdges()
+				: 2 * numberOfEdges() - numberOfSelfLoops();
+			auto idx = Aux::Random::index(upper);
+
+			node u, v;
+
+			if (idx > upper / 2) {
+				// assuming degrees are somewhat distributed uniformly, it's better to start with
+				// larger nodes for large indices. In this case we have to mirror the index:
+				idx  = (upper-1) - idx;
+
+				for(u = upperNodeIdBound() - 1; idx >= degreeOut(u); --u) {
+					assert(0 <= u);
+
+					idx -= degreeOut(u);
+				}
+
+				v = outEdges[u][outEdges[u].size() - 1 - idx];
+
+			} else {
+				for(u = 0; idx >= degreeOut(u); ++u) {
+					assert(u < upperNodeIdBound());
+					idx -= degreeOut(u);
+				}
+
+				v = outEdges[u][idx];
+
+			}
+
+			if (numberOfSelfLoops() && !directed && u > v)
+				// reject (see above)
+				continue;
+
+			return {u, v};
+		}
 	}
 
-	node u, v; // we will return edge (u, v)
+	node u; // we will return edge (u, v)
+
 	// fast way, but not a uniform random edge!
 	do {
 		u = randomNode();
 	} while (outEdges[u].empty());
-	v = randomNeighbor(u);
-	return std::make_pair(u, v);
+
+	const auto v = randomNeighbor(u);
+
+	return {u, v};
 }
 
 std::vector<std::pair<node, node>> Graph::randomEdges(count nr) const {

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -897,11 +897,40 @@ TEST_P(GraphGTest, testHasEdge) {
 }
 
 TEST_P(GraphGTest, testRandomEdge) {
+	Aux::Random::setSeed(1, false);
 	// we only test the uniform version
-	count n = 4;
-	count m = 5;
-	count samples = 100000;
-	double maxAbsoluteError = 0.005;
+	constexpr count n = 4;
+	constexpr count m = 5;
+	constexpr count samples = 100000;
+	constexpr double maxAbsoluteError = 0.005;
+
+	Graph G = createGraph(n);
+	G.addEdge(0, 1); // 0 * 1 = 0
+	G.addEdge(1, 2); // 1 * 2 = 2
+	G.addEdge(3, 2); // 3 * 2 = 1 (mod 5)
+	G.addEdge(2, 2); // 2 * 2 = 4
+	G.addEdge(3, 1); // 3 * 1 = 3
+	ASSERT_EQ(m, G.numberOfEdges());
+
+	std::vector<count> drawCounts(m, 0);
+	for (count i = 0; i < samples; ++i) {
+		const auto e = G.randomEdge(true);
+		count id = (e.first * e.second) % 5;
+		drawCounts[id]++;
+	}
+	for (node id = 0; id < m; id++) {
+		double p = drawCounts[id] / (double)samples;
+		ASSERT_NEAR(1.0 / m, p, maxAbsoluteError);
+	}
+}
+
+TEST_P(GraphGTest, testRandomEdges) {
+	Aux::Random::setSeed(1, false);
+	// we only test the uniform version
+	constexpr count n = 4;
+	constexpr count m = 5;
+	constexpr count samples = 100000;
+	constexpr double maxAbsoluteError = 0.005;
 
 	Graph G = createGraph(n);
 	G.addEdge(0, 1); // 0 * 1 = 0

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -162,6 +162,28 @@ class TestGraph(unittest.TestCase):
 		self.assertEqual(GWeighted.numberOfNodes(),     GTrans.numberOfNodes())
 		self.assertEqual(GWeighted.numberOfEdges(),     GTrans.numberOfEdges())
 
+	def testRandomEdgesReproducibility(self):
+		numSamples = 10
+		numSeeds = 3
+		numRepeats = 10
+
+		for directed in [False, True]:
+			G = self.getSmallGraph(False, directed)
+
+			results = [[] for i in range(numSeeds)]
+			for repeats in range(numRepeats):
+				for seed in range(numSeeds):
+					nk.setSeed(seed, False)
+					results[seed].append(G.randomEdges(numSamples))
+
+			# assert results are different for different seeds
+			for seed in range(1, numSeeds):
+				self.assertNotEqual(results[0][0], results[seed][0])
+
+			# assert results are consistent for same seeds
+			for repeats in results:
+				for x in repeats[1:]:
+					self.assertEqual(repeats[0], x)
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This PR includes:
- Fix: Previously `Graph::randomEdges()` used `std::random_device` to seed its own `std::default_random_engine`. This obviously leads to non-reproducible tests. We now use the generator obtained via `Aux::Random::getURNG()`.
- Improvement: Previously `Graph::randomEdge()` used `Graph::randomEdges(1)` to obtain a single edge uniformly at random. This is highly suboptimal, since `Graph::randomEdges` uses `std::discrete_distribution` which builds a costly Theta(n) data structure -- this effort cannot be amortized when only sampling a single edge. This PR hence uses a single linear scan over the graph. In (maybe unrepresentative) measurements, the new implementation is more than an order of mag. faster.
- Adds CPP and Python unit tests