### PR TITLE
KADABRA: Add tuned parameters from EUROPAR'19 paper

### DIFF
--- a/include/networkit/centrality/KadabraBetweenness.hpp
+++ b/include/networkit/centrality/KadabraBetweenness.hpp
@@ -79,8 +79,11 @@ class SpSampler {
  * @ingroup centrality
  */
 class KadabraBetweenness : public Algorithm {
-
   public:
+    // See EUROPAR'19 paper for the selection of these parameters.
+    unsigned int baseItersPerStep = 1000;
+    double itersPerStepExp = 1.33;
+
     /**
      * Approximation of the betweenness centrality and computation of the top-k
      * nodes with highest betweenness centrality according to the algorithm

--- a/networkit/cpp/centrality/KadabraBetweenness.cpp
+++ b/networkit/cpp/centrality/KadabraBetweenness.cpp
@@ -316,8 +316,13 @@ void KadabraBetweenness::fillResult() {
 void KadabraBetweenness::run() {
     init();
     const count n = G.upperNodeIdBound();
-    const uint8_t itersPerStep = 11;
     const auto omp_max_threads = omp_get_max_threads();
+
+    // Compute the number of samples per SF as in our EUROPAR'19 paper.
+    const auto itersPerStep = std::max(1U,
+            static_cast<unsigned int>(baseItersPerStep
+                                      / std::pow(omp_max_threads, itersPerStepExp)));
+
     // TODO: setting the maximum relateve error to 0 gives the exact diameter
     // but may be inefficient for large graphs. What is the maximum relative
     // error that we can tolerate?
@@ -436,11 +441,11 @@ void KadabraBetweenness::run() {
                 }
             }
 
-            for (uint8_t i = 0; i < itersPerStep; ++i) {
+            for (unsigned int i = 0; i < itersPerStep; ++i) {
                 sampler.randomPath(curFrame);
             }
-
             curFrame->nPairs += itersPerStep;
+
             if (deterministic && curFrame->nPairs > 1000) {
                 finishedQueue.push_back(curFrame);
                 moveToNextEpoch();

--- a/networkit/cpp/centrality/KadabraBetweenness.cpp
+++ b/networkit/cpp/centrality/KadabraBetweenness.cpp
@@ -414,13 +414,13 @@ void KadabraBetweenness::run() {
         while (!stop.load(std::memory_order_relaxed)) {
             // Reader thread
             if (t == 0) {
-                if (epochToRead.load(std::memory_order_acquire) == epochRead) {
-                    epochToRead.store(epochRead + 1, std::memory_order_release);
+                if (epochToRead.load(std::memory_order_relaxed) == epochRead) {
+                    epochToRead.store(epochRead + 1, std::memory_order_relaxed);
                 }
                 checkConvergence(status);
             }
 
-            auto etr = epochToRead.load(std::memory_order_acquire);
+            const auto etr = epochToRead.load(std::memory_order_relaxed);
             if (!deterministic) {
                 if (etr == epochToWrite) {
                     recycleFrame();


### PR DESCRIPTION
This patch series applies a small fix to KADABRA (first commit), refactors memory orderings that are unnecessarily strong (second commit) and adds tuned parameters from our EUROPAR'19 paper that considerably improve performance (third commit).