### PR TITLE
Graph: deprecate and move methods to GraphTools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -277,13 +277,14 @@ matrix:
 
     - name: "Style guide compliance"
       os: linux
-      dist: bionic 
+      dist: bionic
       addons:
-         packages:
-            clang-format-7
+        apt:
+          sources: ['llvm-toolchain-bionic-8']
+          packages: ['clang-format-8']
       script:
         - set -e
-        - ./check_code.sh 
+        - ./check_code.sh
 
 script:
  - $CXX --version

--- a/include/networkit/dynamics/GraphEventProxy.hpp
+++ b/include/networkit/dynamics/GraphEventProxy.hpp
@@ -11,6 +11,8 @@
 #include <networkit/graph/Graph.hpp>
 #include <networkit/dynamics/GraphEventHandler.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -50,7 +52,7 @@ public:
 
     void incrementWeight(node u, node v, edgeweight delta);
 
-    void timeStep();
+    void TLX_DEPRECATED(timeStep());
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/graph/BFS.hpp
+++ b/include/networkit/graph/BFS.hpp
@@ -1,0 +1,109 @@
+#ifndef GRAPH_BFS_H
+#define GRAPH_BFS_H
+
+#include <queue>
+#include <vector>
+
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+namespace Traversal {
+
+/**
+ * Calls the given BFS handle with distance parameter
+ */
+template <class F>
+auto callBFSHandle(F &f, node u, count dist) -> decltype(f(u, dist)) {
+    return f(u, dist);
+}
+
+/**
+ * Calls the given BFS handle without distance parameter
+ */
+template <class F>
+auto callBFSHandle(F &f, node u, count) -> decltype(f(u)) {
+    return f(u);
+}
+
+/**
+ * Iterate over nodes in breadth-first search order starting from the nodes within the given range.
+ *
+ * @param G The input graph.
+ * @param first The first element of the range.
+ * @param last The end of the range.
+ * @param handle Takes a node as input parameter.
+ */
+template <class InputIt, typename L>
+void BFSfrom(const Graph &G, InputIt first, InputIt last, L handle) {
+    std::vector<bool> marked(G.upperNodeIdBound());
+    std::queue<node> q, qNext;
+    count dist = 0;
+    // enqueue start nodes
+    for (; first != last; ++first) {
+        q.push(*first);
+        marked[*first] = true;
+    }
+    do {
+        const auto u = q.front();
+        q.pop();
+        // apply function
+        callBFSHandle(handle, u, dist);
+        G.forNeighborsOf(u, [&](node v) {
+            if (!marked[v]) {
+                qNext.push(v);
+                marked[v] = true;
+            }
+        });
+        if (q.empty() && !qNext.empty()) {
+            q.swap(qNext);
+            ++dist;
+        }
+    } while (!q.empty());
+}
+
+/**
+ * Iterate over nodes in breadth-first search order starting from the given source node.
+ *
+ * @param G The input graph.
+ * @param source The source node.
+ * @param handle Takes a node as input parameter.
+ */
+template <typename L>
+void BFSfrom(const Graph &G, node source, L handle) {
+    std::vector<node> startNodes({source});
+    BFSfrom(G, startNodes.begin(), startNodes.end(), handle);
+}
+
+/**
+ * Iterate over edges in breadth-first search order starting from the given source node.
+ *
+ * @param G The input graph.
+ * @param source The source node.
+ * @param handle Takes a node as input parameter.
+ */
+template <typename L>
+void BFSEdgesFrom(const Graph &G, node source, L handle) {
+    std::vector<bool> marked(G.upperNodeIdBound());
+    std::queue<node> q;
+    q.push(source); // enqueue root
+    marked[source] = true;
+    do {
+        const auto u = q.front();
+        q.pop();
+        // apply function
+        G.forNeighborsOf(u, [&](node, node v, edgeweight w, edgeid eid) {
+            if (!marked[v]) {
+                handle(u, v, w, eid);
+                q.push(v);
+                marked[v] = true;
+            }
+        });
+    } while (!q.empty());
+}
+
+} // namespace Traversal
+
+} // namespace NetworKit
+
+#endif

--- a/include/networkit/graph/BFS.hpp
+++ b/include/networkit/graph/BFS.hpp
@@ -1,5 +1,7 @@
-#ifndef GRAPH_BFS_H
-#define GRAPH_BFS_H
+// networkit-format
+
+#ifndef NETWORKIT_GRAPH_BFS_HPP_
+#define NETWORKIT_GRAPH_BFS_HPP_
 
 #include <queue>
 #include <vector>
@@ -106,4 +108,4 @@ void BFSEdgesFrom(const Graph &G, node source, L handle) {
 
 } // namespace NetworKit
 
-#endif
+#endif // NETWORKIT_GRAPH_BFS_HPP_

--- a/include/networkit/graph/DFS.hpp
+++ b/include/networkit/graph/DFS.hpp
@@ -1,5 +1,7 @@
-#ifndef GRAPH_DFS_H
-#define GRAPH_DFS_H
+// networkit-format
+
+#ifndef NETWORKIT_GRAPH_DFS_HPP_
+#define NETWORKIT_GRAPH_DFS_HPP_
 
 #include <stack>
 #include <vector>
@@ -67,4 +69,4 @@ void DFSEdgesFrom(const Graph &G, node source, L handle) {
 } // namespace Traversal
 
 } // namespace NetworKit
-#endif
+#endif // NETWORKIT_GRAPH_DFS_HPP_

--- a/include/networkit/graph/DFS.hpp
+++ b/include/networkit/graph/DFS.hpp
@@ -1,0 +1,70 @@
+#ifndef GRAPH_DFS_H
+#define GRAPH_DFS_H
+
+#include <stack>
+#include <vector>
+
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+namespace Traversal {
+
+/**
+ * Iterate over nodes in depth-first search order starting from the given source node.
+ *
+ * @param G The input graph.
+ * @param source The source node.
+ * @param handle Takes a node as input parameter.
+ */
+template <typename L>
+void DFSfrom(const Graph &G, node source, L handle) {
+    std::vector<bool> marked(G.upperNodeIdBound());
+    std::stack<node> s;
+    s.push(source); // enqueue root
+    marked[source] = true;
+    do {
+        const auto u = s.top();
+        s.pop();
+        // apply function
+        handle(u);
+        G.forNeighborsOf(u, [&](node v) {
+            if (!marked[v]) {
+                s.push(v);
+                marked[v] = true;
+            }
+        });
+    } while (!s.empty());
+}
+
+/**
+ * Iterate over edges in depth-first search order starting from the given source node.
+ *
+ * @param G The input graph.
+ * @param source The source node.
+ * @param handle Takes a node as input parameter.
+ */
+template <typename L>
+void DFSEdgesFrom(const Graph &G, node source, L handle) {
+    std::vector<bool> marked(G.upperNodeIdBound());
+    std::stack<node> s;
+    s.push(source); // enqueue root
+    marked[source] = true;
+    do {
+        const auto u = s.top();
+        s.pop();
+        // apply function
+        G.forNeighborsOf(u, [&](node, node v, edgeweight w, edgeid eid) {
+            if (!marked[v]) {
+                handle(u, v, w, eid);
+                s.push(v);
+                marked[v] = true;
+            }
+        });
+    } while (!s.empty());
+}
+
+} // namespace Traversal
+
+} // namespace NetworKit
+#endif

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -845,6 +845,38 @@ public:
     void removeNode(node v);
 
     /**
+     * Removes out-going edges from node @u. If the graph is weighted and/or has edge ids, weights and/or edge ids will also be removed.
+     *
+     * @param node u Node.
+     */
+    void removePartialOutEdges(Unsafe, node u) {
+        assert(hasNode(u));
+        outEdges[u].clear();
+        if (isWeighted()) {
+            outEdgeWeights[u].clear();
+        }
+        if (hasEdgeIds()) {
+            outEdgeIds[u].clear();
+        }
+    }
+
+    /**
+     * Removes in-going edges to node @u. If the graph is weighted and/or has edge ids, weights and/or edge ids will also be removed.
+     *
+     * @param node u Node.
+     */
+    void removePartialInEdges(Unsafe, node u) {
+        assert(hasNode(u));
+        inEdges[u].clear();
+        if (isWeighted()) {
+            inEdgeWeights[u].clear();
+        }
+        if (hasEdgeIds()) {
+            inEdgeIds[u].clear();
+        }
+    }
+
+    /**
      * Check if node @a v exists in the graph.
      *
      * @param v Node.
@@ -1077,7 +1109,7 @@ public:
      * @param nodesInSet vector of nodes that form a connected component that
      * is isolated from the rest of the graph.
      */
-    void removeEdgesFromIsolatedSet(const std::vector<node> &nodesInSet);
+    void TLX_DEPRECATED(removeEdgesFromIsolatedSet(const std::vector<node> &nodesInSet));
 
     /**
      * Removes all the edges in the graph.

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -814,7 +814,7 @@ public:
      * Copies all nodes to a new graph
      * @return graph with the same nodes.
      */
-    Graph copyNodes() const;
+    Graph TLX_DEPRECATED(copyNodes() const);
 
     /* NODE MODIFIERS */
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1171,7 +1171,7 @@ public:
      * give you a real uniform distributed edge, but will be slower.
      * Exp. time complexity: O(1) for uniformDistribution = false, O(n) otherwise.
      */
-    std::pair<node, node> randomEdge(bool uniformDistribution = false) const;
+    std::pair<node, node> TLX_DEPRECATED(randomEdge(bool uniformDistribution = false) const);
 
     /**
      * Returns a vector with nr random edges. The edges are chosen uniform

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -889,7 +889,9 @@ public:
      * The subgraph contains all nodes in Nodes + Neighbors and all edge which have one end point in Nodes
      * and the other in Nodes or Neighbors.
      */
-    Graph subgraphFromNodes(const std::unordered_set<node> &nodes, bool includeOutNeighbors = false, bool includeInNeighbors = false) const;
+    Graph TLX_DEPRECATED(subgraphFromNodes(const std::unordered_set<node> &nodes,
+                                           bool includeOutNeighbors = false,
+                                           bool includeInNeighbors = false) const);
 
     /** NODE PROPERTIES **/
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -169,13 +169,6 @@ class Graph final {
                                      bool countSelfLoopsTwice = false) const;
 
     /**
-     * Computes the maximum in/out weighted degree of the graph
-     *
-     * @param inDegree whether to compute the in degree or the out degree
-     */
-    edgeweight computeMaxWeightedDegree(const bool inDegree = false) const;
-
-    /**
      * Returns the edge weight of the outgoing edge of index i in the outgoing
      * edges of node u
      * @param u The node
@@ -975,7 +968,7 @@ public:
      * @note For directed graphs this is the sum of weights of all outgoing
      * edges.
      */
-    edgeweight maxWeightedDegree() const;
+    edgeweight TLX_DEPRECATED(maxWeightedDegree() const);
 
     /**
      * Returns the maximum weighted in degree of the graph.
@@ -984,7 +977,7 @@ public:
      * @note For directed graphs this is the sum of weights of all in-going
      * edges.
      */
-    edgeweight maxWeightedDegreeIn() const;
+    edgeweight TLX_DEPRECATED(maxWeightedDegreeIn() const);
 
     /**
      * Returns the weighted in-degree of @a u.

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1375,14 +1375,14 @@ public:
      *
      * @return undirected graph.
      */
-    Graph toUndirected() const;
+    Graph TLX_DEPRECATED(toUndirected() const);
 
     /**
      * Return an unweighted version of this graph.
      *
      * @return unweighted graph.
      */
-    Graph toUnweighted() const;
+    Graph TLX_DEPRECATED(toUnweighted() const);
 
     /**
      * Return the transpose of this graph. The graph must be directed.

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -20,6 +20,7 @@
 
 #include <networkit/Globals.hpp>
 #include <networkit/auxiliary/FunctionTraits.hpp>
+#include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
 
 #include <tlx/define/deprecated.hpp>

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -873,14 +873,14 @@ public:
      * id remapping.
      * @param G [description]
      */
-    void append(const Graph &G);
+    void TLX_DEPRECATED(append(const Graph &G));
 
     /**
      * Modifies this graph to be the union of it and another graph.
      * Nodes with the same ids are identified with each other.
      * @param G [description]
      */
-    void merge(const Graph &G);
+    void TLX_DEPRECATED(merge(const Graph &G));
 
     // SUBGRAPHS
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -729,7 +729,7 @@ public:
      *
      * @return bool if edges have been indexed
      */
-    bool hasEdgeIds() const { return edgesIndexed; }
+    bool hasEdgeIds() const noexcept { return edgesIndexed; }
 
     /**
      * Get the id of the given edge.
@@ -740,7 +740,7 @@ public:
      * Get an upper bound for the edge ids in the graph.
      * @return An upper bound for the edge ids.
      */
-    index upperEdgeIdBound() const { return omega; }
+    index upperEdgeIdBound() const noexcept { return omega; }
 
     /** GRAPH INFORMATION **/
 
@@ -864,7 +864,7 @@ public:
      * @return @c true if @a v exists, @c false otherwise.
      */
 
-    bool hasNode(node v) const { return (v < z) && this->exists[v]; }
+    bool hasNode(node v) const noexcept { return (v < z) && this->exists[v]; }
 
     /**
      * Restores a previously deleted node @a v with its previous id in the
@@ -1143,7 +1143,7 @@ public:
      * @return <code>true</code> if the edge exists, <code>false</code>
      * otherwise.
      */
-    bool hasEdge(node u, node v) const;
+    bool hasEdge(node u, node v) const noexcept;
 
     /**
      * Returns a random edge. By default a random node u is chosen and then
@@ -1168,37 +1168,37 @@ public:
      * @return <code>true</code> if this graph supports edge weights other
      * than 1.0.
      */
-    bool isWeighted() const { return weighted; }
+    bool isWeighted() const noexcept { return weighted; }
 
     /**
      * Return @c true if this graph supports directed edges.
      * @return @c true if this graph supports directed edges.
      */
-    bool isDirected() const { return directed; }
+    bool isDirected() const noexcept { return directed; }
 
     /**
      * Return <code>true</code> if graph contains no nodes.
      * @return <code>true</code> if graph contains no nodes.
      */
-    bool isEmpty() const { return n == 0; }
+    bool isEmpty() const noexcept { return !n; }
 
     /**
      * Return the number of nodes in the graph.
      * @return The number of nodes.
      */
-    count numberOfNodes() const { return n; }
+    count numberOfNodes() const noexcept { return n; }
 
     /**
      * Return the number of edges in the graph.
      * @return The number of edges.
      */
-    count numberOfEdges() const { return m; }
+    count numberOfEdges() const noexcept { return m; }
 
     /**
      * @return a pair (n, m) where n is the number of nodes and m is the
      * number of edges
      */
-    std::pair<count, count> const size() const { return {n, m}; };
+    std::pair<count, count> const size() const noexcept { return {n, m}; };
 
     /**
      * @return the density of the graph
@@ -1223,13 +1223,13 @@ public:
      * @note This involves calculation, so store result if needed multiple
      * times.
      */
-    count numberOfSelfLoops() const;
+    count numberOfSelfLoops() const noexcept { return storedNumberOfSelfLoops; }
 
     /**
      * Get an upper bound for the node ids in the graph.
      * @return An upper bound for the node ids.
      */
-    index upperNodeIdBound() const { return z; }
+    index upperNodeIdBound() const noexcept { return z; }
 
     /**
      * Check for invalid graph states, such as multi-edges.
@@ -1292,7 +1292,7 @@ public:
      * Returns the sum of all edge weights.
      * @return The sum of all edge weights.
      */
-    edgeweight totalEdgeWeight() const;
+    edgeweight totalEdgeWeight() const noexcept;
 
     /* Collections */
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -6,6 +6,8 @@
  * (klara.reichard@gmail.com), Marvin Ritter (marvin.ritter@gmail.com)
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_GRAPH_GRAPH_HPP_
 #define NETWORKIT_GRAPH_GRAPH_HPP_
 
@@ -57,14 +59,13 @@ inline bool operator==(const Edge &e1, const Edge &e2) {
     return e1.u == e2.u && e1.v == e2.v;
 }
 struct Unsafe {};
-static constexpr Unsafe unsafe {};
+static constexpr Unsafe unsafe{};
 } // namespace NetworKit
 
 namespace std {
-template <> struct hash<NetworKit::Edge> {
-    size_t operator()(const NetworKit::Edge &e) const {
-        return hash_node(e.u) ^ hash_node(e.v);
-    }
+template <>
+struct hash<NetworKit::Edge> {
+    size_t operator()(const NetworKit::Edge &e) const { return hash_node(e.u) ^ hash_node(e.v); }
 
     hash<NetworKit::node> hash_node;
 };
@@ -87,7 +88,7 @@ class Graph final {
     friend class GraphBuilder;
     friend class CurveballDetails::CurveballMaterialization;
 
-  private:
+private:
     // graph attributes
     //!< unique graph id, starts at 0
     count id;
@@ -234,8 +235,7 @@ class Graph final {
      * @param handle The handle that shall be executed for each edge
      * @return void
      */
-    template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds,
-              typename L>
+    template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
     inline void forOutEdgesOfImpl(node u, L handle) const;
 
     /**
@@ -248,8 +248,7 @@ class Graph final {
      * @param handle The handle that shall be executed for each edge
      * @return void
      */
-    template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds,
-              typename L>
+    template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
     inline void forInEdgesOfImpl(node u, L handle) const;
 
     /**
@@ -258,8 +257,7 @@ class Graph final {
      * @param handle The handle that shall be executed for all edges
      * @return void
      */
-    template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds,
-              typename L>
+    template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
     inline void forEdgeImpl(L handle) const;
 
     /**
@@ -269,8 +267,7 @@ class Graph final {
      * @param handle The handle that shall be executed for all edges
      * @return void
      */
-    template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds,
-              typename L>
+    template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
     inline void parallelForEdgesImpl(L handle) const;
 
     /**
@@ -280,8 +277,7 @@ class Graph final {
      * @param handle The handle that shall be executed for all edges
      * @return void
      */
-    template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds,
-              typename L>
+    template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
     inline double parallelSumForEdgesImpl(L handle) const;
 
     /*
@@ -310,13 +306,12 @@ class Graph final {
     typename Aux::FunctionTraits<F>::result_type edgeLambda(F &, ...) const {
         // the strange condition is used in order to delay the evaluation of the
         // static assert to the moment when this function is actually used
-        static_assert(
-            !std::is_same<F, F>::value,
-            "Your lambda does not support the required parameters or the "
-            "parameters have the wrong type.");
-        return std::declval<typename Aux::FunctionTraits<
-            F>::result_type>(); // use the correct return type (this won't
-                                // compile)
+        static_assert(!std::is_same<F, F>::value,
+                      "Your lambda does not support the required parameters or the "
+                      "parameters have the wrong type.");
+        return std::declval<typename Aux::FunctionTraits<F>::result_type>(); // use the correct
+                                                                             // return type (this
+                                                                             // won't compile)
     }
 
     /**
@@ -324,14 +319,13 @@ class Graph final {
      * and third of type edgeweight Note that the decltype check is not enough
      * as edgeweight can be casted to node and we want to assure that .
      */
-    template <
-        class F,
-        typename std::enable_if<
-            (Aux::FunctionTraits<F>::arity >= 3) &&
-            std::is_same<edgeweight, typename Aux::FunctionTraits<
-                                         F>::template arg<2>::type>::value &&
-            std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<
-                                     3>::type>::value>::type * = (void *)0>
+    template <class F,
+              typename std::enable_if<
+                  (Aux::FunctionTraits<F>::arity >= 3)
+                  && std::is_same<edgeweight,
+                                  typename Aux::FunctionTraits<F>::template arg<2>::type>::value
+                  && std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<3>::type>::
+                      value>::type * = (void *)0>
     auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid id) const
         -> decltype(f(u, v, ew, id)) {
         return f(u, v, ew, id);
@@ -345,15 +339,13 @@ class Graph final {
     template <
         class F,
         typename std::enable_if<
-            (Aux::FunctionTraits<F>::arity >= 2) &&
-            std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<
-                                     2>::type>::value &&
-            std::is_same<node, typename Aux::FunctionTraits<F>::template arg<
-                                   1>::type>::value /* prevent f(v, weight, eid)
-                                                     */
+            (Aux::FunctionTraits<F>::arity >= 2)
+            && std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<2>::type>::value
+            && std::is_same<node, typename Aux::FunctionTraits<F>::template arg<1>::type>::
+                value /* prevent f(v, weight, eid)
+                       */
             >::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight, edgeid id) const
-        -> decltype(f(u, v, id)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight, edgeid id) const -> decltype(f(u, v, id)) {
         return f(u, v, id);
     }
 
@@ -364,11 +356,11 @@ class Graph final {
      */
     template <class F,
               typename std::enable_if<
-                  (Aux::FunctionTraits<F>::arity >= 2) &&
-                  std::is_same<edgeweight,
-                               typename Aux::FunctionTraits<F>::template arg<
-                                   2>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid /*id*/) const -> decltype(f(u, v, ew)) {
+                  (Aux::FunctionTraits<F>::arity >= 2)
+                  && std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<
+                                                  2>::type>::value>::type * = (void *)0>
+    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid /*id*/) const
+        -> decltype(f(u, v, ew)) {
         return f(u, v, ew);
     }
 
@@ -377,13 +369,12 @@ class Graph final {
      * argument is of type node, discards edge weight and id Note that the
      * decltype check is not enough as edgeweight can be casted to node.
      */
-    template <
-        class F,
-        typename std::enable_if<
-            (Aux::FunctionTraits<F>::arity >= 1) &&
-            std::is_same<node, typename Aux::FunctionTraits<F>::template arg<
-                                   1>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/, edgeid /*id*/) const -> decltype(f(u, v)) {
+    template <class F, typename std::enable_if<
+                           (Aux::FunctionTraits<F>::arity >= 1)
+                           && std::is_same<node, typename Aux::FunctionTraits<F>::template arg<
+                                                     1>::type>::value>::type * = (void *)0>
+    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/, edgeid /*id*/) const
+        -> decltype(f(u, v)) {
         return f(u, v);
     }
 
@@ -395,10 +386,9 @@ class Graph final {
      */
     template <class F,
               typename std::enable_if<
-                  (Aux::FunctionTraits<F>::arity >= 1) &&
-                  std::is_same<edgeweight,
-                               typename Aux::FunctionTraits<F>::template arg<
-                                   1>::type>::value>::type * = (void *)0>
+                  (Aux::FunctionTraits<F>::arity >= 1)
+                  && std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<
+                                                  1>::type>::value>::type * = (void *)0>
     auto edgeLambda(F &f, node, node v, edgeweight ew, edgeid /*id*/) const -> decltype(f(v, ew)) {
         return f(v, ew);
     }
@@ -429,13 +419,12 @@ class Graph final {
     }
 
 public:
-
     /**
      * Class to iterate over the in/out neighbors of a node.
      */
     class NeighborIterator {
 
-      public:
+    public:
         // The value type of the neighbors (i.e. nodes). Returned by
         // operator*().
         using value_type = node;
@@ -459,7 +448,8 @@ public:
         NeighborIterator(std::vector<node>::const_iterator nodesIter) : nIter(nodesIter) {}
 
         /**
-         * @brief WARNING: This contructor is required for Python and should not be used as the iterator is not initialised.
+         * @brief WARNING: This contructor is required for Python and should not be used as the
+         * iterator is not initialised.
          */
         NeighborIterator() {}
 
@@ -485,17 +475,13 @@ public:
             return *this;
         }
 
-        bool operator==(const NeighborIterator &rhs) const {
-            return nIter == rhs.nIter;
-        }
+        bool operator==(const NeighborIterator &rhs) const { return nIter == rhs.nIter; }
 
-        bool operator!=(const NeighborIterator &rhs) const {
-            return nIter != rhs.nIter;
-        }
+        bool operator!=(const NeighborIterator &rhs) const { return nIter != rhs.nIter; }
 
         node operator*() const { return *nIter; }
 
-      private:
+    private:
         std::vector<node>::const_iterator nIter;
     };
 
@@ -505,7 +491,7 @@ public:
      */
     class NeighborWeightIterator {
 
-      public:
+    public:
         // The value type of the neighbors (i.e. nodes). Returned by
         // operator*().
         using value_type = std::pair<node, edgeweight>;
@@ -526,9 +512,8 @@ public:
         // Own type.
         using self = NeighborWeightIterator;
 
-        NeighborWeightIterator(
-            std::vector<node>::const_iterator nodesIter,
-            std::vector<edgeweight>::const_iterator weightIter)
+        NeighborWeightIterator(std::vector<node>::const_iterator nodesIter,
+                               std::vector<edgeweight>::const_iterator weightIter)
             : nIter(nodesIter), wIter(weightIter) {}
 
         NeighborWeightIterator operator++() {
@@ -569,7 +554,7 @@ public:
             return std::make_pair(*nIter, *wIter);
         }
 
-      private:
+    private:
         std::vector<node>::const_iterator nIter;
         std::vector<edgeweight>::const_iterator wIter;
     };
@@ -578,13 +563,12 @@ public:
      * Wrapper class to iterate over a range of the neighbors of a node within
      * a for loop.
      */
-    template <bool InEdges = false> class NeighborRange {
-      public:
-        NeighborRange(const Graph &G, node u) : G(&G), u(u){
-            assert(G.hasNode(u));
-        };
+    template <bool InEdges = false>
+    class NeighborRange {
+    public:
+        NeighborRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborRange() : G(nullptr) {};
+        NeighborRange() : G(nullptr){};
 
         NeighborIterator begin() const {
             assert(G != nullptr);
@@ -600,7 +584,7 @@ public:
             return NeighborIterator(G->outEdges[u].end());
         }
 
-      private:
+    private:
         const Graph *G;
         node u;
     };
@@ -613,28 +597,25 @@ public:
      * including the edge weights within a for loop.
      * Values are std::pair<node, edgeweight>.
      */
-    template <bool InEdges = false> class NeighborWeightRange {
+    template <bool InEdges = false>
+    class NeighborWeightRange {
 
-      public:
+    public:
         NeighborWeightRange(const Graph &G, node u) : G(G), u(u){};
 
         NeighborWeightIterator begin() const {
             if (InEdges)
-                return NeighborWeightIterator(G.inEdges[u].begin(),
-                                              G.inEdgeWeights[u].begin());
-            return NeighborWeightIterator(G.outEdges[u].begin(),
-                                          G.outEdgeWeights[u].begin());
+                return NeighborWeightIterator(G.inEdges[u].begin(), G.inEdgeWeights[u].begin());
+            return NeighborWeightIterator(G.outEdges[u].begin(), G.outEdgeWeights[u].begin());
         }
 
         NeighborWeightIterator end() const {
             if (InEdges)
-                return NeighborWeightIterator(G.inEdges[u].end(),
-                                              G.inEdgeWeights[u].end());
-            return NeighborWeightIterator(G.outEdges[u].end(),
-                                          G.outEdgeWeights[u].end());
+                return NeighborWeightIterator(G.inEdges[u].end(), G.inEdgeWeights[u].end());
+            return NeighborWeightIterator(G.outEdges[u].end(), G.outEdgeWeights[u].end());
         }
 
-      private:
+    private:
         const Graph &G;
         const node u;
     };
@@ -845,7 +826,8 @@ public:
     void removeNode(node v);
 
     /**
-     * Removes out-going edges from node @u. If the graph is weighted and/or has edge ids, weights and/or edge ids will also be removed.
+     * Removes out-going edges from node @u. If the graph is weighted and/or has edge ids, weights
+     * and/or edge ids will also be removed.
      *
      * @param node u Node.
      */
@@ -861,7 +843,8 @@ public:
     }
 
     /**
-     * Removes in-going edges to node @u. If the graph is weighted and/or has edge ids, weights and/or edge ids will also be removed.
+     * Removes in-going edges to node @u. If the graph is weighted and/or has edge ids, weights
+     * and/or edge ids will also be removed.
      *
      * @param node u Node.
      */
@@ -920,10 +903,11 @@ public:
      *  - Nodes are such passed as arguments
      *  - Neighbors are empty by default.
      *      If includeOutNeighbors is set, it includes all out neighbors of Nodes
-     *      If includeInNeighbors is set, it includes all in neighbors of Nodes (relevant only for directed graphs)
+     *      If includeInNeighbors is set, it includes all in neighbors of Nodes (relevant only for
+     * directed graphs)
      *
-     * The subgraph contains all nodes in Nodes + Neighbors and all edge which have one end point in Nodes
-     * and the other in Nodes or Neighbors.
+     * The subgraph contains all nodes in Nodes + Neighbors and all edge which have one end point in
+     * Nodes and the other in Nodes or Neighbors.
      */
     Graph TLX_DEPRECATED(subgraphFromNodes(const std::unordered_set<node> &nodes,
                                            bool includeOutNeighbors = false,
@@ -946,9 +930,7 @@ public:
      * @return The number of incoming neighbors.
      * @note If the graph is not directed, the outgoing degree is returned.
      */
-    count degreeIn(node v) const {
-        return directed ? inEdges[v].size() : outEdges[v].size();
-    }
+    count degreeIn(node v) const { return directed ? inEdges[v].size() : outEdges[v].size(); }
 
     /**
      * Get the number of outgoing neighbors of @a v.
@@ -1058,17 +1040,18 @@ public:
     void addEdge(node u, node v, edgeweight ew = defaultEdgeWeight);
 
     /**
-    * Insert an edge between the nodes @a u and @a v. Unline the addEdge function, this function does not not add any information to v. If the graph is
-    * weighted you can optionally set a weight for this edge. The default
-    * weight is 1.0. Note: Multi-edges are not supported and will NOT be
-    * handled consistently by the graph data structure.
-    * @param u Endpoint of edge.
-    * @param v Endpoint of edge.
-    * @param weight Optional edge weight.
-    * @param ew Optional edge weight.
-    * @param index Optional node index.
-    */
-    void addPartialEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight, uint64_t index = 0);
+     * Insert an edge between the nodes @a u and @a v. Unline the addEdge function, this function
+     * does not not add any information to v. If the graph is weighted you can optionally set a
+     * weight for this edge. The default weight is 1.0. Note: Multi-edges are not supported and will
+     * NOT be handled consistently by the graph data structure.
+     * @param u Endpoint of edge.
+     * @param v Endpoint of edge.
+     * @param weight Optional edge weight.
+     * @param ew Optional edge weight.
+     * @param index Optional node index.
+     */
+    void addPartialEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight,
+                        uint64_t index = 0);
 
     /**
      * Insert an in edge between the nodes @a u and @a v in a directed graph. If the graph is
@@ -1080,7 +1063,8 @@ public:
      * @param ew Optional edge weight.
      * @param index Optional node index.
      */
-    void addPartialInEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight, uint64_t index = 0);
+    void addPartialInEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight,
+                          uint64_t index = 0);
 
     /**
      * Insert an out edge between the nodes @a u and @a v in a directed graph. If the graph is
@@ -1092,8 +1076,8 @@ public:
      * @param ew Optional edge weight.
      * @param index Optional node index.
      */
-    void addPartialOutEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight, uint64_t index = 0);
-
+    void addPartialOutEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight,
+                           uint64_t index = 0);
 
     /**
      * Removes the undirected edge {@a u,@a v}.
@@ -1321,7 +1305,7 @@ public:
      * @param u Node.
      * @return List of neighbors of @a u.
      */
-     std::vector<node> TLX_DEPRECATED(neighbors(node u) const);
+    std::vector<node> TLX_DEPRECATED(neighbors(node u) const);
 
     /**
      * Get an iterable range over the neighbors of @a.
@@ -1383,7 +1367,8 @@ public:
      * @return @a i -th (outgoing) neighbor of @a u, or @c none if no such
      * neighbor exists.
      */
-    template <bool graphIsDirected> node getIthNeighbor(node u, index i) const {
+    template <bool graphIsDirected>
+    node getIthNeighbor(node u, index i) const {
         node v = outEdges[u][i];
         if (useEdgeInIteration<graphIsDirected>(u, v))
             return v;
@@ -1428,7 +1413,8 @@ public:
      *
      * @param handle Takes parameter <code>(node)</code>.
      */
-    template <typename L> void forNodes(L handle) const;
+    template <typename L>
+    void forNodes(L handle) const;
 
     /**
      * Iterate randomly over all nodes of the graph and call @a handle (lambda
@@ -1436,7 +1422,8 @@ public:
      *
      * @param handle Takes parameter <code>(node)</code>.
      */
-    template <typename L> void parallelForNodes(L handle) const;
+    template <typename L>
+    void parallelForNodes(L handle) const;
 
     /** Iterate over all nodes of the graph and call @a handle (lambda
      * closure) as long as @a condition remains true. This allows for breaking
@@ -1454,7 +1441,8 @@ public:
      *
      * @param handle Takes parameter <code>(node)</code>.
      */
-    template <typename L> void forNodesInRandomOrder(L handle) const;
+    template <typename L>
+    void forNodesInRandomOrder(L handle) const;
 
     /**
      * Iterate in parallel over all nodes of the graph and call handler
@@ -1463,7 +1451,8 @@ public:
      *
      * @param handle Takes parameter <code>(node)</code>.
      */
-    template <typename L> void balancedParallelForNodes(L handle) const;
+    template <typename L>
+    void balancedParallelForNodes(L handle) const;
 
     /**
      * Iterate over all undirected pairs of nodes and call @a handle (lambda
@@ -1471,7 +1460,8 @@ public:
      *
      * @param handle Takes parameters <code>(node, node)</code>.
      */
-    template <typename L> void forNodePairs(L handle) const;
+    template <typename L>
+    void forNodePairs(L handle) const;
 
     /**
      * Iterate over all undirected pairs of nodes in parallel and call @a
@@ -1479,7 +1469,8 @@ public:
      *
      * @param handle Takes parameters <code>(node, node)</code>.
      */
-    template <typename L> void parallelForNodePairs(L handle) const;
+    template <typename L>
+    void parallelForNodePairs(L handle) const;
 
     /* EDGE ITERATORS */
 
@@ -1491,7 +1482,8 @@ public:
      * node, edgweight)</code>, <code>(node, node, edgeid)</code> or
      * <code>(node, node, edgeweight, edgeid)</code>.
      */
-    template <typename L> void forEdges(L handle) const;
+    template <typename L>
+    void forEdges(L handle) const;
 
     /**
      * Iterate in parallel over all edges of the const graph and call @a
@@ -1501,7 +1493,8 @@ public:
      * <code>(node, node, edgweight)</code>, <code>(node, node, edgeid)</code>
      * or <code>(node, node, edgeweight, edgeid)</code>.
      */
-    template <typename L> void parallelForEdges(L handle) const;
+    template <typename L>
+    void parallelForEdges(L handle) const;
 
     /* NEIGHBORHOOD ITERATORS */
 
@@ -1516,7 +1509,8 @@ public:
      * A node is its own neighbor if there is a self-loop.
      *
      */
-    template <typename L> void forNeighborsOf(node u, L handle) const;
+    template <typename L>
+    void forNeighborsOf(node u, L handle) const;
 
     /**
      * Iterate over all incident edges of a node and call @a handle (lamdba
@@ -1530,13 +1524,15 @@ public:
      * @note For undirected graphs all edges incident to @a u are also
      * outgoing edges.
      */
-    template <typename L> void forEdgesOf(node u, L handle) const;
+    template <typename L>
+    void forEdgesOf(node u, L handle) const;
 
     /**
      * Iterate over all neighbors of a node and call handler (lamdba closure).
      * For directed graphs only incoming edges from u are considered.
      */
-    template <typename L> void forInNeighborsOf(node u, L handle) const;
+    template <typename L>
+    void forInNeighborsOf(node u, L handle) const;
 
     /**
      * Iterate over all incoming edges of a node and call handler (lamdba
@@ -1546,7 +1542,8 @@ public:
      *
      * Handle takes parameters (u, v) or (u, v, w) where w is the edge weight.
      */
-    template <typename L> void forInEdgesOf(node u, L handle) const;
+    template <typename L>
+    void forInEdgesOf(node u, L handle) const;
 
     /* REDUCTION ITERATORS */
 
@@ -1554,13 +1551,15 @@ public:
      * Iterate in parallel over all nodes and sum (reduce +) the values
      * returned by the handler
      */
-    template <typename L> double parallelSumForNodes(L handle) const;
+    template <typename L>
+    double parallelSumForNodes(L handle) const;
 
     /**
      * Iterate in parallel over all edges and sum (reduce +) the values
      * returned by the handler
      */
-    template <typename L> double parallelSumForEdges(L handle) const;
+    template <typename L>
+    double parallelSumForEdges(L handle) const;
 
     /* GRAPH SEARCHES */
 
@@ -1571,11 +1570,13 @@ public:
      * @param r Node.
      * @param handle Takes parameter <code>(node)</code>.
      */
-    template <typename L> void TLX_DEPRECATED(BFSfrom(node r, L handle) const);
+    template <typename L>
+    void TLX_DEPRECATED(BFSfrom(node r, L handle) const);
     template <typename L>
     void TLX_DEPRECATED(BFSfrom(const std::vector<node> &startNodes, L handle) const);
 
-    template <typename L> void TLX_DEPRECATED(BFSEdgesFrom(node r, L handle) const);
+    template <typename L>
+    void TLX_DEPRECATED(BFSEdgesFrom(node r, L handle) const);
 
     /**
      * Iterate over nodes in depth-first search order starting from r until
@@ -1584,14 +1585,17 @@ public:
      * @param r Node.
      * @param handle Takes parameter <code>(node)</code>.
      */
-    template <typename L> void TLX_DEPRECATED(DFSfrom(node r, L handle) const);
+    template <typename L>
+    void TLX_DEPRECATED(DFSfrom(node r, L handle) const);
 
-    template <typename L> void TLX_DEPRECATED(DFSEdgesFrom(node r, L handle) const);
+    template <typename L>
+    void TLX_DEPRECATED(DFSEdgesFrom(node r, L handle) const);
 };
 
 /* NODE ITERATORS */
 
-template <typename L> void Graph::forNodes(L handle) const {
+template <typename L>
+void Graph::forNodes(L handle) const {
     for (node v = 0; v < z; ++v) {
         if (exists[v]) {
             handle(v);
@@ -1599,7 +1603,8 @@ template <typename L> void Graph::forNodes(L handle) const {
     }
 }
 
-template <typename L> void Graph::parallelForNodes(L handle) const {
+template <typename L>
+void Graph::parallelForNodes(L handle) const {
 #pragma omp parallel for
     for (omp_index v = 0; v < static_cast<omp_index>(z); ++v) {
         if (exists[v]) {
@@ -1620,7 +1625,8 @@ void Graph::forNodesWhile(C condition, L handle) const {
     }
 }
 
-template <typename L> void Graph::forNodesInRandomOrder(L handle) const {
+template <typename L>
+void Graph::forNodesInRandomOrder(L handle) const {
     std::vector<node> randVec;
     randVec.reserve(numberOfNodes());
     forNodes([&](node u) { randVec.push_back(u); });
@@ -1630,7 +1636,8 @@ template <typename L> void Graph::forNodesInRandomOrder(L handle) const {
     }
 }
 
-template <typename L> void Graph::balancedParallelForNodes(L handle) const {
+template <typename L>
+void Graph::balancedParallelForNodes(L handle) const {
 // TODO: define min block size (and test it!)
 #pragma omp parallel for schedule(guided)
     for (omp_index v = 0; v < static_cast<omp_index>(z); ++v) {
@@ -1640,7 +1647,8 @@ template <typename L> void Graph::balancedParallelForNodes(L handle) const {
     }
 }
 
-template <typename L> void Graph::forNodePairs(L handle) const {
+template <typename L>
+void Graph::forNodePairs(L handle) const {
     for (node u = 0; u < z; ++u) {
         if (exists[u]) {
             for (node v = u + 1; v < z; ++v) {
@@ -1652,7 +1660,8 @@ template <typename L> void Graph::forNodePairs(L handle) const {
     }
 }
 
-template <typename L> void Graph::parallelForNodePairs(L handle) const {
+template <typename L>
+void Graph::parallelForNodePairs(L handle) const {
 #pragma omp parallel for schedule(guided)
     for (omp_index u = 0; u < static_cast<omp_index>(z); ++u) {
         if (exists[u]) {
@@ -1690,7 +1699,8 @@ inline edgeweight Graph::getInEdgeWeight(node u, index i) const {
 }
 
 // implementation for weighted == false
-template <> inline edgeweight Graph::getInEdgeWeight<false>(node, index) const {
+template <>
+inline edgeweight Graph::getInEdgeWeight<false>(node, index) const {
     return defaultEdgeWeight;
 }
 
@@ -1701,7 +1711,8 @@ inline edgeid Graph::getOutEdgeId(node u, index i) const {
 }
 
 // implementation for hasEdgeIds == false
-template <> inline edgeid Graph::getOutEdgeId<false>(node, index) const {
+template <>
+inline edgeid Graph::getOutEdgeId<false>(node, index) const {
     return 0;
 }
 
@@ -1712,7 +1723,8 @@ inline edgeid Graph::getInEdgeId(node u, index i) const {
 }
 
 // implementation for hasEdgeIds == false
-template <> inline edgeid Graph::getInEdgeId<false>(node, index) const {
+template <>
+inline edgeid Graph::getInEdgeId<false>(node, index) const {
     return 0;
 }
 
@@ -1723,12 +1735,12 @@ inline bool Graph::useEdgeInIteration(node /* u */, node v) const {
 }
 
 // implementation for graphIsDirected == false
-template <> inline bool Graph::useEdgeInIteration<false>(node u, node v) const {
+template <>
+inline bool Graph::useEdgeInIteration<false>(node u, node v) const {
     return u >= v;
 }
 
-template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds,
-          typename L>
+template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline void Graph::forOutEdgesOfImpl(node u, L handle) const {
     for (index i = 0; i < outEdges[u].size(); ++i) {
         node v = outEdges[u][i];
@@ -1740,8 +1752,7 @@ inline void Graph::forOutEdgesOfImpl(node u, L handle) const {
     }
 }
 
-template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds,
-          typename L>
+template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline void Graph::forInEdgesOfImpl(node u, L handle) const {
     if (graphIsDirected) {
         for (index i = 0; i < inEdges[u].size(); i++) {
@@ -1764,27 +1775,22 @@ inline void Graph::forInEdgesOfImpl(node u, L handle) const {
     }
 }
 
-template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds,
-          typename L>
+template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline void Graph::forEdgeImpl(L handle) const {
     for (node u = 0; u < z; ++u) {
-        forOutEdgesOfImpl<graphIsDirected, hasWeights, graphHasEdgeIds, L>(
-            u, handle);
+        forOutEdgesOfImpl<graphIsDirected, hasWeights, graphHasEdgeIds, L>(u, handle);
     }
 }
 
-template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds,
-          typename L>
+template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline void Graph::parallelForEdgesImpl(L handle) const {
 #pragma omp parallel for schedule(guided)
     for (omp_index u = 0; u < static_cast<omp_index>(z); ++u) {
-        forOutEdgesOfImpl<graphIsDirected, hasWeights, graphHasEdgeIds, L>(
-            u, handle);
+        forOutEdgesOfImpl<graphIsDirected, hasWeights, graphHasEdgeIds, L>(u, handle);
     }
 }
 
-template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds,
-          typename L>
+template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline double Graph::parallelSumForEdgesImpl(L handle) const {
     double sum = 0.0;
 
@@ -1796,8 +1802,7 @@ inline double Graph::parallelSumForEdgesImpl(L handle) const {
             // undirected, do not iterate over edges twice
             // {u, v} instead of (u, v); if v == none, u > v is not fulfilled
             if (useEdgeInIteration<graphIsDirected>(u, v)) {
-                sum += edgeLambda<L>(handle, u, v,
-                                     getOutEdgeWeight<hasWeights>(u, i),
+                sum += edgeLambda<L>(handle, u, v, getOutEdgeWeight<hasWeights>(u, i),
                                      getOutEdgeId<graphHasEdgeIds>(u, i));
             }
         }
@@ -1806,7 +1811,8 @@ inline double Graph::parallelSumForEdgesImpl(L handle) const {
     return sum;
 }
 
-template <typename L> void Graph::forEdges(L handle) const {
+template <typename L>
+void Graph::forEdges(L handle) const {
     switch (weighted + 2 * directed + 4 * edgesIndexed) {
     case 0: // unweighted, undirected, no edgeIds
         forEdgeImpl<false, false, false, L>(handle);
@@ -1842,7 +1848,8 @@ template <typename L> void Graph::forEdges(L handle) const {
     }
 }
 
-template <typename L> void Graph::parallelForEdges(L handle) const {
+template <typename L>
+void Graph::parallelForEdges(L handle) const {
     switch (weighted + 2 * directed + 4 * edgesIndexed) {
     case 0: // unweighted, undirected, no edgeIds
         parallelForEdgesImpl<false, false, false, L>(handle);
@@ -1880,11 +1887,13 @@ template <typename L> void Graph::parallelForEdges(L handle) const {
 
 /* NEIGHBORHOOD ITERATORS */
 
-template <typename L> void Graph::forNeighborsOf(node u, L handle) const {
+template <typename L>
+void Graph::forNeighborsOf(node u, L handle) const {
     forEdgesOf(u, handle);
 }
 
-template <typename L> void Graph::forEdgesOf(node u, L handle) const {
+template <typename L>
+void Graph::forEdgesOf(node u, L handle) const {
     switch (weighted + 2 * edgesIndexed) {
     case 0: // not weighted, no edge ids
         forOutEdgesOfImpl<true, false, false, L>(u, handle);
@@ -1904,11 +1913,13 @@ template <typename L> void Graph::forEdgesOf(node u, L handle) const {
     }
 }
 
-template <typename L> void Graph::forInNeighborsOf(node u, L handle) const {
+template <typename L>
+void Graph::forInNeighborsOf(node u, L handle) const {
     forInEdgesOf(u, handle);
 }
 
-template <typename L> void Graph::forInEdgesOf(node u, L handle) const {
+template <typename L>
+void Graph::forInEdgesOf(node u, L handle) const {
     switch (weighted + 2 * directed + 4 * edgesIndexed) {
     case 0: // unweighted, undirected, no edge ids
         forInEdgesOfImpl<false, false, false, L>(u, handle);
@@ -1946,7 +1957,8 @@ template <typename L> void Graph::forInEdgesOf(node u, L handle) const {
 
 /* REDUCTION ITERATORS */
 
-template <typename L> double Graph::parallelSumForNodes(L handle) const {
+template <typename L>
+double Graph::parallelSumForNodes(L handle) const {
     double sum = 0.0;
 
 #pragma omp parallel for reduction(+ : sum)
@@ -1959,7 +1971,8 @@ template <typename L> double Graph::parallelSumForNodes(L handle) const {
     return sum;
 }
 
-template <typename L> double Graph::parallelSumForEdges(L handle) const {
+template <typename L>
+double Graph::parallelSumForEdges(L handle) const {
     double sum = 0.0;
 
     switch (weighted + 2 * directed + 4 * edgesIndexed) {
@@ -2001,7 +2014,8 @@ template <typename L> double Graph::parallelSumForEdges(L handle) const {
 
 /* GRAPH SEARCHES */
 
-template <typename L> void Graph::BFSfrom(node r, L handle) const {
+template <typename L>
+void Graph::BFSfrom(node r, L handle) const {
     WARN("Graph::BFSfrom is deprecated, use Traversal::BFSfrom instead.");
     std::vector<node> startNodes(1, r);
     BFSfrom(startNodes, handle);
@@ -2036,7 +2050,8 @@ void Graph::BFSfrom(const std::vector<node> &startNodes, L handle) const {
     } while (!q.empty());
 }
 
-template <typename L> void Graph::BFSEdgesFrom(node r, L handle) const {
+template <typename L>
+void Graph::BFSEdgesFrom(node r, L handle) const {
     WARN("Graph::BFSEdgesFrom is deprecated, use Traversal::BFSEdgesFrom instead.");
     std::vector<bool> marked(z);
     std::queue<node> q;
@@ -2056,7 +2071,8 @@ template <typename L> void Graph::BFSEdgesFrom(node r, L handle) const {
     } while (!q.empty());
 }
 
-template <typename L> void Graph::DFSfrom(node r, L handle) const {
+template <typename L>
+void Graph::DFSfrom(node r, L handle) const {
     WARN("Graph::DFSfrom is deprecated, use Traversal::DFSfrom instead.");
     std::vector<bool> marked(z);
     std::stack<node> s;
@@ -2076,7 +2092,8 @@ template <typename L> void Graph::DFSfrom(node r, L handle) const {
     } while (!s.empty());
 }
 
-template <typename L> void Graph::DFSEdgesFrom(node r, L handle) const {
+template <typename L>
+void Graph::DFSEdgesFrom(node r, L handle) const {
     WARN("Graph::DFSEdgesFrom is deprecated, use Traversal::DFSEdgesFrom instead.");
     std::vector<bool> marked(z);
     std::stack<node> s;
@@ -2130,7 +2147,6 @@ std::pair<count, count> Graph::removeAdjacentEdges(node u, Condition condition, 
 
     return {removedEdges, removedSelfLoops};
 }
-
 
 } /* namespace NetworKit */
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -801,6 +801,13 @@ public:
      */
     void setEdgeCount(Unsafe, count edges) { m = edges; }
 
+    /**
+     * Set upper bound of edge count.
+     *
+     * @param newBound New upper edge id bound.
+     */
+    void setUpperEdgeIdBound(Unsafe, edgeid newBound) { omega = newBound; }
+
     void setNumberOfSelfLoops(Unsafe, count loops) { storedNumberOfSelfLoops = loops; }
     /**
      * Returns a string representation of the graph.
@@ -1382,7 +1389,7 @@ public:
      *
      * @return transpose of the graph.
      */
-    Graph transpose() const;
+    Graph TLX_DEPRECATED(transpose() const);
 
     /* NODE ITERATORS */
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1275,13 +1275,13 @@ public:
      * Get list of all nodes.
      * @return List of all nodes.
      */
-    std::vector<node> nodes() const;
+    std::vector<node> TLX_DEPRECATED(nodes() const);
 
     /**
      * Get list of edges as node pairs.
      * @return List of edges as node pairs.
      */
-    std::vector<std::pair<node, node>> edges() const;
+    std::vector<std::pair<node, node>> TLX_DEPRECATED(edges() const);
 
     /**
      * Get list of neighbors of @a u.
@@ -1583,7 +1583,9 @@ void Graph::forNodesWhile(C condition, L handle) const {
 }
 
 template <typename L> void Graph::forNodesInRandomOrder(L handle) const {
-    std::vector<node> randVec = nodes();
+    std::vector<node> randVec;
+    randVec.reserve(numberOfNodes());
+    forNodes([&](node u) { randVec.push_back(u); });
     std::shuffle(randVec.begin(), randVec.end(), Aux::Random::getURNG());
     for (node v : randVec) {
         handle(v);

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -812,7 +812,13 @@ public:
      */
     void setUpperEdgeIdBound(Unsafe, edgeid newBound) { omega = newBound; }
 
+    /**
+     * Set the number of self-loops.
+     *
+     * @param loops New number of self-loops.
+     */
     void setNumberOfSelfLoops(Unsafe, count loops) { storedNumberOfSelfLoops = loops; }
+
     /**
      * Returns a string representation of the graph.
      * @return A string representation.

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -169,13 +169,6 @@ class Graph final {
                                      bool countSelfLoopsTwice = false) const;
 
     /**
-     * Computes the maximum in/out degree of the graph.
-     *
-     * @param inDegree wheter to compute the in degree or the out degree.
-     */
-    count computeMaxDegree(const bool inDegree = false) const;
-
-    /**
      * Computes the maximum in/out weighted degree of the graph
      *
      * @param inDegree whether to compute the in degree or the out degree
@@ -945,14 +938,14 @@ public:
      *
      * @return The maximum out-degree of the graph.
      */
-    count maxDegree() const;
+    count TLX_DEPRECATED(maxDegree() const);
 
     /**
      * Returns the maximum in-degree of the graph.
      *
      * @return The maximum in-degree of the graph.
      */
-    count maxDegreeIn() const;
+    count TLX_DEPRECATED(maxDegreeIn() const);
 
     /**
      * Check whether @a v is isolated, i.e. degree is 0.

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -156,12 +156,16 @@ class Graph final {
     index indexInOutEdgeArray(node u, node v) const;
 
     /**
-     * Computes the weighted in/out degree of a graph.
+     * Computes the weighted in/out degree of node @a u.
      *
+     * @param u Node.
      * @param inDegree whether to compute the in degree or the out degree.
+     * @param countSelfLoopsTwice If set to true, self-loops will be counted twice.
+     *
+     * @return Weighted in/out degree of node @a u.
      */
-    edgeweight computeWeightedDegree(const node &v,
-                                     const bool inDegree = false) const;
+    edgeweight computeWeightedDegree(node u, bool inDegree = false,
+                                     bool countSelfLoopsTwice = false) const;
 
     /**
      * Computes the maximum in/out degree of the graph.
@@ -955,14 +959,14 @@ public:
     }
 
     /**
-     * Returns the weighted degree of @a v.
+     * Returns the weighted degree of @a u.
      *
-     * @param v Node.
-     * @return Weighted degree of @a v.
-     * @note For directed graphs this is the sum of weights of all outgoing
-     * edges. of @a v.
+     * @param u Node.
+     * @param countSelfLoopsTwice If set to true, self-loops will be counted twice.
+     *
+     * @return Weighted degree of @a u.
      */
-    edgeweight weightedDegree(const node &v) const;
+    edgeweight weightedDegree(node u, bool countSelfLoopsTwice = false) const;
 
     /**
      * Returns the maximum weighted degree of the graph.
@@ -983,14 +987,14 @@ public:
     edgeweight maxWeightedDegreeIn() const;
 
     /**
-     * Returns the weighted in-degree of @a v.
+     * Returns the weighted in-degree of @a u.
      *
-     * @param v Node.
+     * @param u Node.
+     * @param countSelfLoopsTwice If set to true, self-loops will be counted twice.
+     *
      * @return Weighted in-degree of @a v.
-     * @note For directed graphs this is the sum of weights of all ingoing
-     * edges. of @a v.
      */
-    edgeweight weightedDegreeIn(const node &v) const;
+    edgeweight weightedDegreeIn(node u, bool countSelfLoopsTwice = false) const;
 
     /**
      * Returns the volume of the @a v, which is the weighted degree with
@@ -999,7 +1003,7 @@ public:
      * @param v Node.
      * @return The volume of the @a v.
      */
-    edgeweight volume(node v) const;
+    edgeweight TLX_DEPRECATED(volume(node v) const);
 
     /**
      * Returns a random node of the graph.

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1177,7 +1177,7 @@ public:
      * Returns a vector with nr random edges. The edges are chosen uniform
      * random.
      */
-    std::vector<std::pair<node, node>> randomEdges(count nr) const;
+    std::vector<std::pair<node, node>> TLX_DEPRECATED(randomEdges(count nr) const);
 
     /* GLOBAL PROPERTIES */
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -715,11 +715,10 @@ public:
     /**
      * Get the ID of this graph. The ID is a unique unsigned integer given to
      * every graph on construction.
+     *
+     * This method is deprecated and will not be supported in future releases.
      */
-    count TLX_DEPRECATED(getId() const) {
-        WARN("Graph::getId is deprecated and will not be supported in future releases.");
-        return id;
-    }
+    count TLX_DEPRECATED(getId() const) { return id; }
 
     /**
      * Return the type of the graph.
@@ -727,6 +726,8 @@ public:
      * 		WeightedGraph: weighted, undirected
      * 		DirectedGraph: not weighted, directed
      * 		WeightedDirectedGraph: weighted, directed
+     *
+     * This method is deprecated and will not be supported in future releases.
      */
     std::string TLX_DEPRECATED(typ() const);
 
@@ -752,20 +753,18 @@ public:
     /**
      * Set name of graph to @a name.
      * @param name The name.
+     *
+     * This method is deprecated and will not be supported in future releases.
      */
-    void TLX_DEPRECATED(setName(std::string name)) {
-        WARN("Graph::setName is deprecated and will not be supported in future releases.");
-        this->name = name;
-    }
+    void TLX_DEPRECATED(setName(std::string name)) { this->name = name; }
 
     /*
      * Returns the name of the graph.
      * @return The name of the graph.
+     *
+     * This method is deprecated and will not be supported in future releases.
      */
-    std::string TLX_DEPRECATED(getName() const) {
-        WARN("Graph::getName is deprecated and will not be supported in future releases.");
-        return name;
-    }
+    std::string TLX_DEPRECATED(getName() const) { return name; }
 
     /**
      * Set edge count of the graph to edges.
@@ -790,6 +789,8 @@ public:
     /**
      * Returns a string representation of the graph.
      * @return A string representation.
+     *
+     * This method is deprecated and will not be supported in future releases.
      */
     std::string TLX_DEPRECATED(toString() const);
 
@@ -798,6 +799,8 @@ public:
     /*
      * Copies all nodes to a new graph
      * @return graph with the same nodes.
+     *
+     * This method is deprecated, use GraphTools::copyNodes instead.
      */
     Graph TLX_DEPRECATED(copyNodes() const);
 
@@ -884,6 +887,8 @@ public:
      * Appends another graph to this graph as a new subgraph. Performs node
      * id remapping.
      * @param G [description]
+     *
+     * This method is deprecated, use GraphTools::append instead.
      */
     void TLX_DEPRECATED(append(const Graph &G));
 
@@ -891,6 +896,8 @@ public:
      * Modifies this graph to be the union of it and another graph.
      * Nodes with the same ids are identified with each other.
      * @param G [description]
+     *
+     * This method is deprecated, use GraphTools::merge instead.
      */
     void TLX_DEPRECATED(merge(const Graph &G));
 
@@ -908,6 +915,8 @@ public:
      *
      * The subgraph contains all nodes in Nodes + Neighbors and all edge which have one end point in
      * Nodes and the other in Nodes or Neighbors.
+     *
+     * This method is deprecated, use GraphTools::subgraphFromNodes instead.
      */
     Graph TLX_DEPRECATED(subgraphFromNodes(const std::unordered_set<node> &nodes,
                                            bool includeOutNeighbors = false,
@@ -944,6 +953,8 @@ public:
      * Returns the maximum out-degree of the graph.
      *
      * @return The maximum out-degree of the graph.
+     *
+     * This method is deprecated, use GraphTools::maxDegree instead.
      */
     count TLX_DEPRECATED(maxDegree() const);
 
@@ -951,6 +962,8 @@ public:
      * Returns the maximum in-degree of the graph.
      *
      * @return The maximum in-degree of the graph.
+     *
+     * This method is deprecated, use GraphTools::maxWeightedDegree instead.
      */
     count TLX_DEPRECATED(maxDegreeIn() const);
 
@@ -981,6 +994,8 @@ public:
      * @return Maximum weighted degree of the graph.
      * @note For directed graphs this is the sum of weights of all outgoing
      * edges.
+     *
+     * This method is deprecated, use GraphTools::maxWeightedDegree instead.
      */
     edgeweight TLX_DEPRECATED(maxWeightedDegree() const);
 
@@ -990,6 +1005,8 @@ public:
      * @return Maximum weighted in degree of the graph.
      * @note For directed graphs this is the sum of weights of all in-going
      * edges.
+     *
+     * This method is deprecated, use GraphTools::maxWeightedDegreeIn instead.
      */
     edgeweight TLX_DEPRECATED(maxWeightedDegreeIn() const);
 
@@ -1009,12 +1026,16 @@ public:
      *
      * @param v Node.
      * @return The volume of the @a v.
+     *
+     * This method is deprecated, use GraphTools::weightedDegree instead.
      */
     edgeweight TLX_DEPRECATED(volume(node v) const);
 
     /**
      * Returns a random node of the graph.
      * @return A random node.
+     *
+     * This method is deprecated, use GraphTools::randomNode instead.
      */
     node TLX_DEPRECATED(randomNode() const);
 
@@ -1023,6 +1044,8 @@ public:
      *
      * @param u Node.
      * @return A random neighbor of @a u.
+     *
+     * This method is deprecated, use GraphTools::randomNeighbor instead.
      */
     node TLX_DEPRECATED(randomNeighbor(node u) const);
 
@@ -1092,6 +1115,8 @@ public:
      * Kadabra algorithm.
      * @param nodesInSet vector of nodes that form a connected component that
      * is isolated from the rest of the graph.
+     *
+     * This method is deprecated, use GraphTools::removeEdgesFromIsolatedSet instead.
      */
     void TLX_DEPRECATED(removeEdgesFromIsolatedSet(const std::vector<node> &nodesInSet));
 
@@ -1154,12 +1179,16 @@ public:
      * depends on the degree of u. Setting uniformDistribution to true, will
      * give you a real uniform distributed edge, but will be slower.
      * Exp. time complexity: O(1) for uniformDistribution = false, O(n) otherwise.
+     *
+     * This method is deprecated, use GraphTools::randomEdge instead.
      */
     std::pair<node, node> TLX_DEPRECATED(randomEdge(bool uniformDistribution = false) const);
 
     /**
      * Returns a vector with nr random edges. The edges are chosen uniform
      * random.
+     *
+     * This method is deprecated, use GraphTools::randomEdges instead.
      */
     std::vector<std::pair<node, node>> TLX_DEPRECATED(randomEdges(count nr) const);
 
@@ -1205,6 +1234,8 @@ public:
 
     /**
      * @return the density of the graph
+     *
+     * This method is deprecated, use GraphTools::density instead.
      */
     double TLX_DEPRECATED(density() const);
 
@@ -1232,6 +1263,8 @@ public:
 
     /**
      * Trigger a time step - increments counter.
+     *
+     * This method is deprecated and will not be supported in future releases.
      */
     void TLX_DEPRECATED(timeStep()) {
         WARN("Graph::timeStep is deprecated and will not be supported in future releases.");
@@ -1241,6 +1274,8 @@ public:
     /**
      * Get time step counter.
      * @return Time step counter.
+     *
+     * This method is deprecated and will not be supported in future releases.
      */
     count TLX_DEPRECATED(time()) {
         WARN("Graph::time is deprecated and will not be supported in future releases.");
@@ -1290,12 +1325,16 @@ public:
     /**
      * Get list of all nodes.
      * @return List of all nodes.
+     *
+     * This method is deprecated and will not be supported in future releases.
      */
     std::vector<node> TLX_DEPRECATED(nodes() const);
 
     /**
      * Get list of edges as node pairs.
      * @return List of edges as node pairs.
+     *
+     * This method is deprecated and will not be supported in future releases.
      */
     std::vector<std::pair<node, node>> TLX_DEPRECATED(edges() const);
 
@@ -1304,6 +1343,8 @@ public:
      *
      * @param u Node.
      * @return List of neighbors of @a u.
+     *
+     * This method is deprecated and will not be supported in future releases.
      */
     std::vector<node> TLX_DEPRECATED(neighbors(node u) const);
 
@@ -1388,6 +1429,8 @@ public:
      * Return an undirected version of this graph.
      *
      * @return undirected graph.
+     *
+     * This method is deprecated, use GraphTools::toUndirected instead.
      */
     Graph TLX_DEPRECATED(toUndirected() const);
 
@@ -1395,6 +1438,8 @@ public:
      * Return an unweighted version of this graph.
      *
      * @return unweighted graph.
+     *
+     * This method is deprecated, use GraphTools::toUnweighted instead.
      */
     Graph TLX_DEPRECATED(toUnweighted() const);
 
@@ -1402,6 +1447,8 @@ public:
      * Return the transpose of this graph. The graph must be directed.
      *
      * @return transpose of the graph.
+     *
+     * This method is deprecated, use GraphTools::transpose instead.
      */
     Graph TLX_DEPRECATED(transpose() const);
 
@@ -1569,6 +1616,8 @@ public:
      *
      * @param r Node.
      * @param handle Takes parameter <code>(node)</code>.
+     *
+     * These methods are deprecated, use Traversal::BFSfrom instead.
      */
     template <typename L>
     void TLX_DEPRECATED(BFSfrom(node r, L handle) const);
@@ -1584,6 +1633,8 @@ public:
      *
      * @param r Node.
      * @param handle Takes parameter <code>(node)</code>.
+     *
+     * These methods are deprecated, use Traversal::DFSfrom instead.
      */
     template <typename L>
     void TLX_DEPRECATED(DFSfrom(node r, L handle) const);

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -744,7 +744,10 @@ public:
      * Get the ID of this graph. The ID is a unique unsigned integer given to
      * every graph on construction.
      */
-    count getId() const { return id; }
+    count TLX_DEPRECATED(getId() const) {
+        WARN("Graph::getId is deprecated and will not be supported in future releases.");
+        return id;
+    }
 
     /**
      * Return the type of the graph.
@@ -753,7 +756,7 @@ public:
      * 		DirectedGraph: not weighted, directed
      * 		WeightedDirectedGraph: weighted, directed
      */
-    std::string typ() const;
+    std::string TLX_DEPRECATED(typ() const);
 
     /**
      * Try to save some memory by shrinking internal data structures of the
@@ -778,13 +781,19 @@ public:
      * Set name of graph to @a name.
      * @param name The name.
      */
-    void setName(std::string name) { this->name = name; }
+    void TLX_DEPRECATED(setName(std::string name)) {
+        WARN("Graph::setName is deprecated and will not be supported in future releases.");
+        this->name = name;
+    }
 
     /*
      * Returns the name of the graph.
      * @return The name of the graph.
      */
-    std::string getName() const { return name; }
+    std::string TLX_DEPRECATED(getName() const) {
+        WARN("Graph::getName is deprecated and will not be supported in future releases.");
+        return name;
+    }
 
     /**
      * Set edge count of the graph to edges.
@@ -797,7 +806,7 @@ public:
      * Returns a string representation of the graph.
      * @return A string representation.
      */
-    std::string toString() const;
+    std::string TLX_DEPRECATED(toString() const);
 
     /* COPYING */
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1232,13 +1232,19 @@ public:
     /**
      * Trigger a time step - increments counter.
      */
-    void timeStep() { t++; }
+    void TLX_DEPRECATED(timeStep()) {
+        WARN("Graph::timeStep is deprecated and will not be supported in future releases.");
+        t++;
+    }
 
     /**
      * Get time step counter.
      * @return Time step counter.
      */
-    count time() { return t; }
+    count TLX_DEPRECATED(time()) {
+        WARN("Graph::time is deprecated and will not be supported in future releases.");
+        return t;
+    }
 
     /**
      * Return edge weight of edge {@a u,@a v}. Returns 0 if edge does not

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1222,19 +1222,7 @@ public:
     /**
      * @return the density of the graph
      */
-    double density() const {
-        count n = numberOfNodes();
-        count m = numberOfEdges();
-        count loops = numberOfSelfLoops();
-        m -= loops;
-        double d;
-        if (isDirected()) {
-            d = m / (double)(n * (n - 1));
-        } else {
-            d = (2 * m) / (double)(n * (n - 1));
-        }
-        return d;
-    }
+    double TLX_DEPRECATED(density() const);
 
     /**
      * Return the number of loops {v,v} in the graph.

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1217,7 +1217,7 @@ public:
      * @return a pair (n, m) where n is the number of nodes and m is the
      * number of edges
      */
-    std::pair<count, count> const size() const noexcept { return {n, m}; };
+    std::pair<count, count> const TLX_DEPRECATED(size() const noexcept);
 
     /**
      * @return the density of the graph

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1002,7 +1002,7 @@ public:
      * Returns a random node of the graph.
      * @return A random node.
      */
-    node randomNode() const;
+    node TLX_DEPRECATED(randomNode() const);
 
     /**
      * Returns a random neighbor of @a u and @c none if degree is zero.

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1010,7 +1010,7 @@ public:
      * @param u Node.
      * @return A random neighbor of @a u.
      */
-    node randomNeighbor(node u) const;
+    node TLX_DEPRECATED(randomNeighbor(node u) const);
 
     /* EDGE MODIFIERS */
 
@@ -1369,6 +1369,12 @@ public:
             return v;
         else
             return none;
+    }
+
+    node getIthNeighbor(node u, index i) const {
+        if (!hasNode(u) || i >= outEdges[u].size())
+            return none;
+        return outEdges[u][i];
     }
 
     /* Derivative Graphs */

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1542,11 +1542,11 @@ public:
      * @param r Node.
      * @param handle Takes parameter <code>(node)</code>.
      */
-    template <typename L> void BFSfrom(node r, L handle) const;
+    template <typename L> void TLX_DEPRECATED(BFSfrom(node r, L handle) const);
     template <typename L>
-    void BFSfrom(const std::vector<node> &startNodes, L handle) const;
+    void TLX_DEPRECATED(BFSfrom(const std::vector<node> &startNodes, L handle) const);
 
-    template <typename L> void BFSEdgesFrom(node r, L handle) const;
+    template <typename L> void TLX_DEPRECATED(BFSEdgesFrom(node r, L handle) const);
 
     /**
      * Iterate over nodes in depth-first search order starting from r until
@@ -1555,9 +1555,9 @@ public:
      * @param r Node.
      * @param handle Takes parameter <code>(node)</code>.
      */
-    template <typename L> void DFSfrom(node r, L handle) const;
+    template <typename L> void TLX_DEPRECATED(DFSfrom(node r, L handle) const);
 
-    template <typename L> void DFSEdgesFrom(node r, L handle) const;
+    template <typename L> void TLX_DEPRECATED(DFSEdgesFrom(node r, L handle) const);
 };
 
 /* NODE ITERATORS */
@@ -1973,12 +1973,14 @@ template <typename L> double Graph::parallelSumForEdges(L handle) const {
 /* GRAPH SEARCHES */
 
 template <typename L> void Graph::BFSfrom(node r, L handle) const {
+    WARN("Graph::BFSfrom is deprecated, use Traversal::BFSfrom instead.");
     std::vector<node> startNodes(1, r);
     BFSfrom(startNodes, handle);
 }
 
 template <typename L>
 void Graph::BFSfrom(const std::vector<node> &startNodes, L handle) const {
+    WARN("Graph::BFSfrom is deprecated, use Traversal::BFSfrom instead.");
     std::vector<bool> marked(z);
     std::queue<node> q, qNext;
     count dist = 0;
@@ -2006,6 +2008,7 @@ void Graph::BFSfrom(const std::vector<node> &startNodes, L handle) const {
 }
 
 template <typename L> void Graph::BFSEdgesFrom(node r, L handle) const {
+    WARN("Graph::BFSEdgesFrom is deprecated, use Traversal::BFSEdgesFrom instead.");
     std::vector<bool> marked(z);
     std::queue<node> q;
     q.push(r); // enqueue root
@@ -2025,6 +2028,7 @@ template <typename L> void Graph::BFSEdgesFrom(node r, L handle) const {
 }
 
 template <typename L> void Graph::DFSfrom(node r, L handle) const {
+    WARN("Graph::DFSfrom is deprecated, use Traversal::DFSfrom instead.");
     std::vector<bool> marked(z);
     std::stack<node> s;
     s.push(r); // enqueue root
@@ -2044,6 +2048,7 @@ template <typename L> void Graph::DFSfrom(node r, L handle) const {
 }
 
 template <typename L> void Graph::DFSEdgesFrom(node r, L handle) const {
+    WARN("Graph::DFSEdgesFrom is deprecated, use Traversal::DFSEdgesFrom instead.");
     std::vector<bool> marked(z);
     std::stack<node> s;
     s.push(r); // enqueue root

--- a/include/networkit/graph/GraphBuilder.hpp
+++ b/include/networkit/graph/GraphBuilder.hpp
@@ -13,6 +13,8 @@
 #include <networkit/Globals.hpp>
 #include <networkit/graph/Graph.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /*
@@ -88,7 +90,7 @@ public:
      * Set name of graph to @a name.
      * @param name The name.
      */
-    void setName(std::string name) { this->name = name; }
+    void TLX_DEPRECATED(setName(std::string name)) { this->name = name; }
 
     /**
      * Returns <code>true</code> if this graph supports edge weights other

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -60,9 +60,42 @@ node randomNode(const Graph &G);
 node randomNeighbor(const Graph &G, node u);
 
 /**
- * Removes all the edges in the graph.
+ * Returns a random edge. By default a random node u is chosen and then
+ * some random neighbor v. So the probability of choosing (u, v) highly
+ * depends on the degree of u. Setting uniformDistribution to true, will
+ * give you a real uniform distributed edge, but will be slower.
+ * Exp. time complexity: O(1) for uniformDistribution = false, O(n) otherwise.
+ *
+ * @param Graph G The input graph.
+ * @param bool uniformDistribution Whether the random edge should be extracted uniformly at
+ * random.
+ * @return std::pair<node, node> A random edge.
  */
-void removeAllEdges(Graph &G);
+std::pair<node, node> randomEdge(const Graph &G, bool uniformDistribution = false);
+
+/**
+ * Returns a vector with @a nr random edges. The edges are chosen uniformly
+ * random.
+ *
+ * @param G The input graph.
+ * @param nr The number of random edges to be returned.
+ * @return std::vector<std::pair<node, node>> Vector with random edges.
+ */
+std::vector<std::pair<node, node>> randomEdges(const Graph &G, count nr);
+
+/**
+ * Removes all self-loops in the graph.
+ *
+ * @param G The input graph.
+ */
+void removeSelfLoops(Graph &G);
+
+/**
+ * Removes all multi-edges in the graph.
+ *
+ * @param G The input graph.
+ */
+void removeMultiEdges(Graph &G);
 
 /**
  * Efficiently removes all the edges adjacent to a set of nodes that is

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -60,6 +60,36 @@ node randomNode(const Graph &G);
 node randomNeighbor(const Graph &G, node u);
 
 /**
+ * Removes all the edges in the graph.
+ */
+void removeAllEdges(Graph &G);
+
+/**
+ * Efficiently removes all the edges adjacent to a set of nodes that is
+ * not connected to the rest of the graph. This is meant to optimize the
+ * Kadabra algorithm.
+ *
+ * @param G The input graph.
+ * @param first Start of the range that contains the nodes in the set.
+ * @param last End of the range that contains the nodes in the set.
+ * is isolated from the rest of the graph.
+ */
+template <class InputIt>
+void removeEdgesFromIsolatedSet(Graph &G, InputIt first, InputIt last) {
+    count removedEdges = 0;
+    while (first != last) {
+        const auto u = *first++;
+        removedEdges += G.degree(u);
+        G.removePartialOutEdges(unsafe, u);
+        if (G.isDirected()) {
+            G.removePartialInEdges(unsafe, u);
+        }
+    }
+
+    G.setEdgeCount(unsafe, G.numberOfEdges() - (G.isDirected() ? removedEdges : removedEdges / 2));
+}
+
+/**
  * Copies all nodes of the input graph to a new graph (edges are not copied).
  *
  * @param G The input graph.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -43,6 +43,14 @@ edgeweight maxWeightedDegree(const Graph &G);
 edgeweight maxWeightedInDegree(const Graph &G);
 
 /**
+ * Returns a random node of the input graph.
+ *
+ * @param G The input graph.
+ * @return A random node.
+ */
+node randomNode(const Graph &G);
+
+/**
  * Copies all nodes of the input graph to a new graph (edges are not copied).
  *
  * @param G The input graph.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -84,20 +84,6 @@ std::pair<node, node> randomEdge(const Graph &G, bool uniformDistribution = fals
 std::vector<std::pair<node, node>> randomEdges(const Graph &G, count nr);
 
 /**
- * Removes all self-loops in the graph.
- *
- * @param G The input graph.
- */
-void removeSelfLoops(Graph &G);
-
-/**
- * Removes all multi-edges in the graph.
- *
- * @param G The input graph.
- */
-void removeMultiEdges(Graph &G);
-
-/**
  * Efficiently removes all the edges adjacent to a set of nodes that is
  * not connected to the rest of the graph. This is meant to optimize the
  * Kadabra algorithm.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -136,8 +136,8 @@ Graph getRemappedGraph(const Graph& graph, count numNodes, UnaryIdMapper&& oldId
         std::forward<UnaryIdMapper>(oldIdToNew), [](node) { return false; }, preallocate);
 }
 
-
 }	// namespace GraphTools
+
 }	// namespace NetworKit
 
 #endif // NETWORKIT_GRAPH_GRAPH_TOOLS_HPP_

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -109,6 +109,15 @@ void removeEdgesFromIsolatedSet(Graph &G, InputIt first, InputIt last) {
 }
 
 /**
+ * Returns the number of nodes and the number of edges of the input graph.
+ *
+ * @param G The input graph.
+ * @return std::pair<count, count> with the number of nodes and the number
+ * of edges of the input graph.
+ */
+std::pair<node, node> size(const Graph &G) noexcept;
+
+/**
  * Copies all nodes of the input graph to a new graph (edges are not copied).
  *
  * @param G The input graph.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -51,6 +51,15 @@ edgeweight maxWeightedInDegree(const Graph &G);
 node randomNode(const Graph &G);
 
 /**
+ * Returns a random neighbor of node @a u. Returns none if degree is zero.
+ *
+ * @param G The input graph.
+ * @param u Node.
+ * @return A random neighbor of @a u.
+ */
+node randomNeighbor(const Graph &G, node u);
+
+/**
  * Copies all nodes of the input graph to a new graph (edges are not copied).
  *
  * @param G The input graph.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -2,6 +2,8 @@
 #define NETWORKIT_GRAPH_GRAPH_TOOLS_HPP_
 
 #include <unordered_map>
+#include <unordered_set>
+
 #include <networkit/graph/Graph.hpp>
 #include <tlx/unused.hpp>
 
@@ -16,6 +18,19 @@ namespace GraphTools {
  * @return Graph with the same nodes as the input graph (and without any edge).
  */
 Graph copyNodes(const Graph &G);
+
+/**
+ * Returns an induced subgraph of the input graph (including potential edge weights/directions).
+ *
+ * @param G The input graph.
+ * @param nodes Nodes of the induced subgraph.
+ * @param includeOutNeighbors If set to true, out-neighbors will also be included.
+ * @param includeInNeighbors If set to true, in-neighbors will also be included.
+ *
+ * @return Induced subgraph.
+ */
+Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
+                        bool includeOutNeighbors = false, bool includeInNeighbors = false);
 
 /**
  * Computes a graph with the same structure but with continuous node ids.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -118,6 +118,15 @@ void removeEdgesFromIsolatedSet(Graph &G, InputIt first, InputIt last) {
 std::pair<node, node> size(const Graph &G) noexcept;
 
 /**
+ * Return the density of the input graph.
+ *
+ * @param G The input graph.
+ *
+ * @return double The density of the input graph.
+ */
+double density(const Graph &G) noexcept;
+
+/**
  * Copies all nodes of the input graph to a new graph (edges are not copied).
  *
  * @param G The input graph.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -27,6 +27,22 @@ count maxDegree(const Graph &G);
 count maxInDegree(const Graph &G);
 
 /**
+ * Returns the maximum weighted out-degree of the graph.
+ *
+ * @param G The input graph.
+ * @return Maximum weighted degree of the graph.
+ */
+edgeweight maxWeightedDegree(const Graph &G);
+
+/**
+ * Returns the maximum weighted in-degree of the graph.
+ *
+ * @param G The input graph.
+ * @return Maximum weighted in degree of the graph.
+ */
+edgeweight maxWeightedInDegree(const Graph &G);
+
+/**
  * Copies all nodes of the input graph to a new graph (edges are not copied).
  *
  * @param G The input graph.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -33,6 +33,33 @@ Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
                         bool includeOutNeighbors = false, bool includeInNeighbors = false);
 
 /**
+ * Returns an undirected copy of the input graph.
+ *
+ * @param G The input graph.
+ *
+ * @return Undirected copy of the input graph.
+ */
+Graph toUndirected(const Graph &G);
+
+/**
+ * Return an unweighted copy of the input graph.
+ *
+ * @param G The input graph.
+ *
+ * @return Unweighted copy of the input graph.
+ */
+Graph toUnweighted(const Graph &G);
+
+/**
+ * Return a weighted copy of the input graph.
+ *
+ * @param G The input graph.
+ *
+ * @return Weighted copy of the input graph.
+ */
+Graph toWeighted(const Graph &G);
+
+/**
  * Returns the transpose of the input graph. The graph must be directed.
  *
  * @param G The input graph.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -69,6 +69,23 @@ Graph toWeighted(const Graph &G);
 Graph transpose(const Graph &G);
 
 /**
+ * Appends graph @a G1 to graph @a G as a new subgraph. Performs node id remapping.
+ *
+ * @param G Graph where @G1 will be appended to.
+ * @param G1 Graph that will be appended to @a G.
+ */
+void append(Graph &G, const Graph &G1);
+
+/**
+ * Modifies graph @a G to be the union of it and graph @a G1.
+ * Nodes with the same ids are identified with each other.
+ *
+ * @param G Result of the merge.
+ * @param G1 Graph that will be merged with @a G.
+ */
+void merge(Graph &G, const Graph &G1);
+
+/**
  * Computes a graph with the same structure but with continuous node ids.
  * @param  graph     The graph to be compacted.
  * @param  nodeIdMap The map providing the information about the node ids.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -33,6 +33,15 @@ Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
                         bool includeOutNeighbors = false, bool includeInNeighbors = false);
 
 /**
+ * Returns the transpose of the input graph. The graph must be directed.
+ *
+ * @param G The input graph.
+ *
+ * @return Transpose of the input graph.
+ */
+Graph transpose(const Graph &G);
+
+/**
  * Computes a graph with the same structure but with continuous node ids.
  * @param  graph     The graph to be compacted.
  * @param  nodeIdMap The map providing the information about the node ids.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -11,6 +11,22 @@ namespace NetworKit {
 namespace GraphTools {
 
 /**
+ * Returns the maximum out-degree of the graph.
+ *
+ * @param G The input graph.
+ * @return The maximum out-degree of the graph.
+ */
+count maxDegree(const Graph &G);
+
+/**
+ * Returns the maximum in-degree of the graph.
+ *
+ * @param G The input graph.
+ * @return The maximum in-degree of the graph.
+ */
+count maxInDegree(const Graph &G);
+
+/**
  * Copies all nodes of the input graph to a new graph (edges are not copied).
  *
  * @param G The input graph.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -1,11 +1,13 @@
+// networkit-format
+
 #ifndef NETWORKIT_GRAPH_GRAPH_TOOLS_HPP_
 #define NETWORKIT_GRAPH_GRAPH_TOOLS_HPP_
 
 #include <unordered_map>
 #include <unordered_set>
 
-#include <networkit/graph/Graph.hpp>
 #include <tlx/unused.hpp>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 namespace GraphTools {
@@ -207,30 +209,32 @@ void merge(Graph &G, const Graph &G1);
  * @param  nodeIdMap The map providing the information about the node ids.
  * @return           Returns a compacted Graph.
  */
-Graph getCompactedGraph(const Graph& graph, const std::unordered_map<node,node>& nodeIdMap);
+Graph getCompactedGraph(const Graph &graph, const std::unordered_map<node, node> &nodeIdMap);
 
 /**
  * Computes a map of node ids.
  * @param	graph	The graph of which the node id map is wanted.
  * @return			Returns the node id map.
  */
-std::unordered_map<node,node> getContinuousNodeIds(const Graph& graph);
+std::unordered_map<node, node> getContinuousNodeIds(const Graph &graph);
 
 /**
  * Computes a map of random node ids
  * @param	graph	The graph of which the node id map is wanted.
  * @return		Returns the node id map.
  */
-std::unordered_map<node, node> getRandomContinuousNodeIds(const Graph& graph);
-
+std::unordered_map<node, node> getRandomContinuousNodeIds(const Graph &graph);
 
 /**
  * Inverts a given mapping of node ids from a graph with deleted nodes to continuous node ids.
- * @param 	nodeIdMap	The mapping from node ids with gaps to continuous node ids (i.e. from @getContinuousNodeIds)
+ * @param 	nodeIdMap	The mapping from node ids with gaps to continuous node ids (i.e. from
+ * @getContinuousNodeIds)
  * @param 	G 			The compacted graph (currently only needed for the upper node id bound)
- * @return 				A vector of nodes id where the index is the node id of the compacted graph and the value is the node id of the noncontinuous graph.
+ * @return 				A vector of nodes id where the index is the node id of the compacted graph
+ * and the value is the node id of the noncontinuous graph.
  */
-std::vector<node> invertContinuousNodeIds(const std::unordered_map<node,node>& nodeIdMap, const Graph& G);
+std::vector<node> invertContinuousNodeIds(const std::unordered_map<node, node> &nodeIdMap,
+                                          const Graph &G);
 
 /**
  * Constructs a new graph that has the same node ids as before it was compacted.
@@ -238,8 +242,7 @@ std::vector<node> invertContinuousNodeIds(const std::unordered_map<node,node>& n
  * @param  G             The compacted graph.
  * @return               The original graph.
  */
-Graph restoreGraph(const std::vector<node>& invertedIdMap, const Graph& G);
-
+Graph restoreGraph(const std::vector<node> &invertedIdMap, const Graph &G);
 
 /**
  * Rename nodes in a graph using a callback which translates each old id to a new one.
@@ -257,15 +260,12 @@ Graph restoreGraph(const std::vector<node>& invertedIdMap, const Graph& G);
  * @node preallocate is currently not implemented
  */
 template <typename UnaryIdMapper, typename SkipEdgePredicate>
-Graph getRemappedGraph(const Graph& graph, count numNodes,
-    UnaryIdMapper&& oldIdToNew, SkipEdgePredicate&& skipNode, bool preallocate = true)
-{
+Graph getRemappedGraph(const Graph &graph, count numNodes, UnaryIdMapper &&oldIdToNew,
+                       SkipEdgePredicate &&skipNode, bool preallocate = true) {
     tlx::unused(preallocate); // TODO: Add perallocate as soon as Graph supports it
 
 #ifndef NDEBUG
-    graph.forNodes([&] (node u) {
-        assert(skipNode(u) || oldIdToNew(u) < numNodes);
-    });
+    graph.forNodes([&](node u) { assert(skipNode(u) || oldIdToNew(u) < numNodes); });
 #endif // NDEBUG
 
     const auto directed = graph.isDirected();
@@ -291,13 +291,15 @@ Graph getRemappedGraph(const Graph& graph, count numNodes,
 }
 
 template <typename UnaryIdMapper>
-Graph getRemappedGraph(const Graph& graph, count numNodes, UnaryIdMapper&& oldIdToNew, bool preallocate = true) {
-    return getRemappedGraph(graph, numNodes,
-        std::forward<UnaryIdMapper>(oldIdToNew), [](node) { return false; }, preallocate);
+Graph getRemappedGraph(const Graph &graph, count numNodes, UnaryIdMapper &&oldIdToNew,
+                       bool preallocate = true) {
+    return getRemappedGraph(
+        graph, numNodes, std::forward<UnaryIdMapper>(oldIdToNew), [](node) { return false; },
+        preallocate);
 }
 
-}	// namespace GraphTools
+} // namespace GraphTools
 
-}	// namespace NetworKit
+} // namespace NetworKit
 
 #endif // NETWORKIT_GRAPH_GRAPH_TOOLS_HPP_

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -9,6 +9,15 @@ namespace NetworKit {
 namespace GraphTools {
 
 /**
+ * Copies all nodes of the input graph to a new graph (edges are not copied).
+ *
+ * @param G The input graph.
+ *
+ * @return Graph with the same nodes as the input graph (and without any edge).
+ */
+Graph copyNodes(const Graph &G);
+
+/**
  * Computes a graph with the same structure but with continuous node ids.
  * @param  graph     The graph to be compacted.
  * @param  nodeIdMap The map providing the information about the node ids.

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1122,8 +1122,9 @@ cdef class Graph:
 	 	-------
 			undirected graph.
 		"""
+		from warnings import warn
+		warn("Graph.toUndirected is deprecated, use graph.GraphTools.toUndirected instead.")
 		return Graph().setThis(self._this.toUndirected())
-
 
 	def toUnweighted(self):
 		"""
@@ -1133,6 +1134,8 @@ cdef class Graph:
 	 	-------
 		networkit.Graph
 		"""
+		from warnings import warn
+		warn("Graph.toUnweighted is deprecated, use graph.GraphTools.toUnweighted instead.")
 		return Graph().setThis(self._this.toUnweighted())
 
 	def transpose(self):
@@ -5080,6 +5083,9 @@ cdef class Traversal:
 cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphTools":
 
 	_Graph copyNodes(_Graph G) nogil except +
+	_Graph toUndirected(_Graph G) nogil except +
+	_Graph toUnweighted(_Graph G) nogil except +
+	_Graph toWeighted(_Graph G) nogil except +
 	_Graph subgraphFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
 	_Graph getCompactedGraph(_Graph G, unordered_map[node,node]) nogil except +
 	_Graph transpose(_Graph G) nogil except +
@@ -5087,6 +5093,58 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
 
 cdef class GraphTools:
+
+	@staticmethod
+	def toUndirected(Graph graph):
+		"""
+		Returns an undirected copy of the input graph.
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		graph : networkit.Graph
+			Undirected copy of the input graph.
+		"""
+		return Graph().setThis(toUndirected(graph._this))
+
+	@staticmethod
+	def toUnweighted(Graph graph):
+		"""
+		Returns an unweighted copy of the input graph.
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		graph : networkit.Graph
+			Unweighted copy of the input graph.
+		"""
+		return Graph().setThis(toUnweighted(graph._this))
+
+	@staticmethod
+	def toWeighted(Graph graph):
+		"""
+		Returns a weighted copy of the input graph.
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		graph : networkit.Graph
+			Weighted copy of the input graph.
+		"""
+		return Graph().setThis(toWeighted(graph._this))
+
 	@staticmethod
 	def copyNodes(Graph graph):
 		"""

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -964,6 +964,8 @@ cdef class Graph:
 	 	list
 	 		List of all nodes.
 		"""
+		from warnings import warn
+		warn("Graph.nodes is deprecated.")
 		return self._this.nodes()
 
 	def edges(self):
@@ -974,6 +976,8 @@ cdef class Graph:
 	 	list
 	 		List of edges as node pairs.
 		"""
+		from warnings import warn
+		warn("Graph.edges is deprecated.")
 		return self._this.edges()
 
 	def neighbors(self, u):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1269,6 +1269,8 @@ cdef class Graph:
 		node
 			A random neighbor of `v.
 		"""
+		from warnings import warn
+		warn("Graph.randomNeighbor is deprecated, use graphtools.randomNeighbor instead.")
 		return self._this.randomNeighbor(u)
 
 	def randomEdge(self, bool_t uniformDistribution = False):
@@ -5124,6 +5126,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	edgeweight maxWeightedDegree(_Graph G) nogil except +
 	edgeweight maxWeightedInDegree(_Graph G) nogil except +
 	node randomNode(_Graph G) nogil except +
+	node randomNeighbor(_Graph G, node u) nogil except +
 	_Graph copyNodes(_Graph G) nogil except +
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
@@ -5222,6 +5225,25 @@ cdef class GraphTools:
 			A random node.
 		"""
 		return randomNode(G._this)
+
+	@staticmethod
+	def randomNeighbor(Graph G, node u):
+		"""
+		Returns a random neighbor of node `u`.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph.
+		u : node
+			A node in `G`.
+
+		Returns
+		-------
+		node
+			A random neighbor of `u`.
+		"""
+		return randomNeighbor(G._this, u)
 
 	@staticmethod
 	def append(Graph G, Graph G1):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1144,6 +1144,8 @@ cdef class Graph:
 		networkit.Graph
 			Directed graph.
 		"""
+		from warnings import warn
+		warn("Graph.transpose is deprecated, use graph.GraphTools.transpose instead.")
 		return Graph().setThis(self._this.transpose())
 
 	def isWeighted(self):
@@ -4967,6 +4969,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	_Graph copyNodes(_Graph G) nogil except +
 	_Graph subgraphFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
 	_Graph getCompactedGraph(_Graph G, unordered_map[node,node]) nogil except +
+	_Graph transpose(_Graph G) nogil except +
 	unordered_map[node,node] getContinuousNodeIds(_Graph G) nogil except +
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
 
@@ -5012,6 +5015,22 @@ cdef class GraphTools:
 		"""
 		return Graph().setThis(subgraphFromNodes(
 			graph._this, nodes, includeOutNeighbors, includeInNeighbors))
+
+	@staticmethod
+	def transpose(Graph graph):
+		"""
+		Returns the transpose of the input graph. The graph must be directed.
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+
+		Returns
+		graph : networkit.Graph
+			Transpose of the input graph.
+		"""
+		return Graph().setThis(transpose(graph._this))
 
 	@staticmethod
 	def getCompactedGraph(Graph graph, nodeIdMap):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -913,6 +913,8 @@ cdef class Graph:
 			Efficiently removes all the edges adjacent to a set of nodes that is not connected
 			to the rest of the graph. This is meant to optimize the Kadabra algorithm.
 		"""
+		from warnings import warn
+		warn("Graph.removeEdgesFromIsolatedSet is deprecated, use graphtools.removeEdgesFromIsolatedSet instead.")
 		self._this.removeEdgesFromIsolatedSet(nodes)
 		return self
 
@@ -5134,6 +5136,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	_Graph subgraphFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
 	void append(_Graph G, _Graph G1) nogil except +
 	void merge(_Graph G, _Graph G1) nogil except +
+	void removeEdgesFromIsolatedSet[InputIt](_Graph G, InputIt first, InputIt last) except +
 	_Graph getCompactedGraph(_Graph G, unordered_map[node,node]) nogil except +
 	_Graph transpose(_Graph G) nogil except +
 	unordered_map[node,node] getContinuousNodeIds(_Graph G) nogil except +
@@ -5273,6 +5276,29 @@ cdef class GraphTools:
 			Graph that will be merged with `G`.
 		"""
 		merge(G._this, G1._this)
+
+	@staticmethod
+	def removeEdgesFromIsolatedSet(Graph graph, nodes):
+		"""
+		Efficiently removes all the edges adjacent to a set of nodes that is
+		not connected to the rest of the graph. This is meant to optimize the
+		Kadabra algorithm.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph.
+		nodes : list
+			Isolates set of nodes from where the edges will be removed.
+		"""
+		cdef vector[node] isolatedSet
+
+		try:
+			isolatedSet = <vector[node]?>nodes
+		except TypeError:
+			raise RuntimeError("Error, nodes must be a list of nodes.")
+		removeEdgesFromIsolatedSet[vector[node].iterator](graph._this,
+				isolatedSet.begin(), isolatedSet.end())
 
 	@staticmethod
 	def toUndirected(Graph graph):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1252,6 +1252,8 @@ cdef class Graph:
 		node
 			A random node.
 		"""
+		from warnings import warn
+		warn("Graph.randomNode is deprecated, use graphtools.randomNode instead.")
 		return self._this.randomNode()
 
 	def randomNeighbor(self, u):
@@ -5121,6 +5123,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	count maxInDegree(_Graph G) nogil except +
 	edgeweight maxWeightedDegree(_Graph G) nogil except +
 	edgeweight maxWeightedInDegree(_Graph G) nogil except +
+	node randomNode(_Graph G) nogil except +
 	_Graph copyNodes(_Graph G) nogil except +
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
@@ -5202,6 +5205,23 @@ cdef class GraphTools:
 			The maximum weighted in-degree of the graph.
 		"""
 		return maxWeightedInDegree(G._this)
+
+	@staticmethod
+	def randomNode(Graph G):
+		"""
+		Returns a random node of the input graph.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		node
+			A random node.
+		"""
+		return randomNode(G._this)
 
 	@staticmethod
 	def append(Graph G, Graph G1):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -704,6 +704,8 @@ cdef class Graph:
 		double
 			Maximum weighted degree of the graph.
 		"""
+		from warnings import warn
+		warn("Graph.maxWeightedDegree is deprecated, use graphtools.maxWeightedDegree instead.")
 		return self._this.maxWeightedDegree()
 
 	def maxWeightedDegreeIn(self):
@@ -715,6 +717,8 @@ cdef class Graph:
 		double
 			Maximum weighted in degree of the graph.
 		"""
+		from warnings import warn
+		warn("Graph.maxWeightedDegreeIn is deprecated, use graphtools.maxWeightedInDegree instead.")
 		return self._this.maxWeightedDegreeIn()
 
 	def isIsolated(self, u):
@@ -5115,6 +5119,8 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 
 	count maxDegree(_Graph G) nogil except +
 	count maxInDegree(_Graph G) nogil except +
+	edgeweight maxWeightedDegree(_Graph G) nogil except +
+	edgeweight maxWeightedInDegree(_Graph G) nogil except +
 	_Graph copyNodes(_Graph G) nogil except +
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
@@ -5162,6 +5168,40 @@ cdef class GraphTools:
 			The maximum in-degree of the graph.
 		"""
 		return maxInDegree(G._this)
+
+	@staticmethod
+	def maxWeightedDegree(Graph G):
+		"""
+		Returns the maximum weighted out-degree of the graph.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		edgeweight
+			The maximum weighted out-degree of the graph.
+		"""
+		return maxWeightedDegree(G._this)
+
+	@staticmethod
+	def maxWeightedInDegree(Graph G):
+		"""
+		Returns the maximum weighted in-degree of the graph.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		edgeweight
+			The maximum weighted in-degree of the graph.
+		"""
+		return maxWeightedInDegree(G._this)
 
 	@staticmethod
 	def append(Graph G, Graph G1):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1160,6 +1160,8 @@ cdef class Graph:
 		string
 			A string representation of the graph.
 		"""
+		from warnings import warn
+		warn("Graph.toString is deprecated.")
 		return self._this.toString()
 
 	def getName(self):
@@ -1170,6 +1172,8 @@ cdef class Graph:
 		string
 			The name of the graph.
 		"""
+		from warnings import warn
+		warn("Graph.getName is deprecated.")
 		return pystring(self._this.getName())
 
 	def setName(self, name):
@@ -1180,6 +1184,8 @@ cdef class Graph:
 		name : string
 			The name.
 		"""
+		from warnings import warn
+		warn("Graph.setName is deprecated.")
 		self._this.setName(stdstring(name))
 
 	def totalEdgeWeight(self):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1377,6 +1377,8 @@ cdef class Graph:
 		networkit.Graph
 			The subgraph induced by `nodes` (and possibly their neighbors)
 		"""
+		from warnings import warn
+		warn("Graph.subgraphFromNodes is deprecated, use graph.GraphTools.subgraphFromNodes instead.")
 		cdef unordered_set[node] nnodes
 		for node in nodes:
 			nnodes.insert(node)
@@ -4963,6 +4965,7 @@ cdef class GraphClusteringTools:
 cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphTools":
 
 	_Graph copyNodes(_Graph G) nogil except +
+	_Graph subgraphFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
 	_Graph getCompactedGraph(_Graph G, unordered_map[node,node]) nogil except +
 	unordered_map[node,node] getContinuousNodeIds(_Graph G) nogil except +
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
@@ -4984,6 +4987,31 @@ cdef class GraphTools:
 			Graph with the same nodes as the input graph (and without any edge).
 		"""
 		return Graph().setThis(copyNodes(graph._this))
+
+	@staticmethod
+	def subgraphFromNodes(Graph graph, nodes, includeOutNeighbors=False, includeInNeighbors=False):
+		"""
+		Returns an induced subgraph of the input graph (including potential edge
+		weights/directions).
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+		nodes : set
+			Nodes in the induced subgraph.
+		includeOutNeighbors : bool
+			If set to true, out-neighbors will also be included.
+		includeInNeighbors : bool
+			If set to true, in-neighbors will also be included.
+
+		Returns
+		-------
+		graph : networkit.Graph
+			Induced subgraph.
+		"""
+		return Graph().setThis(subgraphFromNodes(
+			graph._this, nodes, includeOutNeighbors, includeInNeighbors))
 
 	@staticmethod
 	def getCompactedGraph(Graph graph, nodeIdMap):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -506,7 +506,7 @@ cdef class Graph:
 			Graph with the same nodes (without edges)
 		"""
 		from warnings import warn
-		warn("Graph.copyNodes is deprecated, use graph.GraphTools.copyNodes instead.")
+		warn("Graph.copyNodes is deprecated, use graphtools.copyNodes instead.")
 		return Graph().setThis(self._this.copyNodes())
 
 	def indexEdges(self, bool_t force = False):
@@ -801,7 +801,7 @@ cdef class Graph:
 		G : networkit.Graph
 		"""
 		from warnings import warn
-		warn("Graph.append is deprecated, use graph.GraphTools.append instead.")
+		warn("Graph.append is deprecated, use graphtools.append instead.")
 		self._this.append(G._this)
 		return self
 
@@ -814,7 +814,7 @@ cdef class Graph:
 		G : networkit.Graph
 		"""
 		from warnings import warn
-		warn("Graph.merge is deprecated, use graph.GraphTools.merge instead.")
+		warn("Graph.merge is deprecated, use graphtools.merge instead.")
 		self._this.merge(G._this)
 		return self
 
@@ -1150,7 +1150,7 @@ cdef class Graph:
 			undirected graph.
 		"""
 		from warnings import warn
-		warn("Graph.toUndirected is deprecated, use graph.GraphTools.toUndirected instead.")
+		warn("Graph.toUndirected is deprecated, use graphtools.toUndirected instead.")
 		return Graph().setThis(self._this.toUndirected())
 
 	def toUnweighted(self):
@@ -1162,7 +1162,7 @@ cdef class Graph:
 		networkit.Graph
 		"""
 		from warnings import warn
-		warn("Graph.toUnweighted is deprecated, use graph.GraphTools.toUnweighted instead.")
+		warn("Graph.toUnweighted is deprecated, use graphtools.toUnweighted instead.")
 		return Graph().setThis(self._this.toUnweighted())
 
 	def transpose(self):
@@ -1175,7 +1175,7 @@ cdef class Graph:
 			Directed graph.
 		"""
 		from warnings import warn
-		warn("Graph.transpose is deprecated, use graph.GraphTools.transpose instead.")
+		warn("Graph.transpose is deprecated, use graphtools.transpose instead.")
 		return Graph().setThis(self._this.transpose())
 
 	def isWeighted(self):
@@ -1418,7 +1418,7 @@ cdef class Graph:
 			The subgraph induced by `nodes` (and possibly their neighbors)
 		"""
 		from warnings import warn
-		warn("Graph.subgraphFromNodes is deprecated, use graph.GraphTools.subgraphFromNodes instead.")
+		warn("Graph.subgraphFromNodes is deprecated, use graphtools.subgraphFromNodes instead.")
 		cdef unordered_set[node] nnodes
 		for node in nodes:
 			nnodes.insert(node)

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -585,6 +585,8 @@ cdef class Graph:
 	 	-------
 	 	double
 		"""
+		from warnings import warn
+		warn("Graph.density is deprecated, use graphtools.density instead.")
 		return self._this.density()
 
 	def upperNodeIdBound(self):
@@ -5138,6 +5140,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	pair[node, node] randomEdge(_Graph G, bool_t uniformDistribution) nogil except +
 	vector[pair[node, node]] randomEdges(_Graph G, count numEdges) nogil except +
 	pair[count, count] size(_Graph G) nogil except +
+	double density(_Graph G) nogil except +
 	_Graph copyNodes(_Graph G) nogil except +
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
@@ -5413,6 +5416,23 @@ cdef class GraphTools:
 			a pair (n, m) where n is the number of nodes and m is the number of edges.
 		"""
 		return size(graph._this)
+
+	@staticmethod
+	def density(Graph graph):
+		"""
+		Get the density of the input graph.
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		double
+			The density of the input graph.
+		"""
+		return density(graph._this)
 
 	@staticmethod
 	def copyNodes(Graph graph):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -307,7 +307,8 @@ cdef extern from "<networkit/graph/Graph.hpp>":
 		count degree(node u) except +
 		count degreeIn(node u) except +
 		count degreeOut(node u) except +
-		double weightedDegree(node u) except +
+		double weightedDegree(node u, bool_t) except +
+		double weightedDegreeIn(node u, bool_t) except +
 		count maxDegree() except +
 		count maxDegreeIn() except +
 		double maxWeightedDegree() except +
@@ -628,23 +629,45 @@ cdef class Graph:
 	def degreeOut(self, u):
 		return self._this.degreeOut(u)
 
-	def weightedDegree(self, v):
+	def weightedDegree(self, u, countSelfLoopsTwice=False):
 		"""
-		Returns the weighted degree of v.
+		Returns the weighted out-degree of u.
 
-		For directed graphs this is the sum of weights of all outgoing edges of v.
+		For directed graphs this is the sum of weights of all outgoing edges of u.
 
 		Parameters
 		----------
-		v : node
+		u : node
 			Node.
+		countSelfLoopsTwice : bool
+			If set to true, self-loops will be counted twice
 
 		Returns
 		-------
 		double
-			The weighted degree of v.
+			The weighted out-degree of u.
 		"""
-		return self._this.weightedDegree(v)
+		return self._this.weightedDegree(u, countSelfLoopsTwice)
+
+	def weightedDegreeIn(self, u, countSelfLoopsTwice=False):
+		"""
+		Returns the weighted in-degree of u.
+
+		For directed graphs this is the sum of weights of all ingoing edges of u.
+
+		Parameters
+		----------
+		u : node
+			Node.
+		countSelfLoopsTwice : bool
+			If set to true, self-loops will be counted twice
+
+		Returns
+		-------
+		double
+			The weighted in-degree of u.
+		"""
+		return self._this.weightedDegreeIn(u, countSelfLoopsTwice)
 
 	def maxDegree(self):
 		"""

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1293,6 +1293,8 @@ cdef class Graph:
 		Fast, but not uniformly random if uniformDistribution is not set,
 		slow and uniformly random otherwise.
 		"""
+		from warnings import warn
+		warn("Graph.randomEdge is deprecated, use graphtools.randomEdge instead.")
 		return self._this.randomEdge(uniformDistribution)
 
 	def randomEdges(self, count numEdges):
@@ -5129,6 +5131,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	edgeweight maxWeightedInDegree(_Graph G) nogil except +
 	node randomNode(_Graph G) nogil except +
 	node randomNeighbor(_Graph G, node u) nogil except +
+	pair[node, node] randomEdge(_Graph G, bool_t uniformDistribution) nogil except +
 	_Graph copyNodes(_Graph G) nogil except +
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
@@ -5247,6 +5250,29 @@ cdef class GraphTools:
 			A random neighbor of `u`.
 		"""
 		return randomNeighbor(G._this, u)
+
+	@staticmethod
+	def randomEdge(Graph G, uniformDistribution = False):
+		""" Get a random edge of the graph.
+
+		Parameters
+		----------
+        G : networkit.Graph
+            The input graph.
+		uniformDistribution : bool
+			If the distribution of the edge shall be uniform.
+
+		Returns
+		-------
+		pair
+			Random edge.
+
+		Notes
+		-----
+		Fast, but not uniformly random if uniformDistribution is not set,
+		slow and uniformly random otherwise.
+		"""
+		return randomEdge(G._this, uniformDistribution)
 
 	@staticmethod
 	def append(Graph G, Graph G1):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -678,6 +678,8 @@ cdef class Graph:
 		count
 			Maximum out-degree of the graph.
 		"""
+		from warnings import warn
+		warn("Graph.maxDegree is deprecated, use graphtools.maxDegree instead.")
 		return self._this.maxDegree()
 
 	def maxDegreeIn(self):
@@ -689,6 +691,8 @@ cdef class Graph:
 		count
 			Maximum in-degree of the graph.
 		"""
+		from warnings import warn
+		warn("Graph.maxDegreeIn is deprecated, use graphtools.maxInDegree instead.")
 		return self._this.maxDegreeIn()
 
 	def maxWeightedDegree(self):
@@ -5109,6 +5113,8 @@ cdef class Traversal:
 
 cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphTools":
 
+	count maxDegree(_Graph G) nogil except +
+	count maxInDegree(_Graph G) nogil except +
 	_Graph copyNodes(_Graph G) nogil except +
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
@@ -5122,6 +5128,40 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
 
 cdef class GraphTools:
+
+	@staticmethod
+	def maxDegree(Graph G):
+		"""
+		Returns the maximum out-degree of the graph.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		count
+			The maximum out-degree of the graph.
+		"""
+		return maxDegree(G._this)
+
+	@staticmethod
+	def maxInDegree(Graph G):
+		"""
+		Returns the maximum in-degree of the graph.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		count
+			The maximum in-degree of the graph.
+		"""
+		return maxInDegree(G._this)
 
 	@staticmethod
 	def append(Graph G, Graph G1):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -777,6 +777,8 @@ cdef class Graph:
 		----------
 		G : networkit.Graph
 		"""
+		from warnings import warn
+		warn("Graph.append is deprecated, use graph.GraphTools.append instead.")
 		self._this.append(G._this)
 		return self
 
@@ -788,6 +790,8 @@ cdef class Graph:
 		----------
 		G : networkit.Graph
 		"""
+		from warnings import warn
+		warn("Graph.merge is deprecated, use graph.GraphTools.merge instead.")
 		self._this.merge(G._this)
 		return self
 
@@ -5087,12 +5091,43 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	_Graph toUnweighted(_Graph G) nogil except +
 	_Graph toWeighted(_Graph G) nogil except +
 	_Graph subgraphFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
+	void append(_Graph G, _Graph G1) nogil except +
+	void merge(_Graph G, _Graph G1) nogil except +
 	_Graph getCompactedGraph(_Graph G, unordered_map[node,node]) nogil except +
 	_Graph transpose(_Graph G) nogil except +
 	unordered_map[node,node] getContinuousNodeIds(_Graph G) nogil except +
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
 
 cdef class GraphTools:
+
+	@staticmethod
+	def append(Graph G, Graph G1):
+		"""
+		Appends graph `G1` to graph `G` as a new subgraph. Performs node id remapping.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			Graph where `G1` will be appended to.
+		G1 : networkit.Graph
+			Graph that will be appended to `G`.
+		"""
+		append(G._this, G1._this)
+
+	@staticmethod
+	def merge(Graph G, Graph G1):
+		"""
+		Modifies graph `G` to be the union of it and graph `G1`.
+		Nodes with the same ids are identified with each other.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			Result of the merge.
+		G1 : networkit.Graph
+			Graph that will be merged with `G`.
+		"""
+		merge(G._this, G1._this)
 
 	@staticmethod
 	def toUndirected(Graph graph):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1285,6 +1285,8 @@ cdef class Graph:
 		callback : object
 			Any callable object that takes the parameter (node, count) (the second parameter is the depth)
 		"""
+		from warnings import warn
+		warn("Graph.BFSfrom is deprecated, use graph.Traversal.BFSfrom instead")
 		cdef NodeDistCallbackWrapper *wrapper
 		try:
 			wrapper = new NodeDistCallbackWrapper(callback)
@@ -1305,6 +1307,8 @@ cdef class Graph:
 		callback : object
 			Any callable object that takes the parameter (node, node)
 		"""
+		from warnings import warn
+		warn("Graph.BFSEdgesFrom is deprecated, use graph.Traversal.BFSEdgesFrom instead")
 		cdef EdgeCallBackWrapper *wrapper
 		try:
 			wrapper = new EdgeCallBackWrapper(callback)
@@ -1322,6 +1326,8 @@ cdef class Graph:
 		callback : object
 			Any callable object that takes the parameter node
 		"""
+		from warnings import warn
+		warn("Graph.DFSfrom is deprecated, use graph.Traversal.DFSfrom instead")
 		cdef NodeCallbackWrapper *wrapper
 		try:
 			wrapper = new NodeCallbackWrapper(callback)
@@ -1339,6 +1345,8 @@ cdef class Graph:
 		callback : object
 			Any callable object that takes the parameter (node, node)
 		"""
+		from warnings import warn
+		warn("Graph.DFSEdgesFrom is deprecated, use graph.Traversal.DFSEdgesFrom instead")
 		cdef NodePairCallbackWrapper *wrapper
 		try:
 			wrapper = new NodePairCallbackWrapper(callback)
@@ -4963,6 +4971,111 @@ cdef class GraphClusteringTools:
 	@staticmethod
 	def equalClustering(Partition zeta, Partition eta, Graph G):
 		return equalClusterings(zeta._this, eta._this, G._this)
+
+cdef extern from "<networkit/graph/BFS.hpp>" namespace "NetworKit::Traversal":
+
+	void BFSfrom[InputIt, Callback](_Graph G, InputIt first, InputIt last, Callback c) nogil except +
+	void BFSEdgesFrom[Callback](_Graph G, node source, Callback c) nogil except +
+
+cdef extern from "<networkit/graph/DFS.hpp>" namespace "NetworKit::Traversal":
+	void DFSfrom[Callback](_Graph G, node source, Callback c) nogil except +
+	void DFSEdgesFrom[Callback](_Graph G, node source, Callback c) nogil except +
+
+cdef class Traversal:
+
+	@staticmethod
+	def BFSfrom(Graph graph, start, object callback):
+		"""
+		Iterate over nodes in breadth-first search order starting from the given node(s).
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+		start : node/list
+			Single node or list of nodes from where the BFS will start.
+		callback : Function
+			Takes either one (node) or two (node, distance) input parameters.
+		"""
+
+		cdef NodeDistCallbackWrapper *wrapper
+		cdef vector[node] sources
+
+		try:
+			wrapper = new NodeDistCallbackWrapper(callback)
+			try:
+				sources = <vector[node]?>start
+			except TypeError:
+				sources = [<node?>start]
+			BFSfrom[vector[node].iterator, NodeDistCallbackWrapper](graph._this, sources.begin(),sources.end(), dereference(wrapper))
+		finally:
+			del wrapper
+
+	@staticmethod
+	def BFSEdgesFrom(Graph graph, node start, object callback):
+		"""
+		Iterate over edges in breadth-first search order starting from the given node(s).
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+		start : node/list
+			Single node or list of nodes from where the BFS will start.
+		callback : Function
+			Takes four input parameters: (u, v, edgeweight, edgeid)
+		"""
+
+		cdef EdgeCallBackWrapper *wrapper
+
+		try:
+			wrapper = new EdgeCallBackWrapper(callback)
+			BFSEdgesFrom[EdgeCallBackWrapper](graph._this, start, dereference(wrapper))
+		finally:
+			del wrapper
+
+	@staticmethod
+	def DFSfrom(Graph graph, node start, object callback):
+		"""
+		Iterate over nodes in depth-first search order starting from the given node(s).
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+		start : node
+			Source node from where the DFS will start.
+		callback : Function
+			Takes a node as input parameter.
+		"""
+		cdef NodeCallbackWrapper *wrapper
+		try:
+			wrapper = new NodeCallbackWrapper(callback)
+			DFSfrom[NodeCallbackWrapper](graph._this, start, dereference(wrapper))
+		finally:
+			del wrapper
+
+	@staticmethod
+	def DFSEdgesFrom(Graph graph, node start, object callback):
+		"""
+		Iterate over edges in depth-first search order starting from the given node(s).
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+		start : node
+			Source node from where the DFS will start.
+		callback : Function
+			Takes four input parameters: (u, v, edgeweight, edgeid)
+		"""
+		cdef EdgeCallBackWrapper *wrapper
+		try:
+			wrapper = new EdgeCallBackWrapper(callback)
+			DFSEdgesFrom[EdgeCallBackWrapper](graph._this, start, dereference(wrapper))
+		finally:
+			del wrapper
+
 
 cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphTools":
 

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -504,6 +504,8 @@ cdef class Graph:
 		networkit.Graph
 			Graph with the same nodes (without edges)
 		"""
+		from warnings import warn
+		warn("Graph.copyNodes is deprecated, use graph.GraphTools.copyNodes instead.")
 		return Graph().setThis(self._this.copyNodes())
 
 	def indexEdges(self, bool_t force = False):
@@ -4960,11 +4962,29 @@ cdef class GraphClusteringTools:
 
 cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphTools":
 
+	_Graph copyNodes(_Graph G) nogil except +
 	_Graph getCompactedGraph(_Graph G, unordered_map[node,node]) nogil except +
 	unordered_map[node,node] getContinuousNodeIds(_Graph G) nogil except +
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
 
 cdef class GraphTools:
+	@staticmethod
+	def copyNodes(Graph graph):
+		"""
+		Copies all nodes of the input graph to a new graph (edges are not copied).
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		graph : networkit.Graph
+			Graph with the same nodes as the input graph (and without any edge).
+		"""
+		return Graph().setThis(copyNodes(graph._this))
+
 	@staticmethod
 	def getCompactedGraph(Graph graph, nodeIdMap):
 		"""

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -572,6 +572,8 @@ cdef class Graph:
 	 	tuple
 	 		a pair (n, m) where n is the number of nodes and m is the number of edges
 		"""
+		from warnings import warn
+		warn("Graph.size is deprecated, use graphtools.size instead.")
 		return self._this.size()
 
 
@@ -2487,7 +2489,7 @@ cdef class BarabasiAlbertGenerator(StaticGraphGenerator):
 
 	@classmethod
 	def fit(cls, Graph G, scale=1):
-		(n, m) = G.size()
+		(n, m) = GraphTools.size(G)
 		k = math.floor(m / n)
 		return cls(nMax=scale * n, k=k, n0=k)
 
@@ -2569,7 +2571,7 @@ cdef class ErdosRenyiGenerator(StaticGraphGenerator):
 	@classmethod
 	def fit(cls, Graph G, scale=1):
 		""" Fit model to input graph"""
-		(n, m) = G.size()
+		(n, m) = GraphTools.size(G)
 		if G.isDirected():
 			raise Exception("TODO: figure out scaling scheme for directed graphs")
 		else:
@@ -2715,7 +2717,7 @@ cdef class ChungLuGenerator(StaticGraphGenerator):
 	@classmethod
 	def fit(cls, Graph G, scale=1):
 		""" Fit model to input graph"""
-		(n, m) = G.size()
+		(n, m) = GraphTools.size(G)
 		degSeq = DegreeCentrality(G).run().scores()
 		return cls(degSeq * scale)
 
@@ -2863,7 +2865,7 @@ For a temperature of 0, the model resembles a unit-disk model in hyperbolic spac
 		""" Fit model to input graph"""
 		degSeq = DegreeCentrality(G).run().scores()
 		gamma = max(-1 * PowerlawDegreeSequence(degSeq).getGamma(), 2.1)
-		(n, m) = G.size()
+		(n, m) = GraphTools.size(G)
 		k = 2 * (m / n)
 		return cls(n * scale, k, gamma)
 
@@ -3048,7 +3050,7 @@ cdef class RmatGenerator(StaticGraphGenerator):
 			(a,b,c,d) = nweights
 		print("using initiator matrix [{0},{1};{2},{3}]".format(a,b,c,d))
 		# other parameters
-		(n,m) = G.size()
+		(n,m) = GraphTools.size(G)
 		scaleParameter = math.ceil(math.log(n * scale, 2))
 		edgeFactor = math.floor(m / n)
 		reduceNodes = (2**scaleParameter) - (scale * n)
@@ -3421,7 +3423,7 @@ cdef class LFRGenerator(Algorithm):
 	@classmethod
 	def fit(cls, Graph G, scale=1, vanilla=False, communityDetectionAlgorithm=PLM, plfit=False):
 		""" Fit model to input graph"""
-		(n, m) = G.size()
+		(n, m) = GraphTools.size(G)
 		# detect communities
 		communities = communityDetectionAlgorithm(G).run().getPartition()
 		# get degree sequence
@@ -5135,6 +5137,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	node randomNeighbor(_Graph G, node u) nogil except +
 	pair[node, node] randomEdge(_Graph G, bool_t uniformDistribution) nogil except +
 	vector[pair[node, node]] randomEdges(_Graph G, count numEdges) nogil except +
+	pair[count, count] size(_Graph G) nogil except +
 	_Graph copyNodes(_Graph G) nogil except +
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
@@ -5398,6 +5401,18 @@ cdef class GraphTools:
 			Weighted copy of the input graph.
 		"""
 		return Graph().setThis(toWeighted(graph._this))
+
+	@staticmethod
+	def size(Graph graph):
+		"""
+		Return the size of the graph.
+
+		Returns
+		-------
+		tuple
+			a pair (n, m) where n is the number of nodes and m is the number of edges.
+		"""
+		return size(graph._this)
 
 	@staticmethod
 	def copyNodes(Graph graph):

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1310,6 +1310,8 @@ cdef class Graph:
 		list of pairs
 			The selected edges.
 		"""
+		from warnings import warn
+		warn("Graph.randomEdges is deprecated, use graphtools.randomEdges instead.")
 		return self._this.randomEdges(numEdges)
 
 	def numberOfSelfLoops(self):
@@ -5132,6 +5134,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	node randomNode(_Graph G) nogil except +
 	node randomNeighbor(_Graph G, node u) nogil except +
 	pair[node, node] randomEdge(_Graph G, bool_t uniformDistribution) nogil except +
+	vector[pair[node, node]] randomEdges(_Graph G, count numEdges) nogil except +
 	_Graph copyNodes(_Graph G) nogil except +
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
@@ -5257,8 +5260,8 @@ cdef class GraphTools:
 
 		Parameters
 		----------
-        G : networkit.Graph
-            The input graph.
+		G : networkit.Graph
+			The input graph.
 		uniformDistribution : bool
 			If the distribution of the edge shall be uniform.
 
@@ -5273,6 +5276,25 @@ cdef class GraphTools:
 		slow and uniformly random otherwise.
 		"""
 		return randomEdge(G._this, uniformDistribution)
+
+	@staticmethod
+	def randomEdges(Graph G, numEdges):
+		"""
+		Returns a list with numEdges random edges. The edges are chosen uniformly at random.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph.
+		numEdges : count
+			The number of edges to choose.
+
+		Returns
+		-------
+		list of pairs
+			List of with `numEdges` random edges.
+		"""
+		return randomEdges(G._this, numEdges)
 
 	@staticmethod
 	def append(Graph G, Graph G1):

--- a/networkit/__init__.py
+++ b/networkit/__init__.py
@@ -138,7 +138,7 @@ def overview(G):
 	print("weighted?\t\t\t{}".format("True" if G.isWeighted() else "False"))
 	print("isolated nodes\t\t\t{}".format(getIsolatedNodes(degrees)))
 	print("self-loops\t\t\t{}".format(numSelfLoops))
-	print("density\t\t\t\t{:.6f}".format(G.density()))
+	print("density\t\t\t\t{:.6f}".format(graphtools.density(G)))
 	if numSelfLoops == 0 and not G.isDirected():
 		print("clustering coefficient\t\t{:.6f}".format(
 			getClusteringCoefficient(G)))

--- a/networkit/__init__.py
+++ b/networkit/__init__.py
@@ -76,6 +76,7 @@ from . import sampling
 from . import viz
 from . import randomization
 from .support import MissingDependencyError
+from _NetworKit import GraphTools as graphtools
 
 if have_plt:
 	from . import plot

--- a/networkit/cpp/centrality/ApproxBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxBetweenness.cpp
@@ -8,7 +8,7 @@
 #include <networkit/centrality/ApproxBetweenness.hpp>
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/distance/Diameter.hpp>
-#include <networkit/graph/Sampling.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/distance/Dijkstra.hpp>
 #include <networkit/distance/BFS.hpp>
 #include <networkit/distance/SSSP.hpp>
@@ -61,9 +61,9 @@ void ApproxBetweenness::run() {
         // DEBUG
         // sample random node pair
         node u, v;
-        u = Sampling::randomNode(G);
+        u = GraphTools::randomNode(G);
         do {
-            v = Sampling::randomNode(G);
+            v = GraphTools::randomNode(G);
         } while (v == u);
 
         // runs faster for unweighted graphs

--- a/networkit/cpp/centrality/ApproxCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxCloseness.cpp
@@ -7,6 +7,8 @@
 
 #include <networkit/centrality/ApproxCloseness.hpp>
 #include <networkit/auxiliary/PrioQueue.hpp>
+#include <networkit/graph/GraphTools.hpp>
+
 #include <cassert>
 #include <queue>
 
@@ -66,9 +68,9 @@ void ApproxCloseness::estimateClosenessForUndirectedGraph() {
     // sample nodes
     std::vector<bool> alreadySampled(G.upperNodeIdBound(), false);
     for (count i = 0; i < nSamples; ++i) { // we have to sample distinct nodes
-        node v = G.randomNode();
+        node v = GraphTools::randomNode(G);
         while (alreadySampled[v]) {
-            v = G.randomNode();
+            v = GraphTools::randomNode(G);
         }
         sampledNodes.push_back(v);
         alreadySampled[v] = true;

--- a/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
@@ -13,6 +13,7 @@
 #include <networkit/centrality/ApproxGroupBetweenness.hpp>
 #include <networkit/distance/BFS.hpp>
 #include <networkit/distance/SSSP.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -45,10 +46,10 @@ void ApproxGroupBetweenness::run() {
 
 #pragma omp parallel for
     for (omp_index l = 0; l < static_cast<omp_index>(samples); ++l) {
-        node s = G.randomNode();
+        node s = GraphTools::randomNode(G);
         node t;
         do {
-            t = G.randomNode();
+            t = GraphTools::randomNode(G);
         } while (s == t);
 
         BFS &bfs = bfss[omp_get_thread_num()];

--- a/networkit/cpp/centrality/DynApproxBetweenness.cpp
+++ b/networkit/cpp/centrality/DynApproxBetweenness.cpp
@@ -8,7 +8,7 @@
 #include <networkit/centrality/DynApproxBetweenness.hpp>
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/distance/Diameter.hpp>
-#include <networkit/graph/Sampling.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/distance/DynDijkstra.hpp>
 #include <networkit/distance/DynBFS.hpp>
 #include <networkit/auxiliary/Log.hpp>
@@ -53,9 +53,9 @@ void DynApproxBetweenness::run() {
     for (count i = 0; i < r; i++) {
         DEBUG("sample ", i);
         // sample random node pair
-        u[i] = Sampling::randomNode(G);
+        u[i] = GraphTools::randomNode(G);
         do {
-            v[i] = Sampling::randomNode(G);
+            v[i] = GraphTools::randomNode(G);
         } while (v[i] == u[i]);
         if (G.isWeighted()) {
             sssp[i].reset(new DynDijkstra(G, u[i], storePreds));

--- a/networkit/cpp/centrality/DynTopHarmonicCloseness.cpp
+++ b/networkit/cpp/centrality/DynTopHarmonicCloseness.cpp
@@ -13,6 +13,7 @@
 #include <networkit/components/StronglyConnectedComponents.hpp>
 #include <networkit/distance/AffectedNodes.hpp>
 #include <networkit/centrality/DynTopHarmonicCloseness.hpp>
+#include <networkit/graph/BFS.hpp>
 
 namespace NetworKit {
 
@@ -148,7 +149,7 @@ void DynTopHarmonicCloseness::BFSbound(node source, std::vector<double> &S2,
 
     auto inverseDistance = [&](edgeweight dist) { return 1.0 / dist; };
 
-    G.BFSfrom(source, [&](node u, count dist) {
+    Traversal::BFSfrom(G, source, [&](node u, count dist) {
         sum_dist += dist > 0 ? inverseDistance(dist) : 0;
 
         ++r;

--- a/networkit/cpp/centrality/EstimateBetweenness.cpp
+++ b/networkit/cpp/centrality/EstimateBetweenness.cpp
@@ -27,7 +27,6 @@ void EstimateBetweenness::run() {
 
     Aux::SignalHandler handler;
 
-    //std::vector<node> sampledNodes = G.nodes();
     std::vector<node> sampledNodes;
 
     // sample nodes

--- a/networkit/cpp/centrality/EstimateBetweenness.cpp
+++ b/networkit/cpp/centrality/EstimateBetweenness.cpp
@@ -12,6 +12,7 @@
 #include <networkit/distance/SSSP.hpp>
 #include <networkit/auxiliary/SignalHandling.hpp>
 #include <networkit/auxiliary/Parallelism.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 
 #include <memory>
@@ -31,7 +32,7 @@ void EstimateBetweenness::run() {
 
     // sample nodes
     for (count i = 0; i <= nSamples; ++i) {
-        sampledNodes.push_back(G.randomNode());
+        sampledNodes.push_back(GraphTools::randomNode(G));
     }
 
 

--- a/networkit/cpp/centrality/KPathCentrality.cpp
+++ b/networkit/cpp/centrality/KPathCentrality.cpp
@@ -11,6 +11,7 @@
 #include <networkit/auxiliary/PrioQueue.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -46,7 +47,7 @@ void KPathCentrality::run() {
     node v;
 
     for (index i = 1; i <= t; i++) { // FIXME: int -> count
-        node s = G.randomNode();
+        node s = GraphTools::randomNode(G);
         auto l = Aux::Random::integer(1, k);
         explored[s] = true;
         stack.push(s);

--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -19,6 +19,7 @@
 #include <networkit/distance/Dijkstra.hpp>
 #include <networkit/distance/SSSP.hpp>
 #include <networkit/centrality/TopCloseness.hpp>
+#include <networkit/graph/BFS.hpp>
 
 namespace NetworKit {
 
@@ -151,7 +152,7 @@ void TopCloseness::computeReachableNodesDir() {
     reachU[v] = reachU_scc[sccs.componentOfNode(v) - 1];
     if (false) { // MICHELE: used to check if the bounds are correct
       count r = 0;
-      G.BFSfrom(v, [&](node, count) { r++; });
+      Traversal::BFSfrom(G, v, [&](node, count) { r++; });
 
       if (reachL[v] > r || reachU[v] < r) {
         DEBUG("BIG MISTAKE! ", reachL[v], " ", r, " ", reachU[v]);
@@ -276,7 +277,7 @@ void TopCloseness::BFSbound(node x, std::vector<double> &S2, count *visEdges,
   count nLevs = 0;
   levels[nLevs].clear();
   double sum_dist = 0;
-  G.BFSfrom(x, [&](node u, count dist) {
+  Traversal::BFSfrom(G, x, [&](node u, count dist) {
     sum_dist += dist;
     r++;
     if (dist > nLevs) {

--- a/networkit/cpp/centrality/TopHarmonicCloseness.cpp
+++ b/networkit/cpp/centrality/TopHarmonicCloseness.cpp
@@ -11,6 +11,7 @@
 #include <networkit/auxiliary/PrioQueue.hpp>
 #include <networkit/components/StronglyConnectedComponents.hpp>
 #include <networkit/centrality/TopHarmonicCloseness.hpp>
+#include <networkit/graph/BFS.hpp>
 
 namespace NetworKit {
 
@@ -137,7 +138,7 @@ void TopHarmonicCloseness::BFSbound(node source, std::vector<double> &S2,
 
   auto inverseDistance = [&](edgeweight dist) { return 1.0 / dist; };
 
-  G.BFSfrom(source, [&](node u, count dist) {
+  Traversal::BFSfrom(G, source, [&](node u, count dist) {
     sum_dist += dist > 0 ? inverseDistance(dist) : 0;
 
     r++;

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -279,7 +279,7 @@ TEST_F(CentralityGTest, testKatzDynamicDeletion) {
     DEBUG("start kc run");
     kc.run();
     DEBUG("finish kc");
-    std::pair<node, node> p = G.randomEdge();
+    std::pair<node, node> p = GraphTools::randomEdge(G);
     node u = p.first;
     node v = p.second;
     INFO("Deleting edge ", u, ", ", v);
@@ -454,7 +454,7 @@ TEST_F(CentralityGTest, testKatzDirectedDeletion) {
     kc.run();
 
     Aux::Random::setSeed(42, false);
-    std::pair<node, node> p = G.randomEdge();
+    std::pair<node, node> p = GraphTools::randomEdge(G);
     node u = p.first;
     node v = p.second;
     INFO("Removing ", u, " -> ", v);

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -39,6 +39,7 @@
 #include <networkit/distance/Dijkstra.hpp>
 #include <networkit/generators/DorogovtsevMendesGenerator.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/io/SNAPGraphReader.hpp>
 #include <networkit/structures/Cover.hpp>
@@ -243,8 +244,8 @@ TEST_F(CentralityGTest, testKatzDynamicAddition) {
     DEBUG("finish kc");
     node u, v;
     do {
-        u = G.randomNode();
-        v = G.randomNode();
+        u = GraphTools::randomNode(G);
+        v = GraphTools::randomNode(G);
     } while (G.hasEdge(u, v));
     GraphEvent e(GraphEvent::EDGE_ADDITION, u, v, 1.0);
     kc.update(e);
@@ -392,8 +393,8 @@ TEST_F(CentralityGTest, testKatzDirectedAddition) {
     node u, v;
     Aux::Random::setSeed(42, false);
     do {
-        u = G.randomNode();
-        v = G.randomNode();
+        u = GraphTools::randomNode(G);
+        v = GraphTools::randomNode(G);
     } while (G.hasEdge(u, v));
     GraphEvent e(GraphEvent::EDGE_ADDITION, u, v, 1.0);
     kc.update(e);
@@ -1653,8 +1654,8 @@ TEST_P(CentralityGTest, testDynTopHarmonicCloseness) {
         node v = G.upperNodeIdBound();
 
         do {
-            u = G.randomNode();
-            v = G.randomNode();
+            u = GraphTools::randomNode(G);
+            v = GraphTools::randomNode(G);
         } while (G.hasEdge(u, v));
 
         GraphEvent edgeAddition(GraphEvent::EDGE_ADDITION, u, v);

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -13,11 +13,11 @@
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/NumericTools.hpp>
-#include <networkit/graph/Sampling.hpp>
 #include <networkit/generators/DorogovtsevMendesGenerator.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/centrality/DynBetweenness.hpp>
 #include <networkit/auxiliary/Random.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -97,8 +97,8 @@ TEST_F(DynBetweennessGTest, runDynVsStatic) {
     std::vector<GraphEvent> batch;
     count nInsertions = 10, i = 0;
     while (i < nInsertions) {
-        node v1 = Sampling::randomNode(G);
-        node v2 = Sampling::randomNode(G);
+        node v1 = GraphTools::randomNode(G);
+        node v2 = GraphTools::randomNode(G);
         if (v1 != v2 && !G.hasEdge(v1, v2)) {
             G.addEdge(v1, v2);
             batch.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, v1, v2, 1.0));
@@ -140,11 +140,11 @@ TEST_F(DynBetweennessGTest, runDynVsStaticCaseInsertDirected){
     Aux::Random::setSeed(0, false);
 
     auto genEdgeInsert = [](const Graph& g){
-        node u = g.randomNode();
-        node v = g.randomNode();
+        node u = GraphTools::randomNode(g);
+        node v = GraphTools::randomNode(g);
         while (u == v || g.hasEdge(u, v)){
-            u = g.randomNode();
-            v = g.randomNode();
+            u = GraphTools::randomNode(g);
+            v = GraphTools::randomNode(g);
         }
         return std::make_pair(u, v);
     };
@@ -177,11 +177,11 @@ TEST_F(DynBetweennessGTest, runDynVsStaticCaseInsertUndirected){
     Aux::Random::setSeed(0, false);
 
     auto genEdgeInsert = [](const Graph& g){
-        node u = g.randomNode();
-        node v = g.randomNode();
+        node u = GraphTools::randomNode(g);
+        node v = GraphTools::randomNode(g);
         while (u == v || g.hasEdge(u, v)){
-            u = g.randomNode();
-            v = g.randomNode();
+            u = GraphTools::randomNode(g);
+            v = GraphTools::randomNode(g);
         }
         return std::make_pair(u, v);
     };

--- a/networkit/cpp/clique/test/MaximalCliquesGTest.cpp
+++ b/networkit/cpp/clique/test/MaximalCliquesGTest.cpp
@@ -128,7 +128,7 @@ TEST_F(MaximalCliquesGTest, benchMaximalCliques) {
     EdgeListReader r('\t',0,"#", false);
     Graph G = r.read(graphPath);
     G.removeSelfLoops();
-    INFO(G.size());
+    INFO(GraphTools::size(G));
     INFO("Starting MaximalCliques");
     Aux::Timer timer;
     count numCliques = 0;

--- a/networkit/cpp/clique/test/MaximalCliquesGTest.cpp
+++ b/networkit/cpp/clique/test/MaximalCliquesGTest.cpp
@@ -2,6 +2,7 @@
 
 #include <networkit/clique/MaximalCliques.hpp>
 #include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/io/EdgeListReader.hpp>
 #include <networkit/auxiliary/Log.hpp>
@@ -21,7 +22,7 @@ TEST_F(MaximalCliquesGTest, testMaximalCliques) {
                          G.neighborRange(seed).end());
     auto sneighbors = std::unordered_set<node>(sn.begin(), sn.end());
     sneighbors.insert(seed);
-    auto subG = G.subgraphFromNodes(sneighbors);
+    const auto subG = GraphTools::subgraphFromNodes(G, sneighbors);
 
     MaximalCliques clique(subG);
 
@@ -35,7 +36,7 @@ TEST_F(MaximalCliquesGTest, testMaximalCliques) {
     // check results (are they cliques?)
     for (auto cliq : result) {
         auto cli = std::unordered_set<node>(cliq.begin(), cliq.end());
-        auto cliqueGraph = G.subgraphFromNodes(cli);
+        const auto cliqueGraph = GraphTools::subgraphFromNodes(G, cli);
 
         EXPECT_EQ(cliqueGraph.numberOfEdges(), (cliqueGraph.numberOfNodes() * (cliqueGraph.numberOfNodes() - 1) / 2));
         EXPECT_EQ(cli.count(seed), 1u);

--- a/networkit/cpp/community/CutClustering.cpp
+++ b/networkit/cpp/community/CutClustering.cpp
@@ -2,14 +2,15 @@
  * Author: Michael Hamann <michael.hamann@kit.edu>
  */
 
-#include <networkit/community/CutClustering.hpp>
-#include <networkit/flow/EdmondsKarp.hpp>
-#include <networkit/components/ConnectedComponents.hpp>
-#include <networkit/auxiliary/Log.hpp>
-
 #include <sstream>
 #include <stdexcept>
 #include <limits>
+
+#include <networkit/auxiliary/Log.hpp>
+#include <networkit/community/CutClustering.hpp>
+#include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/flow/EdmondsKarp.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 NetworKit::CutClustering::CutClustering(const Graph& G, NetworKit::edgeweight alpha) : CommunityDetectionAlgorithm(G), alpha(alpha) { }
 
@@ -119,7 +120,7 @@ std::map< NetworKit::edgeweight, NetworKit::Partition > NetworKit::CutClustering
 
     // If there is more than one connected component, the whole graph is another valid lower bound
     if (connComp.numberOfComponents() > 1) {
-        node rep = G.randomNode();
+        node rep = GraphTools::randomNode(G);
         Partition wholeGraph(G.upperNodeIdBound(), rep);
         wholeGraph.setUpperBound(rep + 1);
 

--- a/networkit/cpp/community/PLM.cpp
+++ b/networkit/cpp/community/PLM.cpp
@@ -28,7 +28,6 @@ PLM::PLM(const Graph& G, const PLM& other) : CommunityDetectionAlgorithm(G), par
 
 void PLM::run() {
     Aux::SignalHandler handler;
-    DEBUG("calling run method on " , G.toString());
 
     count z = G.upperNodeIdBound();
 

--- a/networkit/cpp/components/RandomSpanningForest.cpp
+++ b/networkit/cpp/components/RandomSpanningForest.cpp
@@ -5,11 +5,11 @@
  *      Author: Henning
  */
 
+#include <unordered_set>
+
+#include <networkit/components/ConnectedComponents.hpp>
 #include <networkit/components/RandomSpanningForest.hpp>
 #include <networkit/graph/GraphTools.hpp>
-#include <networkit/graph/Sampling.hpp>
-#include <networkit/components/ConnectedComponents.hpp>
-#include <unordered_set>
 
 namespace NetworKit {
 
@@ -40,7 +40,7 @@ void RandomSpanningForest::run() {
         // random walk starting from root
         while (visited.size() < compSize) {
             // get random neighbor
-            node neigh = G.randomNeighbor(curr);
+            node neigh = GraphTools::randomNeighbor(G, curr);
 
             // if not seen before, insert tree edge
             if (visited.count(neigh) == 0) {

--- a/networkit/cpp/components/RandomSpanningForest.cpp
+++ b/networkit/cpp/components/RandomSpanningForest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <networkit/components/RandomSpanningForest.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/graph/Sampling.hpp>
 #include <networkit/components/ConnectedComponents.hpp>
 #include <unordered_set>
@@ -26,7 +27,7 @@ void RandomSpanningForest::run() {
     cc.run();
     std::vector<std::vector<node> > comps = cc.getComponents();
 
-    forest = G.copyNodes();
+    forest = GraphTools::copyNodes(G);
     for (auto comp: comps) {
         std::unordered_set<node> visited;
         const count compSize = comp.size();

--- a/networkit/cpp/components/test/BiconnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/BiconnectedComponentsGTest.cpp
@@ -11,6 +11,7 @@
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/components/BiconnectedComponents.hpp>
 #include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -44,7 +45,7 @@ TEST_F(BiconnectedComponentsGTest, testBiconnectedComponents) {
 
     for (auto component : bc.getComponents()) {
         std::unordered_set<node> subgraph(component.begin(), component.end());
-        auto G1 = G.subgraphFromNodes(subgraph, false, false);
+        const auto G1 = GraphTools::subgraphFromNodes(G, subgraph, false, false);
 
         G1.forNodes([&](node v) {
             auto G2(G1);

--- a/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
@@ -287,7 +287,7 @@ TEST_F(ConnectedComponentsGTest, testDynConnectedComponents) {
         }
         else {
             while (!G.hasEdge(u, v)) {
-                std::pair<node, node> edge = G.randomEdge();
+                std::pair<node, node> edge = GraphTools::randomEdge(G);
                 u = edge.first;
                 v = edge.second;
             }
@@ -314,7 +314,7 @@ TEST_F(ConnectedComponentsGTest, testDynConnectedComponents) {
         }
         else {
             while (!G.hasEdge(u, v)) {
-                std::pair<node, node> edge = G.randomEdge();
+                std::pair<node, node> edge = GraphTools::randomEdge(G);
                 u = edge.first;
                 v = edge.second;
             }
@@ -475,7 +475,7 @@ TEST_F(ConnectedComponentsGTest, testDynWeaklyConnectedComponents) {
         }
         else {
             while (!G.hasEdge(u, v) || u == v) {
-                std::pair<node, node> edge = G.randomEdge();
+                std::pair<node, node> edge = GraphTools::randomEdge(G);
                 u = edge.first;
                 v = edge.second;
             }
@@ -501,7 +501,7 @@ TEST_F(ConnectedComponentsGTest, testDynWeaklyConnectedComponents) {
         }
         else {
             while (!G.hasEdge(u, v) || u == v) {
-                std::pair<node, node> edge = G.randomEdge();
+                std::pair<node, node> edge = GraphTools::randomEdge(G);
                 u = edge.first;
                 v = edge.second;
             }

--- a/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
@@ -13,6 +13,7 @@
 #include <networkit/components/WeaklyConnectedComponents.hpp>
 #include <networkit/components/DynWeaklyConnectedComponents.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 #include <networkit/distance/Diameter.hpp>
 #include <networkit/io/METISGraphReader.hpp>
@@ -278,8 +279,8 @@ TEST_F(ConnectedComponentsGTest, testDynConnectedComponents) {
         // Perform edge insertion
         if (((double) rand() / (RAND_MAX)) > p) {
             while (G.hasEdge(u, v)) {
-                u = G.randomNode();
-                v = G.randomNode();
+                u = GraphTools::randomNode(G);
+                v = GraphTools::randomNode(G);
             }
             G.addEdge(u, v);
             dccs.update(GraphEvent(GraphEvent::EDGE_ADDITION, u, v, 0));
@@ -301,12 +302,12 @@ TEST_F(ConnectedComponentsGTest, testDynConnectedComponents) {
     // Testing batch update.
     std::vector<GraphEvent> batch(numberOfTests);
     for (int i = 0; i < numberOfTests; ++i) {
-        node u = G.randomNode();
-        node v = G.randomNode();
+        node u = GraphTools::randomNode(G);
+        node v = GraphTools::randomNode(G);
         if (((double) rand() / (RAND_MAX)) > -1) {
             while (G.hasEdge(u, v)) {
-                u = G.randomNode();
-                v = G.randomNode();
+                u = GraphTools::randomNode(G);
+                v = GraphTools::randomNode(G);
             }
             batch[i] = GraphEvent(GraphEvent::EDGE_ADDITION, u, v, 0);
             G.addEdge(u, v);
@@ -466,8 +467,8 @@ TEST_F(ConnectedComponentsGTest, testDynWeaklyConnectedComponents) {
         // Perform edge insertion
         if (((double) rand() / (RAND_MAX)) > p) {
             while (G.hasEdge(u, v)) {
-                u = G.randomNode();
-                v = G.randomNode();
+                u = GraphTools::randomNode(G);
+                v = GraphTools::randomNode(G);
             }
             G.addEdge(u, v);
             dw.update(GraphEvent(GraphEvent::EDGE_ADDITION, u, v, 0));
@@ -488,12 +489,12 @@ TEST_F(ConnectedComponentsGTest, testDynWeaklyConnectedComponents) {
     // Testing batch update.
     std::vector<GraphEvent> batch(numberOfTests);
     for (int i = 0; i < numberOfTests; ++i) {
-        node u = G.randomNode();
-        node v = G.randomNode();
+        node u = GraphTools::randomNode(G);
+        node v = GraphTools::randomNode(G);
         if (((double) rand() / (RAND_MAX)) > p) {
             while (G.hasEdge(u, v) || u == v) {
-                u = G.randomNode();
-                v = G.randomNode();
+                u = GraphTools::randomNode(G);
+                v = GraphTools::randomNode(G);
             }
             batch[i] = GraphEvent(GraphEvent::EDGE_ADDITION, u, v, 0);
             G.addEdge(u, v);

--- a/networkit/cpp/distance/Diameter.cpp
+++ b/networkit/cpp/distance/Diameter.cpp
@@ -13,6 +13,7 @@
 #include <networkit/distance/Eccentricity.hpp>
 #include <networkit/distance/BFS.hpp>
 #include <networkit/distance/Dijkstra.hpp>
+#include <networkit/graph/BFS.hpp>
 #include <networkit/structures/Partition.hpp>
 
 namespace NetworKit {
@@ -118,7 +119,7 @@ std::pair<edgeweight, edgeweight> Diameter::estimatedDiameterRange(const Graph &
         distFirst.resize(numberOfComponents, 0);
         std::vector<bool> foundFirstDeg2Node(numberOfComponents, false);
 
-        G.BFSfrom(startNodes, [&](node v, count dist) {
+        Traversal::BFSfrom(G, startNodes.begin(), startNodes.end(), [&](node v, count dist) {
             distances[v] = dist;
 
             index c = comp.componentOfNode(v);
@@ -280,7 +281,7 @@ edgeweight Diameter::estimatedVertexDiameterPedantic(const Graph& G) {
         G.forNodes([&](node u) {
             if (visited[u] == false) {
                 count maxDist = 0, maxDist2 = 0;
-                G.BFSfrom(u, [&](node v, count dist) {
+                Traversal::BFSfrom(G, u, [&](node v, count dist) {
                     visited[v] = true;
                     if (dist > maxDist) {
                         maxDist2 = maxDist;

--- a/networkit/cpp/distance/Diameter.cpp
+++ b/networkit/cpp/distance/Diameter.cpp
@@ -14,6 +14,7 @@
 #include <networkit/distance/BFS.hpp>
 #include <networkit/distance/Dijkstra.hpp>
 #include <networkit/graph/BFS.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/structures/Partition.hpp>
 
 namespace NetworKit {
@@ -259,7 +260,7 @@ edgeweight Diameter::estimatedVertexDiameter(const Graph& G, count samples) {
     edgeweight vdMax = 0;
     #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(samples); ++i) {
-        node u = G.randomNode();
+        node u = GraphTools::randomNode(G);
         edgeweight vd = estimateFrom(u);
         DEBUG("sampled vertex diameter from node ", u, ": ", vd);
         #pragma omp critical

--- a/networkit/cpp/distance/Eccentricity.cpp
+++ b/networkit/cpp/distance/Eccentricity.cpp
@@ -6,14 +6,14 @@
  */
 
 #include <networkit/distance/Eccentricity.hpp>
-#include <networkit/distance/BFS.hpp>
+#include <networkit/graph/BFS.hpp>
 
 namespace NetworKit {
 
 std::pair<node, count> Eccentricity::getValue(const Graph& G, node u) {
     count ecc = 0;
     node res;
-    G.BFSfrom(u, [&](node v, count dist) {
+    Traversal::BFSfrom(G, u, [&](node v, count dist) {
         ecc = dist;
         res = v;
     });

--- a/networkit/cpp/distance/NeighborhoodFunction.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunction.cpp
@@ -8,6 +8,7 @@
 #include <networkit/distance/NeighborhoodFunction.hpp>
 #include <networkit/components/ConnectedComponents.hpp>
 #include <networkit/auxiliary/Random.hpp>
+#include <networkit/graph/BFS.hpp>
 
 #include <math.h>
 #include <iterator>
@@ -29,7 +30,7 @@ void NeighborhoodFunction::run() {
     std::vector<std::map<count, count>> nf(max_threads);
     G.parallelForNodes([&](node u){
         index tid = omp_get_thread_num();
-        G.BFSfrom(u, [&](node, count dist) {
+        Traversal::BFSfrom(G, u, [&](node, count dist) {
             nf[tid][dist] += 1;
         });
     });

--- a/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
@@ -10,6 +10,7 @@
 #include <networkit/auxiliary/Parallel.hpp>
 #include <networkit/distance/Diameter.hpp>
 #include <networkit/graph/BFS.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 #include <math.h>
 #include <iterator>
@@ -41,7 +42,7 @@ void NeighborhoodFunctionHeuristic::run() {
         diam.run();
         dia = diam.getDiameter().first;
     } else {
-        Graph Gcopy = G.toUnweighted();
+        Graph Gcopy = GraphTools::toUnweighted(G);
         Diameter diam(Gcopy);
         diam.run();
         dia = diam.getDiameter().first;

--- a/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
@@ -108,7 +108,7 @@ std::vector<node> NeighborhoodFunctionHeuristic::random(const Graph& G, count nS
     std::vector<node> start_nodes(nSamples, 0);
     // the vector of start nodes is chosen completely at random with the graphs "randomNode()" function.
     for (index i = 0; i < nSamples; ++i) {
-        start_nodes[i] = G.randomNode();
+        start_nodes[i] = GraphTools::randomNode(G);
     }
     return start_nodes;
 }

--- a/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
@@ -9,6 +9,7 @@
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
 #include <networkit/distance/Diameter.hpp>
+#include <networkit/graph/BFS.hpp>
 
 #include <math.h>
 #include <iterator>
@@ -59,7 +60,7 @@ void NeighborhoodFunctionHeuristic::run() {
     for (omp_index i = 0; i < static_cast<omp_index>(nSamples); ++i) {
         count tid = omp_get_thread_num();
         node u = start_nodes[i];
-        G.BFSfrom(u, [&](node, count dist) {
+        Traversal::BFSfrom(G, u, [&](node, count dist) {
             nf[tid][dist] += 1;
         });
     }

--- a/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
@@ -117,7 +117,9 @@ std::vector<node> NeighborhoodFunctionHeuristic::split(const Graph& G, count nSa
     G.parallelForNodes([&](node u) {
             nodeDeg[u] = G.degree(u);
     });
-    std::vector<node> nodes = G.nodes();
+    std::vector<node> nodes;
+    nodes.reserve(G.numberOfNodes());
+    G.forNodes([&](node u) { nodes.push_back(u); });
     nodes.erase(std::remove_if(nodes.begin(), nodes.end(), [](node u){return u == none;}), nodes.end());
     //std::random_shuffle(nodes.begin(), nodes.end());
     Aux::Parallel::sort(nodes.begin(), nodes.end(), [&nodeDeg](const node& a, const node& b) {return nodeDeg[a] < nodeDeg[b];});

--- a/networkit/cpp/distance/Volume.cpp
+++ b/networkit/cpp/distance/Volume.cpp
@@ -7,6 +7,8 @@
 
 #include <networkit/distance/Volume.hpp>
 #include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphTools.hpp>
+
 #include <unordered_map>
 
 namespace NetworKit {
@@ -40,7 +42,7 @@ std::unordered_map<node, double> Volume::nodesWithinDistance(const Graph &G, dou
 double Volume::volume(const Graph &G, const double r, const count samples) {
     double x = 0;
     for (count j = 0; j < samples; j++) {
-        x += Volume::nodesWithinDistance(G, r, G.randomNode()).size();
+        x += Volume::nodesWithinDistance(G, r, GraphTools::randomNode(G)).size();
     }
     return x / samples;
 }
@@ -49,7 +51,7 @@ std::vector<double> Volume::volume(const Graph &G, const std::vector<double> rs,
     std::vector<double> xs(rs.size(), 0);
     double rmax = *std::max_element(std::begin(rs), std::end(rs));
     for (count j = 0; j < samples; j++) {
-        std::unordered_map<node, double> ms = Volume::nodesWithinDistance(G, rmax, G.randomNode());
+        std::unordered_map<node, double> ms = Volume::nodesWithinDistance(G, rmax, GraphTools::randomNode(G));
         count i = 0;
         for (auto &r : rs) {
             for (auto &it : ms) {

--- a/networkit/cpp/distance/test/APSPGTest.cpp
+++ b/networkit/cpp/distance/test/APSPGTest.cpp
@@ -13,6 +13,7 @@
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/distance/APSP.hpp>
 #include <networkit/distance/DynAPSP.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 
 namespace NetworKit {
@@ -66,8 +67,8 @@ TEST_F(APSPGTest, debugAPSP) {
     count m = int(n * n);
     Graph G(n, true, false);
     for (count i = 0; i < m; i++) {
-        node u = G.randomNode();
-        node v = G.randomNode();
+        node u = GraphTools::randomNode(G);
+        node v = GraphTools::randomNode(G);
         if (u != v && !G.hasEdge(u, v)) {
             G.addEdge(u, v, Aux::Random::integer(10));
         }
@@ -83,11 +84,11 @@ TEST_F(APSPGTest, testDynAPSPRealGraph) {
     DynAPSP apsp(G);
     apsp.run();
     for (count i = 0; i < 10; i++) {
-        count u = G.randomNode();
-        count v = G.randomNode();
+        count u = GraphTools::randomNode(G);
+        count v = GraphTools::randomNode(G);
         while(G.hasEdge(u, v)) {
-            u = G.randomNode();
-            v = G.randomNode();
+            u = GraphTools::randomNode(G);
+            v = GraphTools::randomNode(G);
         }
         DEBUG("u = ", u, ", v = ", v);
         GraphEvent event(GraphEvent::EDGE_ADDITION, u, v, 1);

--- a/networkit/cpp/distance/test/CommuteTimeDistanceGTest.cpp
+++ b/networkit/cpp/distance/test/CommuteTimeDistanceGTest.cpp
@@ -9,6 +9,7 @@
 
 #include <networkit/distance/CommuteTimeDistance.hpp>
 #include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/centrality/SpanningEdgeCentrality.hpp>
 
@@ -183,7 +184,7 @@ TEST_F(CommuteTimeDistanceGTest, runECTDSingleSource) {
     for (auto graphFile: graphFiles) {
         Graph G = reader.read(graphFile);
         CommuteTimeDistance ectd(G);
-        node u = G.randomNode();
+        node u = GraphTools::randomNode(G);
         double sum1 = ectd.runSingleSource(u);
         double sum2 = 0.0;
         G.forNodes([&](node v){

--- a/networkit/cpp/distance/test/DistanceGTest.cpp
+++ b/networkit/cpp/distance/test/DistanceGTest.cpp
@@ -114,10 +114,10 @@ TEST_F(DistanceGTest, testBidirectionalBFS) {
     Graph G = ErdosRenyiGenerator(500, 0.02, false).generate();
     Graph G1 = ErdosRenyiGenerator(500, 0.05, true).generate();
     auto testGraph = [&](const Graph &G) {
-        node source = G.randomNode();
-        node target = G.randomNode();
+        node source = GraphTools::randomNode(G);
+        node target = GraphTools::randomNode(G);
         while (source == target)
-            target = G.randomNode();
+            target = GraphTools::randomNode(G);
         BFS bfs(G, source, true, false, target);
         bfs.run();
         BidirectionalBFS bbfs(G, source, target, true);
@@ -157,10 +157,10 @@ TEST_F(DistanceGTest, testBidirectionalDijkstra) {
     });
 
     auto testGraph = [&](const Graph &G) {
-        node source = G.randomNode();
-        node target = G.randomNode();
+        node source = GraphTools::randomNode(G);
+        node target = GraphTools::randomNode(G);
         while (source == target)
-            target = G.randomNode();
+            target = GraphTools::randomNode(G);
         BidirectionalDijkstra bdij(G, source, target, true);
         bdij.run();
         Dijkstra dij(G, source, true, true, target);

--- a/networkit/cpp/distance/test/DistanceGTest.cpp
+++ b/networkit/cpp/distance/test/DistanceGTest.cpp
@@ -22,6 +22,7 @@
 
 #include <networkit/generators/DorogovtsevMendesGenerator.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 
 namespace NetworKit {
@@ -406,7 +407,7 @@ TEST_F(DistanceGTest, testHopPlotApproximation) {
 
 TEST_F(DistanceGTest, testNeighborhoodFunctionApproximation) {
     METISGraphReader reader;
-    Graph G = reader.read("input/lesmis.graph").toUnweighted();
+    Graph G = GraphTools::toUnweighted(reader.read("input/lesmis.graph"));
     NeighborhoodFunction nf(G);
     nf.run();
     auto exact = nf.getNeighborhoodFunction();
@@ -418,7 +419,7 @@ TEST_F(DistanceGTest, testNeighborhoodFunctionApproximation) {
 
 TEST_F(DistanceGTest, testNeighborhoodFunctionHeuristic) {
     METISGraphReader reader;
-    Graph G = reader.read("input/lesmis.graph").toUnweighted();
+    Graph G = GraphTools::toUnweighted(reader.read("input/lesmis.graph"));
     NeighborhoodFunction nf(G);
     nf.run();
     auto exact = nf.getNeighborhoodFunction();

--- a/networkit/cpp/distance/test/DynSSSPGTest.cpp
+++ b/networkit/cpp/distance/test/DynSSSPGTest.cpp
@@ -14,7 +14,7 @@
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/generators/DorogovtsevMendesGenerator.hpp>
-#include <networkit/graph/Sampling.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <random>
 
 
@@ -179,8 +179,8 @@ TEST_F(DynSSSPGTest, testDynamicBFSGeneratedGraph) {
     count nInsertions = 750, i = 0;
     while (i < nInsertions) {
         DEBUG("Sampling a new edge");
-        node v1 = Sampling::randomNode(G);
-        node v2 = Sampling::randomNode(G);
+        node v1 = GraphTools::randomNode(G);
+        node v2 = GraphTools::randomNode(G);
         if (v1 != v2 && !G.hasEdge(v1, v2)) {
             i++;
             DEBUG("Adding edge number ", i);
@@ -216,8 +216,8 @@ TEST_F(DynSSSPGTest, testDynamicDijkstraGeneratedGraph) {
     count nInsertions = 10, i = 0;
     while (i < nInsertions) {
         DEBUG("Sampling a new edge");
-        node v1 = Sampling::randomNode(G);
-        node v2 = Sampling::randomNode(G);
+        node v1 = GraphTools::randomNode(G);
+        node v2 = GraphTools::randomNode(G);
         if (v1 != v2 && !G.hasEdge(v1, v2)) {
             i++;
             DEBUG("Adding edge number ", i);
@@ -262,8 +262,8 @@ TEST_F(DynSSSPGTest, testDynamicDijkstraBatches) {
             i = 0;
             while (i < batchSize) {
                 DEBUG("Sampling a new edge");
-                node v1 = Sampling::randomNode(G);
-                node v2 = Sampling::randomNode(G);
+                node v1 = GraphTools::randomNode(G);
+                node v2 = GraphTools::randomNode(G);
                 if (v1 != v2 && !G.hasEdge(v1, v2)) {
                     i++;
                     double number = distribution(random_generator);

--- a/networkit/cpp/dynamics/GraphEventProxy.cpp
+++ b/networkit/cpp/dynamics/GraphEventProxy.cpp
@@ -5,6 +5,7 @@
  *      Author: cls
  */
 
+#include <networkit/auxiliary/Log.hpp>
 #include <networkit/dynamics/GraphEventProxy.hpp>
 
 namespace NetworKit {
@@ -77,6 +78,7 @@ void GraphEventProxy::incrementWeight(node u, node v, edgeweight delta) {
 }
 
 void GraphEventProxy::timeStep() {
+    WARN("GraphEventProxy::timeStep is deprecated and will not be supported in future releases.");
 //	TRACE("time step");
     // increment time step counter in G
     this->G->timeStep();

--- a/networkit/cpp/generators/DorogovtsevMendesGenerator.cpp
+++ b/networkit/cpp/generators/DorogovtsevMendesGenerator.cpp
@@ -8,6 +8,7 @@
 #include <tuple>
 
 #include <networkit/generators/DorogovtsevMendesGenerator.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -30,7 +31,7 @@ Graph DorogovtsevMendesGenerator::generate() {
     for (count i = 0; i < (nNodes - 3); ++i) {
         node u;
         node v;
-        std::tie(u, v) = G.randomEdge();
+        std::tie(u, v) = GraphTools::randomEdge(G);
         node w = G.addNode();
         G.addEdge(w, u);
         G.addEdge(w, v);

--- a/networkit/cpp/generators/EdgeSwitchingMarkovChainGenerator.cpp
+++ b/networkit/cpp/generators/EdgeSwitchingMarkovChainGenerator.cpp
@@ -7,6 +7,7 @@
 
 #include <networkit/generators/EdgeSwitchingMarkovChainGenerator.hpp>
 #include <networkit/generators/HavelHakimiGenerator.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 NetworKit::EdgeSwitchingMarkovChainGenerator::EdgeSwitchingMarkovChainGenerator(const std::vector< NetworKit::count > &sequence, bool ignoreIfRealizable): StaticDegreeSequenceGenerator(sequence), ignoreIfRealizable(ignoreIfRealizable) {
 
@@ -34,8 +35,8 @@ NetworKit::Graph NetworKit::EdgeSwitchingMarkovChainGenerator::generate() {
 
         if (s1 == s2) continue;
 
-        node t1 = result.randomNeighbor(s1);
-        node t2 = result.randomNeighbor(s2);
+        node t1 = GraphTools::randomNeighbor(result, s1);
+        node t2 = GraphTools::randomNeighbor(result, s2);
 
         if (t1 == t2 || s1 == t2 || s2 == t1) continue;
 

--- a/networkit/cpp/generators/LFRGenerator.cpp
+++ b/networkit/cpp/generators/LFRGenerator.cpp
@@ -14,6 +14,7 @@
 #include <networkit/generators/PowerlawDegreeSequence.hpp>
 #include <networkit/generators/EdgeSwitchingMarkovChainGenerator.hpp>
 #include <networkit/generators/PubWebGenerator.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 NetworKit::LFRGenerator::LFRGenerator(NetworKit::count n) :
 n(n), hasDegreeSequence(false), hasCommunitySizeSequence(false), hasInternalDegreeSequence(false), hasGraph(false), hasPartition(false) { }
@@ -208,7 +209,7 @@ NetworKit::Graph NetworKit::LFRGenerator::generateInterClusterGraph(const std::v
 
             if (s2 == s1 || s2 == t1) continue;
 
-            node t2 = interG.randomNeighbor(s2);
+            node t2 = GraphTools::randomNeighbor(interG, s2);
 
             if (t2 == none) continue;
 

--- a/networkit/cpp/global/ClusteringCoefficient.cpp
+++ b/networkit/cpp/global/ClusteringCoefficient.cpp
@@ -146,14 +146,14 @@ double ClusteringCoefficient::approxAvgLocal(Graph& G, const count trials) {
         }
 
         TRACE("deg(v) = ", G.degree(v));
-        node u = G.randomNeighbor(v);
-        node w = G.randomNeighbor(v);
+        node u = GraphTools::randomNeighbor(G, v);
+        node w = GraphTools::randomNeighbor(G, v);
         TRACE("u=", u);
         TRACE("w=", w);
 
         // TODO This could be sped up for degree(v) == 2...
         while (u == w) {
-            w = G.randomNeighbor(v);
+            w = GraphTools::randomNeighbor(G, v);
             TRACE("w=", w);
         }
 
@@ -265,12 +265,12 @@ double ClusteringCoefficient::approxGlobal(Graph& G, const count trials) {
             continue;
         }
 
-        node u = G.randomNeighbor(v);
-        node w = G.randomNeighbor(v);
+        node u = GraphTools::randomNeighbor(G, v);
+        node w = GraphTools::randomNeighbor(G, v);
 
         // TODO This could be sped up for degree(v) == 2...
         while (u == w) {
-            w = G.randomNeighbor(v);
+            w = GraphTools::randomNeighbor(G, v);
         }
 
         if (G.hasEdge(u,w)) {

--- a/networkit/cpp/global/ClusteringCoefficient.cpp
+++ b/networkit/cpp/global/ClusteringCoefficient.cpp
@@ -5,13 +5,14 @@
  *      Author: Lukas Barth, David Weiss
  */
 
+#include <omp.h>
 #include <unordered_set>
 
-#include <networkit/global/ClusteringCoefficient.hpp>
-#include <networkit/centrality/LocalClusteringCoefficient.hpp>
-#include <networkit/auxiliary/Random.hpp>
 #include <networkit/auxiliary/Log.hpp>
-#include <omp.h>
+#include <networkit/auxiliary/Random.hpp>
+#include <networkit/centrality/LocalClusteringCoefficient.hpp>
+#include <networkit/global/ClusteringCoefficient.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -134,7 +135,7 @@ double ClusteringCoefficient::approxAvgLocal(Graph& G, const count trials) {
 
     double triangles = 0;
     for (count k = 0; k < trials; ++k) {
-        node v = G.randomNode();
+        node v = GraphTools::randomNode(G);
         TRACE("trial ", k, " sampled node ", v);
 
         if (G.degree(v) < 2) {

--- a/networkit/cpp/global/GlobalClusteringCoefficient.cpp
+++ b/networkit/cpp/global/GlobalClusteringCoefficient.cpp
@@ -4,8 +4,9 @@
  *  Created on: 12.11.2013
  */
 
-#include <networkit/global/GlobalClusteringCoefficient.hpp>
 #include <networkit/auxiliary/Random.hpp>
+#include <networkit/global/GlobalClusteringCoefficient.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -50,10 +51,10 @@ double GlobalClusteringCoefficient::approximate(const Graph& G, int k) {
   for(int i = 0; i < k; i++) {
     int r2 = uniformRandom(w[n]);
     node r = findIndex(w, r2, 0, n);
-    node u = G.randomNeighbor(r);
+    node u = GraphTools::randomNeighbor(G, r);
     node w;
     do {
-      w = G.randomNeighbor(r);
+      w = GraphTools::randomNeighbor(G, r);
     } while (w == u);
     if(G.hasEdge(u, w)) {
       l++;

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -302,6 +302,7 @@ edgeid Graph::edgeId(node u, node v) const {
 /** GRAPH INFORMATION **/
 
 std::string Graph::typ() const {
+    WARN("Graph::typ is deprecated and will not be supported in future releases.");
     if (weighted) {
         return directed ? "WeightedDirectedGraph" : "WeightedGraph";
     } else {
@@ -512,6 +513,7 @@ edgeweight Graph::computeWeightedDegree(const node &v,
 }
 
 std::string Graph::toString() const {
+    WARN("Graph::toString is deprecated and will not be supported in future releases.");
     std::stringstream strm;
     strm << typ() << "(name=" << getName() << ", n=" << numberOfNodes()
          << ", m=" << numberOfEdges() << ")";

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -6,6 +6,8 @@
  * (marvin.ritter@gmail.com)
  */
 
+// networkit-format
+
 #include <cmath>
 #include <map>
 #include <random>
@@ -35,8 +37,8 @@ Graph::Graph(count n, bool weighted, bool directed)
       /* for directed graphs outEdges stores an adjacencylist only considering
       outgoing edges, for undirected graphs outEdges stores the adjacencylist of
       undirected edges*/
-      outEdges(n), inEdgeWeights(weighted && directed ? n : 0),
-      outEdgeWeights(weighted ? n : 0), inEdgeIds(), outEdgeIds() {
+      outEdges(n), inEdgeWeights(weighted && directed ? n : 0), outEdgeWeights(weighted ? n : 0),
+      inEdgeIds(), outEdgeIds() {
 
     // set name from global id
     id = getNextGraphId();
@@ -63,14 +65,13 @@ Graph::Graph(std::initializer_list<WeightedEdge> edges) : Graph(0, true) {
 }
 
 Graph::Graph(const Graph &G, bool weighted, bool directed)
-    : n(G.n), m(G.m), storedNumberOfSelfLoops(G.storedNumberOfSelfLoops),
-      z(G.z), omega(0), t(G.t), weighted(weighted), directed(directed),
+    : n(G.n), m(G.m), storedNumberOfSelfLoops(G.storedNumberOfSelfLoops), z(G.z), omega(0), t(G.t),
+      weighted(weighted), directed(directed),
       edgesIndexed(false), // edges are not indexed by default
       exists(G.exists),
 
       // let the following be empty for the start, we fill them later
-      inEdges(0), outEdges(0), inEdgeWeights(0),
-      outEdgeWeights(0) {
+      inEdges(0), outEdges(0), inEdgeWeights(0), outEdgeWeights(0) {
 
     // set name from global id
     id = getNextGraphId();
@@ -116,23 +117,19 @@ Graph::Graph(const Graph &G, bool weighted, bool directed)
 
             // copy both out and in edges into our new outEdges
             outEdges[u].reserve(G.outEdges[u].size() + G.inEdges[u].size());
-            outEdges[u].insert(outEdges[u].end(), G.outEdges[u].begin(),
-                               G.outEdges[u].end());
-            outEdges[u].insert(outEdges[u].end(), G.inEdges[u].begin(),
-                               G.inEdges[u].end());
+            outEdges[u].insert(outEdges[u].end(), G.outEdges[u].begin(), G.outEdges[u].end());
+            outEdges[u].insert(outEdges[u].end(), G.inEdges[u].begin(), G.inEdges[u].end());
         }
         if (weighted) {
             if (G.isWeighted()) {
                 // same for weights
                 outEdgeWeights.resize(z);
                 for (node u = 0; u < z; u++) {
-                    outEdgeWeights[u].reserve(G.outEdgeWeights[u].size() +
-                                              G.inEdgeWeights[u].size());
-                    outEdgeWeights[u].insert(outEdgeWeights[u].end(),
-                                             G.outEdgeWeights[u].begin(),
+                    outEdgeWeights[u].reserve(G.outEdgeWeights[u].size()
+                                              + G.inEdgeWeights[u].size());
+                    outEdgeWeights[u].insert(outEdgeWeights[u].end(), G.outEdgeWeights[u].begin(),
                                              G.outEdgeWeights[u].end());
-                    outEdgeWeights[u].insert(outEdgeWeights[u].end(),
-                                             G.inEdgeWeights[u].begin(),
+                    outEdgeWeights[u].insert(outEdgeWeights[u].end(), G.inEdgeWeights[u].begin(),
                                              G.inEdgeWeights[u].end());
                 }
             } else {
@@ -175,10 +172,10 @@ void Graph::preallocateUndirected(node u, size_t size) {
     assert(!directed);
     assert(exists[u]);
     outEdges[u].reserve(size);
-    if(weighted) {
+    if (weighted) {
         outEdgeWeights[u].reserve(size);
     }
-    if(edgesIndexed) {
+    if (edgesIndexed) {
         outEdgeIds[u].reserve(size);
     }
 }
@@ -189,11 +186,11 @@ void Graph::preallocateDirected(node u, size_t outSize, size_t inSize) {
     inEdges[u].reserve(inSize);
     outEdges[u].reserve(outSize);
 
-    if(weighted) {
+    if (weighted) {
         inEdgeWeights[u].reserve(inSize);
         outEdgeWeights[u].reserve(outSize);
     }
-    if(edgesIndexed) {
+    if (edgesIndexed) {
         inEdgeIds[u].reserve(inSize);
         outEdgeIds[u].reserve(outSize);
     }
@@ -287,8 +284,7 @@ void Graph::indexEdges(bool force) {
 
 edgeid Graph::edgeId(node u, node v) const {
     if (!edgesIndexed) {
-        throw std::runtime_error(
-            "edges have not been indexed - call indexEdges first");
+        throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
     index i = indexInOutEdgeArray(u, v);
 
@@ -454,9 +450,13 @@ void Graph::sortEdges() {
     }
 }
 
-count Graph::maxDegree() const { return GraphTools::maxDegree(*this); }
+count Graph::maxDegree() const {
+    return GraphTools::maxDegree(*this);
+}
 
-count Graph::maxDegreeIn() const { return GraphTools::maxInDegree(*this); }
+count Graph::maxDegreeIn() const {
+    return GraphTools::maxInDegree(*this);
+}
 
 edgeweight Graph::maxWeightedDegree() const {
     return GraphTools::maxWeightedDegree(*this);
@@ -497,8 +497,8 @@ edgeweight Graph::computeWeightedDegree(node u, bool inDegree, bool countSelfLoo
 std::string Graph::toString() const {
     WARN("Graph::toString is deprecated and will not be supported in future releases.");
     std::stringstream strm;
-    strm << typ() << "(name=" << getName() << ", n=" << numberOfNodes()
-         << ", m=" << numberOfEdges() << ")";
+    strm << typ() << "(name=" << getName() << ", n=" << numberOfNodes() << ", m=" << numberOfEdges()
+         << ")";
     return strm.str();
 }
 
@@ -520,13 +520,17 @@ node Graph::addNode() {
     exists.push_back(true);
 
     outEdges.emplace_back();
-    if (weighted) outEdgeWeights.emplace_back();
-    if (edgesIndexed) outEdgeIds.emplace_back();
+    if (weighted)
+        outEdgeWeights.emplace_back();
+    if (edgesIndexed)
+        outEdgeIds.emplace_back();
 
     if (directed) {
         inEdges.emplace_back();
-        if (weighted) inEdgeWeights.emplace_back();
-        if (edgesIndexed) inEdgeIds.emplace_back();
+        if (weighted)
+            inEdgeWeights.emplace_back();
+        if (edgesIndexed)
+            inEdgeIds.emplace_back();
     }
 
     return v;
@@ -548,16 +552,20 @@ node Graph::addNodes(count numberOfNewNodes) {
     exists.resize(z, true);
 
     outEdges.resize(z);
-    if (weighted) outEdgeWeights.resize(z);
-    if (edgesIndexed) outEdgeIds.resize(z);
+    if (weighted)
+        outEdgeWeights.resize(z);
+    if (edgesIndexed)
+        outEdgeIds.resize(z);
 
     if (directed) {
         inEdges.resize(z);
-        if (weighted) inEdgeWeights.resize(z);
-        if (edgesIndexed) inEdgeIds.resize(z);
+        if (weighted)
+            inEdgeWeights.resize(z);
+        if (edgesIndexed)
+            inEdgeIds.resize(z);
     }
 
-    return z-1;
+    return z - 1;
 }
 
 void Graph::removeNode(node v) {
@@ -728,7 +736,8 @@ void Graph::removeEdge(node u, node v) {
 
     const auto isLoop = (u == v);
     m--; // decrease number of edges
-    if (isLoop) storedNumberOfSelfLoops--;
+    if (isLoop)
+        storedNumberOfSelfLoops--;
 
     erase<node>(u, vi, outEdges);
     if (weighted) {
@@ -859,15 +868,13 @@ void Graph::swapEdge(node s1, node t1, node s2, node t2) {
     }
 }
 
-bool Graph::hasEdge(node u, node v) const noexcept{
+bool Graph::hasEdge(node u, node v) const noexcept {
     if (u >= z || v >= z) {
         return false;
     }
-    if (!directed &&
-        outEdges[u].size() > outEdges[v].size()) {
+    if (!directed && outEdges[u].size() > outEdges[v].size()) {
         return indexInOutEdgeArray(v, u) != none;
-    } else if (directed &&
-               outEdges[u].size() > inEdges[v].size()) {
+    } else if (directed && outEdges[u].size() > inEdges[v].size()) {
         return indexInInEdgeArray(v, u) != none;
     } else {
         return indexInOutEdgeArray(u, v) != none;
@@ -918,8 +925,7 @@ void Graph::setWeight(node u, node v, edgeweight ew) {
 
 void Graph::increaseWeight(node u, node v, edgeweight ew) {
     if (!weighted) {
-        throw std::runtime_error(
-            "Cannot increase edge weight in unweighted graph.");
+        throw std::runtime_error("Cannot increase edge weight in unweighted graph.");
     }
 
     index vi = indexInOutEdgeArray(u, v);
@@ -965,8 +971,7 @@ std::vector<std::pair<node, node>> Graph::edges() const {
     WARN("Graph::edges is deprecated and will not be supported in future releases.");
     std::vector<std::pair<node, node>> edges;
     edges.reserve(numberOfEdges());
-    this->forEdges(
-        [&](node u, node v) { edges.push_back(std::pair<node, node>(u, v)); });
+    this->forEdges([&](node u, node v) { edges.push_back(std::pair<node, node>(u, v)); });
     return edges;
 }
 
@@ -1022,7 +1027,8 @@ void Graph::merge(const Graph &G) {
 
 // SUBGRAPHS
 
-Graph Graph::subgraphFromNodes(const std::unordered_set<node> &nodes, bool includeOutNeighbors, bool includeInNeighbors) const {
+Graph Graph::subgraphFromNodes(const std::unordered_set<node> &nodes, bool includeOutNeighbors,
+                               bool includeInNeighbors) const {
     WARN("Graph::subgraphFromNodes is deprecated, use GraphTools::subgraphFromNodes instead.");
     return GraphTools::subgraphFromNodes(*this, nodes, includeOutNeighbors, includeInNeighbors);
 }

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -1245,6 +1245,7 @@ bool Graph::checkConsistency() const {
 }
 
 void Graph::append(const Graph &G) {
+    WARN("Graph::append is deprecated, use GraphTools::append instead.");
     std::map<node, node> nodeMap;
     G.forNodes([&](node u) {
         node u_ = this->addNode();
@@ -1260,6 +1261,7 @@ void Graph::append(const Graph &G) {
 }
 
 void Graph::merge(const Graph &G) {
+    WARN("Graph::merge is deprecated, use GraphTools::merge instead.");
     // TODO: handle edge weights
     G.forEdges([&](node u, node v) {
         // naive implementation takes $O(m \cdot d)$ for $m$ edges and max. degree

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -523,6 +523,7 @@ std::string Graph::toString() const {
 /** COPYING **/
 
 Graph Graph::copyNodes() const {
+    WARN("Graph::copyNodes is deprecated, use GraphTools::copyNodes instead.");
     Graph C(z, weighted, directed);
     for (node u = 0; u < z; ++u) {
         if (!exists[u]) {

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -599,16 +599,7 @@ edgeweight Graph::volume(node v) const {
 }
 
 node Graph::randomNode() const {
-    if (numberOfNodes() == 0) {
-        return none;
-    }
-
-    node v;
-    do {
-        v = Aux::Random::integer(z - 1);
-    } while (!exists[v]);
-
-    return v;
+    return GraphTools::randomNode(*this);
 }
 
 node Graph::randomNeighbor(node u) const {

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -1209,6 +1209,7 @@ Graph Graph::transpose() const {
 }
 
 Graph Graph::toUndirected() const {
+    WARN("Graph::toUndirected is deprecated, use GraphTools::toUndirected instead.");
     if (directed == false) {
         throw std::runtime_error("this graph is already undirected");
     }
@@ -1217,6 +1218,7 @@ Graph Graph::toUndirected() const {
 }
 
 Graph Graph::toUnweighted() const {
+    WARN("Graph::toUnweighted is deprecated, use GraphTools::toUnweighted instead.");
     if (weighted == false) {
         throw std::runtime_error("this graph is already unweighted");
     }

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -1270,6 +1270,7 @@ void Graph::merge(const Graph &G) {
 // SUBGRAPHS
 
 Graph Graph::subgraphFromNodes(const std::unordered_set<node> &nodes, bool includeOutNeighbors, bool includeInNeighbors) const {
+    WARN("Graph::subgraphFromNodes is deprecated, use GraphTools::subgraphFromNodes instead.");
     const auto neighbors = [&] {
         std::unordered_set<node> neighbors;
 

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -760,6 +760,10 @@ void Graph::removeEdge(node u, node v) {
     }
 }
 
+std::pair<count, count> const Graph::size() const noexcept {
+    return GraphTools::size(*this);
+}
+
 void Graph::removeAllEdges() {
     parallelForNodes([&](const node u) {
         removePartialOutEdges(unsafe, u);

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -871,42 +871,7 @@ std::pair<node, node> Graph::randomEdge(bool uniformDistribution) const {
 }
 
 std::vector<std::pair<node, node>> Graph::randomEdges(count nr) const {
-    if (numberOfEdges() == 0) {
-        throw std::runtime_error(
-            "Graph has no edges to sample from. Add edges to the graph first.");
-    }
-    std::vector<std::pair<node, node>> edges;
-
-    auto& gen = Aux::Random::getURNG();
-    std::vector<count> outDeg(upperNodeIdBound());
-    for (count i = 0; i < upperNodeIdBound(); ++i) {
-        outDeg[i] = outEdges[i].size();
-    }
-    std::discrete_distribution<count> distribution(outDeg.begin(), outDeg.end());
-
-    for (index i = 0; i < nr; i++) {
-        node u, v; // we will pick edge (u, v)
-        if (directed) {
-            u = distribution(gen);
-            // should always be the case as  without
-            // edges should have probability 0
-            assert(outEdges[u].size() > 0);
-            v = GraphTools::randomNeighbor(*this, u);
-        } else {
-            // self-loops which appear only once in the outEdge arrays
-            // easiest way it to ignore edges (u, v) with u > v
-            do {
-                u = distribution(gen);
-                // should always be the case as  without
-                // edges should have probability 0
-                assert(outEdges[u].size() > 0);
-                v = GraphTools::randomNeighbor(*this, u);
-            } while (u > v);
-        }
-        edges.push_back({u, v});
-    }
-
-    return edges;
+    return GraphTools::randomEdges(*this, nr);
 }
 
 /** EDGE ATTRIBUTES **/

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -454,24 +454,9 @@ void Graph::sortEdges() {
     }
 }
 
-count Graph::maxDegree() const { return computeMaxDegree(); }
+count Graph::maxDegree() const { return GraphTools::maxDegree(*this); }
 
-count Graph::maxDegreeIn() const { return computeMaxDegree(true); }
-
-count Graph::computeMaxDegree(const bool inDegree) const {
-    count result = 0;
-#ifndef NETWORKIT_OMP2
-#pragma omp parallel for reduction(max : result)
-    for (omp_index u = 0; u < upperNodeIdBound(); ++u) {
-        result = std::max(result, inDegree ? degreeIn(u) : degreeOut(u));
-    }
-#else
-    this->forNodes([&](const node u) {
-        result = std::max(result, inDegree ? degreeIn(u) : degreeOut(u));
-    });
-#endif
-    return result;
-}
+count Graph::maxDegreeIn() const { return GraphTools::maxInDegree(*this); }
 
 edgeweight Graph::maxWeightedDegree() const {
     return computeMaxWeightedDegree();

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -761,25 +761,12 @@ void Graph::removeEdge(node u, node v) {
 }
 
 void Graph::removeAllEdges() {
-#pragma omp parallel for
-    for (omp_index u = 0; u < z; ++u) {
-        outEdges[u].clear();
-        if (isWeighted()) {
-            outEdgeWeights[u].clear();
-        }
-        if (edgesIndexed) {
-            outEdgeIds[u].clear();
-        }
+    parallelForNodes([&](const node u) {
+        removePartialOutEdges(unsafe, u);
         if (isDirected()) {
-            inEdges[u].clear();
-            if (isWeighted()) {
-                inEdgeWeights[u].clear();
-            }
-            if (edgesIndexed) {
-                inEdgeIds[u].clear();
-            }
+            removePartialInEdges(unsafe, u);
         }
-    }
+    });
 
     m = 0;
 }

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -867,68 +867,7 @@ bool Graph::hasEdge(node u, node v) const noexcept{
 }
 
 std::pair<node, node> Graph::randomEdge(bool uniformDistribution) const {
-    if (m == 0) {
-        throw std::runtime_error("Error: the graph has ne edges!");
-    }
-
-    if (uniformDistribution) {
-        /*
-         * The simple idea here is to interpret all neighborhoods next to each other, resulting
-         * in a virtual vector of size m. Then we draw a random index and return the edge.
-         * For undirected edges, the vector has size 2m; but the idea remains. There is one minor
-         * complication for undirected edges with self-loops: each edge {u,v} with u != v is stored
-         * twice (once in the neighborhood of u, once in v) but a loop (u, u) is only stored once.
-         * To equalize the probabilities we reject edges {u,v} with u > v and try again. This leads
-         * to less than two expected trails in and is only done for undirected graphs with self-loops.
-         */
-
-        while (true) {
-            const auto upper = directed
-                ? numberOfEdges()
-                : 2 * numberOfEdges() - numberOfSelfLoops();
-            auto idx = Aux::Random::index(upper);
-
-            node u, v;
-
-            if (idx > upper / 2) {
-                // assuming degrees are somewhat distributed uniformly, it's better to start with
-                // larger nodes for large indices. In this case we have to mirror the index:
-                idx  = (upper-1) - idx;
-
-                for(u = upperNodeIdBound() - 1; idx >= degreeOut(u); --u) {
-                    idx -= degreeOut(u);
-                }
-
-                v = outEdges[u][outEdges[u].size() - 1 - idx];
-
-            } else {
-                for(u = 0; idx >= degreeOut(u); ++u) {
-                    assert(u < upperNodeIdBound());
-                    idx -= degreeOut(u);
-                }
-
-                v = outEdges[u][idx];
-
-            }
-
-            if (numberOfSelfLoops() && !directed && u > v)
-                // reject (see above)
-                continue;
-
-            return {u, v};
-        }
-    }
-
-    node u; // we will return edge (u, v)
-
-    // fast way, but not a uniform random edge!
-    do {
-        u = GraphTools::randomNode(*this);
-    } while (outEdges[u].empty());
-
-    const auto v = GraphTools::randomNeighbor(*this, u);
-
-    return {u, v};
+    return GraphTools::randomEdge(*this, uniformDistribution);
 }
 
 std::vector<std::pair<node, node>> Graph::randomEdges(count nr) const {

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -764,6 +764,10 @@ std::pair<count, count> const Graph::size() const noexcept {
     return GraphTools::size(*this);
 }
 
+double Graph::density() const {
+    return GraphTools::density(*this);
+}
+
 void Graph::removeAllEdges() {
     parallelForNodes([&](const node u) {
         removePartialOutEdges(unsafe, u);

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -785,27 +785,7 @@ void Graph::removeAllEdges() {
 }
 
 void Graph::removeEdgesFromIsolatedSet(const std::vector<node> &nodesInSet) {
-    count removedEdges = 0;
-    for (node u : nodesInSet) {
-        removedEdges += outEdges[u].size();
-        outEdges[u].clear();
-        if (weighted) {
-            outEdgeWeights[u].clear();
-        }
-        if (edgesIndexed) {
-            outEdgeIds[u].clear();
-        }
-        if (directed) {
-            inEdges[u].clear();
-            if (weighted) {
-                inEdgeWeights[u].clear();
-            }
-            if (edgesIndexed) {
-                inEdgeIds[u].clear();
-            }
-        }
-    }
-    this->m -= removedEdges;
+    GraphTools::removeEdgesFromIsolatedSet(*this, nodesInSet.begin(), nodesInSet.end());
 }
 
 void Graph::removeSelfLoops() {

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -459,28 +459,11 @@ count Graph::maxDegree() const { return GraphTools::maxDegree(*this); }
 count Graph::maxDegreeIn() const { return GraphTools::maxInDegree(*this); }
 
 edgeweight Graph::maxWeightedDegree() const {
-    return computeMaxWeightedDegree();
+    return GraphTools::maxWeightedDegree(*this);
 }
 
 edgeweight Graph::maxWeightedDegreeIn() const {
-    return computeMaxWeightedDegree(true);
-}
-
-edgeweight Graph::computeMaxWeightedDegree(const bool inDegree) const {
-    edgeweight result = 0;
-#ifndef NETWORKIT_OMP2
-#pragma omp parallel for reduction(max : result)
-    for (omp_index u = 0; u < upperNodeIdBound(); ++u) {
-        result =
-            std::max(result, inDegree ? weightedDegreeIn(u) : weightedDegree(u));
-    }
-#else
-    this->forNodes([&](const node u) {
-        result =
-            std::max(result, inDegree ? weightedDegreeIn(u) : weightedDegree(u));
-    });
-#endif
-    return result;
+    return GraphTools::maxWeightedInDegree(*this);
 }
 
 edgeweight Graph::computeWeightedDegree(node u, bool inDegree, bool countSelfLoopsTwice) const {

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -1163,6 +1163,7 @@ std::vector<node> Graph::neighbors(node u) const {
 }
 
 Graph Graph::transpose() const {
+    WARN("Graph::transpose is deprecated, use GraphTools::transpose instead.");
     if (directed == false) {
         throw std::runtime_error("The transpose of an undirected graph is "
                                  "identical to the original graph.");

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -776,15 +776,13 @@ void Graph::removeEdgesFromIsolatedSet(const std::vector<node> &nodesInSet) {
 }
 
 void Graph::removeSelfLoops() {
-#pragma omp parallel for
-    for (omp_index i = 0; i < static_cast<omp_index>(z); ++i) {
-        const auto u = static_cast<node>(i);
-        auto isSelfLoop = [u](node v) { return u == v; };
+    parallelForNodes([&](const node u) {
+        auto isSelfLoop = [u](const node v) { return u == v; };
         removeAdjacentEdges(u, isSelfLoop);
         if (isDirected()) {
             removeAdjacentEdges(u, isSelfLoop, true);
         }
-    }
+    });
 
     m -= storedNumberOfSelfLoops;
     storedNumberOfSelfLoops = 0;
@@ -795,9 +793,9 @@ void Graph::removeMultiEdges() {
     count removedSelfLoops = 0;
     std::unordered_set<node> nodes;
 
-    forNodes([&](node u) {
+    forNodes([&](const node u) {
         nodes.reserve(degree(u));
-        auto isMultiedge = [&nodes](node v) { return !nodes.insert(v).second; };
+        auto isMultiedge = [&nodes](const node v) { return !nodes.insert(v).second; };
         auto result = removeAdjacentEdges(u, isMultiedge);
         removedEdges += result.first;
         removedSelfLoops += result.second;

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -1138,6 +1138,7 @@ edgeweight Graph::totalEdgeWeight() const {
 /** Collections **/
 
 std::vector<node> Graph::nodes() const {
+    WARN("Graph::nodes is deprecated and will not be supported in future releases.");
     std::vector<node> nodes;
     nodes.reserve(numberOfNodes());
     this->forNodes([&](node u) { nodes.push_back(u); });
@@ -1145,6 +1146,7 @@ std::vector<node> Graph::nodes() const {
 }
 
 std::vector<std::pair<node, node>> Graph::edges() const {
+    WARN("Graph::edges is deprecated and will not be supported in future releases.");
     std::vector<std::pair<node, node>> edges;
     edges.reserve(numberOfEdges());
     this->forEdges(

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -603,17 +603,7 @@ node Graph::randomNode() const {
 }
 
 node Graph::randomNeighbor(node u) const {
-    if (outEdges[u].empty()) {
-        return none;
-    }
-
-    node v;
-    do {
-        index i = Aux::Random::integer(outEdges[u].size() - 1);
-        v = outEdges[u][i];
-    } while (v == none);
-
-    return v;
+    return GraphTools::randomNeighbor(*this, u);
 }
 
 /** EDGE MODIFIERS **/
@@ -968,10 +958,10 @@ std::pair<node, node> Graph::randomEdge(bool uniformDistribution) const {
 
     // fast way, but not a uniform random edge!
     do {
-        u = randomNode();
+        u = GraphTools::randomNode(*this);
     } while (outEdges[u].empty());
 
-    const auto v = randomNeighbor(u);
+    const auto v = GraphTools::randomNeighbor(*this, u);
 
     return {u, v};
 }
@@ -997,7 +987,7 @@ std::vector<std::pair<node, node>> Graph::randomEdges(count nr) const {
             // should always be the case as  without
             // edges should have probability 0
             assert(outEdges[u].size() > 0);
-            v = randomNeighbor(u);
+            v = GraphTools::randomNeighbor(*this, u);
         } else {
             // self-loops which appear only once in the outEdge arrays
             // easiest way it to ignore edges (u, v) with u > v
@@ -1006,7 +996,7 @@ std::vector<std::pair<node, node>> Graph::randomEdges(count nr) const {
                 // should always be the case as  without
                 // edges should have probability 0
                 assert(outEdges[u].size() > 0);
-                v = randomNeighbor(u);
+                v = GraphTools::randomNeighbor(*this, u);
             } while (u > v);
         }
         edges.push_back({u, v});

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -937,7 +937,10 @@ void Graph::swapEdge(node s1, node t1, node s2, node t2) {
     }
 }
 
-bool Graph::hasEdge(node u, node v) const {
+bool Graph::hasEdge(node u, node v) const noexcept{
+    if (u >= z || v >= z) {
+        return false;
+    }
     if (!directed &&
         outEdges[u].size() > outEdges[v].size()) {
         return indexInOutEdgeArray(v, u) != none;
@@ -1053,10 +1056,6 @@ std::vector<std::pair<node, node>> Graph::randomEdges(count nr) const {
     return edges;
 }
 
-/** GLOBAL PROPERTIES **/
-
-count Graph::numberOfSelfLoops() const { return storedNumberOfSelfLoops; }
-
 /** EDGE ATTRIBUTES **/
 
 edgeweight Graph::weight(node u, node v) const {
@@ -1116,7 +1115,7 @@ void Graph::increaseWeight(node u, node v, edgeweight ew) {
 
 /** SUMS **/
 
-edgeweight Graph::totalEdgeWeight() const {
+edgeweight Graph::totalEdgeWeight() const noexcept {
     if (weighted) {
         edgeweight sum = 0.0;
         forEdges([&](node, node, edgeweight ew) { sum += ew; });

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -9,6 +9,25 @@ namespace NetworKit {
 
 namespace GraphTools {
 
+count computeMaxDegree(const Graph &G, bool inDegree = false) {
+    count result = 0;
+#ifndef NETWORKIT_OMP2
+#pragma omp parallel for reduction(max : result)
+    for (omp_index u = 0; u < static_cast<omp_index>(G.upperNodeIdBound()); ++u) {
+        result = std::max(result, inDegree ? G.degreeIn(u) : G.degreeOut(u));
+    }
+#else
+    G.forNodes([&](const node u) {
+        result = std::max(result, inDegree ? G.degreeIn(u) : G.degreeOut(u));
+    });
+#endif
+    return result;
+}
+
+count maxDegree(const Graph &G) { return computeMaxDegree(G); }
+
+count maxInDegree(const Graph &G) { return computeMaxDegree(G, true); }
+
 Graph copyNodes(const Graph &G) {
     Graph C(G.upperNodeIdBound(), G.isWeighted(), G.isDirected());
     for (node u = 0; u < G.upperNodeIdBound(); ++u) {

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -1,9 +1,11 @@
+// networkit-format
+
 #include <algorithm>
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
-#include <networkit/graph/GraphTools.hpp>
 #include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -29,21 +31,23 @@ edgeweight computeMaxWeightedDegree(const Graph &G, bool inDegree = false) {
 #ifndef NETWORKIT_OMP2
 #pragma omp parallel for reduction(max : result)
     for (omp_index u = 0; u < static_cast<omp_index>(G.upperNodeIdBound()); ++u) {
-        result =
-            std::max(result, inDegree ? G.weightedDegreeIn(u) : G.weightedDegree(u));
+        result = std::max(result, inDegree ? G.weightedDegreeIn(u) : G.weightedDegree(u));
     }
 #else
     G.forNodes([&](const node u) {
-        result =
-            std::max(result, inDegree ? G.weightedDegreeIn(u) : G.weightedDegree(u));
+        result = std::max(result, inDegree ? G.weightedDegreeIn(u) : G.weightedDegree(u));
     });
 #endif
     return result;
 }
 
-count maxDegree(const Graph &G) { return computeMaxDegree(G); }
+count maxDegree(const Graph &G) {
+    return computeMaxDegree(G);
+}
 
-count maxInDegree(const Graph &G) { return computeMaxDegree(G, true); }
+count maxInDegree(const Graph &G) {
+    return computeMaxDegree(G, true);
+}
 
 edgeweight maxWeightedDegree(const Graph &G) {
     return computeMaxWeightedDegree(G);
@@ -83,13 +87,13 @@ std::pair<node, node> randomEdge(const Graph &G, bool uniformDistribution) {
          * complication for undirected edges with self-loops: each edge {u,v} with u != v is stored
          * twice (once in the neighborhood of u, once in v) but a loop (u, u) is only stored once.
          * To equalize the probabilities we reject edges {u,v} with u > v and try again. This leads
-         * to less than two expected trails in and is only done for undirected graphs with self-loops.
+         * to less than two expected trails in and is only done for undirected graphs with
+         * self-loops.
          */
 
-        do  {
-            const auto upper = G.isDirected()
-                ? G.numberOfEdges()
-                : 2 * G.numberOfEdges() - G.numberOfSelfLoops();
+        do {
+            const auto upper =
+                G.isDirected() ? G.numberOfEdges() : 2 * G.numberOfEdges() - G.numberOfSelfLoops();
             auto idx = Aux::Random::index(upper);
 
             node u, v;
@@ -97,7 +101,7 @@ std::pair<node, node> randomEdge(const Graph &G, bool uniformDistribution) {
             if (idx > upper / 2) {
                 // assuming degrees are somewhat distributed uniformly, it's better to start with
                 // larger nodes for large indices. In this case we have to mirror the index:
-                idx  = (upper-1) - idx;
+                idx = (upper - 1) - idx;
 
                 for (u = G.upperNodeIdBound() - 1; idx >= G.degree(u); --u) {
                     idx -= G.degree(u);
@@ -106,13 +110,12 @@ std::pair<node, node> randomEdge(const Graph &G, bool uniformDistribution) {
                 v = G.getIthNeighbor(u, G.degree(u) - 1 - idx);
 
             } else {
-                for(u = 0; idx >= G.degree(u); ++u) {
+                for (u = 0; idx >= G.degree(u); ++u) {
                     assert(u < G.upperNodeIdBound());
                     idx -= G.degree(u);
                 }
 
                 v = G.getIthNeighbor(u, idx);
-
             }
 
             if (G.numberOfSelfLoops() && !G.isDirected() && u > v)
@@ -136,7 +139,8 @@ std::pair<node, node> randomEdge(const Graph &G, bool uniformDistribution) {
 }
 
 std::vector<std::pair<node, node>> randomEdges(const Graph &G, count nr) {
-    if (!nr) return {};
+    if (!nr)
+        return {};
 
     if (!G.numberOfEdges()) {
         throw std::runtime_error(
@@ -145,7 +149,7 @@ std::vector<std::pair<node, node>> randomEdges(const Graph &G, count nr) {
 
     std::vector<std::pair<node, node>> edges;
 
-    auto& gen = Aux::Random::getURNG();
+    auto &gen = Aux::Random::getURNG();
     std::vector<count> outDeg(G.upperNodeIdBound());
     G.forNodes([&outDeg, &G](const node u) { outDeg[u] = G.degree(u); });
 
@@ -191,7 +195,8 @@ double density(const Graph &G) noexcept {
     if (G.numberOfNodes() <= 1)
         return 0;
     const auto n = static_cast<double>(G.numberOfNodes());
-    const auto m = static_cast<double>((G.numberOfEdges() - G.numberOfSelfLoops()) * (G.isDirected() ? 1 : 2));
+    const auto m =
+        static_cast<double>((G.numberOfEdges() - G.numberOfSelfLoops()) * (G.isDirected() ? 1 : 2));
     return m / (n * (n - 1));
 }
 
@@ -215,11 +220,11 @@ Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
 
         for (node u : nodes) {
             if (includeOutNeighbors)
-                for(const node v : G.neighborRange(u))
+                for (const node v : G.neighborRange(u))
                     neighbors.insert(v);
 
             if (includeInNeighbors)
-                for(const node v : G.inNeighborRange(u))
+                for (const node v : G.inNeighborRange(u))
                     neighbors.insert(v);
         }
 
@@ -232,9 +237,11 @@ Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
      * 1: Is a relevant neighbor (i.e., respective include*Neighbor was set)
      * 0: Neither of both
      */
-    auto isRelevantNode = [&] (const node u) {
-        if (nodes.find(u) != nodes.end()) return 2;
-        if (!neighbors.empty() && neighbors.find(u) != neighbors.end()) return 1;
+    auto isRelevantNode = [&](const node u) {
+        if (nodes.find(u) != nodes.end())
+            return 2;
+        if (!neighbors.empty() && neighbors.find(u) != neighbors.end())
+            return 1;
         return 0;
     };
 
@@ -294,21 +301,21 @@ Graph transpose(const Graph &G) {
         GTranspose.indexEdges();
     }
 
-    #pragma omp parallel for
+#pragma omp parallel for
     for (omp_index u = 0; u < static_cast<omp_index>(G.upperNodeIdBound()); ++u) {
         if (G.hasNode(u)) {
             GTranspose.preallocateDirected(u, G.degreeIn(u), G.degreeOut(u));
 
-            G.forInEdgesOf(u, [&] (node, node v, edgeweight w, edgeid id) {
+            G.forInEdgesOf(u, [&](node, node v, edgeweight w, edgeid id) {
                 GTranspose.addPartialOutEdge(unsafe, u, v, w, id);
             });
 
-            G.forEdgesOf(u, [&] (node, node v, edgeweight w, edgeid id) {
+            G.forEdgesOf(u, [&](node, node v, edgeweight w, edgeid id) {
                 GTranspose.addPartialInEdge(unsafe, u, v, w, id);
             });
 
         } else {
-            #pragma omp critical
+#pragma omp critical
             GTranspose.removeNode(u);
         }
     }
@@ -329,9 +336,7 @@ void append(Graph &G, const Graph &G1) {
     });
 
     if (G.isWeighted()) {
-        G1.forEdges([&](node u, node v, edgeweight ew) {
-            G.addEdge(nodeMap[u], nodeMap[v], ew);
-        });
+        G1.forEdges([&](node u, node v, edgeweight ew) { G.addEdge(nodeMap[u], nodeMap[v], ew); });
     } else {
         G1.forEdges([&](node u, node v) { G.addEdge(nodeMap[u], nodeMap[v]); });
     }
@@ -365,43 +370,42 @@ void merge(Graph &G, const Graph &G1) {
     });
 }
 
-Graph getCompactedGraph(const Graph& graph, const std::unordered_map<node,node>& nodeIdMap) {
-    return getRemappedGraph(graph, nodeIdMap.size(), [&] (node u) {
+Graph getCompactedGraph(const Graph &graph, const std::unordered_map<node, node> &nodeIdMap) {
+    return getRemappedGraph(graph, nodeIdMap.size(), [&](node u) {
         const auto it = nodeIdMap.find(u);
         assert(it != nodeIdMap.cend());
         return it->second;
     });
 }
 
-std::unordered_map<node,node> getContinuousNodeIds(const Graph& graph) {
-    std::unordered_map<node,node> nodeIdMap;
+std::unordered_map<node, node> getContinuousNodeIds(const Graph &graph) {
+    std::unordered_map<node, node> nodeIdMap;
     count continuousId = 0;
-    auto addToMap = [&nodeIdMap,&continuousId](node v) {
-        nodeIdMap.insert(std::make_pair(v,continuousId++));
+    auto addToMap = [&nodeIdMap, &continuousId](node v) {
+        nodeIdMap.insert(std::make_pair(v, continuousId++));
     };
     graph.forNodes(addToMap);
     return nodeIdMap;
 }
-std::unordered_map<node,node> getRandomContinuousNodeIds(const Graph& graph) {
-    std::unordered_map<node,node> nodeIdMap;
+std::unordered_map<node, node> getRandomContinuousNodeIds(const Graph &graph) {
+    std::unordered_map<node, node> nodeIdMap;
     std::vector<node> nodes;
     nodes.reserve(graph.numberOfNodes());
 
-    graph.forNodes([&](node u) {
-        nodes.push_back(u);
-    });
+    graph.forNodes([&](node u) { nodes.push_back(u); });
 
     std::shuffle(nodes.begin(), nodes.end(), Aux::Random::getURNG());
 
     count continuousId = 0;
     for (node v : nodes) {
-        nodeIdMap.insert(std::make_pair(v,continuousId++));
+        nodeIdMap.insert(std::make_pair(v, continuousId++));
     };
 
     return nodeIdMap;
 }
 
-std::vector<node> invertContinuousNodeIds(const std::unordered_map<node,node>& nodeIdMap, const Graph& G) {
+std::vector<node> invertContinuousNodeIds(const std::unordered_map<node, node> &nodeIdMap,
+                                          const Graph &G) {
     assert(nodeIdMap.size() == G.numberOfNodes());
     std::vector<node> invertedIdMap(G.numberOfNodes() + 1);
     // store upper node id bound
@@ -413,15 +417,13 @@ std::vector<node> invertContinuousNodeIds(const std::unordered_map<node,node>& n
     return invertedIdMap;
 }
 
-Graph restoreGraph(const std::vector<node>& invertedIdMap, const Graph& G) {
+Graph restoreGraph(const std::vector<node> &invertedIdMap, const Graph &G) {
     // with the inverted id map and the compacted graph, generate the original graph again
     Graph Goriginal(invertedIdMap.back(), G.isWeighted(), G.isDirected());
     index current = 0;
-    Goriginal.forNodes([&](node u){
+    Goriginal.forNodes([&](node u) {
         if (invertedIdMap[current] == u) {
-            G.forNeighborsOf(current,[&](node v){
-                Goriginal.addEdge(u,invertedIdMap[v]);
-            });
+            G.forNeighborsOf(current, [&](node v) { Goriginal.addEdge(u, invertedIdMap[v]); });
             ++current;
         } else {
             Goriginal.removeNode(u);

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -53,6 +53,23 @@ edgeweight maxWeightedInDegree(const Graph &G) {
     return computeMaxWeightedDegree(G, true);
 }
 
+node randomNode(const Graph &G) {
+    if (!G.numberOfNodes())
+        return none;
+
+    auto &gen = Aux::Random::getURNG();
+    std::uniform_int_distribution<node> distr{0, G.upperNodeIdBound() - 1};
+    node v;
+
+    do {
+        // When there are many deleted nodes, we might call Aux::Random::integer
+        // many times, and it is very expensive.
+        v = distr(gen);
+    } while (!G.hasNode(v));
+
+    return v;
+}
+
 Graph copyNodes(const Graph &G) {
     Graph C(G.upperNodeIdBound(), G.isWeighted(), G.isDirected());
     for (node u = 0; u < G.upperNodeIdBound(); ++u) {

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -24,9 +24,34 @@ count computeMaxDegree(const Graph &G, bool inDegree = false) {
     return result;
 }
 
+edgeweight computeMaxWeightedDegree(const Graph &G, bool inDegree = false) {
+    edgeweight result = 0;
+#ifndef NETWORKIT_OMP2
+#pragma omp parallel for reduction(max : result)
+    for (omp_index u = 0; u < static_cast<omp_index>(G.upperNodeIdBound()); ++u) {
+        result =
+            std::max(result, inDegree ? G.weightedDegreeIn(u) : G.weightedDegree(u));
+    }
+#else
+    G.forNodes([&](const node u) {
+        result =
+            std::max(result, inDegree ? G.weightedDegreeIn(u) : G.weightedDegree(u));
+    });
+#endif
+    return result;
+}
+
 count maxDegree(const Graph &G) { return computeMaxDegree(G); }
 
 count maxInDegree(const Graph &G) { return computeMaxDegree(G, true); }
+
+edgeweight maxWeightedDegree(const Graph &G) {
+    return computeMaxWeightedDegree(G);
+}
+
+edgeweight maxWeightedInDegree(const Graph &G) {
+    return computeMaxWeightedDegree(G, true);
+}
 
 Graph copyNodes(const Graph &G) {
     Graph C(G.upperNodeIdBound(), G.isWeighted(), G.isDirected());

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 
+#include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/graph/GraphTools.hpp>
 #include <networkit/graph/Graph.hpp>
@@ -68,6 +69,30 @@ Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
     });
 
     return S;
+}
+
+Graph toUndirected(const Graph &G) {
+    if (!G.isDirected()) {
+        WARN("The graph is already undirected");
+    }
+
+    return Graph(G, G.isWeighted(), false);
+}
+
+Graph toUnweighted(const Graph &G) {
+    if (!G.isWeighted()) {
+        WARN("The graph is already unweighted");
+    }
+
+    return Graph(G, false, G.isDirected());
+}
+
+Graph toWeighted(const Graph &G) {
+    if (G.isWeighted()) {
+        WARN("The graph is already weighted");
+    }
+
+    return Graph(G, true, G.isDirected());
 }
 
 Graph transpose(const Graph &G) {

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -70,6 +70,13 @@ node randomNode(const Graph &G) {
     return v;
 }
 
+node randomNeighbor(const Graph &G, node u) {
+    if (!G.degree(u))
+        return none;
+
+    return G.getIthNeighbor(u, Aux::Random::integer(G.degree(u) - 1));
+}
+
 Graph copyNodes(const Graph &G) {
     Graph C(G.upperNodeIdBound(), G.isWeighted(), G.isDirected());
     for (node u = 0; u < G.upperNodeIdBound(); ++u) {

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -183,6 +183,18 @@ node randomNeighbor(const Graph &G, node u) {
     return G.getIthNeighbor(u, Aux::Random::integer(G.degree(u) - 1));
 }
 
+std::pair<node, node> size(const Graph &G) noexcept {
+    return {G.numberOfNodes(), G.numberOfEdges()};
+}
+
+double density(const Graph &G) noexcept {
+    if (G.numberOfNodes() <= 1)
+        return 0;
+    const auto n = static_cast<double>(G.numberOfNodes());
+    const auto m = static_cast<double>((G.numberOfEdges() - G.numberOfSelfLoops()) * (G.isDirected() ? 1 : 2));
+    return m / (n * (n - 1));
+}
+
 Graph copyNodes(const Graph &G) {
     Graph C(G.upperNodeIdBound(), G.isWeighted(), G.isDirected());
     for (node u = 0; u < G.upperNodeIdBound(); ++u) {

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <unordered_map>
 
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/graph/GraphTools.hpp>

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -9,6 +9,16 @@ namespace NetworKit {
 
 namespace GraphTools {
 
+Graph copyNodes(const Graph &G) {
+    Graph C(G.upperNodeIdBound(), G.isWeighted(), G.isDirected());
+    for (node u = 0; u < G.upperNodeIdBound(); ++u) {
+        if (!G.hasNode(u)) {
+            C.removeNode(u);
+        }
+    }
+    return C;
+}
+
 Graph getCompactedGraph(const Graph& graph, const std::unordered_map<node,node>& nodeIdMap) {
     return getRemappedGraph(graph, nodeIdMap.size(), [&] (node u) {
         const auto it = nodeIdMap.find(u);

--- a/networkit/cpp/graph/KruskalMSF.cpp
+++ b/networkit/cpp/graph/KruskalMSF.cpp
@@ -7,7 +7,7 @@
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
-
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/graph/KruskalMSF.hpp>
 #include <networkit/graph/SpanningForest.hpp>
 #include <networkit/structures/UnionFind.hpp>
@@ -44,13 +44,12 @@ KruskalMSF::KruskalMSF(const Graph& G): SpanningForest(G) {
 void KruskalMSF::run() {
     if (true || G.isWeighted()) { // FIXME: remove true when SpanningForest is fixed!
         count z = G.upperNodeIdBound();
-        forest = G.copyNodes();
+        forest = GraphTools::copyNodes(G);
         UnionFind uf(z);
 
         // sort edges in decreasing weight order
         std::vector<MyEdge> sortedEdges; // (m);
         G.forEdges([&](node u, node v, edgeweight ew, edgeid) {
-//			INFO("insert edge (", u, ", ", v, ") with weight ", ew);
             MyEdge myEdge(u, v, ew);
             sortedEdges.push_back(myEdge);
         });

--- a/networkit/cpp/graph/RandomMaximumSpanningForest.cpp
+++ b/networkit/cpp/graph/RandomMaximumSpanningForest.cpp
@@ -5,6 +5,7 @@
 #include <networkit/graph/RandomMaximumSpanningForest.hpp>
 #include <networkit/auxiliary/SignalHandling.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -17,7 +18,7 @@ void RandomMaximumSpanningForest::run() {
 
     Aux::SignalHandler handler;
 
-    msf = G.copyNodes();
+    msf = GraphTools::copyNodes(G);
 
     handler.assureRunning();
 

--- a/networkit/cpp/graph/Sampling.cpp
+++ b/networkit/cpp/graph/Sampling.cpp
@@ -6,17 +6,13 @@
  */
 
 #include <networkit/graph/Sampling.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/auxiliary/Random.hpp>
 
 namespace NetworKit {
 
 node Sampling::randomNode(const Graph& G) {
-    assert (G.numberOfNodes() > 0);
-    node v = none;
-    do {
-        v = Aux::Random::integer(G.upperNodeIdBound());
-    } while (!G.hasNode(v));
-    return v;
+    return GraphTools::randomNode(G);
 }
 
 // the following methdods are commented in order to create linker-errors should they be used before

--- a/networkit/cpp/graph/Sampling.cpp
+++ b/networkit/cpp/graph/Sampling.cpp
@@ -15,18 +15,5 @@ node Sampling::randomNode(const Graph& G) {
     return GraphTools::randomNode(G);
 }
 
-// the following methdods are commented in order to create linker-errors should they be used before
-// they are actually defined (not returning from a function with a returntype != void is UB):
-
-//std::pair<node, node> Sampling::randomEdge(const Graph& G) {
-//	// TODO: implement
-//}
-
-//node Sampling::randomNeighbor(const Graph& G, node u) {
-//	// TODO: implement
-//}
-
-
-
 } /* namespace NetworKit */
 

--- a/networkit/cpp/graph/SpanningForest.cpp
+++ b/networkit/cpp/graph/SpanningForest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <networkit/auxiliary/Log.hpp>
+#include <networkit/graph/BFS.hpp>
 #include <networkit/graph/GraphTools.hpp>
 #include <networkit/graph/SpanningForest.hpp>
 
@@ -30,7 +31,7 @@ Graph SpanningForest::generate() {
 
     G.forNodes([&](node s){
         if (! visited[s]) {
-            G.BFSEdgesFrom(s, [&](node u, node v, edgeweight w, edgeid) {
+            Traversal::BFSEdgesFrom(G, s, [&](node u, node v, edgeweight w, edgeid) {
                 visited[u] = true;
                 visited[v] = true;
                 F.addEdge(u, v, w);

--- a/networkit/cpp/graph/SpanningForest.cpp
+++ b/networkit/cpp/graph/SpanningForest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <networkit/auxiliary/Log.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/graph/SpanningForest.hpp>
 
 namespace NetworKit {
@@ -24,7 +25,7 @@ void SpanningForest::run() {
 
 // CLS's code for generating spanning forest with BFS, please fixme!
 Graph SpanningForest::generate() {
-    Graph F = G.copyNodes();
+    Graph F = GraphTools::copyNodes(G);
     std::vector<bool> visited(G.upperNodeIdBound(), false);
 
     G.forNodes([&](node s){

--- a/networkit/cpp/graph/UnionMaximumSpanningForest.cpp
+++ b/networkit/cpp/graph/UnionMaximumSpanningForest.cpp
@@ -2,6 +2,7 @@
 #include <networkit/graph/UnionMaximumSpanningForest.hpp>
 #include <networkit/auxiliary/SignalHandling.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -14,7 +15,7 @@ void UnionMaximumSpanningForest::run() {
 
     Aux::SignalHandler handler;
 
-    umsf = G.copyNodes();
+    umsf = GraphTools::copyNodes(G);
 
     handler.assureRunning();
 

--- a/networkit/cpp/graph/test/CMakeLists.txt
+++ b/networkit/cpp/graph/test/CMakeLists.txt
@@ -2,7 +2,7 @@ networkit_add_test(graph GraphBuilderAutoCompleteGTest auxiliary)
 networkit_add_test(graph GraphBuilderDirectSwapGTest auxiliary)
 networkit_add_test(graph GraphGTest
     auxiliary dyn_distance io generators)
-networkit_add_test(graph GraphToolsGTest)
+networkit_add_test(graph GraphToolsGTest generators)
 networkit_add_test(graph SpanningGTest io)
 
 networkit_add_benchmark(graph Graph2Benchmark)

--- a/networkit/cpp/graph/test/CMakeLists.txt
+++ b/networkit/cpp/graph/test/CMakeLists.txt
@@ -3,6 +3,7 @@ networkit_add_test(graph GraphBuilderDirectSwapGTest auxiliary)
 networkit_add_test(graph GraphGTest
     auxiliary dyn_distance io generators)
 networkit_add_test(graph GraphToolsGTest generators)
+networkit_add_test(graph TraversalGTest generators)
 networkit_add_test(graph SpanningGTest io)
 
 networkit_add_benchmark(graph Graph2Benchmark)

--- a/networkit/cpp/graph/test/GraphBuilderAutoCompleteGTest.cpp
+++ b/networkit/cpp/graph/test/GraphBuilderAutoCompleteGTest.cpp
@@ -12,6 +12,7 @@
 
 #include <networkit/graph/Graph.hpp>
 #include <networkit/graph/GraphBuilder.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
 
@@ -407,7 +408,8 @@ TEST_P(GraphBuilderAutoCompleteGTest, testSameAsGraph) {
             ASSERT_EQ(G_expected.degreeIn(v), G_actual.degreeIn(v));
             ASSERT_EQ(G_expected.degreeOut(v), G_actual.degreeOut(v));
             ASSERT_NEAR(G_expected.weightedDegree(v), G_actual.weightedDegree(v), epsilon);
-            ASSERT_NEAR(G_expected.volume(v), G_actual.volume(v), epsilon);
+            ASSERT_NEAR(G_expected.weightedDegree(v, true),
+                        G_actual.weightedDegree(v, true), epsilon);
         });
         G_expected.forEdges([&](node u, node v, edgeweight ew) {
             ASSERT_TRUE(G_actual.hasEdge(u, v));

--- a/networkit/cpp/graph/test/GraphBuilderDirectSwapGTest.cpp
+++ b/networkit/cpp/graph/test/GraphBuilderDirectSwapGTest.cpp
@@ -14,6 +14,7 @@
 #include <networkit/auxiliary/Parallel.hpp>
 
 #include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/graph/GraphBuilder.hpp>
 
 namespace NetworKit {
@@ -447,7 +448,8 @@ TEST_P(GraphBuilderDirectSwapGTest, testSameAsGraph) {
             ASSERT_EQ(G_expected.degreeIn(v), G_actual.degreeIn(v));
             ASSERT_EQ(G_expected.degreeOut(v), G_actual.degreeOut(v));
             ASSERT_NEAR(G_expected.weightedDegree(v), G_actual.weightedDegree(v), epsilon);
-            ASSERT_NEAR(G_expected.volume(v), G_actual.volume(v), epsilon);
+            ASSERT_NEAR(G_expected.weightedDegree(v, true),
+                        G_actual.weightedDegree(v, true), epsilon);
         });
         G_expected.forEdges([&](node u, node v, edgeweight ew) {
             ASSERT_TRUE(G_actual.hasEdge(u, v));

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -718,25 +718,29 @@ TEST_P(GraphGTest, testRemoveEdge) {
 }
 
 TEST_P(GraphGTest, testRemoveAllEdges) {
-    Graph g = ErdosRenyiGenerator(20, 0.1, false).generate();
-    g.removeAllEdges();
-    EXPECT_EQ(g.numberOfEdges(), 0);
-    count edgeCount = 0;
-    g.forEdges([&edgeCount](node, node) { ++edgeCount; });
-    EXPECT_EQ(edgeCount, 0);
-    g.forNodes([&](node u) {
-        EXPECT_EQ(g.degree(u), 0);
-        EXPECT_EQ(g.degree(u), 0);
-    });
+    constexpr count n = 100;
+    constexpr double p = 0.2;
 
-    g = ErdosRenyiGenerator(20, 0.1, true).generate();
-    g.removeAllEdges();
-    EXPECT_EQ(g.numberOfEdges(), 0);
-    g.forNodes([&](node u) {
-        EXPECT_EQ(g.degree(u), 0);
-        EXPECT_EQ(g.degree(u), 0);
-        EXPECT_EQ(g.degreeIn(u), 0);
-    });
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, false);
+        auto g = ErdosRenyiGenerator(n, p, isDirected()).generate();
+        if (isWeighted()) {
+            g = Graph(g, true, isDirected());
+        }
+
+        g.removeAllEdges();
+
+        EXPECT_EQ(g.numberOfEdges(), 0);
+
+        count edgeCount = 0;
+        g.forEdges([&edgeCount](node, node) { ++edgeCount; });
+        EXPECT_EQ(edgeCount, 0);
+
+        g.forNodes([&](node u) {
+            EXPECT_EQ(g.degree(u), 0);
+            EXPECT_EQ(g.degree(u), 0);
+        });
+    }
 }
 
 TEST_P(GraphGTest, testRemoveSelfLoops) {

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -848,33 +848,6 @@ TEST_P(GraphGTest, testHasEdge) {
     }
 }
 
-TEST_P(GraphGTest, testRandomEdges) {
-    Aux::Random::setSeed(1, false);
-    // we only test the uniform version
-    constexpr count n = 4;
-    constexpr count m = 5;
-    constexpr count samples = 100000;
-    constexpr double maxAbsoluteError = 0.005;
-
-    Graph G = createGraph(n);
-    G.addEdge(0, 1); // 0 * 1 = 0
-    G.addEdge(1, 2); // 1 * 2 = 2
-    G.addEdge(3, 2); // 3 * 2 = 1 (mod 5)
-    G.addEdge(2, 2); // 2 * 2 = 4
-    G.addEdge(3, 1); // 3 * 1 = 3
-    ASSERT_EQ(m, G.numberOfEdges());
-
-    std::vector<count> drawCounts(m, 0);
-    for (const auto e : G.randomEdges(samples)) {
-        count id = (e.first * e.second) % 5;
-        drawCounts[id]++;
-    }
-    for (node id = 0; id < m; id++) {
-        double p = drawCounts[id] / (double)samples;
-        ASSERT_NEAR(1.0 / m, p, maxAbsoluteError);
-    }
-}
-
 /** GLOBAL PROPERTIES **/
 
 TEST_P(GraphGTest, testSelfLoopCountSimple) {

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -580,42 +580,75 @@ TEST_P(GraphGTest, testWeightedDegree) {
     }
 }
 
-TEST_P(GraphGTest, testVolume) {
+TEST_P(GraphGTest, testWeightedDegree2) {
     // add self-loop
     this->Ghouse.addEdge(2, 2, 0.75);
 
     if (isGraph()) {
-        ASSERT_EQ(2 * defaultEdgeWeight, this->Ghouse.volume(0));
-        ASSERT_EQ(4 * defaultEdgeWeight, this->Ghouse.volume(1));
-        ASSERT_EQ(6 * defaultEdgeWeight, this->Ghouse.volume(2));
-        ASSERT_EQ(3 * defaultEdgeWeight, this->Ghouse.volume(3));
-        ASSERT_EQ(3 * defaultEdgeWeight, this->Ghouse.volume(4));
+        ASSERT_EQ(2 * defaultEdgeWeight, this->Ghouse.weightedDegree(0, true));
+        ASSERT_EQ(4 * defaultEdgeWeight, this->Ghouse.weightedDegree(1, true));
+        ASSERT_EQ(6 * defaultEdgeWeight, this->Ghouse.weightedDegree(2, true));
+        ASSERT_EQ(3 * defaultEdgeWeight, this->Ghouse.weightedDegree(3, true));
+        ASSERT_EQ(3 * defaultEdgeWeight, this->Ghouse.weightedDegree(4, true));
     }
 
     if (isWeightedGraph()) {
-        ASSERT_EQ(5.0, this->Ghouse.volume(0));
-        ASSERT_EQ(12.0, this->Ghouse.volume(1));
-        ASSERT_EQ(23.5, this->Ghouse.volume(2));
-        ASSERT_EQ(14.0, this->Ghouse.volume(3));
-        ASSERT_EQ(19.0, this->Ghouse.volume(4));
+        ASSERT_EQ(5.0, this->Ghouse.weightedDegree(0, true));
+        ASSERT_EQ(12.0, this->Ghouse.weightedDegree(1, true));
+        ASSERT_EQ(23.5, this->Ghouse.weightedDegree(2, true));
+        ASSERT_EQ(14.0, this->Ghouse.weightedDegree(3, true));
+        ASSERT_EQ(19.0, this->Ghouse.weightedDegree(4, true));
     }
 
     if (isDirectedGraph()) {
         // only count outgoing edges
-        ASSERT_EQ(1 * defaultEdgeWeight, this->Ghouse.volume(0));
-        ASSERT_EQ(2 * defaultEdgeWeight, this->Ghouse.volume(1));
-        ASSERT_EQ(4 * defaultEdgeWeight, this->Ghouse.volume(2));
-        ASSERT_EQ(2 * defaultEdgeWeight, this->Ghouse.volume(3));
-        ASSERT_EQ(1 * defaultEdgeWeight, this->Ghouse.volume(4));
+        ASSERT_EQ(1 * defaultEdgeWeight, this->Ghouse.weightedDegree(0, true));
+        ASSERT_EQ(2 * defaultEdgeWeight, this->Ghouse.weightedDegree(1, true));
+        ASSERT_EQ(4 * defaultEdgeWeight, this->Ghouse.weightedDegree(2, true));
+        ASSERT_EQ(2 * defaultEdgeWeight, this->Ghouse.weightedDegree(3, true));
+        ASSERT_EQ(1 * defaultEdgeWeight, this->Ghouse.weightedDegree(4, true));
     }
 
     if (isWeightedDirectedGraph()) {
         // only sum weight of outgoing edges
-        ASSERT_EQ(3.0, this->Ghouse.volume(0));
-        ASSERT_EQ(7.0, this->Ghouse.volume(1));
-        ASSERT_EQ(13.5, this->Ghouse.volume(2));
-        ASSERT_EQ(8.0, this->Ghouse.volume(3));
-        ASSERT_EQ(6.0, this->Ghouse.volume(4));
+        ASSERT_EQ(3.0, this->Ghouse.weightedDegree(0, true));
+        ASSERT_EQ(7.0, this->Ghouse.weightedDegree(1, true));
+        ASSERT_EQ(13.5, this->Ghouse.weightedDegree(2, true));
+        ASSERT_EQ(8.0, this->Ghouse.weightedDegree(3, true));
+        ASSERT_EQ(6.0, this->Ghouse.weightedDegree(4, true));
+    }
+}
+
+TEST_P(GraphGTest, testWeightedDegree3) {
+    constexpr count n = 100;
+    constexpr double p = 0.1;
+
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, false);
+        auto G = ErdosRenyiGenerator(n, p, isDirected()).generate();
+        if (isWeighted()) {
+            G = Graph(G, true, G.isDirected());
+            G.forEdges([&](node u, node v) { G.setWeight(u, v, Aux::Random::probability()); });
+        }
+        G.forNodes([&](node u) {
+            edgeweight wDeg = 0, wDegTwice = 0;
+            G.forNeighborsOf(u, [&](node v, edgeweight w) {
+                wDeg += w;
+                wDegTwice += (u == v) ? 2. * w : w;
+            });
+
+            EXPECT_DOUBLE_EQ(G.weightedDegree(u), wDeg);
+            EXPECT_DOUBLE_EQ(G.weightedDegree(u, true), wDegTwice);
+
+            edgeweight wInDeg = 0, wInDegTwice = 0;
+            G.forInNeighborsOf(u, [&](node v, edgeweight w) {
+                wInDeg += w;
+                wInDegTwice += (u == v) ? 2. * w : w;
+            });
+
+            EXPECT_DOUBLE_EQ(G.weightedDegreeIn(u), wInDeg);
+            EXPECT_DOUBLE_EQ(G.weightedDegreeIn(u, true), wInDegTwice);
+        });
     }
 }
 

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -16,6 +16,7 @@
 #include <networkit/auxiliary/Parallel.hpp>
 #include <networkit/graph/Graph.hpp>
 #include <networkit/graph/GraphBuilder.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 
@@ -549,24 +550,6 @@ TEST_P(GraphGTest, testWeightedDegree3) {
     }
 }
 
-TEST_P(GraphGTest, testRandomNode) {
-    count n = 4;
-    count samples = 100000;
-    double maxAbsoluteError = 0.005;
-    Aux::Random::setSeed(42, false);
-
-    Graph G = createGraph(n);
-    std::vector<count> drawCounts(n, 0);
-    for (count i = 0; i < samples; i++) {
-        node x = G.randomNode();
-        drawCounts[x]++;
-    }
-    for (node v = 0; v < n; v++) {
-        double p = drawCounts[v] / (double)samples;
-        ASSERT_NEAR(1.0 / n, p, maxAbsoluteError);
-    }
-}
-
 TEST_P(GraphGTest, testRandomNeighbor) {
     Graph G = createGraph(10);
     G.addEdge(2, 0);
@@ -933,12 +916,12 @@ TEST_P(GraphGTest, testIsEmpty) {
     ASSERT_FALSE(G2.isEmpty());
 
     node v = G1.addNode();
-    G2.removeNode(G2.randomNode());
+    G2.removeNode(GraphTools::randomNode(G2));
     ASSERT_FALSE(G1.isEmpty());
     ASSERT_FALSE(G2.isEmpty());
 
     G1.removeNode(v);
-    G2.removeNode(G2.randomNode());
+    G2.removeNode(GraphTools::randomNode(G2));
     ASSERT_TRUE(G1.isEmpty());
     ASSERT_TRUE(G2.isEmpty());
 }
@@ -2075,7 +2058,7 @@ TEST_P(GraphGTest, testRemoveMultiEdges) {
     std::unordered_set<node> uniqueSelfLoops;
     // Adding multiple self-loops at random
     for (count i = 0; i < nMultiSelfLoops; ++i) {
-        node u = G.randomNode();
+        node u = GraphTools::randomNode(G);
         G.addEdge(u, u);
         G.addEdge(u, u);
         uniqueSelfLoops.insert(u);

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -256,52 +256,6 @@ TEST_P(GraphGTest, testCopyConstructor) {
 
 /** GRAPH INFORMATION **/
 
-TEST_P(GraphGTest, testMaxDegree) {
-    constexpr count n = 100;
-    constexpr double p = 0.1;
-    constexpr count edgeUpdates = 10;
-
-    auto computeMaxDeg = [&](const Graph &G, bool inDegree) {
-        count maxDeg = 0;
-        G.forNodes([&](const node u) {
-            maxDeg = std::max(maxDeg, inDegree ? G.degreeIn(u) : G.degreeOut(u));
-        });
-
-    return maxDeg;
-    };
-
-    auto doTest = [&](const Graph &G) {
-        EXPECT_EQ(G.maxDegree(), computeMaxDeg(G, false));
-        EXPECT_EQ(G.maxDegreeIn(), computeMaxDeg(G, true));
-    };
-
-    for (int seed : {1, 2, 3}) {
-        Aux::Random::setSeed(seed, false);
-        auto G = ErdosRenyiGenerator(n, p, isDirected()).generate();
-        if (isWeighted()) {
-            G = Graph(G, true, G.isDirected());
-        }
-
-        doTest(G);
-        for (count i = 0; i < edgeUpdates; ++i) {
-            const auto e = G.randomEdge();
-            G.removeEdge(e.first, e.second);
-            doTest(G);
-        }
-
-        for (count i = 0; i < edgeUpdates; ++i) {
-            node u = G.randomNode();
-            node v = G.randomNode();
-            while (G.hasEdge(u, v)) {
-                u = G.randomNode();
-                v = G.randomNode();
-            }
-            G.addEdge(u, v);
-            doTest(G);
-        }
-    }
-}
-
 TEST_P(GraphGTest, testMaxWeightedDegreeUndirected) {
     Aux::Random::setSeed(1, false);
     Graph G = ErdosRenyiGenerator(20, 0.2, false).generate();

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -798,7 +798,7 @@ TEST_P(GraphGTest, testRemoveMultiEdges) {
 
         // Adding multiedges at random
         for (count i = 0; i < nMultiEdges; ++i) {
-            const auto e = g.randomEdge();
+            const auto e = GraphTools::randomEdge(g);
             g.addEdge(e.first, e.second);
         }
 
@@ -848,34 +848,6 @@ TEST_P(GraphGTest, testHasEdge) {
     }
 }
 
-TEST_P(GraphGTest, testRandomEdge) {
-    Aux::Random::setSeed(1, false);
-    // we only test the uniform version
-    constexpr count n = 4;
-    constexpr count m = 5;
-    constexpr count samples = 100000;
-    constexpr double maxAbsoluteError = 0.005;
-
-    Graph G = createGraph(n);
-    G.addEdge(0, 1); // 0 * 1 = 0
-    G.addEdge(1, 2); // 1 * 2 = 2
-    G.addEdge(3, 2); // 3 * 2 = 1 (mod 5)
-    G.addEdge(2, 2); // 2 * 2 = 4
-    G.addEdge(3, 1); // 3 * 1 = 3
-    ASSERT_EQ(m, G.numberOfEdges());
-
-    std::vector<count> drawCounts(m, 0);
-    for (count i = 0; i < samples; ++i) {
-        const auto e = G.randomEdge(true);
-        count id = (e.first * e.second) % 5;
-        drawCounts[id]++;
-    }
-    for (node id = 0; id < m; id++) {
-        double p = drawCounts[id] / (double)samples;
-        ASSERT_NEAR(1.0 / m, p, maxAbsoluteError);
-    }
-}
-
 TEST_P(GraphGTest, testRandomEdges) {
     Aux::Random::setSeed(1, false);
     // we only test the uniform version
@@ -893,7 +865,7 @@ TEST_P(GraphGTest, testRandomEdges) {
     ASSERT_EQ(m, G.numberOfEdges());
 
     std::vector<count> drawCounts(m, 0);
-    for (auto e : G.randomEdges(samples)) {
+    for (const auto e : G.randomEdges(samples)) {
         count id = (e.first * e.second) % 5;
         drawCounts[id]++;
     }
@@ -2056,7 +2028,7 @@ TEST_P(GraphGTest, testEdgeIdsAfterRemove) {
     G.removeNode(5);
     G.removeNode(10);
     while(2*G.numberOfEdges() > original.numberOfEdges()) {
-        auto e = G.randomEdge(false);
+        const auto e = GraphTools::randomEdge(G, false);
         G.removeEdge(e.first, e.second);
     }
     ASSERT_GT(G.numberOfEdges(), original.numberOfEdges() / 3);

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -550,38 +550,6 @@ TEST_P(GraphGTest, testWeightedDegree3) {
     }
 }
 
-TEST_P(GraphGTest, testRandomNeighbor) {
-    Graph G = createGraph(10);
-    G.addEdge(2, 0);
-    G.addEdge(2, 1);
-    G.addEdge(2, 2);
-    G.addEdge(5, 6);
-
-    Aux::Random::setSeed(42, false);
-
-    ASSERT_EQ(none, G.randomNeighbor(3));
-    ASSERT_EQ(6u, G.randomNeighbor(5));
-
-    if (G.isDirected()) {
-        ASSERT_EQ(none, G.randomNeighbor(1));
-    } else {
-        ASSERT_EQ(2u, G.randomNeighbor(1));
-    }
-
-    count nn = 3;
-    count samples = 100000;
-    double maxAbsoluteError = 0.005;
-    std::vector<count> drawCounts(nn, 0);
-    for (count i = 0; i < samples; i++) {
-        node x = G.randomNeighbor(2);
-        drawCounts[x]++;
-    }
-    for (node v = 0; v < nn; v++) {
-        double p = drawCounts[v] / (double)samples;
-        ASSERT_NEAR(1.0 / nn, p, maxAbsoluteError);
-    }
-}
-
 /** EDGE MODIFIERS **/
 
 TEST_P(GraphGTest, testAddEdge) {

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -1112,17 +1112,6 @@ TEST_P(GraphGTest, testCheckConsistency_MultiEdgeDetection) {
     ASSERT_TRUE(G.checkConsistency());
 }
 
-/** DYNAMICS **/
-
-TEST_P(GraphGTest, testTime) {
-    ASSERT_EQ(0u, this->Ghouse.time());
-    this->Ghouse.timeStep();
-    ASSERT_EQ(1u, this->Ghouse.time());
-    this->Ghouse.timeStep();
-    this->Ghouse.timeStep();
-    ASSERT_EQ(3u, this->Ghouse.time());
-}
-
 /** EDGE ATTRIBUTES **/
 
 TEST_P(GraphGTest, testWeight) {
@@ -1344,9 +1333,6 @@ TEST_P(GraphGTest, testTranspose) {
         EXPECT_EQ(G.totalEdgeWeight(), Gtrans.totalEdgeWeight());
         EXPECT_EQ(G.numberOfSelfLoops(), Gtrans.numberOfSelfLoops());
 
-        // check time step
-        EXPECT_EQ(G.time(), Gtrans.time());
-
         // check graph names
         EXPECT_EQ(G.getName() + "Transpose", Gtrans.getName());
 
@@ -1554,9 +1540,6 @@ TEST_P(GraphGTest, testParallelForEdges) {
 
     ASSERT_EQ(6.0, weightSum) << "sum of edge weights should be 6 in every case";
 }
-
-// template<typename L> void forEdgesWithAttribute_double(int attrId, L handle)
-// const;
 
 /** NEIGHBORHOOD ITERATORS **/
 

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -254,36 +254,6 @@ TEST_P(GraphGTest, testCopyConstructor) {
     ASSERT_EQ(m_expected, m);
 }
 
-/** GRAPH INFORMATION **/
-
-TEST_P(GraphGTest, testMaxWeightedDegreeUndirected) {
-    Aux::Random::setSeed(1, false);
-    Graph G = ErdosRenyiGenerator(20, 0.2, false).generate();
-
-    edgeweight maxDegOut = 0.0, maxDegIn = 0.0;
-    G.forNodes([&](const node u) {
-        maxDegOut = std::max(maxDegOut, G.weightedDegree(u));
-        maxDegIn = std::max(maxDegIn, G.weightedDegreeIn(u));
-    });
-
-    ASSERT_EQ(G.maxWeightedDegree(), maxDegOut);
-    ASSERT_EQ(G.maxWeightedDegreeIn(), maxDegIn);
-}
-
-TEST_P(GraphGTest, testMaxWeightedDegreeDirected) {
-    Aux::Random::setSeed(1, false);
-    Graph G = ErdosRenyiGenerator(20, 0.2, true).generate();
-
-    edgeweight maxDegOut = 0.0, maxDegIn = 0.0;
-    G.forNodes([&](const node u) {
-        maxDegOut = std::max(maxDegOut, G.weightedDegree(u));
-        maxDegIn = std::max(maxDegIn, G.weightedDegreeIn(u));
-    });
-
-    ASSERT_EQ(G.maxWeightedDegree(), maxDegOut);
-    ASSERT_EQ(G.maxWeightedDegreeIn(), maxDegIn);
-}
-
 /** NODE MODIFIERS **/
 
 TEST_P(GraphGTest, testAddNode) {

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <networkit/auxiliary/Random.hpp>
+#include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/graph/Graph.hpp>
 #include <networkit/graph/GraphTools.hpp>
 
@@ -316,6 +318,35 @@ TEST_P(GraphToolsGTest, testGetRemappedGraphWithDelete) {
                     ASSERT_EQ(G.weight(i, j), G1.weight(perm[i], perm[j]));
                 }
             }
+        }
+    }
+}
+
+TEST_P(GraphToolsGTest, testCopyNodes) {
+    constexpr count n = 200;
+    constexpr double p = 0.01;
+    constexpr count nodesToDelete = 50;
+
+    auto checkNodes = [&](const Graph &G, const Graph &GCopy) {
+        EXPECT_EQ(G.isDirected(), GCopy.isDirected());
+        EXPECT_EQ(G.isWeighted(), GCopy.isWeighted());
+        EXPECT_EQ(G.numberOfNodes(), GCopy.numberOfNodes());
+        EXPECT_EQ(GCopy.numberOfEdges(), 0);
+        for (node u = 0; u < G.upperNodeIdBound(); ++u) {
+            EXPECT_EQ(G.hasNode(u), GCopy.hasNode(u));
+        }
+    };
+
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, false);
+        auto G = ErdosRenyiGenerator(n, p, directed()).generate();
+
+        auto GCopy = GraphTools::copyNodes(G);
+        checkNodes(G, GCopy);
+        for (count i = 0; i < nodesToDelete; ++i) {
+            G.removeNode(G.randomNode());
+            GCopy = GraphTools::copyNodes(G);
+            checkNodes(G, GCopy);
         }
     }
 }

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -461,4 +461,54 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesDirected) {
 
 }
 
+TEST_P(GraphToolsGTest, testTranspose) {
+    auto G = Graph(4, weighted(), true);
+
+    /**
+     *      1
+     *   /  |  \
+     * 0    |    3
+     *   \  |  /
+     *      2
+     */
+
+    G.addNode(); // node 4
+    G.addNode(); // node 5
+    G.addNode(); // node 6
+    G.removeNode(5);
+
+    G.addEdge(0, 0, 3.14);
+    G.addEdge(0, 4, 3.14);
+    G.removeEdge(0, 4);
+    G.addEdge(0, 6, 3.14);
+
+    // expect throw error when G is undirected
+    if (!G.isDirected()) {
+        EXPECT_ANY_THROW(GraphTools::transpose(G));
+    } else {
+        Graph Gtrans = GraphTools::transpose(G);
+        // check summation statistics
+        EXPECT_EQ(G.numberOfNodes(), Gtrans.numberOfNodes());
+        EXPECT_EQ(G.upperNodeIdBound(), Gtrans.upperNodeIdBound());
+        EXPECT_EQ(G.numberOfEdges(), Gtrans.numberOfEdges());
+        EXPECT_EQ(G.upperEdgeIdBound(), Gtrans.upperEdgeIdBound());
+        EXPECT_EQ(G.totalEdgeWeight(), Gtrans.totalEdgeWeight());
+        EXPECT_EQ(G.numberOfSelfLoops(), Gtrans.numberOfSelfLoops());
+
+        // test for regular edges
+        EXPECT_TRUE(G.hasEdge(0, 6));
+        EXPECT_FALSE(G.hasEdge(6, 0));
+        EXPECT_TRUE(Gtrans.hasEdge(6, 0));
+        EXPECT_FALSE(Gtrans.hasEdge(0, 6));
+        // .. and for selfloops
+        EXPECT_TRUE(G.hasEdge(0, 0));
+        EXPECT_TRUE(Gtrans.hasEdge(0, 0));
+
+        // check for edge weights
+        EXPECT_EQ(G.weight(0, 6), weighted() ? 3.14 : defaultEdgeWeight);
+        EXPECT_EQ(Gtrans.weight(6, 0), weighted() ? 3.14 : defaultEdgeWeight);
+        EXPECT_EQ(G.weight(0, 0), Gtrans.weight(0, 0));
+    }
+}
+
 } // namespace NetworKit

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -76,7 +76,7 @@ TEST_P(GraphToolsGTest, testMaxDegree) {
 
         doTest(G);
         for (count i = 0; i < edgeUpdates; ++i) {
-            const auto e = G.randomEdge();
+            const auto e = GraphTools::randomEdge(G);
             G.removeEdge(e.first, e.second);
             doTest(G);
         }
@@ -147,6 +147,34 @@ TEST_P(GraphToolsGTest, testRandomNeighbor) {
     for (node v = 0; v < nn; v++) {
         double p = static_cast<double>(drawCounts[v]) / static_cast<double>(samples);
         ASSERT_NEAR(1.0 / nn, p, maxAbsoluteError);
+    }
+}
+
+TEST_P(GraphToolsGTest, testRandomEdge) {
+    Aux::Random::setSeed(1, false);
+    // we only test the uniform version
+    constexpr count n = 4;
+    constexpr count m = 5;
+    constexpr count samples = 100000;
+    constexpr double maxAbsoluteError = 0.005;
+
+    Graph G(n, weighted(), directed());
+    G.addEdge(0, 1); // 0 * 1 = 0
+    G.addEdge(1, 2); // 1 * 2 = 2
+    G.addEdge(3, 2); // 3 * 2 = 1 (mod 5)
+    G.addEdge(2, 2); // 2 * 2 = 4
+    G.addEdge(3, 1); // 3 * 1 = 3
+    ASSERT_EQ(m, G.numberOfEdges());
+
+    std::vector<count> drawCounts(m, 0);
+    for (count i = 0; i < samples; ++i) {
+        const auto e = GraphTools::randomEdge(G, true);
+        count id = (e.first * e.second) % 5;
+        drawCounts[id]++;
+    }
+    for (node id = 0; id < m; id++) {
+        double p = static_cast<double>(drawCounts[id]) / static_cast<double>(samples);
+        ASSERT_NEAR(1.0 / m, p, maxAbsoluteError);
     }
 }
 

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -51,9 +51,20 @@ TEST_P(GraphToolsGTest, testMaxDegree) {
         return maxDeg;
     };
 
+    auto computeMaxWeightedDeg = [&](const Graph &G, bool inDegree) {
+        edgeweight maxDeg = std::numeric_limits<edgeweight>::min();
+        G.forNodes([&](const node u) {
+            maxDeg = std::max(maxDeg, inDegree ? G.weightedDegreeIn(u) : G.weightedDegree(u));
+        });
+
+        return maxDeg;
+    };
+
     auto doTest = [&](const Graph &G) {
         EXPECT_EQ(GraphTools::maxDegree(G), computeMaxDeg(G, false));
         EXPECT_EQ(GraphTools::maxInDegree(G), computeMaxDeg(G, true));
+        EXPECT_DOUBLE_EQ(GraphTools::maxWeightedDegree(G), computeMaxWeightedDeg(G, false));
+        EXPECT_DOUBLE_EQ(GraphTools::maxWeightedInDegree(G), computeMaxWeightedDeg(G, true));
     };
 
     for (int seed : {1, 2, 3}) {

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -351,4 +351,114 @@ TEST_P(GraphToolsGTest, testCopyNodes) {
     }
 }
 
+TEST_P(GraphToolsGTest, testSubgraphFromNodesUndirected) {
+    auto G = Graph(4, weighted(), false);
+
+    /**
+     *      1
+     *   /  |  \
+     * 0    |    3
+     *   \  |  /
+     *      2
+     */
+
+    G.addEdge(0, 1, 1.0);
+    G.addEdge(0, 2, 2.0);
+    G.addEdge(3, 1, 4.0);
+    G.addEdge(3, 2, 5.0);
+    G.addEdge(1, 2, 3.0);
+
+    {
+        std::unordered_set<node> nodes = {0};
+        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        EXPECT_EQ(weighted(), res.isWeighted());
+        EXPECT_FALSE(res.isDirected());
+        EXPECT_EQ(res.numberOfNodes(), 1);
+        EXPECT_EQ(res.numberOfEdges(), 0);
+    }
+
+    {
+        std::unordered_set<node> nodes = {0};
+        auto res = GraphTools::subgraphFromNodes(G, nodes, true);
+
+        EXPECT_EQ(res.numberOfNodes(), 3);
+        EXPECT_EQ(res.numberOfEdges(), 2); // 0-1, 0-2, NOT 1-2
+
+        EXPECT_DOUBLE_EQ(G.weight(0, 1), weighted() ? 1.0 : defaultEdgeWeight);
+        EXPECT_DOUBLE_EQ(G.weight(0, 2), weighted() ? 2.0 : defaultEdgeWeight);
+    }
+
+    {
+        std::unordered_set<node> nodes = {0, 1};
+        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        EXPECT_EQ(res.numberOfNodes(), 2);
+        EXPECT_EQ(res.numberOfEdges(), 1); // 0 - 1
+    }
+
+    {
+        std::unordered_set<node> nodes = {0, 1};
+        auto res = GraphTools::subgraphFromNodes(G, nodes, true);
+        EXPECT_EQ(res.numberOfNodes(), 4);
+        EXPECT_EQ(res.numberOfEdges(), 4); // 0-1, 0-2, 1-2, 1-3
+    }
+}
+
+TEST_P(GraphToolsGTest, testSubgraphFromNodesDirected) {
+    auto G = Graph(4, weighted(), true);
+
+    /**
+     *      1
+     *   /  |  \
+     * 0    |    3
+     *   \  |  /
+     *      2
+     */
+
+    G.addEdge(0, 1, 1.0);
+    G.addEdge(0, 2, 2.0);
+    G.addEdge(3, 1, 4.0);
+    G.addEdge(3, 2, 5.0);
+    G.addEdge(1, 2, 3.0);
+
+    {
+        std::unordered_set<node> nodes = {0};
+        auto res = GraphTools::subgraphFromNodes(G, nodes);
+
+        EXPECT_EQ(weighted(), res.isWeighted());
+        EXPECT_TRUE(res.isDirected());
+
+        EXPECT_EQ(res.numberOfNodes(), 1);
+        EXPECT_EQ(res.numberOfEdges(), 0);
+    }
+
+    {
+        std::unordered_set<node> nodes = {0};
+        auto res = GraphTools::subgraphFromNodes(G, nodes, true);
+        EXPECT_EQ(res.numberOfNodes(), 3);
+        EXPECT_EQ(res.numberOfEdges(), 2); // 0->1, 0->2, NOT 1->2
+    }
+
+    {
+        std::unordered_set<node> nodes = {0, 1};
+        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        EXPECT_EQ(res.numberOfNodes(), 2);
+        EXPECT_EQ(res.numberOfEdges(), 1); // 0 -> 1
+    }
+
+    {
+        std::unordered_set<node> nodes = {0, 1};
+        auto res = GraphTools::subgraphFromNodes(G, nodes, true);
+        EXPECT_EQ(res.numberOfNodes(), 3);
+        EXPECT_EQ(res.numberOfEdges(), 3); // 0->1, 0->2, 1->2
+    }
+
+    {
+        std::unordered_set<node> nodes = {0, 1};
+        auto res = GraphTools::subgraphFromNodes(G, nodes, true, true);
+        EXPECT_EQ(res.numberOfNodes(), 4);
+        EXPECT_EQ(res.numberOfEdges(), 4); // 0->1, 0->2, 1->2, 3->1
+    }
+
+}
+
 } // namespace NetworKit

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -37,6 +37,38 @@ bool GraphToolsGTest::weighted() const noexcept { return GetParam().first; }
 
 bool GraphToolsGTest::directed() const noexcept { return GetParam().second; }
 
+TEST_P(GraphToolsGTest, testSize) {
+    constexpr count n = 100;
+    constexpr double p = 0.1;
+    constexpr count updates = 10;
+
+    auto doTest = [](const Graph &G) {
+        const auto size = GraphTools::size(G);
+        EXPECT_EQ(size.first,  G.numberOfNodes());
+        EXPECT_EQ(size.second, G.numberOfEdges());
+    };
+
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, false);
+        auto G = ErdosRenyiGenerator(n, p, directed()).generate();
+        if (weighted()) {
+            G = generateRandomWeights(G);
+        }
+
+        doTest(G);
+        for (count i = 0; i < updates; ++i) {
+            G.removeNode(GraphTools::randomNode(G));
+            doTest(G);
+        }
+
+        for (count i = 0; i < updates && G.numberOfEdges(); ++i) {
+            const auto randomEdge = GraphTools::randomEdge(G);
+            G.removeEdge(randomEdge.first, randomEdge.second);
+            doTest(G);
+        }
+    }
+}
+
 TEST_P(GraphToolsGTest, testMaxDegree) {
     constexpr count n = 100;
     constexpr double p = 0.1;

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -5,6 +5,8 @@
  *      Author: Maximilian Vogel
  */
 
+// networkit-format
+
 #include <gtest/gtest.h>
 
 #include <networkit/auxiliary/Random.hpp>
@@ -21,11 +23,11 @@ protected:
     bool directed() const noexcept;
 };
 
-INSTANTIATE_TEST_CASE_P(InstantiationName, GraphToolsGTest,
-                        testing::Values(std::make_pair(false, false),
-                                        std::make_pair(true, false),
-                                        std::make_pair(false, true),
-                                        std::make_pair(true, true)), ); // comma required for variadic macro
+INSTANTIATE_TEST_CASE_P(
+    InstantiationName, GraphToolsGTest,
+    testing::Values(std::make_pair(false, false), std::make_pair(true, false),
+                    std::make_pair(false, true),
+                    std::make_pair(true, true)), ); // comma required for variadic macro
 
 Graph GraphToolsGTest::generateRandomWeights(const Graph &G) const {
     Graph Gw(G, true, G.isDirected());
@@ -33,9 +35,13 @@ Graph GraphToolsGTest::generateRandomWeights(const Graph &G) const {
     return Gw;
 }
 
-bool GraphToolsGTest::weighted() const noexcept { return GetParam().first; }
+bool GraphToolsGTest::weighted() const noexcept {
+    return GetParam().first;
+}
 
-bool GraphToolsGTest::directed() const noexcept { return GetParam().second; }
+bool GraphToolsGTest::directed() const noexcept {
+    return GetParam().second;
+}
 
 TEST_P(GraphToolsGTest, testSize) {
     constexpr count n = 100;
@@ -44,7 +50,7 @@ TEST_P(GraphToolsGTest, testSize) {
 
     auto doTest = [](const Graph &G) {
         const auto size = GraphTools::size(G);
-        EXPECT_EQ(size.first,  G.numberOfNodes());
+        EXPECT_EQ(size.first, G.numberOfNodes());
         EXPECT_EQ(size.second, G.numberOfEdges());
     };
 
@@ -266,8 +272,9 @@ TEST_P(GraphToolsGTest, testRandomEdges) {
 TEST_P(GraphToolsGTest, testGetContinuousOnContinuous) {
     Graph G(10, weighted(), directed());
     auto nodeIds = GraphTools::getContinuousNodeIds(G);
-    std::unordered_map<node,node> reference = {{0,0},{1,1},{2,2},{3,3},{4,4},{5,5},{6,6},{7,7},{8,8},{9,9}};
-    EXPECT_EQ(reference,nodeIds);
+    std::unordered_map<node, node> reference = {{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4},
+                                                {5, 5}, {6, 6}, {7, 7}, {8, 8}, {9, 9}};
+    EXPECT_EQ(reference, nodeIds);
 }
 
 TEST_P(GraphToolsGTest, testGetContinuousOnDeletedNodes1) {
@@ -278,8 +285,8 @@ TEST_P(GraphToolsGTest, testGetContinuousOnDeletedNodes1) {
     G.removeNode(3);
     G.removeNode(4);
     auto nodeIds = GraphTools::getContinuousNodeIds(G);
-    std::unordered_map<node,node> reference = {{5,0},{6,1},{7,2},{8,3},{9,4}};
-    EXPECT_EQ(reference,nodeIds);
+    std::unordered_map<node, node> reference = {{5, 0}, {6, 1}, {7, 2}, {8, 3}, {9, 4}};
+    EXPECT_EQ(reference, nodeIds);
 }
 
 TEST_P(GraphToolsGTest, testGetContinuousOnDeletedNodes2) {
@@ -290,133 +297,138 @@ TEST_P(GraphToolsGTest, testGetContinuousOnDeletedNodes2) {
     G.removeNode(6);
     G.removeNode(8);
     auto nodeIds = GraphTools::getContinuousNodeIds(G);
-    std::unordered_map<node,node> reference = {{1,0},{3,1},{5,2},{7,3},{9,4}};
-    EXPECT_EQ(reference,nodeIds);
+    std::unordered_map<node, node> reference = {{1, 0}, {3, 1}, {5, 2}, {7, 3}, {9, 4}};
+    EXPECT_EQ(reference, nodeIds);
 }
 
 TEST_F(GraphToolsGTest, testGetCompactedGraphUndirectedUnweighted1) {
-    Graph G(10,false,false);
-    G.addEdge(0,1);
-    G.addEdge(2,1);
-    G.addEdge(0,3);
-    G.addEdge(2,4);
-    G.addEdge(3,6);
-    G.addEdge(4,8);
-    G.addEdge(5,9);
-    G.addEdge(3,7);
-    G.addEdge(5,7);
+    Graph G(10, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(2, 1);
+    G.addEdge(0, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 6);
+    G.addEdge(4, 8);
+    G.addEdge(5, 9);
+    G.addEdge(3, 7);
+    G.addEdge(5, 7);
 
     auto nodeMap = GraphTools::getContinuousNodeIds(G);
-    auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
+    auto Gcompact = GraphTools::getCompactedGraph(G, nodeMap);
 
-    EXPECT_EQ(G.numberOfNodes(),Gcompact.numberOfNodes());
-    EXPECT_EQ(G.numberOfEdges(),Gcompact.numberOfEdges());
-    EXPECT_EQ(G.isDirected(),Gcompact.isDirected());
-    EXPECT_EQ(G.isWeighted(),Gcompact.isWeighted());
+    EXPECT_EQ(G.numberOfNodes(), Gcompact.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), Gcompact.numberOfEdges());
+    EXPECT_EQ(G.isDirected(), Gcompact.isDirected());
+    EXPECT_EQ(G.isWeighted(), Gcompact.isWeighted());
     // TODOish: find a deeper test to check if the structure of the graphs are the same,
-    // probably compare results of some algorithms or compare each edge with a reference node id map.
+    // probably compare results of some algorithms or compare each edge with a reference node id
+    // map.
 }
 
 TEST_F(GraphToolsGTest, testGetCompactedGraphUndirectedUnweighted2) {
-    Graph G(10,false,false);
+    Graph G(10, false, false);
     G.removeNode(0);
     G.removeNode(2);
     G.removeNode(4);
     G.removeNode(6);
     G.removeNode(8);
-    G.addEdge(1,3);
-    G.addEdge(5,3);
-    G.addEdge(7,5);
-    G.addEdge(7,9);
-    G.addEdge(1,9);
+    G.addEdge(1, 3);
+    G.addEdge(5, 3);
+    G.addEdge(7, 5);
+    G.addEdge(7, 9);
+    G.addEdge(1, 9);
 
     auto nodeMap = GraphTools::getContinuousNodeIds(G);
-    auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
+    auto Gcompact = GraphTools::getCompactedGraph(G, nodeMap);
 
-    EXPECT_NE(G.upperNodeIdBound(),Gcompact.upperNodeIdBound());
-    EXPECT_EQ(G.numberOfNodes(),Gcompact.numberOfNodes());
-    EXPECT_EQ(G.numberOfEdges(),Gcompact.numberOfEdges());
-    EXPECT_EQ(G.isDirected(),Gcompact.isDirected());
-    EXPECT_EQ(G.isWeighted(),Gcompact.isWeighted());
+    EXPECT_NE(G.upperNodeIdBound(), Gcompact.upperNodeIdBound());
+    EXPECT_EQ(G.numberOfNodes(), Gcompact.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), Gcompact.numberOfEdges());
+    EXPECT_EQ(G.isDirected(), Gcompact.isDirected());
+    EXPECT_EQ(G.isWeighted(), Gcompact.isWeighted());
     // TODOish: find a deeper test to check if the structure of the graphs are the same,
-    // probably compare results of some algorithms or compare each edge with a reference node id map.
+    // probably compare results of some algorithms or compare each edge with a reference node id
+    // map.
 }
 
 TEST_F(GraphToolsGTest, testGetCompactedGraphUndirectedWeighted1) {
-    Graph G(10,true,false);
+    Graph G(10, true, false);
     G.removeNode(0);
     G.removeNode(2);
     G.removeNode(4);
     G.removeNode(6);
     G.removeNode(8);
-    G.addEdge(1,3,0.2);
-    G.addEdge(5,3,2132.351);
-    G.addEdge(7,5,3.14);
-    G.addEdge(7,9,2.7);
-    G.addEdge(1,9,0.12345);
+    G.addEdge(1, 3, 0.2);
+    G.addEdge(5, 3, 2132.351);
+    G.addEdge(7, 5, 3.14);
+    G.addEdge(7, 9, 2.7);
+    G.addEdge(1, 9, 0.12345);
 
     auto nodeMap = GraphTools::getContinuousNodeIds(G);
-    auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
+    auto Gcompact = GraphTools::getCompactedGraph(G, nodeMap);
 
-    EXPECT_EQ(G.totalEdgeWeight(),Gcompact.totalEdgeWeight());
-    EXPECT_NE(G.upperNodeIdBound(),Gcompact.upperNodeIdBound());
-    EXPECT_EQ(G.numberOfNodes(),Gcompact.numberOfNodes());
-    EXPECT_EQ(G.numberOfEdges(),Gcompact.numberOfEdges());
-    EXPECT_EQ(G.isDirected(),Gcompact.isDirected());
-    EXPECT_EQ(G.isWeighted(),Gcompact.isWeighted());
+    EXPECT_EQ(G.totalEdgeWeight(), Gcompact.totalEdgeWeight());
+    EXPECT_NE(G.upperNodeIdBound(), Gcompact.upperNodeIdBound());
+    EXPECT_EQ(G.numberOfNodes(), Gcompact.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), Gcompact.numberOfEdges());
+    EXPECT_EQ(G.isDirected(), Gcompact.isDirected());
+    EXPECT_EQ(G.isWeighted(), Gcompact.isWeighted());
     // TODOish: find a deeper test to check if the structure of the graphs are the same,
-    // probably compare results of some algorithms or compare each edge with a reference node id map.
+    // probably compare results of some algorithms or compare each edge with a reference node id
+    // map.
 }
 
 TEST_F(GraphToolsGTest, testGetCompactedGraphDirectedWeighted1) {
-    Graph G(10,true,true);
+    Graph G(10, true, true);
     G.removeNode(0);
     G.removeNode(2);
     G.removeNode(4);
     G.removeNode(6);
     G.removeNode(8);
-    G.addEdge(1,3,0.2);
-    G.addEdge(5,3,2132.351);
-    G.addEdge(7,5,3.14);
-    G.addEdge(7,9,2.7);
-    G.addEdge(1,9,0.12345);
+    G.addEdge(1, 3, 0.2);
+    G.addEdge(5, 3, 2132.351);
+    G.addEdge(7, 5, 3.14);
+    G.addEdge(7, 9, 2.7);
+    G.addEdge(1, 9, 0.12345);
 
     auto nodeMap = GraphTools::getContinuousNodeIds(G);
-    auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
+    auto Gcompact = GraphTools::getCompactedGraph(G, nodeMap);
 
-    EXPECT_EQ(G.totalEdgeWeight(),Gcompact.totalEdgeWeight());
-    EXPECT_NE(G.upperNodeIdBound(),Gcompact.upperNodeIdBound());
-    EXPECT_EQ(G.numberOfNodes(),Gcompact.numberOfNodes());
-    EXPECT_EQ(G.numberOfEdges(),Gcompact.numberOfEdges());
-    EXPECT_EQ(G.isDirected(),Gcompact.isDirected());
-    EXPECT_EQ(G.isWeighted(),Gcompact.isWeighted());
+    EXPECT_EQ(G.totalEdgeWeight(), Gcompact.totalEdgeWeight());
+    EXPECT_NE(G.upperNodeIdBound(), Gcompact.upperNodeIdBound());
+    EXPECT_EQ(G.numberOfNodes(), Gcompact.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), Gcompact.numberOfEdges());
+    EXPECT_EQ(G.isDirected(), Gcompact.isDirected());
+    EXPECT_EQ(G.isWeighted(), Gcompact.isWeighted());
     // TODOish: find a deeper test to check if the structure of the graphs are the same,
-    // probably compare results of some algorithms or compare each edge with a reference node id map.
+    // probably compare results of some algorithms or compare each edge with a reference node id
+    // map.
 }
 
 TEST_F(GraphToolsGTest, testGetCompactedGraphDirectedUnweighted1) {
-    Graph G(10,false,true);
+    Graph G(10, false, true);
     G.removeNode(0);
     G.removeNode(2);
     G.removeNode(4);
     G.removeNode(6);
     G.removeNode(8);
-    G.addEdge(1,3);
-    G.addEdge(5,3);
-    G.addEdge(7,5);
-    G.addEdge(7,9);
-    G.addEdge(1,9);
+    G.addEdge(1, 3);
+    G.addEdge(5, 3);
+    G.addEdge(7, 5);
+    G.addEdge(7, 9);
+    G.addEdge(1, 9);
     auto nodeMap = GraphTools::getContinuousNodeIds(G);
-    auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
+    auto Gcompact = GraphTools::getCompactedGraph(G, nodeMap);
 
-    EXPECT_EQ(G.totalEdgeWeight(),Gcompact.totalEdgeWeight());
-    EXPECT_NE(G.upperNodeIdBound(),Gcompact.upperNodeIdBound());
-    EXPECT_EQ(G.numberOfNodes(),Gcompact.numberOfNodes());
-    EXPECT_EQ(G.numberOfEdges(),Gcompact.numberOfEdges());
-    EXPECT_EQ(G.isDirected(),Gcompact.isDirected());
-    EXPECT_EQ(G.isWeighted(),Gcompact.isWeighted());
+    EXPECT_EQ(G.totalEdgeWeight(), Gcompact.totalEdgeWeight());
+    EXPECT_NE(G.upperNodeIdBound(), Gcompact.upperNodeIdBound());
+    EXPECT_EQ(G.numberOfNodes(), Gcompact.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), Gcompact.numberOfEdges());
+    EXPECT_EQ(G.isDirected(), Gcompact.isDirected());
+    EXPECT_EQ(G.isWeighted(), Gcompact.isWeighted());
     // TODOish: find a deeper test to check if the structure of the graphs are the same,
-    // probably compare results of some algorithms or compare each edge with a reference node id map.
+    // probably compare results of some algorithms or compare each edge with a reference node id
+    // map.
 }
 
 TEST_P(GraphToolsGTest, testInvertedMapping) {
@@ -426,49 +438,48 @@ TEST_P(GraphToolsGTest, testInvertedMapping) {
     G.removeNode(4);
     G.removeNode(6);
     G.removeNode(8);
-    G.addEdge(1,3);
-    G.addEdge(5,3);
-    G.addEdge(7,5);
-    G.addEdge(7,9);
-    G.addEdge(1,9);
+    G.addEdge(1, 3);
+    G.addEdge(5, 3);
+    G.addEdge(7, 5);
+    G.addEdge(7, 9);
+    G.addEdge(1, 9);
     auto nodeMap = GraphTools::getContinuousNodeIds(G);
-    auto invertedNodeMap = GraphTools::invertContinuousNodeIds(nodeMap,G);
+    auto invertedNodeMap = GraphTools::invertContinuousNodeIds(nodeMap, G);
 
-    EXPECT_EQ(6,invertedNodeMap.size());
+    EXPECT_EQ(6, invertedNodeMap.size());
 
-    std::vector<node> reference = {1,3,5,7,9,10};
-    EXPECT_EQ(reference,invertedNodeMap);
+    std::vector<node> reference = {1, 3, 5, 7, 9, 10};
+    EXPECT_EQ(reference, invertedNodeMap);
 }
 
 TEST_F(GraphToolsGTest, testRestoreGraph) {
-    Graph G(10,false,true);
+    Graph G(10, false, true);
     G.removeNode(0);
     G.removeNode(2);
     G.removeNode(4);
     G.removeNode(6);
     G.removeNode(8);
-    G.addEdge(1,3);
-    G.addEdge(5,3);
-    G.addEdge(7,5);
-    G.addEdge(7,9);
-    G.addEdge(1,9);
+    G.addEdge(1, 3);
+    G.addEdge(5, 3);
+    G.addEdge(7, 5);
+    G.addEdge(7, 9);
+    G.addEdge(1, 9);
     auto nodeMap = GraphTools::getContinuousNodeIds(G);
-    auto invertedNodeMap = GraphTools::invertContinuousNodeIds(nodeMap,G);
-    std::vector<node> reference = {1,3,5,7,9,10};
+    auto invertedNodeMap = GraphTools::invertContinuousNodeIds(nodeMap, G);
+    std::vector<node> reference = {1, 3, 5, 7, 9, 10};
 
+    EXPECT_EQ(6, invertedNodeMap.size());
+    EXPECT_EQ(reference, invertedNodeMap);
 
-    EXPECT_EQ(6,invertedNodeMap.size());
-    EXPECT_EQ(reference,invertedNodeMap);
+    auto Gcompact = GraphTools::getCompactedGraph(G, nodeMap);
+    Graph Goriginal = GraphTools::restoreGraph(invertedNodeMap, Gcompact);
 
-    auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
-    Graph Goriginal = GraphTools::restoreGraph(invertedNodeMap,Gcompact);
-
-    EXPECT_EQ(Goriginal.totalEdgeWeight(),Gcompact.totalEdgeWeight());
-    EXPECT_NE(Goriginal.upperNodeIdBound(),Gcompact.upperNodeIdBound());
-    EXPECT_EQ(Goriginal.numberOfNodes(),Gcompact.numberOfNodes());
-    EXPECT_EQ(Goriginal.numberOfEdges(),Gcompact.numberOfEdges());
-    EXPECT_EQ(Goriginal.isDirected(),Gcompact.isDirected());
-    EXPECT_EQ(Goriginal.isWeighted(),Gcompact.isWeighted());
+    EXPECT_EQ(Goriginal.totalEdgeWeight(), Gcompact.totalEdgeWeight());
+    EXPECT_NE(Goriginal.upperNodeIdBound(), Gcompact.upperNodeIdBound());
+    EXPECT_EQ(Goriginal.numberOfNodes(), Gcompact.numberOfNodes());
+    EXPECT_EQ(Goriginal.numberOfEdges(), Gcompact.numberOfEdges());
+    EXPECT_EQ(Goriginal.isDirected(), Gcompact.isDirected());
+    EXPECT_EQ(Goriginal.isWeighted(), Gcompact.isWeighted());
 }
 
 TEST_P(GraphToolsGTest, testGetRemappedGraph) {
@@ -481,7 +492,8 @@ TEST_P(GraphToolsGTest, testGetRemappedGraph) {
         G.addEdge(1, 1, 12);
 
     std::vector<node> perm(n);
-    for (int i = 0; i < n; ++i) perm[i] = i;
+    for (int i = 0; i < n; ++i)
+        perm[i] = i;
 
     std::mt19937_64 gen;
     for (int iter = 0; iter < 10; iter++) {
@@ -510,35 +522,36 @@ TEST_P(GraphToolsGTest, testGetRemappedGraphWithDelete) {
         G.addEdge(1, 1, 12);
 
     std::vector<node> perm(n);
-    for (int i = 0; i < n; ++i) perm[i] = i;
+    for (int i = 0; i < n; ++i)
+        perm[i] = i;
 
     std::mt19937_64 gen;
-    std::uniform_int_distribution<node> distr(0, n-1);
+    std::uniform_int_distribution<node> distr(0, n - 1);
     for (int iter = 0; iter < 10; iter++) {
         std::shuffle(perm.begin(), perm.end(), gen);
 
         const auto del = distr(gen);
 
-        auto G1 = GraphTools::getRemappedGraph(G, n,
-            [&](node i) { return perm[i]; },
-            [&](node i) { return i == del; }
-        );
+        auto G1 = GraphTools::getRemappedGraph(
+            G, n, [&](node i) { return perm[i]; }, [&](node i) { return i == del; });
 
         auto expected_num_edges = G.numberOfEdges();
         expected_num_edges -= G.degree(del);
         if (directed())
             expected_num_edges -= G.degreeIn(del);
-        //do double count self-loops
+        // do double count self-loops
         expected_num_edges += G.hasEdge(del, del);
 
         ASSERT_EQ(G1.numberOfNodes(), n);
         ASSERT_EQ(G1.numberOfEdges(), expected_num_edges) << " del=" << del;
-        ASSERT_EQ(G1.numberOfSelfLoops(), G.numberOfSelfLoops() - G.hasEdge(del, del)) << " del=" << del;
+        ASSERT_EQ(G1.numberOfSelfLoops(), G.numberOfSelfLoops() - G.hasEdge(del, del))
+            << " del=" << del;
 
         for (int i = 0; i < n; ++i) {
             for (int j = 0; i < n; ++i) {
                 if (i == static_cast<int>(del) || j == static_cast<int>(del)) {
-                    ASSERT_FALSE(G1.hasEdge(perm[i], perm[j])) << "i=" << i << " j=" << j << " del=" << del;
+                    ASSERT_FALSE(G1.hasEdge(perm[i], perm[j]))
+                        << "i=" << i << " j=" << j << " del=" << del;
                 } else {
                     ASSERT_EQ(G.hasEdge(i, j), G1.hasEdge(perm[i], perm[j]));
                     ASSERT_EQ(G.weight(i, j), G1.weight(perm[i], perm[j]));
@@ -684,7 +697,6 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesDirected) {
         EXPECT_EQ(res.numberOfNodes(), 4);
         EXPECT_EQ(res.numberOfEdges(), 4); // 0->1, 0->2, 1->2, 3->1
     }
-
 }
 
 TEST_P(GraphToolsGTest, testTranspose) {
@@ -804,7 +816,7 @@ TEST_P(GraphToolsGTest, testAppend) {
     constexpr double p1 = 0.01, p2 = 0.05;
     constexpr count nodesToDelete = 20;
 
-    auto testGraphs = [&] (const Graph &G, const Graph &G1, const Graph &G2) {
+    auto testGraphs = [&](const Graph &G, const Graph &G1, const Graph &G2) {
         EXPECT_EQ(G.numberOfNodes(), G1.numberOfNodes() + G2.numberOfNodes());
         EXPECT_EQ(G.numberOfEdges(), G1.numberOfEdges() + G2.numberOfEdges());
         EXPECT_EQ(G.isDirected(), G1.isDirected());

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -118,6 +118,38 @@ TEST_P(GraphToolsGTest, testRandomNode) {
     }
 }
 
+TEST_P(GraphToolsGTest, testRandomNeighbor) {
+    constexpr count n = 10;
+    auto G = Graph(n, weighted(), directed());
+    G.addEdge(2, 0);
+    G.addEdge(2, 1);
+    G.addEdge(2, 2);
+    G.addEdge(5, 6);
+
+    Aux::Random::setSeed(42, false);
+
+    ASSERT_EQ(none, GraphTools::randomNeighbor(G, 3));
+    ASSERT_EQ(6u, GraphTools::randomNeighbor(G, 5));
+
+    if (G.isDirected()) {
+        ASSERT_EQ(none, GraphTools::randomNeighbor(G, 1));
+    } else {
+        ASSERT_EQ(2u, GraphTools::randomNeighbor(G, 1));
+    }
+
+    constexpr count nn = 3;
+    constexpr count samples = 100000;
+    constexpr double maxAbsoluteError = 0.005;
+    std::vector<count> drawCounts(nn, 0);
+    for (count i = 0; i < samples; i++) {
+        ++drawCounts[GraphTools::randomNeighbor(G, 2)];
+    }
+    for (node v = 0; v < nn; v++) {
+        double p = static_cast<double>(drawCounts[v]) / static_cast<double>(samples);
+        ASSERT_NEAR(1.0 / nn, p, maxAbsoluteError);
+    }
+}
+
 TEST_P(GraphToolsGTest, testGetContinuousOnContinuous) {
     Graph G(10, weighted(), directed());
     auto nodeIds = GraphTools::getContinuousNodeIds(G);

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -69,6 +69,32 @@ TEST_P(GraphToolsGTest, testSize) {
     }
 }
 
+TEST_P(GraphToolsGTest, testDensity) {
+    constexpr count n = 100;
+    constexpr double p = 0.1;
+
+    auto doTest = [](const Graph &G) {
+        const auto density = GraphTools::density(G);
+        EXPECT_TRUE(density >= 0);
+        EXPECT_EQ(density > 0, G.numberOfNodes() > 1 && G.numberOfEdges() - G.numberOfSelfLoops());
+    };
+
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, false);
+        auto G = ErdosRenyiGenerator(n, p, directed()).generate();
+        if (weighted()) {
+            G = generateRandomWeights(G);
+        }
+
+        doTest(G);
+        for (node u = 0; u < G.upperNodeIdBound(); ++u) {
+            if (G.hasNode(u))
+                G.removeNode(u);
+            doTest(G);
+        }
+    }
+}
+
 TEST_P(GraphToolsGTest, testMaxDegree) {
     constexpr count n = 100;
     constexpr double p = 0.1;

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -37,6 +37,52 @@ bool GraphToolsGTest::weighted() const noexcept { return GetParam().first; }
 
 bool GraphToolsGTest::directed() const noexcept { return GetParam().second; }
 
+TEST_P(GraphToolsGTest, testMaxDegree) {
+    constexpr count n = 100;
+    constexpr double p = 0.1;
+    constexpr count edgeUpdates = 10;
+
+    auto computeMaxDeg = [&](const Graph &G, bool inDegree) {
+        count maxDeg = 0;
+        G.forNodes([&](const node u) {
+            maxDeg = std::max(maxDeg, inDegree ? G.degreeIn(u) : G.degreeOut(u));
+        });
+
+        return maxDeg;
+    };
+
+    auto doTest = [&](const Graph &G) {
+        EXPECT_EQ(GraphTools::maxDegree(G), computeMaxDeg(G, false));
+        EXPECT_EQ(GraphTools::maxInDegree(G), computeMaxDeg(G, true));
+    };
+
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, false);
+        auto G = ErdosRenyiGenerator(n, p, directed()).generate();
+        if (weighted()) {
+            G = Graph(G, true, G.isDirected());
+        }
+
+        doTest(G);
+        for (count i = 0; i < edgeUpdates; ++i) {
+            const auto e = G.randomEdge();
+            G.removeEdge(e.first, e.second);
+            doTest(G);
+        }
+
+        for (count i = 0; i < edgeUpdates; ++i) {
+            node u = G.randomNode();
+            node v = G.randomNode();
+            while (G.hasEdge(u, v)) {
+                u = G.randomNode();
+                v = G.randomNode();
+            }
+            G.addEdge(u, v);
+            doTest(G);
+        }
+    }
+}
+
 TEST_P(GraphToolsGTest, testGetContinuousOnContinuous) {
     Graph G(10, weighted(), directed());
     auto nodeIds = GraphTools::getContinuousNodeIds(G);

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -178,6 +178,33 @@ TEST_P(GraphToolsGTest, testRandomEdge) {
     }
 }
 
+TEST_P(GraphToolsGTest, testRandomEdges) {
+    Aux::Random::setSeed(1, false);
+    // we only test the uniform version
+    constexpr count n = 4;
+    constexpr count m = 5;
+    constexpr count samples = 100000;
+    constexpr double maxAbsoluteError = 0.005;
+
+    Graph G(n, weighted(), directed());
+    G.addEdge(0, 1); // 0 * 1 = 0
+    G.addEdge(1, 2); // 1 * 2 = 2
+    G.addEdge(3, 2); // 3 * 2 = 1 (mod 5)
+    G.addEdge(2, 2); // 2 * 2 = 4
+    G.addEdge(3, 1); // 3 * 1 = 3
+    ASSERT_EQ(m, G.numberOfEdges());
+
+    std::vector<count> drawCounts(m, 0);
+    for (const auto e : GraphTools::randomEdges(G, samples)) {
+        const auto id = (e.first * e.second) % 5;
+        ++drawCounts[id];
+    }
+    for (node id = 0; id < m; id++) {
+        const double p = static_cast<double>(drawCounts[id]) / static_cast<double>(samples);
+        ASSERT_NEAR(1.0 / static_cast<double>(m), p, maxAbsoluteError);
+    }
+}
+
 TEST_P(GraphToolsGTest, testGetContinuousOnContinuous) {
     Graph G(10, weighted(), directed());
     auto nodeIds = GraphTools::getContinuousNodeIds(G);

--- a/networkit/cpp/graph/test/TraversalGTest.cpp
+++ b/networkit/cpp/graph/test/TraversalGTest.cpp
@@ -1,0 +1,139 @@
+#include <gtest/gtest.h>
+
+#include <networkit/generators/ErdosRenyiGenerator.hpp>
+#include <networkit/graph/BFS.hpp>
+#include <networkit/graph/DFS.hpp>
+#include <networkit/graph/GraphTools.hpp>
+
+namespace NetworKit {
+
+class TraversalGTest : public testing::TestWithParam<std::pair<bool, bool>> {
+protected:
+    Graph generateRandomWeights(const Graph &G) const;
+    bool weighted() const noexcept;
+    bool directed() const noexcept;
+};
+
+INSTANTIATE_TEST_CASE_P(
+    InstantiationName, TraversalGTest,
+    testing::Values(std::make_pair(false, false), std::make_pair(true, false),
+                    std::make_pair(false, true),
+                    std::make_pair(true, true)), ); // comma required for variadic macro
+
+Graph TraversalGTest::generateRandomWeights(const Graph &G) const {
+    Graph Gw(G, true, G.isDirected());
+    Gw.forEdges([&](node u, node v) { Gw.setWeight(u, v, Aux::Random::probability()); });
+    return Gw;
+}
+
+bool TraversalGTest::weighted() const noexcept { return GetParam().first; }
+
+bool TraversalGTest::directed() const noexcept { return GetParam().second; }
+
+TEST_P(TraversalGTest, testBFSfrom) {
+    constexpr count n = 200;
+    constexpr double p = 0.15;
+    std::vector<unsigned char> visited(n);
+    std::vector<node> sequence;
+    sequence.reserve(n);
+    std::vector<std::pair<node, node>> edgeSequence;
+
+    auto doBFS = [&](const Graph &G, const std::vector<node> &sources) {
+        std::fill(visited.begin(), visited.end(), 0);
+        sequence.clear();
+        edgeSequence.clear();
+        std::queue<node> q;
+
+        for (node source : sources) {
+            q.push(source);
+            visited[source] = 1;
+        }
+
+        do {
+            node u = q.front();
+            q.pop();
+            sequence.push_back(u);
+            G.forNeighborsOf(u, [&](node v) {
+                if (!visited[v]) {
+                    q.push(v);
+                    visited[v] = 1;
+                    edgeSequence.push_back({u, v});
+                }
+            });
+        } while (!q.empty());
+    };
+
+    std::vector<node> randNodes;
+    for (node u = 0; u < n; ++u) {
+        randNodes.push_back(u);
+    }
+
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, false);
+        std::shuffle(randNodes.begin(), randNodes.end(), Aux::Random::getURNG());
+        const auto G = ErdosRenyiGenerator(n, p, directed()).generate();
+        for (count i = 1; i <= n; ++i) {
+            std::vector<node> sources(randNodes.begin(), randNodes.begin() + i);
+            doBFS(G, sources);
+            count curNode = 0;
+            Traversal::BFSfrom(G, sources.begin(), sources.end(),
+                                    [&](node u) { EXPECT_EQ(sequence[curNode++], u); });
+
+            sources.clear();
+            sources.push_back(randNodes[i - 1]);
+            doBFS(G, sources);
+            curNode = 0;
+            Traversal::BFSEdgesFrom(
+                G, randNodes[i - 1], [&](node u, node v, edgeweight, edgeid) {
+                    EXPECT_EQ(edgeSequence[curNode++], std::make_pair(u, v));
+                });
+        }
+    }
+}
+
+TEST_P(TraversalGTest, testDFSfrom) {
+    constexpr count n = 200;
+    constexpr double p = 0.15;
+    std::vector<unsigned char> visited(n);
+    std::vector<node> sequence;
+    sequence.reserve(n);
+    std::vector<std::pair<node, node>> edgeSequence;
+
+    auto doDFS = [&](const Graph &G, node source) {
+        sequence.clear();
+        edgeSequence.clear();
+        std::fill(visited.begin(), visited.end(), 0);
+        visited[source] = 1;
+        std::stack<node> s;
+        s.push(source);
+
+        do {
+            node u = s.top();
+            s.pop();
+            sequence.push_back(u);
+            G.forNeighborsOf(u, [&](node v) {
+                if (!visited[v]) {
+                    s.push(v);
+                    visited[v] = 1;
+                    edgeSequence.push_back({u, v});
+                }
+            });
+        } while (!s.empty());
+    };
+
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, false);
+        const auto G = ErdosRenyiGenerator(n, p, directed()).generate();
+        G.forNodes([&](node source) {
+            doDFS(G, source);
+            count curNode = 0;
+            Traversal::DFSfrom(G, source, [&](node u) { EXPECT_EQ(sequence[curNode++], u); });
+            curNode = 0;
+            Traversal::DFSEdgesFrom(G, source, [&](node u, node v, edgeweight, edgeid) {
+                EXPECT_EQ(edgeSequence[curNode++], std::make_pair(u, v));
+            });
+        });
+    }
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/independentset/test/IndependentSetGTest.cpp
+++ b/networkit/cpp/independentset/test/IndependentSetGTest.cpp
@@ -21,8 +21,6 @@ TEST_F(IndependentSetGTest, debugLuby) {
     ErdosRenyiGenerator generator(n, 0.001);
     Graph G = generator.generate();
 
-    INFO("G: " , G.toString());
-
     Luby luby;
     std::vector<bool> I = luby.run(G);
 
@@ -45,8 +43,6 @@ TEST_F(IndependentSetGTest, debugLubyWithSelfLoops) {
     G.forNodes([&](node u){
         G.addEdge(u,u);
     });
-
-    INFO("G: " , G.toString());
 
     Luby luby;
     std::vector<bool> I = luby.run(G);

--- a/networkit/cpp/linkprediction/LinkPredictor.cpp
+++ b/networkit/cpp/linkprediction/LinkPredictor.cpp
@@ -51,15 +51,14 @@ double LinkPredictor::run(node u, node v) {
 }
 
 std::vector<LinkPredictor::prediction> LinkPredictor::runAll() {
-  std::vector<node> nodes = G->nodes();
   std::vector<std::pair<node, node>> nodePairs;
   // Exclude all node-pairs that are already connected and ensure u != v for all node-pairs (u, v).
-  for (index i = 0; i < nodes.size(); ++i) {
-    for (index j = i + 1; j < nodes.size(); ++j) {
+  G->forNodes([&](node i) {
+    G->forNodes([&](node j) {
       if (!G->hasEdge(i, j))
         nodePairs.push_back(std::make_pair(i, j));
-    }
-  }
+    });
+  });
   return runOn(nodePairs);
 }
 

--- a/networkit/cpp/linkprediction/MissingLinksFinder.cpp
+++ b/networkit/cpp/linkprediction/MissingLinksFinder.cpp
@@ -18,7 +18,9 @@ MissingLinksFinder::MissingLinksFinder(const Graph& G) : G(G) {
 
 std::vector<std::pair<node, node>> MissingLinksFinder::findAtDistance(count k) {
   std::vector<std::pair<node, node>> missingLinks;
-  std::vector<node> nodes = G.nodes();
+  std::vector<node> nodes;
+  nodes.reserve(G.numberOfNodes());
+  G.forNodes([&](node u) { nodes.push_back(u); });
   #pragma omp parallel
   {
     std::vector<std::pair<node, node>> missingLinksPrivate;

--- a/networkit/cpp/linkprediction/RandomLinkSampler.cpp
+++ b/networkit/cpp/linkprediction/RandomLinkSampler.cpp
@@ -5,6 +5,7 @@
  *      Author: Kolja Esders (kolja.esders@student.kit.edu)
  */
 
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/linkprediction/RandomLinkSampler.hpp>
 
 namespace NetworKit {
@@ -24,7 +25,7 @@ Graph byCount(const Graph& G, count numTrainLinks) {
   }
   Graph trainingGraph(G);
   for (count i = 0; i < G.numberOfEdges() - numTrainLinks; ++i) {
-    std::pair<node, node> edgeToRemove = trainingGraph.randomEdge();
+    std::pair<node, node> edgeToRemove = GraphTools::randomEdge(trainingGraph);
     trainingGraph.removeEdge(edgeToRemove.first, edgeToRemove.second);
   }
   return trainingGraph;

--- a/networkit/cpp/scd/ApproximatePageRank.cpp
+++ b/networkit/cpp/scd/ApproximatePageRank.cpp
@@ -8,6 +8,7 @@
 
 #include <utility>
 #include <queue>
+
 #include <networkit/scd/ApproximatePageRank.hpp>
 
 namespace NetworKit {
@@ -19,11 +20,11 @@ ApproximatePageRank::ApproximatePageRank(const Graph& g, double alpha_, double e
 
 void ApproximatePageRank::push(node u, std::queue<node>& activeNodes) {
     double res = pr_res[u].second;
-    double volume = G.volume(u);
+    double volume = G.weightedDegree(u, true);
 
     G.forNeighborsOf(u, [&](node, node v, edgeweight w) {
         double mass = (1.0 - alpha) * res * w / (2.0 * volume);
-        double vol_v = G.volume(v);
+        double vol_v = G.weightedDegree(v, true);
         // the first check is for making sure the node is not added twice.
         // the second check ensures that enough residual is left.
         if ( pr_res[v].second < vol_v * eps && (pr_res[v].second + mass) >= eps * vol_v ) {

--- a/networkit/cpp/scd/PageRankNibble.cpp
+++ b/networkit/cpp/scd/PageRankNibble.cpp
@@ -24,7 +24,7 @@ std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>>
     // order vertices
     TRACE("Before sorting");
     for (size_t i = 0; i < pr.size(); i++) {
-        pr[i].second = pr[i].second / G.volume(pr[i].first);
+        pr[i].second = pr[i].second / G.weightedDegree(pr[i].first, true);
     }
     auto comp([&](const std::pair<node, double>& a, const std::pair<node, double>& b) {
         return a.second > b.second;

--- a/networkit/cpp/simulation/EpidemicSimulationSEIR.cpp
+++ b/networkit/cpp/simulation/EpidemicSimulationSEIR.cpp
@@ -7,7 +7,7 @@
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
-
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/simulation/EpidemicSimulationSEIR.hpp>
 
 namespace NetworKit {
@@ -81,7 +81,7 @@ void EpidemicSimulationSEIR::run() {
 
     // if starting node node provided, start with random node
     if (zero == none) {
-        zero = G.randomNode();
+        zero = GraphTools::randomNode(G);
     }
     INFO("zero node: ", zero);
     setState(zero, State::I);	// infect node zero

--- a/networkit/cpp/sparsification/ForestFireScore.cpp
+++ b/networkit/cpp/sparsification/ForestFireScore.cpp
@@ -5,12 +5,14 @@
  *      Author: Gerd Lindner
  */
 
-#include <networkit/sparsification/ForestFireScore.hpp>
 #include <limits>
-#include <set>
 #include <queue>
+#include <set>
+
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/sparsification/ForestFireScore.hpp>
 
 namespace NetworKit {
 
@@ -29,7 +31,7 @@ void ForestFireScore::run() {
         //Start a new fire
         std::queue<node> activeNodes;
         std::vector<bool> visited (G.upperNodeIdBound(), false);
-        activeNodes.push(G.randomNode());
+        activeNodes.push(GraphTools::randomNode(G));
 
         auto forwardNeighbors = [&](node u) {
             std::vector<std::pair<node, edgeid>> validEdges;

--- a/networkit/cpp/sparsification/RandomNodeEdgeScore.cpp
+++ b/networkit/cpp/sparsification/RandomNodeEdgeScore.cpp
@@ -47,7 +47,7 @@ void RandomNodeEdgeScore::run() {
                 }
             }
         } else { // random node - edge
-            auto edge = sparseGraph.randomEdge();
+            const auto edge = GraphTools::randomEdge(sparseGraph);
 
             edgeid id = sparseGraph.edgeId(edge.first, edge.second);
 

--- a/networkit/cpp/sparsification/RandomNodeEdgeScore.cpp
+++ b/networkit/cpp/sparsification/RandomNodeEdgeScore.cpp
@@ -5,8 +5,9 @@
  *      Author: Michael Hamann
  */
 
-#include <networkit/sparsification/RandomNodeEdgeScore.hpp>
 #include <networkit/auxiliary/Random.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/sparsification/RandomNodeEdgeScore.hpp>
 
 namespace NetworKit {
 
@@ -29,7 +30,7 @@ void RandomNodeEdgeScore::run() {
 
             while (!edgeFound) {
                 if (uniformlyRandomEdges.empty()) {
-                    uniformlyRandomEdges = sparseGraph.randomEdges(sparseGraph.numberOfEdges() * (1.0 - rneRatio) + 20);
+                    uniformlyRandomEdges = GraphTools::randomEdges(sparseGraph, sparseGraph.numberOfEdges() * (1.0 - rneRatio) + 20);
                 }
 
                 auto edge = uniformlyRandomEdges.back();

--- a/networkit/cpp/viz/PivotMDS.cpp
+++ b/networkit/cpp/viz/PivotMDS.cpp
@@ -16,6 +16,8 @@
 #include <networkit/distance/BFS.hpp>
 #include <networkit/distance/Dijkstra.hpp>
 
+#include <networkit/graph/GraphTools.hpp>
+
 namespace NetworKit {
 
 PivotMDS::PivotMDS(const Graph &graph, count dim, count numPivots)
@@ -115,7 +117,7 @@ std::vector<node> PivotMDS::computePivots() {
 
     index pivotIdx = 0;
     while (pivotIdx < numPivots) {
-        node pivotCandidate = G.randomNode();
+        node pivotCandidate = GraphTools::randomNode(G);
         if (!pivot[pivotCandidate]) {
             pivots[pivotIdx++] = pivotCandidate;
             pivot[pivotCandidate] = true;

--- a/networkit/graph.py
+++ b/networkit/graph.py
@@ -1,2 +1,2 @@
 # extension imports
-from _NetworKit import Graph, SpanningForest, GraphTools, RandomMaximumSpanningForest, UnionMaximumSpanningForest, Traversal
+from _NetworKit import Graph, SpanningForest, RandomMaximumSpanningForest, UnionMaximumSpanningForest, Traversal

--- a/networkit/graph.py
+++ b/networkit/graph.py
@@ -1,2 +1,2 @@
 # extension imports
-from _NetworKit import Graph, SpanningForest, GraphTools, RandomMaximumSpanningForest, UnionMaximumSpanningForest
+from _NetworKit import Graph, SpanningForest, GraphTools, RandomMaximumSpanningForest, UnionMaximumSpanningForest, Traversal

--- a/networkit/profiling/profiling.py
+++ b/networkit/profiling/profiling.py
@@ -730,7 +730,7 @@ class Profile:
 		self.__properties["Name"] = self.__G.getName()
 		self.__properties["Nodes"] = self.__G.numberOfNodes()
 		self.__properties["Edges"] = self.__G.numberOfEdges()
-		self.__properties["Density"] = self.__G.density()
+		self.__properties["Density"] = kit.graphtools.density(self.__G)
 		self.__properties["Directed"] = self.__G.isDirected()
 		self.__properties["Weighted"] = self.__G.isWeighted()
 		self.__properties["Self Loops"] = self.__G.numberOfSelfLoops()

--- a/networkit/sampling.py
+++ b/networkit/sampling.py
@@ -5,7 +5,7 @@ __author__ = "Elisabetta Bergamini"
 def bfsSample(G, source=None, k = 50):
     """ Start a BFS from source node, return node-induced subgraph of the first k nodes discovered"""
     if not source:
-        source = G.randomNode()
+        source = nk.graphtools.randomNode(G)
     n = G.numberOfNodes()
     visited = [False]*n
     Q = [source]

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -313,10 +313,10 @@ class Test_SelfLoops(unittest.TestCase):
 	def test_flow_EdmondsKarp(self):
 		self.L.indexEdges()
 		self.LL.indexEdges()
-		r1 = self.L.randomNode()
-		r2 = self.L.randomNode()
+		r1 = graphtools.randomNode(self.L)
+		r2 = graphtools.randomNode(self.L)
 		while r1 is r2:
-			r2 = self.L.randomNode()
+			r2 = graphtools.randomNode(self.L)
 		EKL = flow.EdmondsKarp(self.L, r1, r2)
 		EKLL = flow.EdmondsKarp(self.LL, r1, r2)
 		EKL.run()

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -367,7 +367,7 @@ class Test_SelfLoops(unittest.TestCase):
 		bcc.run()
 
 		for component in bcc.getComponents():
-			G1 = self.LL.subgraphFromNodes(component, False, False)
+			G1 = graphtools.subgraphFromNodes(self.LL, component)
 			def test_node(v):
 				G2 = Graph(G1)
 				G2.removeNode(v)

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -279,5 +279,76 @@ class TestGraph(unittest.TestCase):
 		self.assertEqual(G.numberOfNodes(), 3)
 		self.assertEqual(G.numberOfEdges(), 2)
 
+	def testMaxDegree(self):
+		n = 100
+		p = 0.2
+		edgeUpdates = 10
+
+		def computeMaxDeg(G, inDegree = False):
+			nodes = []
+			G.forNodes(lambda u: nodes.append(u))
+			maxDeg = 0
+			for u in nodes:
+				maxDeg = max(maxDeg, G.degreeIn(u) if inDegree else G.degreeOut(u))
+			return maxDeg
+
+		def doTest(G):
+			self.assertEqual(G.maxDegree(), computeMaxDeg(G))
+			self.assertEqual(G.maxDegreeIn(), computeMaxDeg(G, True))
+
+		for seed in range(1, 4):
+			nk.setSeed(seed, False)
+			for directed in [True, False]:
+				for weighted in [True, False]:
+					G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
+					if weighted:
+						G = nk.graph.GraphTools.toWeighted(G)
+
+					doTest(G)
+					for _ in range(edgeUpdates):
+						e = G.randomEdge()
+						G.removeEdge(e[0], e[1])
+						doTest(G)
+
+					for _ in range(edgeUpdates):
+						e = G.randomNode(), G.randomNode()
+						while G.hasEdge(e[0], e[1]):
+							e = G.randomNode(), G.randomNode()
+						G.addEdge(e[0], e[1])
+						doTest(G)
+
+	def testWeightedDegree(self):
+		n = 100
+		p = 0.2
+
+		for seed in range(1, 4):
+			nk.setSeed(seed, False)
+			random.seed(seed)
+			for directed in [True, False]:
+				for weighted in [True, False]:
+					G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
+					if weighted:
+						G = nk.graph.GraphTools.toWeighted(G)
+						G.forEdges(lambda u, v, w, eid: G.setWeight(u, v, random.random()))
+
+					def testWeightedDegreeOfNode(u):
+						wDeg, wDegTwice = 0, 0
+						for v in G.iterNeighbors(u):
+							w = G.weight(u, v)
+							wDeg += w
+							wDegTwice += w if u != v else 2 * w
+
+						self.assertEqual(G.weightedDegre(u), wDeg)
+						self.assertEqual(G.weightedDegre(u, True), wDegTwice)
+
+						wInDeg, wInDegTwice = 0, 0
+						for v in G.iterInNeighbors(u):
+							w = G.weight(v, u)
+							wInDeg += w
+							wInDegTwice += w if u != v else 2 * w
+
+						self.assertEqual(G.weightedDegreeIn(u), wInDeg)
+						self.assertEqual(G.weightedDegreeIn(u, True), wInDegTwice)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -302,7 +302,7 @@ class TestGraph(unittest.TestCase):
 				for weighted in [True, False]:
 					G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
 					if weighted:
-						G = nk.graph.GraphTools.toWeighted(G)
+						G = nk.graphtools.toWeighted(G)
 
 					doTest(G)
 					for _ in range(edgeUpdates):
@@ -328,7 +328,7 @@ class TestGraph(unittest.TestCase):
 				for weighted in [True, False]:
 					G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
 					if weighted:
-						G = nk.graph.GraphTools.toWeighted(G)
+						G = nk.graphtools.toWeighted(G)
 						G.forEdges(lambda u, v, w, eid: G.setWeight(u, v, random.random()))
 
 					def testWeightedDegreeOfNode(u):

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -102,7 +102,7 @@ class TestGraph(unittest.TestCase):
 			for repeats in range(numRepeats):
 				for seed in range(numSeeds):
 					nk.setSeed(seed, False)
-					results[seed].append(G.randomEdges(numSamples))
+					results[seed].append(nk.graphtools.randomEdges(G, numSamples))
 
 			# assert results are different for different seeds
 			for seed in range(1, numSeeds):

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -186,44 +186,6 @@ class TestGraph(unittest.TestCase):
 		self.assertEqual(G.numberOfNodes(), 3)
 		self.assertEqual(G.numberOfEdges(), 2)
 
-	def testMaxDegree(self):
-		n = 100
-		p = 0.2
-		edgeUpdates = 10
-
-		def computeMaxDeg(G, inDegree = False):
-			nodes = []
-			G.forNodes(lambda u: nodes.append(u))
-			maxDeg = 0
-			for u in nodes:
-				maxDeg = max(maxDeg, G.degreeIn(u) if inDegree else G.degreeOut(u))
-			return maxDeg
-
-		def doTest(G):
-			self.assertEqual(G.maxDegree(), computeMaxDeg(G))
-			self.assertEqual(G.maxDegreeIn(), computeMaxDeg(G, True))
-
-		for seed in range(1, 4):
-			nk.setSeed(seed, False)
-			for directed in [True, False]:
-				for weighted in [True, False]:
-					G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
-					if weighted:
-						G = nk.graphtools.toWeighted(G)
-
-					doTest(G)
-					for _ in range(edgeUpdates):
-						e = G.randomEdge()
-						G.removeEdge(e[0], e[1])
-						doTest(G)
-
-					for _ in range(edgeUpdates):
-						e = G.randomNode(), G.randomNode()
-						while G.hasEdge(e[0], e[1]):
-							e = G.randomNode(), G.randomNode()
-						G.addEdge(e[0], e[1])
-						doTest(G)
-
 	def testWeightedDegree(self):
 		n = 100
 		p = 0.2

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -14,58 +14,6 @@ class TestGraph(unittest.TestCase):
 
 		return G
 
-	def testSubgraphFromNodesDirected(self):
-		G = self.getSmallGraph(True, True)
-
-		res = G.subgraphFromNodes([0])
-		self.assertTrue(res.isWeighted())
-		self.assertTrue(res.isDirected())
-		self.assertEqual(res.numberOfNodes(), 1)
-		self.assertEqual(res.numberOfEdges(), 0)
-
-		res = G.subgraphFromNodes([0], True)
-		self.assertEqual(res.numberOfNodes(), 3)
-		self.assertEqual(res.numberOfEdges(), 2)
-
-		res = G.subgraphFromNodes([0, 1])
-		self.assertEqual(res.numberOfNodes(), 2)
-		self.assertEqual(res.numberOfEdges(), 1)
-
-		res = G.subgraphFromNodes([0, 1], True)
-		self.assertEqual(res.numberOfNodes(), 3)
-		self.assertEqual(res.numberOfEdges(), 3)
-
-		res = G.subgraphFromNodes([0, 1], True, True)
-		self.assertEqual(res.numberOfNodes(), 4)
-		self.assertEqual(res.numberOfEdges(), 4)
-
-	def testSubgraphFromNodesUndirected(self):
-		G = self.getSmallGraph(True, False)
-
-		res = G.subgraphFromNodes([0])
-		self.assertTrue(res.isWeighted())
-		self.assertFalse(res.isDirected())
-		self.assertEqual(res.numberOfNodes(), 1)
-		self.assertEqual(res.numberOfEdges(), 0)
-
-		res = G.subgraphFromNodes([0], True)
-		self.assertEqual(res.numberOfNodes(), 3)
-		self.assertEqual(res.numberOfEdges(), 2)
-		self.assertEqual(G.weight(0, 1), 1.0)
-		self.assertEqual(G.weight(0, 2), 2.0)
-
-		res = G.subgraphFromNodes([0, 1])
-		self.assertEqual(res.numberOfNodes(), 2)
-		self.assertEqual(res.numberOfEdges(), 1)
-
-		res = G.subgraphFromNodes([0, 1], True)
-		self.assertEqual(res.numberOfNodes(), 4)
-		self.assertEqual(res.numberOfEdges(), 4)
-
-		res = G.subgraphFromNodes(set([0, 1]), True)
-		self.assertEqual(res.numberOfNodes(), 4)
-		self.assertEqual(res.numberOfEdges(), 4)
-
 	def testRemoveMultiEdges(self):
 
 		def addMultiEdges(G, nMultiEdges):
@@ -120,47 +68,6 @@ class TestGraph(unittest.TestCase):
 		self.assertEqual(sorted(G.neighbors(1)), [0, 2, 3])
 		self.assertEqual(sorted(G.neighbors(2)), [0, 1, 3])
 		self.assertEqual(sorted(G.neighbors(3)), [1, 2])
-
-	def testGraphTranspose(self):
-		nk.setSeed(1, True)
-		G = nk.generators.ErdosRenyiGenerator(100, 0.2, True).generate()
-
-		for i in range(20):
-			u = G.randomNode()
-			if not G.hasEdge(u, u):
-				G.addEdge(u, u)
-		self.assertGreater(G.numberOfSelfLoops(), 0)
-
-		# Delete a few nodes
-		for i in range(10):
-			G.removeNode(G.randomNode())
-		self.assertGreater(G.numberOfSelfLoops(), 0)
-
-		# Assign random weights
-		GWeighted = nk.Graph(G, True, True)
-		for u, v in GWeighted.edges():
-			GWeighted.setWeight(u, v, random.random())
-
-		GWeighted.indexEdges()
-
-		GTrans = GWeighted.transpose()
-
-		for u, v in GWeighted.edges():
-			self.assertEqual(GWeighted.edgeId(u, v), GTrans.edgeId(v, u))
-			self.assertEqual(GWeighted.weight(u, v), GTrans.weight(v, u))
-
-		for v, u in GTrans.edges():
-			self.assertEqual(GWeighted.edgeId(u, v), GTrans.edgeId(v, u))
-			self.assertEqual(GWeighted.weight(u, v), GTrans.weight(v, u))
-
-		for u in range(GWeighted.upperNodeIdBound()):
-			self.assertEqual(GWeighted.hasNode(u), GTrans.hasNode(u))
-
-		self.assertEqual(GWeighted.upperEdgeIdBound(),  GTrans.upperEdgeIdBound())
-		self.assertEqual(GWeighted.upperNodeIdBound(),  GTrans.upperNodeIdBound())
-		self.assertEqual(GWeighted.numberOfSelfLoops(), GTrans.numberOfSelfLoops())
-		self.assertEqual(GWeighted.numberOfNodes(),     GTrans.numberOfNodes())
-		self.assertEqual(GWeighted.numberOfEdges(),     GTrans.numberOfEdges())
 
 	def testRandomEdgesReproducibility(self):
 		numSamples = 10

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -14,6 +14,14 @@ class TestGraph(unittest.TestCase):
 
 		return G
 
+	def testRemoveAllEdges(self):
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				G = self.getSmallGraph(weighted, directed)
+				G.removeAllEdges()
+				self.assertEqual(G.numberOfEdges(), 0)
+				G.forNodePairs(lambda u, v: self.assertFalse(G.hasEdge(u, v)))
+
 	def testRemoveMultiEdges(self):
 
 		def addMultiEdges(G, nMultiEdges):

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -186,38 +186,5 @@ class TestGraph(unittest.TestCase):
 		self.assertEqual(G.numberOfNodes(), 3)
 		self.assertEqual(G.numberOfEdges(), 2)
 
-	def testWeightedDegree(self):
-		n = 100
-		p = 0.2
-
-		for seed in range(1, 4):
-			nk.setSeed(seed, False)
-			random.seed(seed)
-			for directed in [True, False]:
-				for weighted in [True, False]:
-					G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
-					if weighted:
-						G = nk.graphtools.toWeighted(G)
-						G.forEdges(lambda u, v, w, eid: G.setWeight(u, v, random.random()))
-
-					def testWeightedDegreeOfNode(u):
-						wDeg, wDegTwice = 0, 0
-						for v in G.iterNeighbors(u):
-							w = G.weight(u, v)
-							wDeg += w
-							wDegTwice += w if u != v else 2 * w
-
-						self.assertEqual(G.weightedDegre(u), wDeg)
-						self.assertEqual(G.weightedDegre(u, True), wDegTwice)
-
-						wInDeg, wInDegTwice = 0, 0
-						for v in G.iterInNeighbors(u):
-							w = G.weight(v, u)
-							wInDeg += w
-							wInDegTwice += w if u != v else 2 * w
-
-						self.assertEqual(G.weightedDegreeIn(u), wInDeg)
-						self.assertEqual(G.weightedDegreeIn(u, True), wInDegTwice)
-
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -22,31 +22,44 @@ class TestGraph(unittest.TestCase):
 				self.assertEqual(G.numberOfEdges(), 0)
 				G.forNodePairs(lambda u, v: self.assertFalse(G.hasEdge(u, v)))
 
+	def testRemoveSelfLoops(self):
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				g  = self.getSmallGraph(weighted, directed)
+				for i in range(10):
+					u = nk.graphtools.randomNode(g)
+					g.addEdge(u, u)
+
+				nSelfLoops = g.numberOfSelfLoops()
+				nEdges = g.numberOfEdges()
+
+				g.removeSelfLoops()
+
+				self.assertEqual(nEdges - nSelfLoops, g.numberOfEdges())
+				self.assertEqual(g.numberOfSelfLoops(), 0)
+
+				g.forNodes(lambda u: self.assertFalse(g.hasEdge(u, u)))
+
 	def testRemoveMultiEdges(self):
+		nMultiedges = 5
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				G = self.getSmallGraph(weighted, directed)
+				nEdges = G.numberOfEdges()
 
-		def addMultiEdges(G, nMultiEdges):
-			for i in range(nMultiEdges):
-				e = G.randomEdge()
-				G.addEdge(e[0], e[1])
-			return G
+				for _ in range(nMultiedges):
+					u, v = G.randomEdge()
+					G.addEdge(u, v)
 
-		def testGraph(G):
-			addMultiEdges(G, nMultiEdges)
-			self.assertEqual(G.numberOfEdges(), m + nMultiEdges)
-			G.removeMultiEdges()
-			self.assertEqual(G.numberOfEdges(), m)
+				G.removeMultiEdges()
+				self.assertEqual(G.numberOfEdges(), nEdges)
 
-		nMultiEdges = 5
+				for _ in range(nEdges):
+					u, v = G.randomEdge()
+					G.removeEdge(u, v)
+					self.assertFalse(G.hasEdge(u, v))
+				self.assertEqual(G.numberOfEdges(), 0)
 
-		# Directed
-		G = self.getSmallGraph(True, True)
-		m = G.numberOfEdges()
-		testGraph(G)
-
-		# Undirected
-		G = self.getSmallGraph(True, False)
-		m = G.numberOfEdges()
-		testGraph(G)
 
 	def testNeighbors(self):
 		# Directed

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -48,14 +48,14 @@ class TestGraph(unittest.TestCase):
 				nEdges = G.numberOfEdges()
 
 				for _ in range(nMultiedges):
-					u, v = G.randomEdge()
+					u, v = nk.graphtools.randomEdge(G)
 					G.addEdge(u, v)
 
 				G.removeMultiEdges()
 				self.assertEqual(G.numberOfEdges(), nEdges)
 
 				for _ in range(nEdges):
-					u, v = G.randomEdge()
+					u, v = nk.graphtools.randomEdge(G)
 					G.removeEdge(u, v)
 					self.assertFalse(G.hasEdge(u, v))
 				self.assertEqual(G.numberOfEdges(), 0)

--- a/networkit/test/test_graph_traversal.py
+++ b/networkit/test/test_graph_traversal.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+import networkit as nk
+import random
+import unittest
+
+class TestTraversal(unittest.TestCase):
+	def getSmallGraph(self, weighted=False, directed=False):
+		G = nk.Graph(4, weighted, directed)
+		G.addEdge(0, 1, 1.0)
+		G.addEdge(0, 2, 2.0)
+		G.addEdge(3, 1, 4.0)
+		G.addEdge(3, 2, 5.0)
+		G.addEdge(1, 2, 3.0)
+
+		return G
+
+	def generateRandomWeights(self, G):
+		if not G.isWeighted():
+			G = nk.graph.Traversal.toWeighted(G)
+		G.forEdges(lambda u, v, w, eid: G.setWeight(u, v, random.random()))
+
+		return G
+
+	def testBFSfrom(self):
+		n = 200
+		p = 0.15
+
+		def doBFS(G, sources):
+			visited = [False for _ in range(n)]
+			sequence = []
+			edgeSequence = []
+			queue = []
+
+			for source in sources:
+				queue.append(source)
+				visited[source] = True
+
+			while len(queue) > 0:
+				u = queue.pop(0)
+				sequence.append(u)
+				for v in G.neighbors(u):
+					if visited[v] == False:
+						queue.append(v)
+						visited[v] = True
+						edgeSequence.append((u, v))
+
+			return sequence, edgeSequence
+
+		randNodes = [x for x in range(n)]
+
+		for seed in range(1, 4):
+			nk.setSeed(seed, False)
+			random.seed(seed)
+			random.shuffle(randNodes)
+			for directed in [False, True]:
+				G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
+				for i in range(1, n + 1):
+					sources = randNodes[:i]
+					sequence, _ = doBFS(G, sources)
+
+					result = []
+					nk.graph.Traversal.BFSfrom(G, sources, lambda u, d: result.append(u))
+					self.assertListEqual(sequence, result)
+
+					sources = randNodes[i - 1]
+					_, edgeSequence = doBFS(G, [sources])
+
+					result = []
+					nk.graph.Traversal.BFSEdgesFrom(
+						G, sources, lambda u, v, w, eid: result.append((u, v)))
+					self.assertListEqual(edgeSequence, result)
+
+	def testDFSfrom(self):
+		n = 200
+		p = 0.15
+
+		def doDFS(G, source):
+			visited = [False for _ in range(n)]
+			sequence = []
+			edgeSequence = []
+			visited[source] = 1
+			stack = [source]
+
+			while len(stack) > 0:
+				u = stack.pop()
+				sequence.append(u)
+				for v in G.neighbors(u):
+					if visited[v] == False:
+						stack.append(v)
+						visited[v] = True
+						edgeSequence.append((u, v))
+
+			return sequence, edgeSequence
+
+		for seed in range(1, 4):
+			nk.setSeed(seed, False)
+			for directed in [False, True]:
+				G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
+				for source in range(n):
+					sequence, edgeSequence = doDFS(G, source)
+
+					result = []
+					nk.graph.Traversal.DFSfrom(G, source, lambda u: result.append(u))
+					self.assertListEqual(sequence, result)
+
+					result = []
+					nk.graph.Traversal.DFSEdgesFrom(
+						G, source, lambda u, v, w, eid: result.append((u, v)))
+					self.assertListEqual(edgeSequence, result)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -131,6 +131,27 @@ class TestGraphTools(unittest.TestCase):
 						G.removeEdge(u, v)
 						doTest(G)
 
+	def testDensity(self):
+		def doTest(G):
+			d = nk.graphtools.density(G)
+			self.assertGreaterEqual(d, 0)
+			self.assertEqual(
+					d > 0,
+					G.numberOfNodes() >= 1 and G.numberOfEdges() - G.numberOfSelfLoops() > 0)
+
+		n, p = 100, 0.1
+		for seed in range(1, 4):
+			for directed in [True, False]:
+				for weighted in [True, False]:
+					G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
+					if weighted:
+						G = nk.graphtools.toWeighted(G)
+					doTest(G)
+
+					for _ in range(n):
+						G.removeNode(nk.graphtools.randomNode(G))
+						doTest(G)
+
 	def testCopyNodes(self):
 		def checkNodes(G, GCopy):
 			self.assertEqual(G.isDirected(), GCopy.isDirected())

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -105,6 +105,32 @@ class TestGraphTools(unittest.TestCase):
 					for u, v in randomEdges:
 						self.assertTrue(G.hasEdge(u, v))
 
+	def testSize(self):
+		def doTest(G):
+			(n, m) = nk.graphtools.size(G)
+			self.assertEqual(G.numberOfNodes(), n)
+			self.assertEqual(G.numberOfEdges(), m)
+
+		n, p = 100, 0.1
+		for seed in range(1, 4):
+			for directed in [True, False]:
+				for weighted in [True, False]:
+					G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
+					if weighted:
+						G = nk.graphtools.toWeighted(G)
+					doTest(G)
+
+					for _ in range(10):
+						G.removeNode(nk.graphtools.randomNode(G))
+						doTest(G)
+
+					for _ in range(10):
+						if G.numberOfEdges() == 0:
+							break
+						u, v = nk.graphtools.randomEdge(G)
+						G.removeEdge(u, v)
+						doTest(G)
+
 	def testCopyNodes(self):
 		def checkNodes(G, GCopy):
 			self.assertEqual(G.isDirected(), GCopy.isDirected())

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -79,6 +79,16 @@ class TestGraphTools(unittest.TestCase):
 					G.removeNode(i)
 				self.assertEqual(nk.graphtools.randomNode(G), nk.none)
 
+	def testRandomNeighbor(self):
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				G = self.getSmallGraph(weighted, directed)
+				for i in range(10):
+					u = nk.graphtools.randomNode(G)
+					v = nk.graphtools.randomNeighbor(G, u)
+					self.assertNotEqual(G.degree(u) == 0, G.hasNode(v))
+
+
 	def testCopyNodes(self):
 		def checkNodes(G, GCopy):
 			self.assertEqual(G.isDirected(), GCopy.isDirected())

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -347,5 +347,31 @@ class TestGraphTools(unittest.TestCase):
 					nk.graphtools.merge(Gmerge, G1)
 					testGraphs(Gorig, Gmerge, G1)
 
+	def testRemoveEdgesFromIsolatedSet(self):
+		n = 6
+
+		def generateTwoComponents(directed, weighted):
+			G = nk.Graph(n, directed, weighted)
+			G.addEdge(0, 1)
+			G.addEdge(1, 2)
+			G.addEdge(2, 0)
+
+			G.addEdge(3, 4)
+			G.addEdge(4, 5)
+			G.addEdge(5, 3)
+
+			return G
+
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				G = generateTwoComponents(directed, weighted)
+				nk.graphtools.removeEdgesFromIsolatedSet(G, [0, 1, 2])
+				self.assertEqual(G.numberOfEdges(), 3)
+				self.assertTrue(G.hasEdge(3, 4))
+				self.assertTrue(G.hasEdge(4, 5))
+				self.assertTrue(G.hasEdge(5, 3))
+				nk.graphtools.removeEdgesFromIsolatedSet(G, [3, 4, 5])
+				self.assertEqual(G.numberOfEdges(), 0)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -17,7 +17,7 @@ class TestGraphTools(unittest.TestCase):
 
 	def generateRandomWeights(self, G):
 		if not G.isWeighted():
-			G = nk.graph.GraphTools.toWeighted(G)
+			G = nk.graphtools.toWeighted(G)
 		G.forEdges(lambda u, v, w, eid: G.setWeight(u, v, random.random()))
 
 		return G
@@ -33,25 +33,25 @@ class TestGraphTools(unittest.TestCase):
 		for directed in [True, False]:
 			for weighted in [True, False]:
 				G = self.getSmallGraph(weighted, directed)
-				GCopy = nk.graph.GraphTools.copyNodes(G)
+				GCopy = nk.graphtools.copyNodes(G)
 				checkNodes(G, GCopy)
 
 				for _ in range(1, G.numberOfNodes()):
 					G.removeNode(G.randomNode())
-					GCopy = nk.graph.GraphTools.copyNodes(G)
+					GCopy = nk.graphtools.copyNodes(G)
 					checkNodes(G, GCopy)
 
 	def testSubgraphFromNodesUndirected(self):
 		G = self.getSmallGraph(True, False)
 
 		nodes = set([0])
-		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes)
+		res = nk.graphtools.subgraphFromNodes(G, nodes)
 		self.assertTrue(res.isWeighted())
 		self.assertFalse(res.isDirected())
 		self.assertEqual(res.numberOfNodes(), 1)
 		self.assertEqual(res.numberOfEdges(), 0)
 
-		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
 
 		self.assertEqual(res.numberOfNodes(), 3)
 		self.assertEqual(res.numberOfEdges(), 2) # 0-1, 0-2, NOT 1-2
@@ -60,11 +60,11 @@ class TestGraphTools(unittest.TestCase):
 		self.assertEqual(G.weight(0, 2), 2.0)
 
 		nodes = set([0, 1])
-		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes)
+		res = nk.graphtools.subgraphFromNodes(G, nodes)
 		self.assertEqual(res.numberOfNodes(), 2)
 		self.assertEqual(res.numberOfEdges(), 1) # 0 - 1
 
-		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
 		self.assertEqual(res.numberOfNodes(), 4)
 		self.assertEqual(res.numberOfEdges(), 4) # 0-1, 0-2, 1-2, 1-3
 
@@ -72,7 +72,7 @@ class TestGraphTools(unittest.TestCase):
 		G = self.getSmallGraph(True, True)
 
 		nodes = set([0])
-		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes)
+		res = nk.graphtools.subgraphFromNodes(G, nodes)
 
 		self.assertTrue(res.isWeighted())
 		self.assertTrue(res.isDirected())
@@ -81,22 +81,22 @@ class TestGraphTools(unittest.TestCase):
 		self.assertEqual(res.numberOfEdges(), 0)
 
 		nodes = set([0])
-		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
 		self.assertEqual(res.numberOfNodes(), 3)
 		self.assertEqual(res.numberOfEdges(), 2) # 0->1, 0->2, NOT 1->2
 
 		nodes = set([0, 1])
-		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes)
+		res = nk.graphtools.subgraphFromNodes(G, nodes)
 		self.assertEqual(res.numberOfNodes(), 2)
 		self.assertEqual(res.numberOfEdges(), 1) # 0 -> 1
 
 		nodes = set([0, 1])
-		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
 		self.assertEqual(res.numberOfNodes(), 3)
 		self.assertEqual(res.numberOfEdges(), 3) # 0->1, 0->2, 1->2
 
 		nodes = set([0, 1])
-		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes, True, True)
+		res = nk.graphtools.subgraphFromNodes(G, nodes, True, True)
 		self.assertEqual(res.numberOfNodes(), 4)
 		self.assertEqual(res.numberOfEdges(), 4) # 0->1, 0->2, 1->2, 3->1
 
@@ -120,7 +120,7 @@ class TestGraphTools(unittest.TestCase):
 			GWeighted = self.generateRandomWeights(G)
 
 			GWeighted.indexEdges()
-			GTrans = nk.graph.GraphTools.transpose(GWeighted)
+			GTrans = nk.graphtools.transpose(GWeighted)
 
 			def checkGWeightedEdges(u, v, w, eid):
 				self.assertEqual(GWeighted.edgeId(u, v), GTrans.edgeId(v, u))
@@ -166,7 +166,7 @@ class TestGraphTools(unittest.TestCase):
 			for weighted in [True, False]:
 				if weighted:
 					G = self.generateRandomWeights(G)
-				G1 = nk.graph.GraphTools.toUndirected(G)
+				G1 = nk.graphtools.toUndirected(G)
 				testGraphs(G, G1)
 
 	def testToUnWeighted(self):
@@ -193,12 +193,12 @@ class TestGraphTools(unittest.TestCase):
 			for directed in [True, False]:
 				G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
 
-				G1 = nk.graph.GraphTools.toWeighted(G)
+				G1 = nk.graphtools.toWeighted(G)
 				testGraphs(G, G1)
 
 				G = self.generateRandomWeights(G)
 
-				G1 = nk.graph.GraphTools.toUnweighted(G)
+				G1 = nk.graphtools.toUnweighted(G)
 				testGraphs(G, G1)
 
 	def testAppend(self):
@@ -238,14 +238,14 @@ class TestGraphTools(unittest.TestCase):
 						G2 = self.generateRandomWeights(G2)
 
 					G = copy(G1)
-					nk.graph.GraphTools.append(G, G2)
+					nk.graphtools.append(G, G2)
 					testGraphs(G, G1, G2)
 
 					for _ in range(nodesToDelete):
 						G1.removeNode(G1.randomNode())
 						G2.removeNode(G2.randomNode())
 						G3 = copy(G1)
-						nk.graph.GraphTools.append(G3, G2)
+						nk.graphtools.append(G3, G2)
 						testGraphs(G3, G1, G2)
 
 	def testMerge(self):
@@ -277,7 +277,7 @@ class TestGraphTools(unittest.TestCase):
 						Gorig = self.generateRandomWeights(Gorig)
 						G1 = self.generateRandomWeights(G1)
 					Gmerge = copy(Gorig)
-					nk.graph.GraphTools.merge(Gmerge, G1)
+					nk.graphtools.merge(Gmerge, G1)
 					testGraphs(Gorig, Gmerge, G1)
 
 if __name__ == "__main__":

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -22,6 +22,45 @@ class TestGraphTools(unittest.TestCase):
 
 		return G
 
+	def testMaxDegree(self):
+		n = 100
+		p = 0.2
+		edgeUpdates = 10
+
+		def computeMaxDeg(G, inDegree = False):
+			nodes = []
+			G.forNodes(lambda u: nodes.append(u))
+			maxDeg = 0
+			for u in nodes:
+				maxDeg = max(maxDeg, G.degreeIn(u) if inDegree else G.degreeOut(u))
+			return maxDeg
+
+		def doTest(G):
+			self.assertEqual(nk.graphtools.maxDegree(G), computeMaxDeg(G))
+			self.assertEqual(nk.graphtools.maxInDegree(G), computeMaxDeg(G, True))
+
+		for seed in range(1, 4):
+			nk.setSeed(seed, False)
+			for directed in [True, False]:
+				for weighted in [True, False]:
+					G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
+					if weighted:
+						G = nk.graphtools.toWeighted(G)
+
+					doTest(G)
+					for _ in range(edgeUpdates):
+						e = G.randomEdge()
+						G.removeEdge(e[0], e[1])
+						doTest(G)
+
+					for _ in range(edgeUpdates):
+						e = G.randomNode(), G.randomNode()
+						while G.hasEdge(e[0], e[1]):
+							e = G.randomNode(), G.randomNode()
+						G.addEdge(e[0], e[1])
+						doTest(G)
+
+
 	def testCopyNodes(self):
 		def checkNodes(G, GCopy):
 			self.assertEqual(G.isDirected(), GCopy.isDirected())

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -57,7 +57,7 @@ class TestGraphTools(unittest.TestCase):
 
 					doTest(G)
 					for _ in range(edgeUpdates):
-						e = G.randomEdge()
+						e = nk.graphtools.randomEdge(G)
 						G.removeEdge(e[0], e[1])
 						doTest(G)
 
@@ -88,6 +88,13 @@ class TestGraphTools(unittest.TestCase):
 					v = nk.graphtools.randomNeighbor(G, u)
 					self.assertNotEqual(G.degree(u) == 0, G.hasNode(v))
 
+	def testRandomEdge(self):
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				G = self.getSmallGraph(weighted, directed)
+				for i in range(10):
+					u, v = nk.graphtools.randomEdge(G)
+					self.assertTrue(G.hasEdge(u, v))
 
 	def testCopyNodes(self):
 		def checkNodes(G, GCopy):

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import unittest
+import random
+import networkit as nk
+
+class TestGraphTools(unittest.TestCase):
+	def getSmallGraph(self, weighted=False, directed=False):
+		G = nk.Graph(4, weighted, directed)
+		G.addEdge(0, 1, 1.0)
+		G.addEdge(0, 2, 2.0)
+		G.addEdge(3, 1, 4.0)
+		G.addEdge(3, 2, 5.0)
+		G.addEdge(1, 2, 3.0)
+
+		return G
+
+	def testCopyNodes(self):
+		def checkNodes(G, GCopy):
+			self.assertEqual(G.isDirected(), GCopy.isDirected())
+			self.assertEqual(G.isWeighted(), GCopy.isWeighted())
+			self.assertEqual(GCopy.numberOfEdges(), 0)
+			for u in range(G.upperNodeIdBound()):
+				self.assertEqual(G.hasNode(u), GCopy.hasNode(u))
+
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				G = self.getSmallGraph(weighted, directed)
+				GCopy = nk.graph.GraphTools.copyNodes(G)
+				checkNodes(G, GCopy)
+
+				for _ in range(1, G.numberOfNodes()):
+					G.removeNode(G.randomNode())
+					GCopy = nk.graph.GraphTools.copyNodes(G)
+					checkNodes(G, GCopy)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -62,11 +62,22 @@ class TestGraphTools(unittest.TestCase):
 						doTest(G)
 
 					for _ in range(edgeUpdates):
-						e = G.randomNode(), G.randomNode()
+						e = nk.graphtools.randomNode(G), nk.graphtools.randomNode(G)
 						while G.hasEdge(e[0], e[1]):
-							e = G.randomNode(), G.randomNode()
+							e = nk.graphtools.randomNode(G), nk.graphtools.randomNode(G)
 						G.addEdge(e[0], e[1])
 						doTest(G)
+
+	def testRandomNode(self):
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				G = self.getSmallGraph(weighted, directed)
+				for i in range(10):
+					self.assertTrue(G.hasNode(nk.graphtools.randomNode(G)))
+				n = G.numberOfNodes()
+				for i in range(n):
+					G.removeNode(i)
+				self.assertEqual(nk.graphtools.randomNode(G), nk.none)
 
 	def testCopyNodes(self):
 		def checkNodes(G, GCopy):
@@ -83,7 +94,7 @@ class TestGraphTools(unittest.TestCase):
 				checkNodes(G, GCopy)
 
 				for _ in range(1, G.numberOfNodes()):
-					G.removeNode(G.randomNode())
+					G.removeNode(nk.graphtools.randomNode(G))
 					GCopy = nk.graphtools.copyNodes(G)
 					checkNodes(G, GCopy)
 
@@ -153,13 +164,13 @@ class TestGraphTools(unittest.TestCase):
 			G = nk.generators.ErdosRenyiGenerator(100, 0.2, True).generate()
 
 			for _ in range(20):
-				u = G.randomNode()
+				u = nk.graphtools.randomNode(G)
 				if not G.hasEdge(u, u):
 					G.addEdge(u, u)
 
 			# Delete a few nodes
 			for _ in range(10):
-				G.removeNode(G.randomNode())
+				G.removeNode(nk.graphtools.randomNode(G))
 			self.assertGreater(G.numberOfSelfLoops(), 0)
 
 			# Assign random weights
@@ -288,8 +299,8 @@ class TestGraphTools(unittest.TestCase):
 					testGraphs(G, G1, G2)
 
 					for _ in range(nodesToDelete):
-						G1.removeNode(G1.randomNode())
-						G2.removeNode(G2.randomNode())
+						G1.removeNode(nk.graphtools.randomNode(G1))
+						G2.removeNode(nk.graphtools.randomNode(G2))
 						G3 = copy(G1)
 						nk.graphtools.append(G3, G2)
 						testGraphs(G3, G1, G2)

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -96,6 +96,15 @@ class TestGraphTools(unittest.TestCase):
 					u, v = nk.graphtools.randomEdge(G)
 					self.assertTrue(G.hasEdge(u, v))
 
+	def testRandomEdges(self):
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				G = self.getSmallGraph(weighted, directed)
+				for i in range(10):
+					randomEdges = nk.graphtools.randomEdges(G, 5)
+					for u, v in randomEdges:
+						self.assertTrue(G.hasEdge(u, v))
+
 	def testCopyNodes(self):
 		def checkNodes(G, GCopy):
 			self.assertEqual(G.isDirected(), GCopy.isDirected())

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -140,5 +140,65 @@ class TestGraphTools(unittest.TestCase):
 			self.assertEqual(GWeighted.upperEdgeIdBound(), GTrans.upperEdgeIdBound())
 			self.assertEqual(GWeighted.numberOfSelfLoops(), GTrans.numberOfSelfLoops())
 
+	def testToUndirected(self):
+		n = 200
+		p = 0.2
+
+		def testGraphs(G, G1):
+			self.assertEqual(G.numberOfNodes(), G1.numberOfNodes())
+			self.assertEqual(G.upperNodeIdBound(), G1.upperNodeIdBound())
+			self.assertEqual(G.numberOfEdges(), G1.numberOfEdges())
+			self.assertEqual(G.upperEdgeIdBound(), G1.upperEdgeIdBound())
+			self.assertEqual(G.isWeighted(), G1.isWeighted())
+			self.assertNotEqual(G.isDirected(), G1.isDirected())
+			self.assertEqual(G.hasEdgeIds(), G1.hasEdgeIds())
+
+			def testEdges(u, v, w, eid):
+				self.assertTrue(G1.hasEdge(u, v))
+				self.assertEqual(G1.weight(u, v), w)
+			G.forEdges(testEdges)
+
+		for seed in range(1, 4):
+			nk.setSeed(seed, False)
+			random.seed(seed)
+			G = nk.generators.ErdosRenyiGenerator(n, p, True).generate()
+			for weighted in [True, False]:
+				if weighted:
+					G = self.generateRandomWeights(G)
+				G1 = nk.graph.GraphTools.toUndirected(G)
+				testGraphs(G, G1)
+
+	def testToUnWeighted(self):
+		n = 200
+		p = 0.2
+
+		def testGraphs(G, G1):
+			self.assertEqual(G.numberOfNodes(), G1.numberOfNodes())
+			self.assertEqual(G.upperNodeIdBound(), G1.upperNodeIdBound())
+			self.assertEqual(G.numberOfEdges(), G1.numberOfEdges())
+			self.assertNotEqual(G.isWeighted(), G1.isWeighted())
+			self.assertEqual(G.isDirected(), G1.isDirected())
+			self.assertEqual(G.hasEdgeIds(), G1.hasEdgeIds())
+
+			def checkEdges(u, v, w, eid):
+				self.assertTrue(G1.hasEdge(u, v))
+				if G1.isWeighted():
+					self.assertEqual(G1.weight(u, v), 1.0)
+			G.forEdges(checkEdges)
+
+		for seed in range(1, 4):
+			nk.setSeed(seed, False)
+			random.seed(seed)
+			for directed in [True, False]:
+				G = nk.generators.ErdosRenyiGenerator(n, p, directed).generate()
+
+				G1 = nk.graph.GraphTools.toWeighted(G)
+				testGraphs(G, G1)
+
+				G = self.generateRandomWeights(G)
+
+				G1 = nk.graph.GraphTools.toUnweighted(G)
+				testGraphs(G, G1)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -27,17 +27,25 @@ class TestGraphTools(unittest.TestCase):
 		p = 0.2
 		edgeUpdates = 10
 
-		def computeMaxDeg(G, inDegree = False):
+		def computeMaxDeg(G, weighted = False, inDegree = False):
 			nodes = []
 			G.forNodes(lambda u: nodes.append(u))
 			maxDeg = 0
+			def getDegree(u):
+				if weighted:
+					return G.weightedDegreeIn(u) if inDegree else G.weightedDegree(u)
+				return G.degreeIn(u) if inDegree else G.degreeOut(u)
+
 			for u in nodes:
-				maxDeg = max(maxDeg, G.degreeIn(u) if inDegree else G.degreeOut(u))
+				maxDeg = max(maxDeg, getDegree(u))
+
 			return maxDeg
 
 		def doTest(G):
-			self.assertEqual(nk.graphtools.maxDegree(G), computeMaxDeg(G))
-			self.assertEqual(nk.graphtools.maxInDegree(G), computeMaxDeg(G, True))
+			self.assertEqual(nk.graphtools.maxDegree(G), computeMaxDeg(G, False))
+			self.assertEqual(nk.graphtools.maxInDegree(G), computeMaxDeg(G, False, True))
+			self.assertEqual(nk.graphtools.maxWeightedDegree(G), computeMaxDeg(G, True))
+			self.assertEqual(nk.graphtools.maxWeightedInDegree(G), computeMaxDeg(G, True, True))
 
 		for seed in range(1, 4):
 			nk.setSeed(seed, False)
@@ -59,7 +67,6 @@ class TestGraphTools(unittest.TestCase):
 							e = G.randomNode(), G.randomNode()
 						G.addEdge(e[0], e[1])
 						doTest(G)
-
 
 	def testCopyNodes(self):
 		def checkNodes(G, GCopy):

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -33,5 +33,65 @@ class TestGraphTools(unittest.TestCase):
 					GCopy = nk.graph.GraphTools.copyNodes(G)
 					checkNodes(G, GCopy)
 
+	def testSubgraphFromNodesUndirected(self):
+		G = self.getSmallGraph(True, False)
+
+		nodes = set([0])
+		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes)
+		self.assertTrue(res.isWeighted())
+		self.assertFalse(res.isDirected())
+		self.assertEqual(res.numberOfNodes(), 1)
+		self.assertEqual(res.numberOfEdges(), 0)
+
+		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes, True)
+
+		self.assertEqual(res.numberOfNodes(), 3)
+		self.assertEqual(res.numberOfEdges(), 2) # 0-1, 0-2, NOT 1-2
+
+		self.assertEqual(G.weight(0, 1), 1.0)
+		self.assertEqual(G.weight(0, 2), 2.0)
+
+		nodes = set([0, 1])
+		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes)
+		self.assertEqual(res.numberOfNodes(), 2)
+		self.assertEqual(res.numberOfEdges(), 1) # 0 - 1
+
+		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes, True)
+		self.assertEqual(res.numberOfNodes(), 4)
+		self.assertEqual(res.numberOfEdges(), 4) # 0-1, 0-2, 1-2, 1-3
+
+	def testSubgraphFromNodesDirected(self):
+		G = self.getSmallGraph(True, True)
+
+		nodes = set([0])
+		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes)
+
+		self.assertTrue(res.isWeighted())
+		self.assertTrue(res.isDirected())
+
+		self.assertEqual(res.numberOfNodes(), 1)
+		self.assertEqual(res.numberOfEdges(), 0)
+
+		nodes = set([0])
+		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes, True)
+		self.assertEqual(res.numberOfNodes(), 3)
+		self.assertEqual(res.numberOfEdges(), 2) # 0->1, 0->2, NOT 1->2
+
+		nodes = set([0, 1])
+		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes)
+		self.assertEqual(res.numberOfNodes(), 2)
+		self.assertEqual(res.numberOfEdges(), 1) # 0 -> 1
+
+		nodes = set([0, 1])
+		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes, True)
+		self.assertEqual(res.numberOfNodes(), 3)
+		self.assertEqual(res.numberOfEdges(), 3) # 0->1, 0->2, 1->2
+
+		nodes = set([0, 1])
+		res = nk.graph.GraphTools.subgraphFromNodes(G, nodes, True, True)
+		self.assertEqual(res.numberOfNodes(), 4)
+		self.assertEqual(res.numberOfEdges(), 4) # 0->1, 0->2, 1->2, 3->1
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/workflows.py
+++ b/networkit/workflows.py
@@ -10,9 +10,7 @@ import os
 import csv
 import fnmatch
 
-
-
-from networkit import graph, generators, components
+import networkit as nk
 
 def extractLargestComponent(G):
 	"""
@@ -28,9 +26,9 @@ def extractLargestComponent(G):
 		Subgraph of largest component, preserving node ids of orignal graph.
 	"""
 
-	cc = components.ConnectedComponents(G)
+	cc = nk.components.Connectednk.components(G)
 	cc.run()
-	cSizes = cc.getComponentSizes()
+	cSizes = cc.getnk.componentsizes()
 	(largestCompo, size) = max(cSizes.items(), key=operator.itemgetter(1))
 	logging.info("extracting component {0} containing {1} nodes".format(largestCompo, size))
 	compoNodes = [v for v in G.nodes() if cc.componentOfNode(v) is largestCompo]
@@ -58,7 +56,7 @@ def batch(graphDir, match, format, function, outPath, header=None):
 					print("processing {0}".format(filename))
 					graphPath = os.path.join(root, filename)
 					timer = stopwatch.Timer()
-					G = graphio.readGraph(graphPath)
+					G = nk.graphio.readGraph(graphPath)
 					timer.stop()
 					result = function(G)
 					if type(result) is tuple:
@@ -78,7 +76,7 @@ class TestWorkflows(unittest.TestCase):
 	def testExtractLargestComponent(self):
 		G = generators.DorogovtsevMendesGenerator(100).generate()
 		C = extractLargestComponent(G)
-		self.assertEqual(C.size(), G.size())
+		self.assertEqual(nk.graphtools.size(C), nk.graphtools.size(G))
 
 if __name__ == '__main__':
     unittest.main()

--- a/notebooks/GraphNotebook.ipynb
+++ b/notebooks/GraphNotebook.ipynb
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "newGraph = nk.graph.GraphTools.getCompactedGraph(G, nk.graph.GraphTools.getContinuousNodeIds(G))"
+    "newGraph = nk.graphtools.getCompactedGraph(G, nk.graphtools.getContinuousNodeIds(G))"
    ]
   },
   {


### PR DESCRIPTION
This PR deprecates several methods of `Graph`, and copies some of them to `GraphTools`.
In particular:
- `getId`,  `typ`, `set/getName`, `toString`, `nodes`, `edges`, `time/timeStep`, and `volume`  have been deprecated but **not** copied to `GraphTools` because we should drop those features in the future (or move them somewhere outside `Graph`, if there is some good reason to do so).
Since `volume` is a particular case of weighted degree, ad additional parameter has been added to `weightedDegree` to also support volume calculation.
- `copyNodes`, `subgraphFromNodes`, `transpose`, `BFS/DFSfrom`, `toUnweighted/Undirected`, `append`, `merge`, `maxDegree`, `maxWeightedDegree`, `randomNode/Edge/Edges`, `removeEdgesFromIsolatedSet`, `size`, `density` have been deprecated **and** copied to `GraphTools`. All NetworKit classes using them now use the implementation in `GraphTools`.

Further changes are:
- Parametrized `GraphToolGTest` to deal with all combinations of directed/weighted graphs.
- The version of `BFSfrom` that accepts multiple source nodes now takes iterators as input parameters, so it can be invoked using an arbitrary container.
- New function `GraphTools::toWeighted`.
- New `unsafe` function `Graph::setOmega`. This is needed by `GraphTools::transpose` because `addPartialIn/OutEdge` does not affect `omega` (i.e., `upperEdgeIdBound`).
- Refactor `merge` implementation so it can handle merge operations of a graph with a larger one.
- C++ (where missing) and Python tests for all the functions moved to `GraphTools`.
- Clang-format of heavily modified files