### PR TITLE
Fix: move out parameters

### DIFF
--- a/include/networkit/algebraic/algorithms/AlgebraicTriangleCounting.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicTriangleCounting.hpp
@@ -10,6 +10,8 @@
 
 #include <networkit/base/Algorithm.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -42,14 +44,17 @@ public:
     }
 
     /**
-     * Returns the scores for all nodes of the graph. If @a moveOut is set to true (false by default) then the scores
-     * are std::moved such that no copy is constructed.
-     * @param moveOut
+     * Returns the scores for all nodes of the graph.
      */
-    std::vector<count> getScores(bool moveOut = false) {
+    std::vector<count> TLX_DEPRECATED(getScores(bool moveOut)) {
         assureFinished();
         hasRun = !moveOut;
         return moveOut? std::move(nodeScores) : nodeScores;
+    }
+
+    const std::vector<count> &getScores() const {
+        assureFinished();
+        return nodeScores;
     }
 
 private:

--- a/include/networkit/centrality/Centrality.hpp
+++ b/include/networkit/centrality/Centrality.hpp
@@ -11,6 +11,8 @@
 #include <networkit/graph/Graph.hpp>
 #include <networkit/base/Algorithm.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -39,10 +41,11 @@ public:
 
     /**
      * Get a vector containing the centrality score for each node in the graph.
-     * @param moveOut Return the actual internal data instead of a copy. Resets the hasRun-state. Default: false.
+     *
      * @return The centrality scores calculated by @link run().
      */
-    virtual std::vector<double> scores(bool moveOut = false);
+    virtual std::vector<double> TLX_DEPRECATED(scores(bool moveOut));
+    virtual const std::vector<double> &scores() const;
 
     /**
      * Get a vector containing the edge centrality score for each edge in the graph (where applicable).
@@ -73,14 +76,14 @@ public:
     virtual double maximum();
 
     /**
-     * 	Compute the centralization of a network with respect to some centrality measure.
+     * Compute the centralization of a network with respect to some centrality measure.
 
-        The centralization of any network is a measure of how central its most central
-        node is in relation to how central all the other nodes are.
-        Centralization measures then (a) calculate the sum in differences
-        in centrality between the most central node in a network and all other nodes;
-        and (b) divide this quantity by the theoretically largest such sum of
-        differences in any network of the same size.
+     * The centralization of any network is a measure of how central its most central
+     * node is in relation to how central all the other nodes are.
+     * Centralization measures then (a) calculate the sum in differences
+     * in centrality between the most central node in a network and all other nodes;
+     * and (b) divide this quantity by the theoretically largest such sum of
+     * differences in any network of the same size.
 
      * @return centrality index
      */

--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -48,8 +48,6 @@ public:
      * Returns a vector of weighted distances from the source node, i.e. the
      * length of the shortest path from the source node to any other node.
      *
-     * @param moveOut If set to true, the container will be moved out of the
-     * class instead of copying it; default=true.
      * @return The weighted distances from the source node to any other node in
      * the graph.
      */
@@ -115,12 +113,10 @@ public:
     /**
      * Returns a vector of nodes ordered in increasing distance from the source.
      *
-     *	For this functionality to be available, storeNodesSortedByDistance has
-     *to be set to true in the constructor. There are no guarantees regarding
-     *the ordering of two nodes with the same distance to the source.
+     * For this functionality to be available, storeNodesSortedByDistance has
+     * to be set to true in the constructor. There are no guarantees regarding
+     * the ordering of two nodes with the same distance to the source.
      *
-     * @param moveOut If set to true, the container will be moved out of the
-     *class instead of copying it; default=true.
      * @return vector of nodes ordered in increasing distance from the source
      */
     std::vector<node> TLX_DEPRECATED(getNodesSortedByDistance(bool moveOut));

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1562,13 +1562,12 @@ cdef extern from "<networkit/distance/SSSP.hpp>":
 
 	cdef cppclass _SSSP "NetworKit::SSSP"(_Algorithm):
 		_SSSP(_Graph G, node source, bool_t storePaths, bool_t storeNodesSortedByDistance, node target) except +
-		vector[edgeweight] getDistances(bool_t moveOut) except +
 		vector[edgeweight] getDistances() except +
 		edgeweight distance(node t) except +
 		vector[node] getPredecessors(node t) except +
 		vector[node] getPath(node t, bool_t forward) except +
 		set[vector[node]] getPaths(node t, bool_t forward) except +
-		vector[node] getNodesSortedByDistance(bool_t moveOut) except +
+		vector[node] getNodesSortedByDistance() except +
 		double _numberOfPaths(node t) except +
 		void setSource(node s) except +
 		void setTarget(node t) except +
@@ -1582,7 +1581,7 @@ cdef class SSSP(Algorithm):
 		if type(self) == SSSP:
 			raise RuntimeError("Error, you may not use SSSP directly, use a sub-class instead")
 
-	def getDistances(self, moveOut):
+	def getDistances(self, moveOut=False):
 		"""
 		DEPRECATED
 		Returns a list of weighted distances from the source node, i.e. the
@@ -1593,18 +1592,10 @@ cdef class SSSP(Algorithm):
  	 	vector
  	 		The weighted distances from the source node to any other node in the graph.
 		"""
-		return (<_SSSP*>(self._this)).getDistances(moveOut)
+		if moveOut:
+			from warnings import warn
+			warn("moveOut parameter is deprecated and not used")
 
-	def getDistances(self):
-		"""
-		Returns a list of weighted distances from the source node, i.e. the
-		length of the shortest path from the source node to any other node.
-
-		Returns
-		-------
-		list
-			The weighted distances from the source node to any other node in the graph.
-		"""
 		return (<_SSSP*>(self._this)).getDistances()
 
 	def distance(self, t):
@@ -1682,23 +1673,21 @@ cdef class SSSP(Algorithm):
 			result.append(list(elem))
 		return result
 
-	def getNodesSortedByDistance(self, moveOut=True):
+	def getNodesSortedByDistance(self, moveOut=False):
 		""" Returns a list of nodes ordered in increasing distance from the source.
 
 		For this functionality to be available, storeNodesSortedByDistance has to be set to true in the constructor.
 		There are no guarantees regarding the ordering of two nodes with the same distance to the source.
-
-		Parameters
-		----------
-		moveOut : bool
-			If set to true, the container will be moved out of the class instead of copying it; default=true.
 
 		Returns
 		-------
 		list
 			Nodes ordered in increasing distance from the source.
 		"""
-		return (<_SSSP*>(self._this)).getNodesSortedByDistance(moveOut)
+		if moveOut:
+			from warnings import warn
+			warn("moveOut parameter is deprecated and not used")
+		return (<_SSSP*>(self._this)).getNodesSortedByDistance()
 
 	def numberOfPaths(self, t):
 		"""

--- a/networkit/cpp/algebraic/algorithms/test/AlgebraicTriangleCountingGTest.cpp
+++ b/networkit/cpp/algebraic/algorithms/test/AlgebraicTriangleCountingGTest.cpp
@@ -156,7 +156,7 @@ TEST(AlgebraicTriangleCountingGTest, testLocalClusteringCoefficient) {
     LocalClusteringCoefficient lcc(graph);
     timer.start();
     lcc.run();
-    std::vector<double> lccValues = lcc.scores(true);
+    std::vector<double> lccValues = lcc.scores();
     timer.stop();
 
     INFO("Graph theoretic local clustering coefficient took ", timer.elapsedTag());

--- a/networkit/cpp/algebraic/algorithms/test/AlgebraicTriangleCountingGTest.cpp
+++ b/networkit/cpp/algebraic/algorithms/test/AlgebraicTriangleCountingGTest.cpp
@@ -27,7 +27,7 @@ TEST(AlgebraicTriangleCountingGTest, testToyGraphOne) {
     AlgebraicTriangleCounting<CSRMatrix> atc(graph);
     atc.run();
 
-    std::vector<count> nodeScores = atc.getScores(true);
+    std::vector<count> nodeScores = atc.getScores();
 
     EXPECT_EQ(1u, nodeScores[0]) << "wrong triangle count";
     EXPECT_EQ(1u, nodeScores[1]) << "wrong triangle count";
@@ -50,8 +50,7 @@ TEST(AlgebraicTriangleCountingGTest, testToyGraphTwo) {
     atc.run();
 
     EXPECT_TRUE(atc.hasFinished());
-    std::vector<count> nodeScores = atc.getScores(true);
-    EXPECT_FALSE(atc.hasFinished());
+    std::vector<count> nodeScores = atc.getScores();
 
     EXPECT_EQ(1u, nodeScores[0]) << "wrong triangle count";
     EXPECT_EQ(1u, nodeScores[1]) << "wrong triangle count";
@@ -80,7 +79,7 @@ TEST(AlgebraicTriangleCountingGTest, testDirectedToyGraphOne) {
     AlgebraicTriangleCounting<CSRMatrix> atc(graph);
     atc.run();
 
-    std::vector<count> nodeScores = atc.getScores(true);
+    std::vector<count> nodeScores = atc.getScores();
 
     EXPECT_EQ(1u, nodeScores[0]) << "wrong triangle count";
     EXPECT_EQ(1u, nodeScores[1]) << "wrong triangle count";
@@ -99,7 +98,7 @@ TEST(AlgebraicTriangleCountingGTest, testDirectedToyGraphTwo) {
     AlgebraicTriangleCounting<CSRMatrix> atc(graph);
     atc.run();
 
-    std::vector<count> nodeScores = atc.getScores(true);
+    std::vector<count> nodeScores = atc.getScores();
 
     EXPECT_EQ(0u, nodeScores[0]) << "wrong triangle count";
     EXPECT_EQ(0u, nodeScores[1]) << "wrong triangle count";
@@ -121,7 +120,7 @@ TEST(AlgebraicTriangleCountingGTest, testDirectedToyGraphThree) {
     AlgebraicTriangleCounting<CSRMatrix> atc(graph);
     atc.run();
 
-    std::vector<count> nodeScores = atc.getScores(true);
+    std::vector<count> nodeScores = atc.getScores();
 
     EXPECT_EQ(2u, nodeScores[0]) << "wrong triangle count";
     EXPECT_EQ(2u, nodeScores[1]) << "wrong triangle count";
@@ -140,7 +139,7 @@ TEST(AlgebraicTriangleCountingGTest, testLocalClusteringCoefficient) {
     timer.start();
     atc.run();
 
-    std::vector<count> nodeScores = atc.getScores(true);
+    std::vector<count> nodeScores = atc.getScores();
     std::vector<double> lccAlgebraic(graph.numberOfNodes());
     graph.parallelForNodes([&](node u) {
         if (graph.degree(u) < 2) {
@@ -164,7 +163,6 @@ TEST(AlgebraicTriangleCountingGTest, testLocalClusteringCoefficient) {
     graph.forNodes([&](node u) {
         EXPECT_EQ(lccValues[u], lccAlgebraic[u]);
     });
-
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/centrality/Centrality.cpp
+++ b/networkit/cpp/centrality/Centrality.cpp
@@ -46,6 +46,11 @@ std::vector<double> Centrality::scores(bool moveOut) {
   return moveOut ? std::move(scoreData) : scoreData;
 }
 
+const std::vector<double> &Centrality::scores() const {
+  assureFinished();
+  return scoreData;
+}
+
 std::vector<double> Centrality::edgeScores() {
   assureFinished();
   return edgeScoreData;


### PR DESCRIPTION
Some NetworKit classes provide a `moveOut` parameter that, if set true, should move the content of a vector outside the class. However, as @avdgrinten commented in https://github.com/networkit/networkit/pull/334#discussion_r292924992, move-out parameters cannot work as expected.

This PR deprecates all methods using `moveOut`, and provides alternative methods that return a const ref. to the vector.