### PR TITLE
Fix VarInt and Zigzag coding of NKBG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -290,7 +290,7 @@ script:
  - mkdir core_build && cd "$_"
  - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD -DNETWORKIT_WARNINGS=ON ..
  - make -j2
- - ctest -V
+ - UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ASAN_OPTIONS=abort_on_error=1 ctest -V
  - cd ..
 
  # Finally, build the Python extension and run Python tests.

--- a/include/networkit/io/NetworkitBinaryGraph.hpp
+++ b/include/networkit/io/NetworkitBinaryGraph.hpp
@@ -98,6 +98,19 @@ inline size_t varIntDecode(const uint8_t *data, uint64_t &value) noexcept {
 	return n + 1;
 }
 
+/**
+ * Encodes a singed value, s.t. the sign bit is in the LSB bit, while the absolute value is
+ * stored in the remaining upper 63 bits. This allows more effective compression using varint.
+ */
+inline uint64_t zigzagEncode(int64_t value) noexcept {
+	return (value << 1) ^ (value >> 31);
+}
+
+//! Reverses zigzagEncode.
+inline int64_t zigzagDecode(uint64_t value) noexcept {
+	return (value >> 1) ^ (-(value & 1));
+}
+
 } // namespace nkbg
 } // namespace NetworKit
 

--- a/include/networkit/io/NetworkitBinaryGraph.hpp
+++ b/include/networkit/io/NetworkitBinaryGraph.hpp
@@ -1,7 +1,21 @@
+/*
+ * NetworkitBinaryGraph.hpp
+ *
+ *      Author: Charmaine Ndolo <charmaine.ndolo@b-tu.de>
+ */
+
 #ifndef NETWORKIT_BINARY_GRAPH_HPP
 #define NETWORKIT_BINARY_GRAPH_HPP
 
