### PR TITLE
New algorithm: Spanning Edge Centrality Approximation

### DIFF
--- a/include/networkit/centrality/ApproxSpanningEdge.hpp
+++ b/include/networkit/centrality/ApproxSpanningEdge.hpp
@@ -1,0 +1,86 @@
+/*
+ * ApproxSpanningEdge.hpp
+ *
+ *  Created on: 29.09.2019
+ *     Authors: Eugenio Angriman <angrimae@hu-berlin.de>
+ *
+ */
+
+// networkit-format
+
+#ifndef NETWORKIT_CENTRALITY_APPROX_SPANNING_EDGE_HPP_
+#define NETWORKIT_CENTRALITY_APPROX_SPANNING_EDGE_HPP_
+
+#include <vector>
+
+#include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+/**
+ * @ingroup centrality
+ */
+class ApproxSpanningEdge final : public Algorithm {
+
+    enum class NodeStatus : unsigned char {
+        NOT_IN_COMPONENT,
+        IN_SPANNING_TREE,
+        IN_RANDOM_WALK,
+        NOT_VISITED
+    };
+
+public:
+    /**
+     * Computes an epsilon-approximation of the spanning edge centrality of every edge of the input
+     * graph with probability (1 - 1/n), based on "Efficient Algorithms for Spanning Tree
+     * Centrality", Hayashi et al., IJCAI, 2016. This implementation also support multi-threading.
+     *
+     * @param G An undirected graph.
+     * @param eps Maximum additive error.
+     */
+    ApproxSpanningEdge(const Graph &G, double eps = 0.1);
+
+    ~ApproxSpanningEdge() = default;
+
+    /**
+     * Executes the algorithm.
+     */
+    void run() override;
+
+    /**
+     * Return the spanning edge approximation for each edge of the graph.
+     *
+     * @return Spanning edge approximation for each edge of the input graph.
+     */
+    std::vector<double> scores() const;
+
+private:
+    const Graph &G;
+    double eps;
+    double delta;
+    count nSamples;
+
+    // For each thread, marks which nodes have been visited by the random walk.
+    std::vector<std::vector<NodeStatus>> visitedNodes;
+
+    // For each thread, counts how many times each edge appears in a random
+    // spanning tree.
+    std::vector<std::vector<count>> edgeScores;
+
+    // Sequence of biconnected components.
+    std::vector<std::vector<node>> sequences;
+
+    // Parent pointers.
+    std::vector<std::vector<node>> parents;
+
+    // Ids of edge connecting the nodes to their parents.
+    std::vector<std::vector<edgeid>> parentsEdgeIds;
+
+    // Samples a spanning tree uniformly at random.
+    void sampleUST();
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_CENTRALITY_APPROX_SPANNING_EDGE_HPP_

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1800,6 +1800,21 @@ public:
         return outEdges[u][i];
     }
 
