### PR TITLE
NetworKit binary graphs: Fix weight auto detection for unweighted graphs

### DIFF
--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -24,8 +24,10 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
     Aux::enforceOpened(outfile);
     nkbg::WEIGHT_FORMAT weightFormat;
 
-    auto detectWeightsType = [&] () {
-        weightFormat = nkbg::WEIGHT_FORMAT::VARINT;
+    auto detectWeightsType = [&] () -> nkbg::WEIGHT_FORMAT {
+        if(!G.isWeighted())
+            return nkbg::WEIGHT_FORMAT::NONE;
+
         bool isUnsigned = true;
         bool fitsIntoInt64 = true;
         bool fitsIntoFloat = true;
@@ -41,16 +43,14 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
         });
         if(fitsIntoInt64) {
             if(isUnsigned) {
-                weightFormat = nkbg::WEIGHT_FORMAT::VARINT;
+                return nkbg::WEIGHT_FORMAT::VARINT;
             } else {
-                weightFormat = nkbg::WEIGHT_FORMAT::SIGNED_VARINT;
+                return nkbg::WEIGHT_FORMAT::SIGNED_VARINT;
             }
+        } else if(fitsIntoFloat) {
+            return nkbg::WEIGHT_FORMAT::FLOAT;
         } else {
-            if(fitsIntoFloat) {
-                weightFormat = nkbg::WEIGHT_FORMAT::FLOAT;
-            } else {
-                weightFormat = nkbg::WEIGHT_FORMAT::DOUBLE;
-            }
+            return nkbg::WEIGHT_FORMAT::DOUBLE;
         }
     };
 
@@ -59,7 +59,7 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
             weightFormat = nkbg::WEIGHT_FORMAT::NONE;
             break;
         case NetworkitBinaryWeights::autoDetect:
-            detectWeightsType();
+            weightFormat = detectWeightsType();
             break;
         case NetworkitBinaryWeights::unsignedFormat:
             weightFormat = nkbg::WEIGHT_FORMAT::VARINT;

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -31,15 +31,13 @@ void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
         bool isUnsigned = true;
         bool fitsIntoInt64 = true;
         bool fitsIntoFloat = true;