+#include <cstdint>
+#include <cstddef>
+
+#include <tlx/math/clz.hpp>
+#include <tlx/math/ffs.hpp>
+
+namespace NetworKit {
 namespace nkbg {
+
 struct Header {
 	char magic[8];
 	uint64_t checksum;
@@ -28,5 +42,48 @@ static constexpr uint64_t DIR_MASK = 0x1; // bit 0
 static constexpr uint64_t WGHT_MASK = 0xE; //bit 1-3
 static constexpr uint64_t WGHT_SHIFT = 0x1;
 
+/// Serializes value into a buffer and returns the number of bytes written.
+inline size_t varIntEncode(uint64_t value, uint8_t *buffer) noexcept {
+	uint64_t n;
+	if(!value) {
+		buffer[0] =1;
+		return 1;
+	}
+
+	if (value > (uint64_t(1) << 63)) {
+		n = 8;
+		buffer[0] = 0;
+	} else {
+		n = (64 - tlx::clz(value)) / 7;
+		buffer[0] = (1 << n) | (value << (n + 1));
+		value >>= 8 - (n + 1);
+	}
+
+	for(uint64_t i = 0; i < n; i++) {
+		buffer[i+1] = value & 0xFF;
+		value >>= 8;
+	}
+	return n + 1;
 }
+
+/// Converts a serialized varint into an uint64_t value and returns the number of bytes consumed.
+inline size_t varIntDecode(const uint8_t *data, uint64_t &value) noexcept {
+	int n;
+	if(!data[0]) {
+		n = 8;
+		value = 0;
+	} else {
+		n = tlx::ffs(data[0]) -1;
+		value = data[0] >> (n+1);
+	}
+
+	for(int i = 0; i < n; i++) {
+		value |= data[i+1] << (8 - (n + 1) + i * 8);
+	}
+	return n+1;
+}
+
+} // namespace nkbg
+} // namespace NetworKit
+
 #endif

--- a/include/networkit/io/NetworkitBinaryGraph.hpp
+++ b/include/networkit/io/NetworkitBinaryGraph.hpp
@@ -103,7 +103,7 @@ inline size_t varIntDecode(const uint8_t *data, uint64_t &value) noexcept {
  * stored in the remaining upper 63 bits. This allows more effective compression using varint.
  */
 inline uint64_t zigzagEncode(int64_t value) noexcept {
-	return (value << 1) ^ (value >> 31);
+	return (static_cast<uint64_t>(value) << 1) ^ (int64_t(-1) * (value < 0));
 }
 
 //! Reverses zigzagEncode.

--- a/include/networkit/io/NetworkitBinaryReader.hpp
+++ b/include/networkit/io/NetworkitBinaryReader.hpp
@@ -1,8 +1,9 @@
 /*
- * NetworkitBinaryReader.h
+ * NetworkitBinaryReader.hpp
  *
- *@author Charmaine Ndolo <charmaine.ndolo@b-tu.de>
+ *      Author: Charmaine Ndolo <charmaine.ndolo@b-tu.de>
  */
+
 #ifndef NETWORKIT_BINARY_READER_H
 #define NETWORKIT_BINARY_READER_H
 

--- a/include/networkit/io/NetworkitBinaryReader.hpp
+++ b/include/networkit/io/NetworkitBinaryReader.hpp
@@ -25,8 +25,6 @@ public:
 	Graph read(const std::string& path) override; 
 
 private:
-	static size_t decode(const uint8_t* data, uint64_t& result);
-
 	static int64_t decodeZigzag(uint64_t value);
 
 	count nodes;

--- a/include/networkit/io/NetworkitBinaryReader.hpp
+++ b/include/networkit/io/NetworkitBinaryReader.hpp
@@ -26,8 +26,6 @@ public:
 	Graph read(const std::string& path) override; 
 
 private:
-	static int64_t decodeZigzag(uint64_t value);
-
 	count nodes;
 	count chunks;
 	bool directed;

--- a/include/networkit/io/NetworkitBinaryWriter.hpp
+++ b/include/networkit/io/NetworkitBinaryWriter.hpp
@@ -1,7 +1,7 @@
 /*
  * NetworkitBinaryWriter.hpp
  *
- * @author Charmaine Ndolo <charmaine.ndolo@b-tu.de>
+ *      Author: Charmaine Ndolo <charmaine.ndolo@b-tu.de>
  */
 
 #ifndef NETWORKIT_BINARY_WRITER_H
@@ -12,11 +12,6 @@
 
 namespace NetworKit {
 
-/**
- * @ingroup io
- *
- * Writes a graph in the custom Networkit format documented in cpp/io/NetworkitGraph.md
- */
 enum class NetworkitBinaryWeights {
 	none,
 	unsignedFormat,
@@ -26,6 +21,11 @@ enum class NetworkitBinaryWeights {
 	autoDetect
 };
 
+/**
+ * @ingroup io
+ *
+ * Writes a graph in the custom Networkit format documented in cpp/io/NetworkitGraph.md
+ */
 class NetworkitBinaryWriter final : public GraphWriter {
 
 public:

--- a/include/networkit/io/NetworkitBinaryWriter.hpp
+++ b/include/networkit/io/NetworkitBinaryWriter.hpp
@@ -34,10 +34,6 @@ public:
 	void write(const Graph &G, const std::string &path) override;
 
 private:
-	static size_t encode(uint64_t value, uint8_t* buffer);
-
-	static uint64_t encodeZigzag(int64_t value);
-
 	count chunks;
 	NetworkitBinaryWeights weightsType;
 };

--- a/include/networkit/io/NetworkitBinaryWriter.hpp
+++ b/include/networkit/io/NetworkitBinaryWriter.hpp
@@ -41,5 +41,7 @@ private:
 	count chunks;
 	NetworkitBinaryWeights weightsType;
 };
-} /* namespace */
+
+} // namespace NetworKit
+
 #endif

--- a/networkit/cpp/io/CMakeLists.txt
+++ b/networkit/cpp/io/CMakeLists.txt
@@ -3,8 +3,6 @@ networkit_add_module(io
     BinaryEdgeListPartitionWriter.cpp
     BinaryPartitionReader.cpp
     BinaryPartitionWriter.cpp
-    NetworkitBinaryReader.cpp
-    NetworkitBinaryWriter.cpp
     CoverReader.cpp
     CoverWriter.cpp
     DGSReader.cpp
@@ -27,6 +25,8 @@ networkit_add_module(io
     METISGraphReader.cpp
     METISGraphWriter.cpp
     METISParser.cpp
+    NetworkitBinaryReader.cpp
+    NetworkitBinaryWriter.cpp
     MatrixMarketReader.cpp
     PartitionReader.cpp
     PartitionWriter.cpp

--- a/networkit/cpp/io/NetworkitBinaryReader.cpp
+++ b/networkit/cpp/io/NetworkitBinaryReader.cpp
@@ -13,10 +13,6 @@
 
 namespace NetworKit {
 
-int64_t NetworkitBinaryReader::decodeZigzag(uint64_t value) {
-	 return (value >> 1) ^ (-(value & 1));
-}
-
 Graph NetworkitBinaryReader::read(const std::string& path) {
 	nkbg::Header header = {};
 	nkbg::WEIGHT_FORMAT weightFormat;
@@ -158,7 +154,7 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 					{
 						uint64_t unsignedWeight;
 						wghtOff += nkbg::varIntDecode(reinterpret_cast<const uint8_t*>(adjWghtIt + wghtOff), unsignedWeight);
-						weight = decodeZigzag(unsignedWeight);
+						weight = nkbg::zigzagDecode(unsignedWeight);
 					}
 						break;
 					case nkbg::WEIGHT_FORMAT::FLOAT:
@@ -200,7 +196,7 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 					{
 						uint64_t unsignedWeight;
 						transWghtOff += nkbg::varIntDecode(reinterpret_cast<const uint8_t*>(transpWghtIt + transWghtOff), unsignedWeight);
-						weight = decodeZigzag(unsignedWeight);
+						weight = nkbg::zigzagDecode(unsignedWeight);
 					}
 						break;
 					case nkbg::WEIGHT_FORMAT::FLOAT:

--- a/networkit/cpp/io/NetworkitBinaryReader.cpp
+++ b/networkit/cpp/io/NetworkitBinaryReader.cpp
@@ -7,28 +7,11 @@
 #include <networkit/io/NetworkitBinaryReader.hpp>
 #include <networkit/io/NetworkitBinaryGraph.hpp>
 #include <networkit/io/MemoryMappedFile.hpp>
-#include <tlx/math/ffs.hpp>
 #include <fstream>
 #include <string.h>
 #include <atomic>
 
 namespace NetworKit {
-
-size_t NetworkitBinaryReader::decode(const uint8_t* data, uint64_t& value) {
-	int n;
-	if(!data[0]) {
-		n = 8;
-		value = 0;
-	} else {
-		n = tlx::ffs(data[0]) -1;
-		value = data[0] >> (n+1);
-	}
-
-	for(int i = 0; i < n; i++) {
-		value |= data[i+1] << (8 - (n + 1) + i * 8);
-	}
-	return n+1;
-}
 
 int64_t NetworkitBinaryReader::decodeZigzag(uint64_t value) {
 	 return (value >> 1) ^ (-(value & 1));
@@ -146,9 +129,9 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 		for (uint64_t i = 0; i < n; i++) {
 			uint64_t curr = vertex+i;
 			uint64_t outNbrs;
-			off += NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(adjIt + off), outNbrs);
+			off += nkbg::varIntDecode(reinterpret_cast<const uint8_t*>(adjIt + off), outNbrs);
 			uint64_t inNbrs;
-			transpOff += NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(transpIt + transpOff), inNbrs);
+			transpOff += nkbg::varIntDecode(reinterpret_cast<const uint8_t*>(transpIt + transpOff), inNbrs);
 			if(!directed) {
 				G.preallocateUndirected(curr, outNbrs+inNbrs);
 			} else  {
@@ -158,12 +141,12 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 			for (uint64_t j = 0; j < outNbrs; j++) {
 				uint64_t add;
 				double weight;
-				off += NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(adjIt + off), add);
+				off += nkbg::varIntDecode(reinterpret_cast<const uint8_t*>(adjIt + off), add);
 				switch(weightFormat) {
 					case nkbg::WEIGHT_FORMAT::VARINT:
 					{
 						uint64_t unsignedWeight;
-						wghtOff += NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(adjWghtIt + wghtOff), unsignedWeight);
+						wghtOff += nkbg::varIntDecode(reinterpret_cast<const uint8_t*>(adjWghtIt + wghtOff), unsignedWeight);
 						weight = unsignedWeight;
 					}
 						break;
@@ -174,7 +157,7 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 					case nkbg::WEIGHT_FORMAT::SIGNED_VARINT:
 					{
 						uint64_t unsignedWeight;
-						wghtOff += NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(adjWghtIt + wghtOff), unsignedWeight);
+						wghtOff += nkbg::varIntDecode(reinterpret_cast<const uint8_t*>(adjWghtIt + wghtOff), unsignedWeight);
 						weight = decodeZigzag(unsignedWeight);
 					}
 						break;
@@ -200,12 +183,12 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 			for (uint64_t j = 0; j < inNbrs; j++) {
 				uint64_t add;
 				double weight =1;
-				transpOff += NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(transpIt + transpOff), add);
+				transpOff += nkbg::varIntDecode(reinterpret_cast<const uint8_t*>(transpIt + transpOff), add);
 				switch(weightFormat) {
 					case nkbg::WEIGHT_FORMAT::VARINT:
 					{
 						uint64_t unsignedWeight;
-						transWghtOff += NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(transpWghtIt + transWghtOff), unsignedWeight);
+						transWghtOff += nkbg::varIntDecode(reinterpret_cast<const uint8_t*>(transpWghtIt + transWghtOff), unsignedWeight);
 						weight = unsignedWeight;
 					}
 						break;
@@ -216,7 +199,7 @@ Graph NetworkitBinaryReader::read(const std::string& path) {
 					case nkbg::WEIGHT_FORMAT::SIGNED_VARINT:
 					{
 						uint64_t unsignedWeight;
-						transWghtOff += NetworkitBinaryReader::decode(reinterpret_cast<const uint8_t*>(transpWghtIt + transWghtOff), unsignedWeight);
+						transWghtOff += nkbg::varIntDecode(reinterpret_cast<const uint8_t*>(transpWghtIt + transWghtOff), unsignedWeight);
 						weight = decodeZigzag(unsignedWeight);
 					}
 						break;

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -17,29 +17,6 @@ namespace NetworKit {
 
 NetworkitBinaryWriter::NetworkitBinaryWriter(uint64_t chunks, NetworkitBinaryWeights weightsType): chunks(chunks), weightsType(weightsType) {}
 
-size_t NetworkitBinaryWriter::encode(uint64_t value, uint8_t* buffer) {
-	uint64_t n;
-	if(!value) {
-		buffer[0] =1;
-		return 1;
-	}
-
-	if (value > (uint64_t(1) << 63)) {
-		n = 8;
-		buffer[0] = 0;
-	} else {
-		n = (64 - tlx::clz(value)) / 7;
-		buffer[0] = (1 << n) | (value << (n + 1));
-		value >>= 8 - (n + 1);
-	}
-
-	for(uint64_t i = 0; i < n; i++) {
-		buffer[i+1] = value & 0xFF;
-	   	value >>= 8;
-	}
-	return n + 1;
-}
-
 uint64_t NetworkitBinaryWriter::encodeZigzag(int64_t value) {
 	return (value << 1) ^ (value >> 31);
 }
@@ -128,7 +105,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
 		uint64_t weightSize;
 		switch(weightFormat) {
 			case nkbg::WEIGHT_FORMAT::VARINT:
-				weightSize = encode(w, tmp);
+				weightSize = nkbg::varIntEncode(w, tmp);
 				outfile.write(reinterpret_cast<char*>(tmp), weightSize);
 				break;
 			case nkbg::WEIGHT_FORMAT::DOUBLE:
@@ -137,7 +114,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
 			case nkbg::WEIGHT_FORMAT::SIGNED_VARINT:
 			{
 				uint64_t weight = encodeZigzag(w);
-				weightSize = encode(weight,tmp);
+				weightSize = nkbg::varIntEncode(weight,tmp);
 				outfile.write(reinterpret_cast<char*>(tmp), weightSize);
 			}
 				break;
@@ -183,7 +160,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
 		uint8_t tmp [10];
 		switch(weightFormat) {
 			case nkbg::WEIGHT_FORMAT::VARINT:
-				size = encode(w,tmp);
+				size = nkbg::varIntEncode(w,tmp);
 				break;
 			case nkbg::WEIGHT_FORMAT::DOUBLE:
 				size = sizeof(double);
@@ -191,7 +168,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
 			case nkbg::WEIGHT_FORMAT::SIGNED_VARINT:
 			{
 				uint64_t weight = encodeZigzag(w);
-				size += encode(weight,tmp);
+				size += nkbg::varIntEncode(weight,tmp);
 			}
 				break;
 			case nkbg::WEIGHT_FORMAT::FLOAT:
@@ -211,33 +188,33 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
 				G.forNeighborsOf(n,[&](node v, edgeweight w) {
 					if(v <= n) {
 						outNbrs++;
-						adjSize += encode(v, tmp);
+						adjSize += nkbg::varIntEncode(v, tmp);
 						adjWeightSize += computeWeightsOffsets(w);
 					}
 					if (v >= n) {
 						inNbrs++;
-						transpSize += encode(v, tmp);
+						transpSize += nkbg::varIntEncode(v, tmp);
 						transpWeightSize += computeWeightsOffsets(w);
 					}
 				});
 			} else {
 				G.forNeighborsOf(n, [&] (node v, edgeweight w) {
 					outNbrs++;
-					adjSize += encode(v, tmp);
+					adjSize += nkbg::varIntEncode(v, tmp);
 					adjWeightSize += computeWeightsOffsets(w);
 				});
 				G.forInNeighborsOf(n, [&] (node v, edgeweight w) {
 					inNbrs++;
-					transpSize += encode(v, tmp);
+					transpSize += nkbg::varIntEncode(v, tmp);
 					transpWeightSize += computeWeightsOffsets(w);
 				});
 			}
 			adjListSize += outNbrs;
-			adjSize += encode(outNbrs, tmp);
+			adjSize += nkbg::varIntEncode(outNbrs, tmp);
 			nrOutNbrs.push_back(outNbrs);
 
 			adjTransposeSize += inNbrs;
-			transpSize += encode(inNbrs, tmp);
+			transpSize += nkbg::varIntEncode(inNbrs, tmp);
 			nrInNbrs.push_back(inNbrs);
 		}
 		adjOffsets.push_back(adjSize);
@@ -294,17 +271,17 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
 	outfile.write(reinterpret_cast<char*>(&adjListSize), sizeof(uint64_t));
 	G.forNodes([&](node u) {
 		uint8_t tmp [10];
-		uint64_t nbrsSize = encode(nrOutNbrs[u], tmp);
+		uint64_t nbrsSize = nkbg::varIntEncode(nrOutNbrs[u], tmp);
 		outfile.write(reinterpret_cast<char*>(tmp), nbrsSize);
 		G.forNeighborsOf(u,[&](node v){
 			uint64_t nodeSize;
 			if(!G.isDirected()) {
 				if(v <= u) {
-					nodeSize = encode(v, tmp);
+					nodeSize = nkbg::varIntEncode(v, tmp);
 					outfile.write(reinterpret_cast<char*>(tmp), nodeSize);
 				}
 			} else {
-				nodeSize = encode(v, tmp);
+				nodeSize = nkbg::varIntEncode(v, tmp);
 				outfile.write(reinterpret_cast<char*>(tmp), nodeSize);
 			}
 		});
@@ -318,19 +295,19 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
 	outfile.write(reinterpret_cast<char*>(&adjTransposeSize), sizeof(uint64_t));
 	G.forNodes([&](node u) {
 		uint8_t tmp [10];
-		uint64_t nbrsSize = encode(nrInNbrs[u], tmp);
+		uint64_t nbrsSize = nkbg::varIntEncode(nrInNbrs[u], tmp);
 		outfile.write(reinterpret_cast<char*>(tmp), nbrsSize);
 		uint64_t nodeSize;
 		if(!G.isDirected()) {
 			G.forNeighborsOf(u,[&](node v){
 				if(v >= u) {
-					nodeSize = encode(v, tmp);
+					nodeSize = nkbg::varIntEncode(v, tmp);
 					outfile.write(reinterpret_cast<char*>(tmp), nodeSize);
 				}
 			});
 		} else {
 			G.forInNeighborsOf(u,[&](node v){
-				nodeSize = encode(v, tmp);
+				nodeSize = nkbg::varIntEncode(v, tmp);
 				outfile.write(reinterpret_cast<char*>(tmp), nodeSize);
 			});
 		}

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -17,10 +17,6 @@ namespace NetworKit {
 
 NetworkitBinaryWriter::NetworkitBinaryWriter(uint64_t chunks, NetworkitBinaryWeights weightsType): chunks(chunks), weightsType(weightsType) {}
 
-uint64_t NetworkitBinaryWriter::encodeZigzag(int64_t value) {
-	return (value << 1) ^ (value >> 31);
-}
-
 void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
 
 	std::ofstream outfile(path, std::ios::binary);
@@ -113,7 +109,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
 				break;
 			case nkbg::WEIGHT_FORMAT::SIGNED_VARINT:
 			{
-				uint64_t weight = encodeZigzag(w);
+				uint64_t weight = nkbg::zigzagEncode(w);
 				weightSize = nkbg::varIntEncode(weight,tmp);
 				outfile.write(reinterpret_cast<char*>(tmp), weightSize);
 			}
@@ -167,7 +163,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
 				break;
 			case nkbg::WEIGHT_FORMAT::SIGNED_VARINT:
 			{
-				uint64_t weight = encodeZigzag(w);
+				uint64_t weight = nkbg::zigzagEncode(w);
 				size += nkbg::varIntEncode(weight,tmp);
 			}
 				break;

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -7,11 +7,14 @@
 
 #include <gtest/gtest.h>
 
-#include <fstream>
-#include <unordered_set>
-#include <vector>
+#include <array>
+#include <cassert>
 #include <chrono>
 #include <iostream>
+#include <fstream>
+#include <limits>
+#include <unordered_set>
+#include <vector>
 
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/io/METISGraphWriter.hpp>
@@ -40,6 +43,7 @@
 #include <networkit/io/BinaryPartitionReader.hpp>
 #include <networkit/io/BinaryEdgeListPartitionWriter.hpp>
 #include <networkit/io/BinaryEdgeListPartitionReader.hpp>
+#include <networkit/io/NetworkitBinaryGraph.hpp>
 #include <networkit/io/NetworkitBinaryReader.hpp>
 #include <networkit/io/NetworkitBinaryWriter.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
@@ -938,4 +942,63 @@ TEST_F(IOGTest, testNetworkitBinaryDirectedSelfLoops) {
 	Graph G2 = reader.read("output/loops");
 	ASSERT_EQ(G.numberOfSelfLoops(), G2.numberOfSelfLoops());
 }
+
+TEST_F(IOGTest, testNetworkitVarInt) {
+	std::array<uint8_t, 10> buffer;
+
+	// write defined values into buffer
+	{
+		uint8_t i = 0;
+		for(auto& x : buffer)
+			x = i++;
+	}
+
+	std::mt19937_64 gen{1};
+
+	uint64_t checked_bits = 0;
+
+	for (int bits = 0; bits < 64; ++bits) {
+		auto min = uint64_t(1) << bits;
+		auto max = 2*min - 1;
+
+		// special cases
+		if (bits == 0) {
+			min = 0;
+			max = 0;
+		} else if (bits == 64) {
+			max = std::numeric_limits<uint64_t>::max();
+		}
+
+		std::uniform_int_distribution<uint64_t> distr{min, max};
+
+		const auto nSamples = std::min<size_t>(10 * max + 2, 1000);
+
+		for (size_t i = 0; i < nSamples; ++i) {
+			// first two iterations test min/max values, all other random values
+			const auto orig = [&] {
+				if (i == 0) return min;
+				if (i == 1) return max;
+				return distr(gen);
+			}();
+
+			uint64_t valueRead;
+			const auto bytesWritten = nkbg::varIntEncode(orig, buffer.data());
+			const auto bytesRead    = nkbg::varIntDecode(buffer.data(), valueRead);
+
+			ASSERT_EQ(bytesWritten, bytesRead) << "bits=" << bits << ", i=" << i;
+			ASSERT_EQ(valueRead, orig)         << "bits=" << bits << ", i=" << i;
+			ASSERT_GT(buffer[bytesWritten-1], 0) << "bits=" << bits << ", i=" << i;
+
+			for(size_t j = bytesWritten; j < buffer.size(); ++j)
+				ASSERT_EQ(buffer[j], j);
+
+			checked_bits |= orig;
+		}
+	}
+
+	// make sure we touched each bit at least once
+	ASSERT_EQ(checked_bits, std::numeric_limits<uint64_t>::max());
+
+}
+
 } /* namespace NetworKit */

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -943,7 +943,7 @@ TEST_F(IOGTest, testNetworkitBinaryDirectedSelfLoops) {
 	ASSERT_EQ(G.numberOfSelfLoops(), G2.numberOfSelfLoops());
 }
 
-TEST_F(IOGTest, testNetworkitVarInt) {
+TEST_F(IOGTest, testNetworkitBinaryVarInt) {
 	std::array<uint8_t, 10> buffer;
 
 	// write defined values into buffer
@@ -999,6 +999,25 @@ TEST_F(IOGTest, testNetworkitVarInt) {
 	// make sure we touched each bit at least once
 	ASSERT_EQ(checked_bits, std::numeric_limits<uint64_t>::max());
 
+}
+
+TEST_F(IOGTest, testNetworkitBinaryZigzag) {
+	std::mt19937_64 gen(1);
+	std::uniform_int_distribution<uint64_t> distr(0, (std::numeric_limits<uint64_t>::max() >> 1) - 1);
+
+	for(int i = 0; i < 10000; ++i) {
+		auto check = [] (int64_t value) {
+			const auto encoded = nkbg::zigzagEncode(value);
+			const auto decoded = nkbg::zigzagDecode(encoded);
+
+			ASSERT_EQ(value, decoded);
+			ASSERT_LE(encoded, 2u * static_cast<uint64_t>(std::abs(value)));
+		};
+
+		const auto x = distr(gen);
+		check(x);
+		check(-1 * x);
+	}
 }
 
 } /* namespace NetworKit */


### PR DESCRIPTION
UBSAN was complaining about both encodings used in NKBG. As all related routines were private methods to the Reader and Writer, I first moved the implementation into the `nkgb` namespace and added unit tests -- checking that `x == decode(encode(x)`). Unfortunately both failed.

While zigzagEncode was very similar to [a GitHub gitst](https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba), our implementation uses 64bit rather than 32bit integers leading to different constants. Additionally in C++ a left shift of signed ints is UB, while a right shift is implementation specific. I believe that my fix avoids both issues. Also the expression is more complicated GCC and CLANG yield the intended assembly of three instructions.

The implementation of the (de)serialization of varints had corner cases which lead to negative shifts. Also I do not understand why the number of bytes required was derived by dividing the number of bits by seven. As I did not find a documentation of the varint format, I assumed that the following format was intended:
The first byte stores the number of following bytes unary as the number of least significant zeros. This pattern is followed by a 1 (if n < 8). The potentially remaining bits are used to store the least significant bits of the value. The subsequent bytes then encode 8 bits of the value. I reimplemented both (de|en)coding routings to emit these structure.

Be advised that both fixes potentially break compatibility with existing files. I consider this a minor issue since the previous implementation was unable to consistently recover its own files. Should we bump up the magic code?

Two lessons learned:
- When ever we are in the comfortable situation to have both forward and inverse projects, we should add a unit test to check that their composition yields identity.
- We should pay attention to UBSAN messages. **Hence, this PR also treats ASAN and UBSAN warnings as errors during CI**.

(As a sidenote I also moved the `nkgb` namespace into the `NetworKit`)