### PR TITLE
RFC: Graph: Support 32-bit node IDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(NETWORKIT_COVERAGE "Build with support for coverage" OFF)
 set(NETWORKIT_PYTHON "" CACHE STRING "Directory containing Python.h. Implies MONOLITH=TRUE")
 set(NETWORKIT_PYTHON_SOABI "" CACHE STRING "Platform specific file extension. Implies MONOLITH=TRUE")
 set(NETWORKIT_WITH_SANITIZERS "" CACHE STRING "Uses sanitizers during the compilation")
+set(NETWORKIT_NODE_STORAGE "u64" CACHE STRING "Override node storage data type of NetworKit graphs (u64/u32) [affects ABI, define NETWORKIT_U32_NODES]")
 set(NETWORKIT_RELEASE_LOGGING "AUTO" CACHE STRING "Do not compile log messages at levels TRACE or DEBUG (AUTO|ON|OFF)")
 set(NETWORKIT_PYTHON_RPATH "" CACHE STRING "Build specific rpath references.")
 
@@ -53,6 +54,12 @@ endif()
 # Compilation Flags
 set(NETWORKIT_CXX_FLAGS "")
 set(NETWORKIT_LINK_FLAGS "")
+
+if (NETWORKIT_NODE_STORAGE STREQUAL "u32")
+	set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} -DNETWORKIT_U32_NODES")
+elseif(NOT NETWORKIT_NODE_STORAGE STREQUAL "u64")
+	message(FATAL_ERROR "Unsupported setting ${NETWORKIT_NODE_STORAGE} for NETWORKIT_NODE_STORAGE")
+endif()
 
 if (NETWORKIT_QUIET_LOGGING)
 	set(NETWORKIT_CXX_FLAGS "-DNETWORKIT_QUIET_LOGGING")

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -29,6 +29,12 @@
 namespace NetworKit {
 
 /**
+ * Data type of nodes inside adjacency lists.
+ * This is an internal detail of NetworKit; there is no need for users to use this type.
+ */
+using storednode = node;
+
+/**
  * A weighted edge used for the graph constructor with
  * initializer list syntax.
  */
@@ -127,10 +133,10 @@ class Graph final {
 
     //!< only used for directed graphs, inEdges[v] contains all nodes u that
     //!< have an edge (u, v)
-    std::vector<std::vector<node>> inEdges;
+    std::vector<std::vector<storednode>> inEdges;
     //!< (outgoing) edges, for each edge (u, v) v is saved in outEdges[u] and
     //!< for undirected also u in outEdges[v]
-    std::vector<std::vector<node>> outEdges;
+    std::vector<std::vector<storednode>> outEdges;
 
     //!< only used for directed graphs, same schema as inEdges
     std::vector<std::vector<edgeweight>> inEdgeWeights;
@@ -469,7 +475,7 @@ public:
         // Own type.
         using self = NeighborIterator;
 
-        NeighborIterator(std::vector<node>::const_iterator nodesIter) : nIter(nodesIter) {}
+        NeighborIterator(std::vector<storednode>::const_iterator nodesIter) : nIter(nodesIter) {}
 
         /**
          * @brief WARNING: This contructor is required for Python and should not be used as the iterator is not initialised.
@@ -509,7 +515,7 @@ public:
         node operator*() const { return *nIter; }
 
       private:
-        std::vector<node>::const_iterator nIter;
+        std::vector<storednode>::const_iterator nIter;
     };
 
     /**
@@ -540,7 +546,7 @@ public:
         using self = NeighborWeightIterator;
 
         NeighborWeightIterator(
-            std::vector<node>::const_iterator nodesIter,
+            std::vector<storednode>::const_iterator nodesIter,
             std::vector<edgeweight>::const_iterator weightIter)
             : nIter(nodesIter), wIter(weightIter) {}
 
@@ -583,7 +589,7 @@ public:
         }
 
       private:
-        std::vector<node>::const_iterator nIter;
+        std::vector<storednode>::const_iterator nIter;
         std::vector<edgeweight>::const_iterator wIter;
     };
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -28,11 +28,19 @@
 
 namespace NetworKit {
 
-/**
- * Data type of nodes inside adjacency lists.
- * This is an internal detail of NetworKit; there is no need for users to use this type.
- */
-using storednode = node;
+#ifdef NETWORKIT_U32_NODES
+	/**
+	 * Data type of nodes inside adjacency lists.
+	 * This is an internal detail of NetworKit; there is no need for users to use this type.
+	 */
+	using storednode = uint32_t;
+#else
+	/**
+	 * Data type of nodes inside adjacency lists.
+	 * This is an internal detail of NetworKit; there is no need for users to use this type.
+	 */
+	using storednode = node;
+#endif
 
 /**
  * A weighted edge used for the graph constructor with

--- a/include/networkit/graph/GraphBuilder.hpp
+++ b/include/networkit/graph/GraphBuilder.hpp
@@ -49,13 +49,13 @@ private:
 	bool weighted; //!< true if the graph will be weighted, false otherwise
 	bool directed; //!< true if the graph will be directed, false otherwise
 
-	std::vector<std::vector<node>>
+	std::vector<std::vector<storednode>>
 	    outEdges; //!< (outgoing) edges, for each edge (u, v) v is saved in
 	              //!< outEdges[u] and for undirected also u in outEdges[v]
 	std::vector<std::vector<edgeweight>>
 	    outEdgeWeights; //!< same schema (and same order!) as outEdges
 
-	std::vector<std::vector<node>>
+	std::vector<std::vector<storednode>>
 	    inEdges; //!< only used for directed graphs, inEdges[v] contains all nodes
 	             //!< u that have an edge (u, v)
 	std::vector<std::vector<edgeweight>>

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -392,7 +392,7 @@ void Graph::compactEdges() {
 }
 
 void Graph::sortEdges() {
-	std::vector<std::vector<node>> targetAdjacencies(upperNodeIdBound());
+	std::vector<std::vector<storednode>> targetAdjacencies(upperNodeIdBound());
 	std::vector<std::vector<edgeweight>> targetWeight;
 	std::vector<std::vector<edgeid>> targetEdgeIds;
 
@@ -536,6 +536,7 @@ node Graph::addNode() {
 	node v = z; // node gets maximum id
 	z++;        // increment node range
 	n++;        // increment node count
+	assert(v == static_cast<node>(std::numeric_limits<storednode>::max()));
 
 	// update per node data structures
 	exists.push_back(true);
@@ -548,9 +549,9 @@ node Graph::addNode() {
 		outEdgeWeights.push_back(edgeWeight);
 	}
 
-	outEdges.push_back(std::vector<node>{});
+	outEdges.push_back(std::vector<storednode>{});
 	if (directed) {
-		inEdges.push_back(std::vector<node>{});
+		inEdges.push_back(std::vector<storednode>{});
 	}
 
 	return v;
@@ -767,7 +768,7 @@ void Graph::removeEdge(node u, node v) {
 	}
 
 	m--; // decrease number of edges
-	erase<node>(u, vi, outEdges);
+	erase<storednode>(u, vi, outEdges);
 	if (weighted) {
 		erase<edgeweight>(u, vi, outEdgeWeights);
 	}
@@ -775,13 +776,13 @@ void Graph::removeEdge(node u, node v) {
 	if (directed) {
 		assert(ui != none);
 
-		erase<node>(v, ui, inEdges);
+		erase<storednode>(v, ui, inEdges);
 		if (weighted) {
 			erase<edgeweight>(v, ui, inEdgeWeights);
 		}
 	} else if (u != v) {
 		// undirected, not self-loop
-		erase<node>(v, ui, outEdges);
+		erase<storednode>(v, ui, outEdges);
 		if (weighted) {
 			erase<edgeweight>(v, ui, outEdgeWeights);
 		}

--- a/networkit/cpp/randomization/CurveballImpl.cpp
+++ b/networkit/cpp/randomization/CurveballImpl.cpp
@@ -21,11 +21,11 @@ namespace CurveballDetails {
 
 using degree_vector = std::vector<count>;
 using trade_vector = std::vector<trade_descriptor>;
-using neighbour_vector = std::vector<node>;
+using neighbour_vector = std::vector<storednode>;
 using node_vector = std::vector<node>;
 using nodepair_vector = std::vector<std::pair<node, node>>;
 
-using neighbour_vector = std::vector<node>;
+using neighbour_vector = std::vector<storednode>;
 using degree_vector = std::vector<count>;
 using degree_it = std::vector<count>::const_iterator;
 using pos_vector = std::vector<edgeid>;
@@ -146,7 +146,7 @@ void CurveballMaterialization::toGraphParallel(Graph &G) {
 	std::vector<count> missingEdgesCounts(numNodes, 0);
 
 	std::vector<std::vector<edgeweight>> new_edgeWeights(numNodes);
-	std::vector<std::vector<node>> new_outEdges(numNodes);
+	std::vector<std::vector<storednode>> new_outEdges(numNodes);
 	std::vector<count> outDeg(numNodes);
 
 	// Add first half of edges and count missing edges for each node
@@ -203,7 +203,7 @@ void CurveballMaterialization::toGraphSequential(Graph &G) {
 	missingEdgesCounts.reserve(numNodes);
 
 	std::vector<std::vector<edgeweight>> new_edgeWeights(numNodes);
-	std::vector<std::vector<node>> new_outEdges(numNodes);
+	std::vector<std::vector<storednode>> new_outEdges(numNodes);
 	std::vector<count> outDeg(numNodes);
 
 	// Add first half of edges and count missing edges for each node


### PR DESCRIPTION
This PR allows NetworKit configurations that store *adjacency lists* consisting of 32-bit node IDs. In the best case, this should roughly half the memory required for `NetworKit::Graph` objects, at the cost of supporting fewer nodes.

Because we expect some code in NetworKit to depend on 64-bit nodes, we do not change the `node` data type - this type is still a `uint64_t`. Instead, we change the `std::vector`s that store the adjacency lists to use a 32-bit integer and convert at the `NetworKit::Graph` boundary.

This requires some changes in the GraphBuilder (and in Curveball's clone of GraphBuilder). One thing to note is that `GraphBuilder::swapAdjacency` is much more expensive when 32-bit node IDs are used; however, I do not think that this is a bottleneck for existing algorithms (if you disagree, please comment!).

Furthermore, the resulting NetworKit library is not ABI compatible with the default build. Users of the library are currently expected to pass `-DNETWORKIT_U32_NODES` when compiling programs that link against a 32-bit node ID build. This mechanism should probably be revisited (possibly in an update of this PR): instead of forcing the user to pass such a definition, we can install a configuration header for NetworKit.