-        G.forNodes([&](node n) {
-            G.forNeighborsOf(n,[&](node, edgeweight w) {
-                if(w < 0)
-                    isUnsigned = false;
-                if(w != static_cast<int64_t>(w))
-                    fitsIntoInt64 = false;
-                if(w != static_cast<float>(w))
-                    fitsIntoFloat = false;
-            });
+        G.forEdges([&](node, node, edgeweight w) {
+            if(w < 0)
+                isUnsigned = false;
+            if(w != static_cast<int64_t>(w))
+                fitsIntoInt64 = false;
+            if(w != static_cast<float>(w))
+                fitsIntoFloat = false;
         });
         if(fitsIntoInt64) {
             if(isUnsigned) {

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -807,6 +807,8 @@ TEST_F(IOGTest, testNetworkitBinaryTiny01) {
 
     NetworkitBinaryReader reader;
     Graph G2 = reader.read("output/binary_tiny01");
+    EXPECT_EQ(G2.isDirected(), false);
+    EXPECT_EQ(G2.isWeighted(), false);
     ASSERT_EQ(G2.numberOfNodes(), G.numberOfNodes());
     ASSERT_EQ(G2.numberOfEdges(), G.numberOfEdges());
     G.forNodes([&](node u){
@@ -826,6 +828,8 @@ TEST_F(IOGTest, testNetworkitBinaryKonect) {
 
     NetworkitBinaryReader reader;
     Graph G2 = reader.read("output/binary_konect");
+    EXPECT_EQ(G2.isDirected(), true);
+    EXPECT_EQ(G2.isWeighted(), true);
     ASSERT_EQ(G2.numberOfEdges(), G.numberOfEdges());
     ASSERT_EQ(G2.numberOfNodes(), G.numberOfNodes());
     G.forNodes([&](node u){
@@ -845,6 +849,8 @@ TEST_F(IOGTest, testNetworkitBinaryJazz) {
 
     NetworkitBinaryReader reader;
     Graph G2 = reader.read("output/binary_jazz");
+    EXPECT_EQ(G2.isDirected(), false);
+    EXPECT_EQ(G2.isWeighted(), false);
     ASSERT_EQ(G2.numberOfEdges(), G.numberOfEdges());
     ASSERT_EQ(G2.numberOfNodes(), G.numberOfNodes());
     G.forNodes([&](node u){
@@ -855,8 +861,7 @@ TEST_F(IOGTest, testNetworkitBinaryJazz) {
 }
 
 TEST_F(IOGTest, testNetworkitBinaryWiki) {
-    bool directed = true;
-    SNAPGraphReader reader2(directed);
+    SNAPGraphReader reader2(true);
     Graph G = reader2.read("input/wiki-Vote.txt");
     NetworkitBinaryWriter writer;
 
@@ -865,6 +870,8 @@ TEST_F(IOGTest, testNetworkitBinaryWiki) {
 
     NetworkitBinaryReader reader;
     Graph G2 = reader.read("output/binary_wiki");
+    EXPECT_EQ(G2.isDirected(), true);
+    EXPECT_EQ(G2.isWeighted(), false);
     ASSERT_EQ(G2.numberOfEdges(), G.numberOfEdges());
     ASSERT_EQ(G2.numberOfNodes(), G.numberOfNodes());
     G.forNodes([&](node u){
@@ -887,6 +894,8 @@ TEST_F(IOGTest, testNetworkitBinarySignedWeights) {
 
     NetworkitBinaryReader reader;
     Graph G2 = reader.read("output/binarySigned");
+    EXPECT_EQ(G2.isDirected(), false);
+    EXPECT_EQ(G2.isWeighted(), true);
     G.forNodes([&](node u){
         G.forEdgesOf(u, [&](node v) {
             ASSERT_TRUE(G2.hasEdge(u,v));
@@ -908,6 +917,8 @@ TEST_F(IOGTest, testNetworkitBinaryFloatWeights) {
 
     NetworkitBinaryReader reader;
     Graph G2 = reader.read("output/binaryFloats");
+    EXPECT_EQ(G2.isDirected(), false);
+    EXPECT_EQ(G2.isWeighted(), true);
     G.forNodes([&](node u){
         G.forEdgesOf(u, [&](node v) {
             ASSERT_TRUE(G2.hasEdge(u,v));
@@ -928,6 +939,8 @@ TEST_F(IOGTest, testNetworkitBinaryUndirectedSelfLoops) {
     writer.write(G, "output/loops");
     NetworkitBinaryReader reader;
     Graph G2 = reader.read("output/loops");
+    EXPECT_EQ(G2.isDirected(), false);
+    EXPECT_EQ(G2.isWeighted(), false);
     ASSERT_EQ(G.numberOfSelfLoops(), G2.numberOfSelfLoops());
 }
 
@@ -943,6 +956,8 @@ TEST_F(IOGTest, testNetworkitBinaryDirectedSelfLoops) {
     writer.write(G, "output/loops");
     NetworkitBinaryReader reader;
     Graph G2 = reader.read("output/loops");
+    EXPECT_EQ(G2.isDirected(), true);
+    EXPECT_EQ(G2.isWeighted(), false);
     ASSERT_EQ(G.numberOfSelfLoops(), G2.numberOfSelfLoops());
 }
 

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -835,6 +835,7 @@ TEST_F(IOGTest, testNetworkitBinaryKonect) {
     G.forNodes([&](node u){
         G.forEdgesOf(u, [&](node v) {
             ASSERT_TRUE(G2.hasEdge(u,v));
+            ASSERT_EQ(G.weight(u,v), G2.weight(u,v));
         });
     });
 }


### PR DESCRIPTION
The current auto detection code chooses the positive varint storage format for unweighted graphs. Fix the detection to not store weights at all.