### PR TITLE
Handle multiple self-loops removal

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1086,11 +1086,11 @@ public:
      * @param condition A function that takes a node as an input and returns a
      * bool. If true the edge (u, v) is removed.
      * @param edgesIn Whether in-going or out-going edges shall be removed.
-     * @return count The number of removed edges.
+     * @return std::pair<count, count> The number of removed edges (first) and the number of removed
+     * self-loops (second).
      */
     template <typename Condition>
-    count removeAdjacentEdges(node u, Condition condition, bool edgesIn = false);
-
+    std::pair<count, count> removeAdjacentEdges(node u, Condition condition, bool edgesIn = false);
 
     /**
      * Removes all self-loops in the graph.
@@ -2129,12 +2129,18 @@ template <typename L> void Graph::DFSEdgesFrom(node r, L handle) const {
 /* EDGE MODIFIERS */
 
 template <typename Condition>
-count Graph::removeAdjacentEdges(node u, Condition condition, bool edgesIn) {
+std::pair<count, count> Graph::removeAdjacentEdges(node u, Condition condition, bool edgesIn) {
 	count removedEdges = 0;
-	auto &edges_ = outEdges[u];
+	count removedSelfLoops = 0;
+
+	// For directed graphs, this function is supposed to be called twice: one to remove out-edges,
+	// and one to remove in-edges.
+	auto &edges_ = edgesIn ? inEdges[u] : outEdges[u];
 	for (index vi = 0; vi < edges_.size();) {
 		if (condition(edges_[vi])) {
-			++removedEdges;
+            const auto isSelfLoop = (edges_[vi] == u);
+            removedSelfLoops += isSelfLoop;
+            removedEdges += !isSelfLoop;
 			edges_[vi] = edges_.back();
 			edges_.pop_back();
 			if (isWeighted()) {
@@ -2152,7 +2158,7 @@ count Graph::removeAdjacentEdges(node u, Condition condition, bool edgesIn) {
 		}
 	}
 
-	return removedEdges;
+	return {removedEdges, removedSelfLoops};
 }
 
 

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -2413,8 +2413,9 @@ TEST_P(GraphGTest, testSubgraphFromNodesDirected) {
 TEST_P(GraphGTest, testRemoveMultiEdges) {
 	Aux::Random::setSeed(42, false);
 	Graph G(this->Ghouse);
-	auto edgeSet = G.edges();
-	const count nMultiEdges = 10;
+	const auto edgeSet = G.edges();
+	constexpr count nMultiEdges = 10;
+	constexpr count nMultiSelfLoops = 10;
 	const count m = G.numberOfEdges();
 
 	// Adding multiedges at random
@@ -2423,8 +2424,19 @@ TEST_P(GraphGTest, testRemoveMultiEdges) {
 		G.addEdge(e.first, e.second);
 	}
 
-	EXPECT_EQ(G.numberOfEdges(), m + nMultiEdges);
+	std::unordered_set<node> uniqueSelfLoops;
+	// Adding multiple self-loops at random
+	for (count i = 0; i < nMultiSelfLoops; ++i) {
+		node u = G.randomNode();
+		G.addEdge(u, u);
+		G.addEdge(u, u);
+		uniqueSelfLoops.insert(u);
+	}
+
+	EXPECT_EQ(G.numberOfEdges(), m + nMultiEdges + 2 * nMultiSelfLoops);
 	G.removeMultiEdges();
+	EXPECT_EQ(G.numberOfEdges(), m + uniqueSelfLoops.size());
+	G.removeSelfLoops();
 	EXPECT_EQ(G.numberOfEdges(), m);
 	auto edgeSet_ = G.edges();
 


### PR DESCRIPTION
This PR fixes a bug in `removeMultiEdges`: If a node has multiple self-loops, and the graph is undirected, `removeMultiEdges` counts self-loop removals twice, and therefore the edge count is updated wrongly.

I dislike that to do this fix the return value of `removeAdjacentEdges` is changed because we need to distinguish between removed non-self-loop edges and removed self-loops. If we want to avoid this, I am open to suggestions.