+    /**
+     * Get i-th (outgoing) neighbor of @a u and the corresponding edge id.
+     *
+     * @param u Node.
+     * @param i index; should be in [0, degreeOut(u))
+     * @return pair: i-th (outgoing) neighbor of @a u and the corresponding
+     * edge id, or @c none if no such neighbor exists.
+     */
+    std::pair<node, edgeid> getIthNeighborWithId(node u, index i) const {
+        assert(hasEdgeIds());
+        if (!hasNode(u) || i >= outEdges[u].size())
+            return {none, none};
+        return {outEdges[u][i], outEdgeIds[u][i]};
+    }
+
     /* Derivative Graphs */
 
     /**

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -12182,6 +12182,43 @@ cdef class SpanningEdgeCentrality(Algorithm):
 		return (<_SpanningEdgeCentrality*>(self._this)).scores()
 
 
+cdef extern from "<networkit/centrality/ApproxSpanningEdge.hpp>":
+	cdef cppclass _ApproxSpanningEdge "NetworKit::ApproxSpanningEdge"(_Algorithm):
+		_ApproxSpanningEdge(_Graph G, double eps) except +
+		vector[edgeweight] scores() except +
+
+cdef class ApproxSpanningEdge(Algorithm):
+	"""
+	Computes an epsilon-approximation of the spanning edge centrality of every edge of the input
+	graph with probability (1 - 1/n), based on "Efficient Algorithms for Spanning Tree
+	Centrality", Hayashi et al., IJCAI, 2016. This implementation also support multi-threading.
+
+	Parameters
+	----------
+	G : networkit.Graph
+		The graph.
+	eps : double
+		Maximum additive error.
+	"""
+
+	cdef Graph _G
+
+	def __cinit__(self, Graph G, double eps = 0.1):
+		self._G = G
+		self._this = new _ApproxSpanningEdge(G._this, eps)
+
+	def scores(self):
+		"""
+		Return the spanning edge approximation for each edge of the graph.
+
+
+		Returns
+		-------
+		list
+			Spanning edge approximation for each edge of the input graph.
+		"""
+		return (<_ApproxSpanningEdge*>(self._this)).scores();
+
 ## Module: viz
 
 

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1318,17 +1318,17 @@ cdef class Graph:
 		return self._this.randomNode()
 
 	def randomNeighbor(self, u):
-		""" Get a random neighbor of `v` and `none` if degree is zero.
+		""" Get a random neighbor of `u`. Returns `none` if the degree of `u` is zero.
 
 		Parameters
 		----------
-		v : node
+		u : node
 			Node.
 
 		Returns
 		-------
 		node
-			A random neighbor of `v.
+			A random neighbor of `u`, `none` if the degree of `u` is zero.
 		"""
 		from warnings import warn
 		warn("Graph.randomNeighbor is deprecated, use graphtools.randomNeighbor instead.")

--- a/networkit/centrality.py
+++ b/networkit/centrality.py
@@ -13,7 +13,7 @@ ApproxBetweenness2, EstimateBetweenness, DynApproxBetweenness, Closeness, Harmon
 KatzCentrality, LocalClusteringCoefficient, ApproxCloseness, LocalPartitionCoverage, Sfigality, SpanningEdgeCentrality,\
 PermanenceCentrality, TopCloseness, TopHarmonicCloseness, DynTopHarmonicCloseness, DynBetweenness,\
 GroupDegree, GroupCloseness, DynBetweennessOneNode, LaplacianCentrality, ApproxGroupBetweenness, DynKatzCentrality,\
-KadabraBetweenness
+KadabraBetweenness, ApproxSpanningEdge
 from _NetworKit import _ClosenessVariant as ClosenessVariant
 
 # local imports

--- a/networkit/cpp/centrality/ApproxSpanningEdge.cpp
+++ b/networkit/cpp/centrality/ApproxSpanningEdge.cpp
@@ -1,0 +1,199 @@
+/*
+ * ApproxSpanningEdge.hpp
+ *
+ *  Created on: 29.09.2019
+ *     Authors: Eugenio Angriman <angrimae@hu-berlin.de>
+ */
+
+// networkit-format
+
+#include <cassert>
+#include <cmath>
+#include <omp.h>
+#include <queue>
+
+#include <networkit/centrality/ApproxSpanningEdge.hpp>
+#include <networkit/components/BiconnectedComponents.hpp>
+
+namespace NetworKit {
+
+ApproxSpanningEdge::ApproxSpanningEdge(const Graph &G, double eps) : G(G), eps(eps) {
+    if (!G.numberOfEdges())
+        throw std::runtime_error("Error: graph is empty!");
+
+    if (!G.hasEdgeIds())
+        throw std::runtime_error("Error: edges not indexed, use indexEdges() before.");
+
+    delta = 1. / static_cast<double>(G.numberOfNodes());
+    visitedNodes.resize(
+        omp_get_max_threads(),
+        std::vector<NodeStatus>(G.upperNodeIdBound(), NodeStatus::NOT_IN_COMPONENT));
+    edgeScores.resize(omp_get_max_threads(), std::vector<count>(G.upperEdgeIdBound(), 0));
+    parents.resize(omp_get_max_threads(), std::vector<node>(G.upperNodeIdBound(), none));
+    parentsEdgeIds.resize(omp_get_max_threads(), std::vector<edgeid>(G.upperNodeIdBound(), none));
+}
+
+std::vector<double> ApproxSpanningEdge::scores() const {
+    assureFinished();
+    std::vector<double> scores(edgeScores[0].begin(), edgeScores[0].end());
+#pragma omp parallel for
+    for (omp_index i = 0; i < static_cast<omp_index>(scores.size()); ++i)
+        scores[i] /= static_cast<double>(nSamples);
+    return scores;
+}
+
+void ApproxSpanningEdge::sampleUST() {
+    auto &status = visitedNodes[omp_get_thread_num()];
+    auto &scores = edgeScores[omp_get_thread_num()];
+    auto &parent = parents[omp_get_thread_num()];
+    auto &parentId = parentsEdgeIds[omp_get_thread_num()];
+    auto &generator = Aux::Random::getURNG();
+
+    for (const auto &sequence : sequences) {
+
+        if (sequence.size() == 3) {
+            // Biconnected component of size 3: we pick 2 edges uniformly at random as spanning
+            // tree.
+            const node u = sequence[Aux::Random::integer(2)];
+            for (node v : sequence) {
+                if (v != u)
+                    status[v] = NodeStatus::NOT_VISITED;
+            }
+            G.forNeighborsOf(u, [&](node, const node v, edgeweight, const edgeid eid) {
+                if (status[v] == NodeStatus::NOT_VISITED)
+                    ++scores[eid];
+            });
+
+            for (node v : sequence)
+                status[v] = NodeStatus::NOT_IN_COMPONENT;
+
+            continue;
+        }
+
+        // We start building the spanning tree from the first node of the
+        // sequence
+        status[sequence[0]] = NodeStatus::IN_SPANNING_TREE;
+
+        // All the remaining nodes in the components need to be visited
+        std::for_each(sequence.begin() + 1, sequence.end(),
+                      [&](const node u) { status[u] = NodeStatus::NOT_VISITED; });
+
+        // Iterate over the remaining nodes to create the spanning tree
+        count nodesInSpanningTree = 1;
+        for (auto it = sequence.begin() + 1; it != sequence.end(); ++it) {
+            const node walkStart = *it;
+            if (status[walkStart] == NodeStatus::IN_SPANNING_TREE)
+                continue;
+
+            node currentNode = walkStart;
+            do {
+                // Get a random neighbor within the component
+                node randomNeighbor = none;
+                edgeid randomNeighborId = none;
+                do {
+                    std::tie(randomNeighbor, randomNeighborId) = G.getIthNeighborWithId(
+                        currentNode, std::uniform_int_distribution<count>{0, G.degree(currentNode)
+                                                                                 - 1}(generator));
+                } while (status[randomNeighbor] == NodeStatus::NOT_IN_COMPONENT);
+
+                assert(randomNeighbor != none);
+                parent[currentNode] = randomNeighbor;
+                parentId[currentNode] = randomNeighborId;
+                currentNode = randomNeighbor;
+            } while (status[currentNode] != NodeStatus::IN_SPANNING_TREE);
+
+            const node walkEnd = currentNode;
+            for (currentNode = walkStart; currentNode != walkEnd;
+                 currentNode = parent[currentNode]) {
+                status[currentNode] = NodeStatus::IN_SPANNING_TREE;
+                ++scores[parentId[currentNode]];
+                ++nodesInSpanningTree;
+            }
+
+            if (nodesInSpanningTree == sequence.size())
+                break;
+        }
+
+#ifndef NDEBUG
+        for (node u : sequence)
+            assert(status[u] == NodeStatus::IN_SPANNING_TREE);
+#endif
+        for (node u : sequence)
+            status[u] = NodeStatus::NOT_IN_COMPONENT;
+    }
+}
+
+void ApproxSpanningEdge::run() {
+    const auto m = static_cast<double>(G.numberOfEdges());
+    nSamples = static_cast<count>(std::ceil(std::log(2. * m / delta) / (2. * eps * eps)));
+
+    BiconnectedComponents bcc(G);
+    bcc.run();
+
+    auto &toVisit = visitedNodes[0];
+    std::queue<node> queue;
+    std::vector<node> sequence;
+    sequence.reserve(G.upperNodeIdBound());
+
+    for (auto curComponent : bcc.getComponents()) {
+        if (curComponent.size() == 2) {
+            // An edge connecting two articulation nodes is always in a ST
+            edgeScores[0][G.edgeId(curComponent[0], curComponent[1])] = nSamples;
+            continue;
+        }
+
+        if (curComponent.size() == 3) {
+            // Biconnected components with 3 nodes can be handled easily
+            sequences.push_back(curComponent);
+            continue;
+        }
+
+        if (curComponent.size() > 2) {
+            node source = curComponent[0];
+            // We set all nodes to be visited to IN_SPANNING_TREE, and we re-set them to
+            // NOT_IN_COMPONENT during the BFS. After the visit, the vector will be ready
+            // for the next phase of the algorithm (we do not have to re-set the visited
+            // nodes to NOT_IN_COMPONENT again).
+            for (const node curComponentNode : curComponent) {
+                if (G.degree(curComponentNode) > G.degree(source)) {
+                    source = curComponentNode;
+                }
+                toVisit[curComponentNode] = NodeStatus::IN_SPANNING_TREE;
+            }
+
+            queue.push(source);
+            toVisit[source] = NodeStatus::NOT_IN_COMPONENT;
+            count nVisited = 0;
+
+            do {
+                const node u = queue.front();
+                queue.pop();
+                sequence.push_back(u);
+                ++nVisited;
+                G.forNeighborsOf(u, [&](const node v) {
+                    if (toVisit[v] != NodeStatus::NOT_IN_COMPONENT) {
+                        toVisit[v] = NodeStatus::NOT_IN_COMPONENT;
+                        queue.push(v);
+                    }
+                });
+            } while (!queue.empty());
+
+            sequences.push_back(std::move(sequence));
+            assert(nVisited == curComponent.size());
+        }
+    }
+
+#pragma omp parallel for schedule(guided)
+    for (omp_index i = 0; i < static_cast<omp_index>(nSamples); ++i)
+        sampleUST();
+
+    for (count t = 1; t < edgeScores.size(); ++t) {
+        const auto &scores = edgeScores[t];
+#pragma omp parallel for
+        for (omp_index j = 0; j < static_cast<omp_index>(scores.size()); ++j)
+            edgeScores[0][j] += scores[j];
+    }
+
+    hasRun = true;
+}
+} // namespace NetworKit

