### PR TITLE
Fix BarabasiAlbertGenerator

### DIFF
--- a/include/networkit/generators/BarabasiAlbertGenerator.hpp
+++ b/include/networkit/generators/BarabasiAlbertGenerator.hpp
@@ -4,6 +4,7 @@
  *  Created on: May 28, 2013
  *      Author: forigem
  */
+// networkit-format
 
 #ifndef BarabasiAlbertGenerator_H_
 #define BarabasiAlbertGenerator_H_
@@ -16,12 +17,12 @@ namespace NetworKit {
  * @ingroup generators
  * Generates a scale-free graph using the Barabasi-Albert preferential attachment model.
  */
-class BarabasiAlbertGenerator: public StaticGraphGenerator {
+class BarabasiAlbertGenerator : public StaticGraphGenerator {
 private:
     Graph initGraph;
-    count k{0}; //!< Attachments made per node
+    count k{0};    //!< Attachments made per node
     count nMax{0}; //!< The maximal number of nodes attached
-    count n0{0}; //!< The number of initial connected nodes
+    count n0{0};   //!< The number of initial connected nodes
     bool batagelj; //!< Specifies whether to use batagelj's method or the original one
 
     /**
@@ -38,11 +39,10 @@ public:
     BarabasiAlbertGenerator() = default;
 
     /**
-     * This generator implements the preferential attachment model as introduced by Barabasi and Albert[1].
-     * The original algorithm is very slow and thus, the much faster method from Batagelj and Brandes[2] is
-     * implemented and the current default.
-     * The original method can be chosen by setting \p batagelj to false.
-     * [1] Barabasi, Albert: Emergence of Scaling in Random Networks
+     * This generator implements the preferential attachment model as introduced by Barabasi and
+     * Albert[1]. The original algorithm is very slow and thus, the much faster method from Batagelj
+     * and Brandes[2] is implemented and the current default. The original method can be chosen by
+     * setting \p batagelj to false. [1] Barabasi, Albert: Emergence of Scaling in Random Networks
      *   http://arxiv.org/pdf/cond-mat/9910332.pdf
      * [2] ALG 5 of Batagelj, Brandes: Efficient Generation of Large Random Networks
      *   https://kops.uni-konstanz.de/bitstream/handle/123456789/5799/random.pdf?sequence=1
@@ -53,11 +53,12 @@ public:
      * @param k     Number of attachments per node
      * @param nMax  Number of nodes in the graph
      * @param n0    Number of connected nodes to begin with
-     * @param turbo Specifies whether to use Batagelj and Brandes's method rather than the naive one; default: true
+     * @param batagelj Specifies whether to use Batagelj and Brandes's method (much faster)
+     *              rather than the naive one; default: true
      */
-    BarabasiAlbertGenerator(count k, count nMax, count n0 = 0, bool turbo=true);
+    BarabasiAlbertGenerator(count k, count nMax, count n0 = 0, bool batagelj = true);
 
-    BarabasiAlbertGenerator(count k, count nMax, const Graph& initGraph, bool turbo=true);
+    BarabasiAlbertGenerator(count k, count nMax, const Graph &initGraph, bool batagelj = true);
 
     Graph generate() override;
 };

--- a/include/networkit/generators/BarabasiAlbertGenerator.hpp
+++ b/include/networkit/generators/BarabasiAlbertGenerator.hpp
@@ -19,9 +19,9 @@ namespace NetworKit {
 class BarabasiAlbertGenerator: public StaticGraphGenerator {
 private:
     Graph initGraph;
-    count k; //!< Attachments made per node
-    count nMax; //!< The maximal number of nodes attached
-    count n0; //!< The number of initial connected nodes
+    count k{0}; //!< Attachments made per node
+    count nMax{0}; //!< The maximal number of nodes attached
+    count n0{0}; //!< The number of initial connected nodes
     bool batagelj; //!< Specifies whether to use batagelj's method or the original one
 
     /**
@@ -35,24 +35,29 @@ private:
     Graph generateOriginal();
 
 public:
-    BarabasiAlbertGenerator();
+    BarabasiAlbertGenerator() = default;
 
     /**
      * This generator implements the preferential attachment model as introduced by Barabasi and Albert[1].
      * The original algorithm is very slow and thus, the much faster method from Batagelj and Brandes[2] is
      * implemented and the current default.
      * The original method can be chosen by setting \p batagelj to false.
-     * [1] Barabasi, Albert: Emergence of Scaling in Random Networks http://arxiv.org/pdf/cond-mat/9910332.pdf
-     * [2] ALG 5 of Batagelj, Brandes: Efficient Generation of Large Random Networks https://kops.uni-konstanz.de/bitstream/handle/123456789/5799/random.pdf?sequence=1
+     * [1] Barabasi, Albert: Emergence of Scaling in Random Networks
+     *   http://arxiv.org/pdf/cond-mat/9910332.pdf
+     * [2] ALG 5 of Batagelj, Brandes: Efficient Generation of Large Random Networks
+     *   https://kops.uni-konstanz.de/bitstream/handle/123456789/5799/random.pdf?sequence=1
      *
-     * @param k Number of attachments per node
-     * @param nMax Maximum number of nodes in the graph
-     * @param n0 Number of connected nodes to begin with
-     * @param batagelj Specifies whether to use batagelj's method or the original one; default: true
+     * The generator will emit a simple graph (given that the seed graph is simple), where all
+     * new nodes are initially connected to k random neighbors.
+     *
+     * @param k     Number of attachments per node
+     * @param nMax  Number of nodes in the graph
+     * @param n0    Number of connected nodes to begin with
+     * @param turbo Specifies whether to use Batagelj and Brandes's method rather than the naive one; default: true
      */
-    BarabasiAlbertGenerator(count k, count nMax, count n0 = 0, bool batagelj=true);
+    BarabasiAlbertGenerator(count k, count nMax, count n0 = 0, bool turbo=true);
 
-    BarabasiAlbertGenerator(count k, count nMax, const Graph& initGraph, bool batagelj=true);
+    BarabasiAlbertGenerator(count k, count nMax, const Graph& initGraph, bool turbo=true);
 
     Graph generate() override;
 };

--- a/networkit/cpp/generators/BarabasiAlbertGenerator.cpp
+++ b/networkit/cpp/generators/BarabasiAlbertGenerator.cpp
@@ -4,22 +4,25 @@
  *  Created on: May 28, 2013
  *      Author: forigem, Manuel Penschuck <networkit@manuel.jetzt>
  */
+// networkit-format
 
-#include <unordered_set>
 #include <random>
+#include <unordered_set>
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/auxiliary/SignalHandling.hpp>
 #include <networkit/generators/BarabasiAlbertGenerator.hpp>
 
-
 namespace NetworKit {
-BarabasiAlbertGenerator::BarabasiAlbertGenerator(count k, count nMax, count n0, bool batagelj) : initGraph(0), k(k), nMax(nMax), batagelj(batagelj) {
+BarabasiAlbertGenerator::BarabasiAlbertGenerator(count k, count nMax, count n0, bool batagelj)
+    : initGraph(0), k(k), nMax(nMax), batagelj(batagelj) {
     if (k > nMax)
-        throw std::runtime_error("k (number of attachments per node) may not be larger than the number of nodes in the target graph (nMax)");
+        throw std::runtime_error("k (number of attachments per node) may not be larger than the "
+                                 "number of nodes in the target graph (nMax)");
     if (n0 > nMax)
-        throw std::runtime_error("n0 (number of initially connected nodes) may not be larger than the number of nodes in the target graph (nMax)");
+        throw std::runtime_error("n0 (number of initially connected nodes) may not be larger than "
+                                 "the number of nodes in the target graph (nMax)");
 
     if (n0 < k) {
         if (n0 > 0) {
@@ -31,15 +34,20 @@ BarabasiAlbertGenerator::BarabasiAlbertGenerator(count k, count nMax, count n0, 
     }
 }
 
-BarabasiAlbertGenerator::BarabasiAlbertGenerator(count k, count nMax, const Graph& initGraph, bool batagelj) : initGraph(initGraph), k(k), nMax(nMax), n0(0), batagelj(batagelj) {
+BarabasiAlbertGenerator::BarabasiAlbertGenerator(count k, count nMax, const Graph &initGraph,
+                                                 bool batagelj)
+    : initGraph(initGraph), k(k), nMax(nMax), n0(0), batagelj(batagelj) {
     if (initGraph.numberOfNodes() != initGraph.upperNodeIdBound())
         throw std::runtime_error("initGraph is expected to have consecutive node ids");
     if (k > nMax)
-        throw std::runtime_error("k (number of attachments per node) may not be larger than the number of nodes in the target graph (nMax)");
+        throw std::runtime_error("k (number of attachments per node) may not be larger than the "
+                                 "number of nodes in the target graph (nMax)");
     if (initGraph.numberOfNodes() > nMax)
-        throw std::runtime_error("initialization graph cannot have more nodes than the target graph (nMax)");
+        throw std::runtime_error(
+            "initialization graph cannot have more nodes than the target graph (nMax)");
     if (!batagelj && initGraph.numberOfNodes() < k) {
-        throw std::runtime_error("initialization graph for the original method needs at least k nodes");
+        throw std::runtime_error(
+            "initialization graph for the original method needs at least k nodes");
     }
 }
 
@@ -59,17 +67,15 @@ Graph BarabasiAlbertGenerator::generateOriginal() {
     if (n0 != 0) {
         // initialize the graph with n0 connected nodes
         for (count i = 1; i < n0; i++) {
-            G.addEdge(i-1, i);
+            G.addEdge(i - 1, i);
         }
     } else {
         // initialize the graph with the edges from initGraph
         // and set n0 accordingly
-        initGraph.forEdges([&G](node u, node v) {
-            G.addEdge(u, v);
-        });
+        initGraph.forEdges([&G](node u, node v) { G.addEdge(u, v); });
         n0 = initGraph.upperNodeIdBound();
     }
-    assert (G.numberOfNodes() >= k);
+    assert(G.numberOfNodes() >= k);
 
     Aux::SignalHandler handler;
     auto &gen = Aux::Random::getURNG();
@@ -83,7 +89,7 @@ Graph BarabasiAlbertGenerator::generateOriginal() {
         while (targets.size() - 1 < k) {
             auto randomIndex = indexDist(gen);
             bool found = false; // break from node iteration when done
-            auto notFound = [&](){ return ! found; };
+            auto notFound = [&]() { return !found; };
 
             G.forNodesWhile(notFound, [&](node v) {
                 if (randomIndex <= G.degree(v)) {
@@ -116,7 +122,8 @@ Graph BarabasiAlbertGenerator::generateBatagelj() {
     // TODO: Once we've a fast GraphBuilder remove degree and migrate to GraphBuilder
     std::vector<node> M;
     std::vector<count> degree(n, 0);
-    auto addEdge = [&] (node u, node v) {
+
+    auto addEdge = [&](node u, node v) {
         M.push_back(u);
         M.push_back(v);
         degree[u]++;
@@ -125,24 +132,22 @@ Graph BarabasiAlbertGenerator::generateBatagelj() {
 
     // copy seed graph into M
     if (initGraph.numberOfNodes() == 0) {
-        M.reserve(2*n0 + 2*(n - n0)*k);
+        M.reserve(2 * n0 + 2 * (n - n0) * k);
 
         // initialize n0 connected nodes
-        for (index v = 0; v < n0-1; ++v) {
-            addEdge(v, v+1);
+        for (index v = 0; v < n0 - 1; ++v) {
+            addEdge(v, v + 1);
         }
         addEdge(0, n0 - 1);
     } else {
-        M.reserve(2*initGraph.numberOfEdges() + 2*(n - initGraph.numberOfNodes()) * k);
+        M.reserve(2 * initGraph.numberOfEdges() + 2 * (n - initGraph.numberOfNodes()) * k);
 
-        initGraph.forEdges( [&] (node u, node v) {
-            addEdge(u, v);
-        });
+        initGraph.forEdges([&](node u, node v) { addEdge(u, v); });
         n0 = initGraph.numberOfNodes();
     }
 
     // for each of the remaining nodes [n0, n), we draw k random DIFFERENT neighbors
-    auto& gen = Aux::Random::getURNG();
+    auto &gen = Aux::Random::getURNG();
     Aux::SignalHandler handler;
     for (index v = n0; v < n; ++v) {
         // If we were to update the range in the next loop, the additionally available nodes
@@ -152,7 +157,7 @@ Graph BarabasiAlbertGenerator::generateBatagelj() {
 
         for (index i = 0; i < k; ++i) {
             // let's sample a new neighbor and repeat if we're already connected to it
-            while(true) {
+            while (true) {
                 const auto randomIndex = distr(gen);
                 const auto newNeighbor = M[randomIndex];
 
@@ -161,7 +166,7 @@ Graph BarabasiAlbertGenerator::generateBatagelj() {
                 // | v | Neigh | v | Neigh | v | Neigh ...
                 // Hence, we need to compare the new neighbor to the previous (i-1) odd positions
                 bool alreadyIncident = false;
-                for(auto j = firstNeighbor; j < M.size(); j += 2) {
+                for (auto j = firstNeighbor; j < M.size(); j += 2) {
                     assert(M[j] != v); // ensure that we're not off by 1
 
                     if (M[j] == newNeighbor) {
@@ -182,11 +187,11 @@ Graph BarabasiAlbertGenerator::generateBatagelj() {
 
     Graph G(nMax);
 
-    for(node u = 0; u < n; ++u)
+    for (node u = 0; u < n; ++u)
         G.preallocateUndirected(u, degree[u]);
 
-    for(size_t i = 0; i < M.size(); i += 2)
-        G.addEdge(M[i], M[i+1]);
+    for (size_t i = 0; i < M.size(); i += 2)
+        G.addEdge(M[i], M[i + 1]);
 
     return G;
 }

--- a/networkit/cpp/generators/BarabasiAlbertGenerator.cpp
+++ b/networkit/cpp/generators/BarabasiAlbertGenerator.cpp
@@ -10,6 +10,7 @@
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
+#include <networkit/auxiliary/SignalHandling.hpp>
 #include <networkit/generators/BarabasiAlbertGenerator.hpp>
 
 
@@ -70,6 +71,7 @@ Graph BarabasiAlbertGenerator::generateOriginal() {
     }
     assert (G.numberOfNodes() >= k);
 
+    Aux::SignalHandler handler;
     for (count i = n0; i < nMax; i++) {
         count degreeSum = G.numberOfEdges() * 2;
         node u = i;
@@ -89,6 +91,8 @@ Graph BarabasiAlbertGenerator::generateOriginal() {
                 }
                 random -= G.degree(v);
             });
+
+            handler.assureRunning();
         }
 
         targets.erase(u);
@@ -137,6 +141,7 @@ Graph BarabasiAlbertGenerator::generateBatagelj() {
 
     // for each of the remaining nodes [n0, n), we draw k random DIFFERENT neighbors
     auto& gen = Aux::Random::getURNG();
+    Aux::SignalHandler handler;
     for (index v = n0; v < n; ++v) {
         // If we were to update the range in the next loop, the additionally available nodes
         // would only lead to self-loops are multi-edges.
@@ -167,6 +172,8 @@ Graph BarabasiAlbertGenerator::generateBatagelj() {
                     addEdge(v, newNeighbor);
                     break;
                 }
+
+                handler.assureRunning();
             }
         }
     }

--- a/networkit/cpp/generators/test/GeneratorsGTest.cpp
+++ b/networkit/cpp/generators/test/GeneratorsGTest.cpp
@@ -413,7 +413,7 @@ TEST_F(GeneratorsGTest, testBarabasiAlbertGeneratorConstructor) {
 
 TEST_F(GeneratorsGTest, testBarabasiAlbertGeneratorBatagelj) {
     count k = 3;
-    count nMax = 100;
+    count nMax = 1000;
     count n0 = 3;
 
     BarabasiAlbertGenerator BarabasiAlbert(k, nMax, n0, true);

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -11,6 +11,9 @@ def run_notebook(path):
     with open(path) as f:
         nb = nbformat.read(f, as_version=4)
 
+    print("Start ", path)
+    sys.stdout.flush()
+
     proc = ExecutePreprocessor(timeout=600, kernel_name='python3')
     proc.allow_errors = True
 
@@ -22,10 +25,10 @@ def run_notebook(path):
                 if output.output_type == 'error':
                     errors.append(output)
     if errors == []:
-        print(path + " test successfully completed.")
+        print(" " + path + " test successfully completed.")
         return 0
     else:
-        print(path + " test exited with errors.")
+        print(" " + path + " test exited with errors.")
         return 1
 
 if __name__ == '__main__':


### PR DESCRIPTION
The default implementation of the Barabasi Albert Generator (due to Batagelj and Brandes) was buggy, inefficient and unnecessarily complicated (rather than using push_back on a vector, the index was (wrongly) computed each time). This PR tries to resolve it:

- Originally the index computation miscalculated the edges from the initial seed graph. This led to reads from uninitialized memory or to overwriting the parts of the seed graph
- The original implementation maintained an vector `M` (required for constant time sampling), a set of produced edges and a graph G. The new implementation exploits the fact that only the $k$ most recent additions can lead to parallel edges and hence does not require the set.
- The original implementation removed duplicated edges, changing the degree distribution. Thus, technically, the generator did not produce BA graphs.

- The new implementation also counts degrees which requires a little bit more memory, but accelerates the generator by ~20%. This should be changed as soon as we have a fast graph builder. 