--- a/networkit/cpp/centrality/CMakeLists.txt
+++ b/networkit/cpp/centrality/CMakeLists.txt
@@ -2,6 +2,7 @@ networkit_add_module(centrality
     ApproxBetweenness.cpp
     ApproxCloseness.cpp
     ApproxGroupBetweenness.cpp
+    ApproxSpanningEdge.cpp
     Betweenness.cpp
     Centrality.cpp
     Closeness.cpp

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -171,6 +171,19 @@ class Test_SelfLoops(unittest.TestCase):
 		CLL.run()
 		self.assertEqual(len(CL.ranking()), len(centrality.relativeRankErrors(CL.ranking(),CLL.ranking())))
 
+	def test_centrality_ApproxSpanningEdge(self):
+		setSeed(42, False)
+		g = generators.ErdosRenyiGenerator(300, 0.1, False).generate()
+		g.indexEdges()
+		eps = 0.1
+
+		apx = centrality.ApproxSpanningEdge(g, eps)
+		apx.run()
+		se = centrality.SpanningEdgeCentrality(g, eps)
+		se.runParallelApproximation()
+
+		for apxScore, exactScore in zip(apx.scores(), se.scores()):
+			self.assertLessEqual(abs(apxScore - exactScore), 2*eps)
 
 	def test_community_PLM(self):
 		PLML = community.PLM(self.L)

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -4,7 +4,7 @@ import os
 
 import networkit as nk
 
-class Test_SelfLoops(unittest.TestCase):
+class TestSelfLoops(unittest.TestCase):
 
 	def checkCovers(self, c1, c2):
 		if not c1.numberOfElements() == c2.numberOfElements(): return False
@@ -20,14 +20,14 @@ class Test_SelfLoops(unittest.TestCase):
 		self.L = nk.readGraph("input/looptest1.gml", nk.Format.GML) #without self-loops
 		self.LL = nk.readGraph("input/looptest2.gml", nk.Format.GML) #with self-loops sprinkled in
 
-	def test_centrality_Betweenness(self):
+	def testCentralityBetweenness(self):
 		CL = nk.centrality.Betweenness(self.L)
 		CL.run()
 		CLL = nk.centrality.Betweenness(self.LL)
 		CLL.run()
 		self.assertEqual(CL.ranking(), CLL.ranking())
 
-	def test_centrality_ApproxBetweenness(self):
+	def testCentralityApproxBetweenness(self):
 		CL = nk.centrality.ApproxBetweenness(self.L, epsilon=0.01, delta=0.1)
 		CL.run()
 		CLL = nk.centrality.ApproxBetweenness(self.LL, epsilon=0.01, delta=0.1)
@@ -38,7 +38,7 @@ class Test_SelfLoops(unittest.TestCase):
 			self.assertAlmostEqual(CL.ranking()[i][1], CLL.ranking()[i][1], delta=0.2*CL.ranking()[i][1])
 
 
-	def test_centrality_Closeness(self):
+	def testCentralityCloseness(self):
 		CL = nk.centrality.Closeness(self.L, True, nk.centrality.ClosenessVariant.Generalized)
 		CL.run()
 		CLL = nk.centrality.Closeness(self.LL, True, nk.centrality.ClosenessVariant.Generalized)
@@ -46,21 +46,21 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(CL.ranking(), CLL.ranking())
 
 
-	def test_centrality_TopCloseness(self):
-		CC = centrality.Closeness(self.L, True, centrality.ClosenessVariant.Generalized)
+	def testCentralityTopCloseness(self):
+		CC = nk.centrality.Closeness(self.L, True, nk.centrality.ClosenessVariant.Generalized)
 		CC.run()
 		k = 5
-		TC1 = centrality.TopCloseness(self.L, k, True, True)
+		TC1 = nk.centrality.TopCloseness(self.L, k, True, True)
 		TC1.run()
-		TC2 = centrality.TopCloseness(self.L, k, True, False)
+		TC2 = nk.centrality.TopCloseness(self.L, k, True, False)
 		TC2.run()
-		TC3 = centrality.TopCloseness(self.L, k, False, True)
+		TC3 = nk.centrality.TopCloseness(self.L, k, False, True)
 		TC3.run()
-		TC4 = centrality.TopCloseness(self.L, k, False, False)
+		TC4 = nk.centrality.TopCloseness(self.L, k, False, False)
 		TC4.run()
 
 		# Test if top nodes and scores lists have the same length
-		def test_topk_lists(with_trail):
+		def testTopKLists(with_trail):
 			if not with_trail:
 				self.assertEqual(len(TC1.topkNodesList()), k)
 				self.assertEqual(len(TC2.topkNodesList()), k)
@@ -72,7 +72,7 @@ class Test_SelfLoops(unittest.TestCase):
 			self.assertEqual(len(TC4.topkNodesList(with_trail)), len(TC4.topkScoresList(with_trail)))
 
 		# Test if the ranking is correct
-		def test_topk_ranking(with_trail):
+		def testTopKRanking(with_trail):
 			def zip_ranking(nodes, scores):
 				return [(node, score) for node, score in zip(nodes, scores)]
 			length = len(TC1.topkNodesList(with_trail))
@@ -81,13 +81,13 @@ class Test_SelfLoops(unittest.TestCase):
 			self.assertEqual(CC.ranking()[:length], zip_ranking(TC3.topkNodesList(), TC3.topkScoresList()))
 			self.assertEqual(CC.ranking()[:length], zip_ranking(TC4.topkNodesList(), TC4.topkScoresList()))
 
-		test_topk_lists(False)
-		test_topk_lists(True)
-		test_topk_ranking(False)
-		test_topk_ranking(True)
+		testTopKLists(False)
+		testTopKLists(True)
+		testTopKRanking(False)
+		testTopKRanking(True)
 
 
-	def test_centrality_CoreDecomposition(self):
+	def testCentralityCoreDecomposition(self):
 		CL = nk.centrality.CoreDecomposition(self.L)
 		CL.run()
 		try:
@@ -101,7 +101,7 @@ class Test_SelfLoops(unittest.TestCase):
 			self.assertTrue(self.checkCovers(CL.getCover(),CLL.getCover()))
 
 
-	def test_centrality_EigenvectorCentrality(self):
+	def testCentralityEigenvectorCentrality(self):
 		CL = nk.centrality.EigenvectorCentrality(self.L)
 		CL.run()
 		CLL = nk.centrality.EigenvectorCentrality(self.LL)
@@ -110,7 +110,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 
-	def test_centrality_KPathCentrality(self):
+	def testCentralityKPathCentrality(self):
 		CL = nk.centrality.KPathCentrality(self.L)
 		CL.run()
 		CLL = nk.centrality.KPathCentrality(self.LL)
@@ -119,7 +119,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 
-	def test_centrality_KatzCentrality(self):
+	def testCentralityKatzCentrality(self):
 		CL = nk.centrality.KatzCentrality(self.L)
 		CL.run()
 		CLL = nk.centrality.KatzCentrality(self.LL)
@@ -128,7 +128,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 
-	def test_centrality_PageRank(self):
+	def testCentralityPageRank(self):
 		CL = nk.centrality.PageRank(self.L)
 		CL.run()
 		CLL = nk.centrality.PageRank(self.LL)
@@ -137,7 +137,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 
-	def test_centrality_rankPerNode(self):
+	def testCentralityRankPerNode(self):
 		CL = nk.centrality.PageRank(self.L)
 		CL.run()
 		CLL = nk.centrality.PageRank(self.LL)
@@ -147,7 +147,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(len(CLL.ranking()),len(nk.centrality.rankPerNode(CLL.ranking())))
 
 
-	def test_centrality_SciPyPageRank(self):
+	def testCentralitySciPyPageRank(self):
 		CL = nk.centrality.SciPyPageRank(self.L)
 		CL.run()
 		CLL = nk.centrality.SciPyPageRank(self.LL)
@@ -156,7 +156,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 
-	def test_centrality_SciPyEVZ(self):
+	def testCentralitySciPyEVZ(self):
 		CL = nk.centrality.SciPyEVZ(self.L)
 		CL.run()
 		CLL = nk.centrality.SciPyEVZ(self.LL)
@@ -164,14 +164,14 @@ class Test_SelfLoops(unittest.TestCase):
 		#test if lists have the same length
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
-	def test_centrality_relativeRankErrors(self):
+	def testCentralityRelativeRankErrors(self):
 		CL = nk.centrality.Betweenness(self.L)
 		CL.run()
 		CLL = nk.centrality.Betweenness(self.LL)
 		CLL.run()
 		self.assertEqual(len(CL.ranking()), len(nk.centrality.relativeRankErrors(CL.ranking(),CLL.ranking())))
 
-	def test_centrality_ApproxSpanningEdge(self):
+	def testCentralityApproxSpanningEdge(self):
 		nk.setSeed(42, False)
 		g = nk.generators.ErdosRenyiGenerator(300, 0.1, False).generate()
 		g.indexEdges()
@@ -185,7 +185,7 @@ class Test_SelfLoops(unittest.TestCase):
 		for apxScore, exactScore in zip(apx.scores(), se.scores()):
 			self.assertLessEqual(abs(apxScore - exactScore), 2*eps)
 
-	def test_community_PLM(self):
+	def testCommunityPLM(self):
 		PLML = nk.community.PLM(self.L)
 		PLMLL = nk.community.PLM(self.LL)
 		PLML.run()
@@ -206,7 +206,7 @@ class Test_SelfLoops(unittest.TestCase):
 				reconstructedSet.append(j)
 		self.assertEqual(set(self.LL.iterNodes()), set(reconstructedSet))
 
-	def test_community_PLP(self):
+	def testCommunityPLP(self):
 		PLPL = nk.community.PLP(self.L)
 		PLPLL = nk.community.PLP(self.LL)
 		PLPL.run()
@@ -228,7 +228,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(set(self.LL.iterNodes()), set(reconstructedSet))
 
 
-	def test_community_CutClustering(self):
+	def testCommunityCutClustering(self):
 		CL = nk.community.CutClustering(self.L, 0.2)
 		CLL = nk.community.CutClustering(self.LL, 0.2)
 		CL.run()
@@ -250,7 +250,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(set(self.LL.iterNodes()), set(reconstructedSet))
 
 
-	def test_community_GraphClusteringTools(self):
+	def testCommunityGraphClusteringTools(self):
 		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
@@ -265,7 +265,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertIsInstance(GCT.isSingletonClustering(self.LL, PLPLLP), bool)
 
 
-	def test_community_GraphStructuralRandMeasure(self):
+	def testCommunityGraphStructuralRandMeasure(self):
 		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
@@ -276,7 +276,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertAlmostEqual(GSRM.getDissimilarity(self.LL, PLMLLP, PLPLLP),0.5, delta=0.5 )
 
 
-	def test_community_Hubdominance(self):
+	def testCommunityHubdominance(self):
 		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
@@ -284,7 +284,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertIsInstance(HD.getQuality(PLMLLP, self.LL),float )
 
 
-	def test_community_JaccardMeasure(self):
+	def testCommunityJaccardMeasure(self):
 		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
@@ -295,7 +295,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertIsInstance(JM.getDissimilarity(self.LL, PLMLLP, PLPLLP),float)
 
 
-	def test_community_LPDegreeOrdered(self):
+	def testCommunityLPDegreeOrdered(self):
 		CL = nk.community.LPDegreeOrdered(self.L)
 		CLL = nk.community.LPDegreeOrdered(self.LL)
 		CL.run()
@@ -316,7 +316,7 @@ class Test_SelfLoops(unittest.TestCase):
 				reconstructedSet.append(j)
 		self.assertEqual(set(self.LL.iterNodes()), set(reconstructedSet))
 
-	def test_community_Modularity(self):
+	def testCommunityModularity(self):
 		PLPLL = nk.community.PLP(self.LL)
 		PLPLL.run()
 		PLPLLP = PLPLL.getPartition()
@@ -324,7 +324,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertAlmostEqual(Mod.getQuality(PLPLLP, self.LL),0.25, delta=0.75)
 
 
-	def test_community_NMIDistance(self):
+	def testCommunityNMIDistance(self):
 		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
@@ -335,7 +335,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertIsInstance(NMI.getDissimilarity(self.LL, PLMLLP, PLPLLP),float)
 
 
-	def test_community_NodeStructuralRandMeasure(self):
+	def testCommunityNodeStructuralRandMeasure(self):
 		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
@@ -346,7 +346,7 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertAlmostEqual(NSRM.getDissimilarity(self.LL, PLMLLP, PLPLLP),0.5, delta=0.5 )
 
 
-	def test_community_communityGraph(self):
+	def testCommunityCommunityGraph(self):
 		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
@@ -354,17 +354,17 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertIsInstance(len(CG.nodes()), int)
 
 
-	def test_community_evaluateCommunityDetection(self):
+	def testCommunityEvaluateCommunityDetection(self):
 		PLMLL = nk.community.PLM(self.LL)
 		nk.community.evalCommunityDetection(PLMLL, self.LL)
 
 
-	def test_community_kCoreCommunityDetection(self):
+	def testCommunityKCoreCommunityDetection(self):
 		with self.assertRaises(RuntimeError) as cm:
 			kCCD = nk.community.kCoreCommunityDetection(self.LL, 1, inspect=False)
 
 
-	def test_flow_EdmondsKarp(self):
+	def testFlowEdmondsKarp(self):
 		self.L.indexEdges()
 		self.LL.indexEdges()
 		r1 = nk.graphtools.randomNode(self.L)
@@ -377,7 +377,7 @@ class Test_SelfLoops(unittest.TestCase):
 		EKLL.run()
 
 
-	def test_globals_ClusteringCoefficient(self):
+	def testGlobalsClusteringCoefficient(self):
 		CL = nk.globals.ClusteringCoefficient()
 		CL.exactGlobal(self.L)
 		CL.exactGlobal(self.LL)
@@ -392,7 +392,7 @@ class Test_SelfLoops(unittest.TestCase):
 		CL.sequentialAvgLocal(self.LL)
 
 
-	def test_components_ConnectedComponents(self):
+	def testComponentsConnectedComponents(self):
 		CC = nk.components.ConnectedComponents(self.LL)
 		CC.run()
 		CC.componentOfNode(1)
@@ -400,7 +400,7 @@ class Test_SelfLoops(unittest.TestCase):
 		CC.getPartition()
 		CC.numberOfComponents()
 
-	def test_extractLargestConnectedComponent(self):
+	def testExtractLargestConnectedComponent(self):
 		G = nk.Graph(10)
 		for i in range(3):
 			G.addEdge(i, i+1)
@@ -416,22 +416,22 @@ class Test_SelfLoops(unittest.TestCase):
 		for i in range(G.numberOfNodes()):
 			self.assertEqual(G2.hasNode(i), (4 <= i <= 9))
 
-	def test_components_BiconnectedComponents(self):
+	def testComponentsBiconnectedComponents(self):
 		bcc = nk.components.BiconnectedComponents(self.LL)
 		bcc.run()
 
 		for component in bcc.getComponents():
 			G1 = nk.graphtools.subgraphFromNodes(self.LL, component)
-			def test_node(v):
+			def testNode(v):
 				G2 = nk.Graph(G1)
 				G2.removeNode(v)
 				cc = nk.components.ConnectedComponents(G2)
 				cc.run()
 				self.assertEqual(cc.numberOfComponents(), 1)
-			G1.forNodes(test_node)
+			G1.forNodes(testNode)
 
 
-	def test_distance_Diameter(self):
+	def testDistanceDiameter(self):
 		D = nk.distance.Diameter(self.LL, nk.distance.DiameterAlgo.EstimatedRange, error = 0.1)
 		D.run()
 		D = nk.distance.Diameter(self.LL, nk.distance.DiameterAlgo.EstimatedSamples, nSamples = 5)
@@ -440,48 +440,48 @@ class Test_SelfLoops(unittest.TestCase):
 		D.run()
 
 
-	def test_distance_Eccentricity(self):
+	def testDistanceEccentricity(self):
 		E = nk.distance.Eccentricity()
 		E.getValue(self.LL, 0)
 
 
-	def test_distance_EffectiveDiameter(self):
+	def testDistanceEffectiveDiameter(self):
 		algo = nk.distance.EffectiveDiameter(self.L)
 		algo.run()
 		algo = nk.distance.EffectiveDiameter(self.LL)
 		algo.run()
 
 
-	def test_distance_ApproxEffectiveDiameter(self):
+	def testDistanceApproxEffectiveDiameter(self):
 		algo = nk.distance.EffectiveDiameterApproximation(self.L)
 		algo.run()
 		algo = nk.distance.EffectiveDiameterApproximation(self.LL)
 		algo.run()
 
 
-	def test_distance_ApproxHopPlot(self):
+	def testDistanceApproxHopPlot(self):
 		algo = nk.distance.HopPlotApproximation(self.L)
 		algo.run()
 		algo = nk.distance.HopPlotApproximation(self.LL)
 		algo.run()
 
 
-	def test_distance_NeighborhoodFunction(self):
+	def testDistanceNeighborhoodFunction(self):
 		algo = nk.distance.NeighborhoodFunction(self.L)
 		algo.run()
 		algo = nk.distance.NeighborhoodFunction(self.LL)
 		algo.run()
 
 
-	def test_distance_ApproxNeighborhoodFunction(self):
+	def testDistanceApproxNeighborhoodFunction(self):
 		algo = nk.distance.NeighborhoodFunctionApproximation(self.L)
 		algo.run()
 		algo = nk.distance.NeighborhoodFunctionApproximation(self.LL)
 		algo.run()
 
-	def test_distance_AStar(self):
+	def testDistanceAStar(self):
 		# Builds a mesh graph with the given number of rows and columns
-		def build_mesh(rows, cols):
+		def buildMesh(rows, cols):
 			G = nk.Graph(rows * cols, False, False)
 			for i in range(rows):
 				for j in range(cols):
@@ -492,20 +492,20 @@ class Test_SelfLoops(unittest.TestCase):
 			return G
 
 		# Test the AStar algorithm on a mesh with the given number of rows and columns
-		def test_mesh(rows, cols):
-			G = build_mesh(rows, cols)
+		def testMesh(rows, cols):
+			G = buildMesh(rows, cols)
 
 			# Test A* on the given source-target pair
-			def test_pair(s, t):
+			def testPair(s, t):
 
 				# Some distance heuristics:
 
 				# Always returns 0, A* degenerates to Dijkstra
-				def zero_dist(u):
+				def zeroDist(u):
 					return 0
 
 				# Returns the exact distance from u to the target
-				def exact_dist(u):
+				def exactDist(u):
 					rowU = int(u / cols)
 					colU = int(u % cols)
 					rowT = int(t / cols)
@@ -513,7 +513,7 @@ class Test_SelfLoops(unittest.TestCase):
 					return abs(rowU - rowT) + abs(colU - colT)
 
 				# Returns the eucledian distance from u to the target
-				def eucledian_dist(u):
+				def eucledianDist(u):
 					rowT = int(t / cols)
 					colT = int(t % cols)
 					rowDiff = abs(int(u / cols) - rowT)
@@ -524,7 +524,7 @@ class Test_SelfLoops(unittest.TestCase):
 				bfs = nk.distance.BFS(G, s, True, False, t).run()
 
 				# Test A* on all the heuristics
-				for heu in [zero_dist, exact_dist, eucledian_dist]:
+				for heu in [zeroDist, exactDist, eucledianDist]:
 					heuristics = [heu(u) for u in range(G.numberOfNodes())]
 					astar = nk.distance.AStar(G, heuristics, s, t, True)
 					astar.run()
@@ -541,13 +541,13 @@ class Test_SelfLoops(unittest.TestCase):
 						self.assertTrue(G.hasEdge(path[i], path[i + 1]))
 
 			# Iterate over all possible source-target pairs
-			G.forNodePairs(test_pair)
+			G.forNodePairs(testPair)
 
 		# Test some meshes
-		test_mesh(10, 10)
-		test_mesh(21, 5)
-		test_mesh(9, 18)
-		test_mesh(7, 1)
+		testMesh(10, 10)
+		testMesh(21, 5)
+		testMesh(9, 18)
+		testMesh(7, 1)
 
 
 if __name__ == "__main__":

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -2,7 +2,7 @@
 import unittest
 import os
 
-from networkit import *
+import networkit as nk
 
 class Test_SelfLoops(unittest.TestCase):
 
@@ -15,22 +15,22 @@ class Test_SelfLoops(unittest.TestCase):
 
 	def setUp(self):
 		# toggle the comment/uncomment to test on small or large test cases
-		#self.L = readGraph("PGPgiantcompo.graph", Format.METIS) #without self-loops
-		#self.LL = readGraph("PGPConnectedCompoLoops.gml", Format.GML) #with self-loops sprinkled in
-		self.L = readGraph("input/looptest1.gml", Format.GML) #without self-loops
-		self.LL = readGraph("input/looptest2.gml", Format.GML) #with self-loops sprinkled in
+		#self.L = nk.readGraph("PGPgiantcompo.graph", nk.Format.METIS) #without self-loops
+		#self.LL = nk.readGraph("PGPConnectedCompoLoops.gml", nk.Format.GML) #with self-loops sprinkled in
+		self.L = nk.readGraph("input/looptest1.gml", nk.Format.GML) #without self-loops
+		self.LL = nk.readGraph("input/looptest2.gml", nk.Format.GML) #with self-loops sprinkled in
 
 	def test_centrality_Betweenness(self):
-		CL = centrality.Betweenness(self.L)
+		CL = nk.centrality.Betweenness(self.L)
 		CL.run()
-		CLL = centrality.Betweenness(self.LL)
+		CLL = nk.centrality.Betweenness(self.LL)
 		CLL.run()
 		self.assertEqual(CL.ranking(), CLL.ranking())
 
 	def test_centrality_ApproxBetweenness(self):
-		CL = centrality.ApproxBetweenness(self.L, epsilon=0.01, delta=0.1)
+		CL = nk.centrality.ApproxBetweenness(self.L, epsilon=0.01, delta=0.1)
 		CL.run()
-		CLL = centrality.ApproxBetweenness(self.LL, epsilon=0.01, delta=0.1)
+		CLL = nk.centrality.ApproxBetweenness(self.LL, epsilon=0.01, delta=0.1)
 		CLL.run()
 		#test if lists have the same length
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
@@ -39,9 +39,9 @@ class Test_SelfLoops(unittest.TestCase):
 
 
 	def test_centrality_Closeness(self):
-		CL = centrality.Closeness(self.L, True, centrality.ClosenessVariant.Generalized)
+		CL = nk.centrality.Closeness(self.L, True, nk.centrality.ClosenessVariant.Generalized)
 		CL.run()
-		CLL = centrality.Closeness(self.LL, True, centrality.ClosenessVariant.Generalized)
+		CLL = nk.centrality.Closeness(self.LL, True, nk.centrality.ClosenessVariant.Generalized)
 		CLL.run()
 		self.assertEqual(CL.ranking(), CLL.ranking())
 
@@ -88,106 +88,106 @@ class Test_SelfLoops(unittest.TestCase):
 
 
 	def test_centrality_CoreDecomposition(self):
-		CL = centrality.CoreDecomposition(self.L)
+		CL = nk.centrality.CoreDecomposition(self.L)
 		CL.run()
 		try:
-			CLL = centrality.CoreDecomposition(self.LL)
+			CLL = nk.centrality.CoreDecomposition(self.LL)
 		except RuntimeError:
 			import copy
 			tmp = copy.deepcopy(self.LL)
 			tmp.removeSelfLoops()
-			CLL = centrality.CoreDecomposition(tmp)
+			CLL = nk.centrality.CoreDecomposition(tmp)
 			CLL.run()
 			self.assertTrue(self.checkCovers(CL.getCover(),CLL.getCover()))
 
 
 	def test_centrality_EigenvectorCentrality(self):
-		CL = centrality.EigenvectorCentrality(self.L)
+		CL = nk.centrality.EigenvectorCentrality(self.L)
 		CL.run()
-		CLL = centrality.EigenvectorCentrality(self.LL)
+		CLL = nk.centrality.EigenvectorCentrality(self.LL)
 		CLL.run()
 		#test if lists have the same length
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 
 	def test_centrality_KPathCentrality(self):
-		CL = centrality.KPathCentrality(self.L)
+		CL = nk.centrality.KPathCentrality(self.L)
 		CL.run()
-		CLL = centrality.KPathCentrality(self.LL)
+		CLL = nk.centrality.KPathCentrality(self.LL)
 		CLL.run()
 		#test if lists have the same length
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 
 	def test_centrality_KatzCentrality(self):
-		CL = centrality.KatzCentrality(self.L)
+		CL = nk.centrality.KatzCentrality(self.L)
 		CL.run()
-		CLL = centrality.KatzCentrality(self.LL)
+		CLL = nk.centrality.KatzCentrality(self.LL)
 		CLL.run()
 		#test if lists have the same length
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 
 	def test_centrality_PageRank(self):
-		CL = centrality.PageRank(self.L)
+		CL = nk.centrality.PageRank(self.L)
 		CL.run()
-		CLL = centrality.PageRank(self.LL)
+		CLL = nk.centrality.PageRank(self.LL)
 		CLL.run()
 		#test if lists have the same length
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 
 	def test_centrality_rankPerNode(self):
-		CL = centrality.PageRank(self.L)
+		CL = nk.centrality.PageRank(self.L)
 		CL.run()
-		CLL = centrality.PageRank(self.LL)
+		CLL = nk.centrality.PageRank(self.LL)
 		CLL.run()
 		#test if list of pairs and list of ranks have the same length
-		self.assertEqual(len(CL.ranking()),len(centrality.rankPerNode(CL.ranking())))
-		self.assertEqual(len(CLL.ranking()),len(centrality.rankPerNode(CLL.ranking())))
+		self.assertEqual(len(CL.ranking()),len(nk.centrality.rankPerNode(CL.ranking())))
+		self.assertEqual(len(CLL.ranking()),len(nk.centrality.rankPerNode(CLL.ranking())))
 
 
 	def test_centrality_SciPyPageRank(self):
-		CL = centrality.SciPyPageRank(self.L)
+		CL = nk.centrality.SciPyPageRank(self.L)
 		CL.run()
-		CLL = centrality.SciPyPageRank(self.LL)
+		CLL = nk.centrality.SciPyPageRank(self.LL)
 		CLL.run()
 		#test if lists have the same length
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 
 	def test_centrality_SciPyEVZ(self):
-		CL = centrality.SciPyEVZ(self.L)
+		CL = nk.centrality.SciPyEVZ(self.L)
 		CL.run()
-		CLL = centrality.SciPyEVZ(self.LL)
+		CLL = nk.centrality.SciPyEVZ(self.LL)
 		CLL.run()
 		#test if lists have the same length
 		self.assertEqual(len(CL.ranking()),len(CLL.ranking()))
 
 	def test_centrality_relativeRankErrors(self):
-		CL = centrality.Betweenness(self.L)
+		CL = nk.centrality.Betweenness(self.L)
 		CL.run()
-		CLL = centrality.Betweenness(self.LL)
+		CLL = nk.centrality.Betweenness(self.LL)
 		CLL.run()
-		self.assertEqual(len(CL.ranking()), len(centrality.relativeRankErrors(CL.ranking(),CLL.ranking())))
+		self.assertEqual(len(CL.ranking()), len(nk.centrality.relativeRankErrors(CL.ranking(),CLL.ranking())))
 
 	def test_centrality_ApproxSpanningEdge(self):
-		setSeed(42, False)
-		g = generators.ErdosRenyiGenerator(300, 0.1, False).generate()
+		nk.setSeed(42, False)
+		g = nk.generators.ErdosRenyiGenerator(300, 0.1, False).generate()
 		g.indexEdges()
 		eps = 0.1
 
-		apx = centrality.ApproxSpanningEdge(g, eps)
+		apx = nk.centrality.ApproxSpanningEdge(g, eps)
 		apx.run()
-		se = centrality.SpanningEdgeCentrality(g, eps)
+		se = nk.centrality.SpanningEdgeCentrality(g, eps)
 		se.runParallelApproximation()
 
 		for apxScore, exactScore in zip(apx.scores(), se.scores()):
 			self.assertLessEqual(abs(apxScore - exactScore), 2*eps)
 
 	def test_community_PLM(self):
-		PLML = community.PLM(self.L)
-		PLMLL = community.PLM(self.LL)
+		PLML = nk.community.PLM(self.L)
+		PLMLL = nk.community.PLM(self.LL)
 		PLML.run()
 		PLMLL.run()
 		PLMLP = PLML.getPartition()
@@ -207,8 +207,8 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(set(self.LL.iterNodes()), set(reconstructedSet))
 
 	def test_community_PLP(self):
-		PLPL = community.PLP(self.L)
-		PLPLL = community.PLP(self.LL)
+		PLPL = nk.community.PLP(self.L)
+		PLPLL = nk.community.PLP(self.LL)
 		PLPL.run()
 		PLPLL.run()
 		PLPLP = PLPL.getPartition()
@@ -229,8 +229,8 @@ class Test_SelfLoops(unittest.TestCase):
 
 
 	def test_community_CutClustering(self):
-		CL = community.CutClustering(self.L, 0.2)
-		CLL = community.CutClustering(self.LL, 0.2)
+		CL = nk.community.CutClustering(self.L, 0.2)
+		CLL = nk.community.CutClustering(self.LL, 0.2)
 		CL.run()
 		CLL.run()
 		CLP = CL.getPartition()
@@ -251,13 +251,13 @@ class Test_SelfLoops(unittest.TestCase):
 
 
 	def test_community_GraphClusteringTools(self):
-		PLMLL = community.PLM(self.LL)
+		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
-		PLPLL = community.PLP(self.LL)
+		PLPLL = nk.community.PLP(self.LL)
 		PLPLL.run()
 		PLPLLP = PLPLL.getPartition()
-		GCT = community.GraphClusteringTools()
+		GCT = nk.community.GraphClusteringTools()
 		self.assertIsInstance(GCT.equalClustering(PLMLLP,PLPLLP, self.LL), bool)
 		self.assertIsInstance(GCT.getImbalance(PLMLLP), float)
 		self.assertIsInstance(GCT.isOneClustering(self.LL, PLPLLP), bool)
@@ -266,38 +266,38 @@ class Test_SelfLoops(unittest.TestCase):
 
 
 	def test_community_GraphStructuralRandMeasure(self):
-		PLMLL = community.PLM(self.LL)
+		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
-		PLPLL = community.PLP(self.LL)
+		PLPLL = nk.community.PLP(self.LL)
 		PLPLL.run()
 		PLPLLP = PLPLL.getPartition()
-		GSRM = community.GraphStructuralRandMeasure()
+		GSRM = nk.community.GraphStructuralRandMeasure()
 		self.assertAlmostEqual(GSRM.getDissimilarity(self.LL, PLMLLP, PLPLLP),0.5, delta=0.5 )
 
 
 	def test_community_Hubdominance(self):
-		PLMLL = community.PLM(self.LL)
+		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
-		HD = community.HubDominance()
+		HD = nk.community.HubDominance()
 		self.assertIsInstance(HD.getQuality(PLMLLP, self.LL),float )
 
 
 	def test_community_JaccardMeasure(self):
-		PLMLL = community.PLM(self.LL)
+		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
-		PLPLL = community.PLP(self.LL)
+		PLPLL = nk.community.PLP(self.LL)
 		PLPLL.run()
 		PLPLLP = PLPLL.getPartition()
-		JM = community.JaccardMeasure()
+		JM = nk.community.JaccardMeasure()
 		self.assertIsInstance(JM.getDissimilarity(self.LL, PLMLLP, PLPLLP),float)
 
 
 	def test_community_LPDegreeOrdered(self):
-		CL = community.LPDegreeOrdered(self.L)
-		CLL = community.LPDegreeOrdered(self.LL)
+		CL = nk.community.LPDegreeOrdered(self.L)
+		CLL = nk.community.LPDegreeOrdered(self.LL)
 		CL.run()
 		CLL.run()
 		CLP = CL.getPartition()
@@ -317,67 +317,68 @@ class Test_SelfLoops(unittest.TestCase):
 		self.assertEqual(set(self.LL.iterNodes()), set(reconstructedSet))
 
 	def test_community_Modularity(self):
-		PLPLL = community.PLP(self.LL)
+		PLPLL = nk.community.PLP(self.LL)
 		PLPLL.run()
 		PLPLLP = PLPLL.getPartition()
-		Mod = community.Modularity()
+		Mod = nk.community.Modularity()
 		self.assertAlmostEqual(Mod.getQuality(PLPLLP, self.LL),0.25, delta=0.75)
 
 
 	def test_community_NMIDistance(self):
-		PLMLL = community.PLM(self.LL)
+		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
-		PLPLL = community.PLP(self.LL)
+		PLPLL = nk.community.PLP(self.LL)
 		PLPLL.run()
 		PLPLLP = PLPLL.getPartition()
-		NMI = community.NMIDistance()
+		NMI = nk.community.NMIDistance()
 		self.assertIsInstance(NMI.getDissimilarity(self.LL, PLMLLP, PLPLLP),float)
 
 
 	def test_community_NodeStructuralRandMeasure(self):
-		PLMLL = community.PLM(self.LL)
+		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
-		PLPLL = community.PLP(self.LL)
+		PLPLL = nk.community.PLP(self.LL)
 		PLPLL.run()
 		PLPLLP = PLPLL.getPartition()
-		NSRM = community.NodeStructuralRandMeasure()
+		NSRM = nk.community.NodeStructuralRandMeasure()
 		self.assertAlmostEqual(NSRM.getDissimilarity(self.LL, PLMLLP, PLPLLP),0.5, delta=0.5 )
 
 
 	def test_community_communityGraph(self):
-		PLMLL = community.PLM(self.LL)
+		PLMLL = nk.community.PLM(self.LL)
 		PLMLL.run()
 		PLMLLP = PLMLL.getPartition()
-		CG = community.communityGraph(self.LL, PLMLLP)
+		CG = nk.community.communityGraph(self.LL, PLMLLP)
+		self.assertIsInstance(len(CG.nodes()), int)
 
 
 	def test_community_evaluateCommunityDetection(self):
-		PLMLL = community.PLM(self.LL)
-		community.evalCommunityDetection(PLMLL, self.LL)
+		PLMLL = nk.community.PLM(self.LL)
+		nk.community.evalCommunityDetection(PLMLL, self.LL)
 
 
 	def test_community_kCoreCommunityDetection(self):
 		with self.assertRaises(RuntimeError) as cm:
-			kCCD = community.kCoreCommunityDetection(self.LL, 1, inspect=False)
+			kCCD = nk.community.kCoreCommunityDetection(self.LL, 1, inspect=False)
 
 
 	def test_flow_EdmondsKarp(self):
 		self.L.indexEdges()
 		self.LL.indexEdges()
-		r1 = graphtools.randomNode(self.L)
-		r2 = graphtools.randomNode(self.L)
+		r1 = nk.graphtools.randomNode(self.L)
+		r2 = nk.graphtools.randomNode(self.L)
 		while r1 is r2:
-			r2 = graphtools.randomNode(self.L)
-		EKL = flow.EdmondsKarp(self.L, r1, r2)
-		EKLL = flow.EdmondsKarp(self.LL, r1, r2)
+			r2 = self.L.randomNode()
+		EKL = nk.flow.EdmondsKarp(self.L, r1, r2)
+		EKLL = nk.flow.EdmondsKarp(self.LL, r1, r2)
 		EKL.run()
 		EKLL.run()
 
 
 	def test_globals_ClusteringCoefficient(self):
-		CL = globals.ClusteringCoefficient()
+		CL = nk.globals.ClusteringCoefficient()
 		CL.exactGlobal(self.L)
 		CL.exactGlobal(self.LL)
 		CL.approxGlobal(self.L, 5)
@@ -392,7 +393,7 @@ class Test_SelfLoops(unittest.TestCase):
 
 
 	def test_components_ConnectedComponents(self):
-		CC = components.ConnectedComponents(self.LL)
+		CC = nk.components.ConnectedComponents(self.LL)
 		CC.run()
 		CC.componentOfNode(1)
 		CC.getComponentSizes()
@@ -400,88 +401,88 @@ class Test_SelfLoops(unittest.TestCase):
 		CC.numberOfComponents()
 
 	def test_extractLargestConnectedComponent(self):
-		G = Graph(10)
+		G = nk.Graph(10)
 		for i in range(3):
 			G.addEdge(i, i+1)
 
 		for i in range(4, 9):
 			G.addEdge(i, i+1)
 
-		G1 = components.ConnectedComponents.extractLargestConnectedComponent(G, True)
+		G1 = nk.components.ConnectedComponents.extractLargestConnectedComponent(G, True)
 		self.assertEqual(G1.numberOfNodes(), 6)
 		self.assertEqual(G1.numberOfEdges(), 5)
 
-		G2 = components.ConnectedComponents.extractLargestConnectedComponent(G, False)
+		G2 = nk.components.ConnectedComponents.extractLargestConnectedComponent(G, False)
 		for i in range(G.numberOfNodes()):
 			self.assertEqual(G2.hasNode(i), (4 <= i <= 9))
 
 	def test_components_BiconnectedComponents(self):
-		bcc = components.BiconnectedComponents(self.LL)
+		bcc = nk.components.BiconnectedComponents(self.LL)
 		bcc.run()
 
 		for component in bcc.getComponents():
-			G1 = graphtools.subgraphFromNodes(self.LL, component)
+			G1 = nk.graphtools.subgraphFromNodes(self.LL, component)
 			def test_node(v):
-				G2 = Graph(G1)
+				G2 = nk.Graph(G1)
 				G2.removeNode(v)
-				cc = components.ConnectedComponents(G2)
+				cc = nk.components.ConnectedComponents(G2)
 				cc.run()
 				self.assertEqual(cc.numberOfComponents(), 1)
 			G1.forNodes(test_node)
 
 
 	def test_distance_Diameter(self):
-		D = distance.Diameter(self.LL, distance.DiameterAlgo.EstimatedRange, error = 0.1)
+		D = nk.distance.Diameter(self.LL, nk.distance.DiameterAlgo.EstimatedRange, error = 0.1)
 		D.run()
-		D = distance.Diameter(self.LL, distance.DiameterAlgo.EstimatedSamples, nSamples = 5)
+		D = nk.distance.Diameter(self.LL, nk.distance.DiameterAlgo.EstimatedSamples, nSamples = 5)
 		D.run()
-		D = distance.Diameter(self.LL, distance.DiameterAlgo.Exact)
+		D = nk.distance.Diameter(self.LL, nk.distance.DiameterAlgo.Exact)
 		D.run()
 
 
 	def test_distance_Eccentricity(self):
-		E = distance.Eccentricity()
+		E = nk.distance.Eccentricity()
 		E.getValue(self.LL, 0)
 
 
 	def test_distance_EffectiveDiameter(self):
-		algo = distance.EffectiveDiameter(self.L)
+		algo = nk.distance.EffectiveDiameter(self.L)
 		algo.run()
-		algo = distance.EffectiveDiameter(self.LL)
+		algo = nk.distance.EffectiveDiameter(self.LL)
 		algo.run()
 
 
 	def test_distance_ApproxEffectiveDiameter(self):
-		algo = distance.EffectiveDiameterApproximation(self.L)
+		algo = nk.distance.EffectiveDiameterApproximation(self.L)
 		algo.run()
-		algo = distance.EffectiveDiameterApproximation(self.LL)
+		algo = nk.distance.EffectiveDiameterApproximation(self.LL)
 		algo.run()
 
 
 	def test_distance_ApproxHopPlot(self):
-		algo = distance.HopPlotApproximation(self.L)
+		algo = nk.distance.HopPlotApproximation(self.L)
 		algo.run()
-		algo = distance.HopPlotApproximation(self.LL)
+		algo = nk.distance.HopPlotApproximation(self.LL)
 		algo.run()
 
 
 	def test_distance_NeighborhoodFunction(self):
-		algo = distance.NeighborhoodFunction(self.L)
+		algo = nk.distance.NeighborhoodFunction(self.L)
 		algo.run()
-		algo = distance.NeighborhoodFunction(self.LL)
+		algo = nk.distance.NeighborhoodFunction(self.LL)
 		algo.run()
 
 
 	def test_distance_ApproxNeighborhoodFunction(self):
-		algo = distance.NeighborhoodFunctionApproximation(self.L)
+		algo = nk.distance.NeighborhoodFunctionApproximation(self.L)
 		algo.run()
-		algo = distance.NeighborhoodFunctionApproximation(self.LL)
+		algo = nk.distance.NeighborhoodFunctionApproximation(self.LL)
 		algo.run()
 
 	def test_distance_AStar(self):
 		# Builds a mesh graph with the given number of rows and columns
 		def build_mesh(rows, cols):
-			G = Graph(rows * cols, False, False)
+			G = nk.Graph(rows * cols, False, False)
 			for i in range(rows):
 				for j in range(cols):
 					if j < cols - 1:
@@ -520,12 +521,12 @@ class Test_SelfLoops(unittest.TestCase):
 					return (rowDiff**2 + colDiff**2)**.5
 
 				# Use BFS as ground truth
-				bfs = distance.BFS(G, s, True, False, t).run()
+				bfs = nk.distance.BFS(G, s, True, False, t).run()
 
 				# Test A* on all the heuristics
 				for heu in [zero_dist, exact_dist, eucledian_dist]:
 					heuristics = [heu(u) for u in range(G.numberOfNodes())]
-					astar = distance.AStar(G, heuristics, s, t, True)
+					astar = nk.distance.AStar(G, heuristics, s, t, True)
 					astar.run()
 
 					# Test distance of target

--- a/notebooks/Centrality.ipynb
+++ b/notebooks/Centrality.ipynb
@@ -753,14 +753,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### SpanningEdge Centrality"
+    "### Spanning Edge Centrality"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The spanning centrality of an edge e .in an undirected graph is the fraction of the spanning trees of the graph that contain the edge e. The [SpanningEdgeCentrality(const Graph& G, double tol = 0.1)](https://networkit.github.io/dev-docs/python_api/centrality.html?highlight=spanning#networkit.centrality.SpanningEdgeCentrality) constructor expects a [networkit.Graph](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=graph#module-networkit.graph) as a mandatory parameter. The `tol` parameter determines the tolerance used for approximation: with probability at least 1-1/n, the approximated scores are within a factor 1+`tol` from the exact scores. \n",
+    "The spanning centrality of an edge `e` in an undirected graph is the fraction of the spanning trees of the graph that contain the edge `e`. The [SpanningEdgeCentrality(const Graph& G, double tol = 0.1)](https://networkit.github.io/dev-docs/python_api/centrality.html?highlight=spanning#networkit.centrality.SpanningEdgeCentrality) constructor expects a [networkit.Graph](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=graph#module-networkit.graph) as a mandatory parameter. The `tol` parameter determines the tolerance used for approximation: with probability at least 1-1/n, the approximated scores are within a factor 1+`tol` from the exact scores. \n",
     "\n",
     "Computing the SpanningEdge Centrality in NetworKit is then demonstrated below."
    ]
@@ -806,6 +806,50 @@
    "outputs": [],
    "source": [
     "span.scores()[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Approximate Spanning Edge Centrality"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An algorithm from [Hayashi et al.](https://www.ijcai.org/Proceedings/16/Papers/525.pdf) based on sampling of spanning trees uniformly at random approximates the spanning edge centrality of each edge of a graph up to a maximum absolute error. `ApproxSpanningEdge(G, eps=0.1)` expects as input an undirected graph, and the maximum absolute error `eps`. The algorithm requires the edges of the graph to be indexed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Read a graph\n",
+    "G = nk.graphtools.toUndirected(nk.readGraph(\"../input/foodweb-baydry.konect\", nk.Format.KONECT))\n",
+    "G.indexEdges()\n",
+    "apx_span = nk.centrality.ApproxSpanningEdge(G, 0.05)\n",
+    "_=apx_span.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "apx_span.scores()[:10]"
    ]
   },
   {


### PR DESCRIPTION
This PR brings a parallel implementation of the [Hayashi et al. algorithm](https://www.ijcai.org/Proceedings/16/Papers/525.pdf) for spanning edge centrality approximation.

To make the algorithm more efficient, this PR also includes a new function `Graph::getIthNeighborWithId` that returns the ith neighbor of a node `u` together with the id of the edge `(u, v)`. This is faster than using `Graph::getIthNeighbor` and retrieving the edge id with `Graph::edgeId`.