### PR TITLE
Fix Graph::addNode, Add Graph::addNodes, Guard Python Graph.addEdge

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -820,6 +820,13 @@ public:
     node addNode();
 
     /**
+     * Add numberOfNewNodes new nodes.
+     * @param  numberOfNewNodes Number of new nodes.
+     * @return The index of the last node added.
+     */
+    node addNodes(count numberOfNewNodes);
+
+    /**
      * DEPRECATED: Coordinates should be handled outside the Graph class
      * like general node attributes.
      *

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -305,6 +305,7 @@ cdef extern from "<networkit/graph/Graph.hpp>":
 		bool_t isIsolated(node u) except +
 		_Graph copyNodes() except +
 		node addNode() except +
+		node addNodes(node) except +
 		void removeNode(node u) except +
 		bool_t hasNode(node u) except +
 		void restoreNode(node u) except +

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -707,6 +707,23 @@ cdef class Graph:
 	 	"""
 		return self._this.addNode()
 
+	def addNodes(self, numberOfNewNodes):
+		""" Add numberOfNewNodes many new nodes to the graph and return
+		the id of the last node added.
+
+		Parameters
+		----------
+		numberOfNewNodes : node
+			Number of nodes to be added.
+
+		Returns
+		-------
+		node
+			The id of the last node added.
+		"""
+		assert(numberOfNewNodes >= 0)
+		return self._this.addNodes(numberOfNewNodes)
+
 	def removeNode(self, u):
 		""" Remove a node `v` and all incident edges from the graph.
 
@@ -715,7 +732,7 @@ cdef class Graph:
 	 	Parameters
 	 	----------
 	 	u : node
-	 		Node.
+	 		Id of node to be removed.
 		"""
 		self._this.removeNode(u)
 
@@ -735,7 +752,7 @@ cdef class Graph:
 		Parameters
 		----------
 		u : node
-			Node
+			Id of node queried.
 
 		Returns
 		-------
@@ -765,9 +782,10 @@ cdef class Graph:
 		self._this.merge(G._this)
 		return self
 
-	def addEdge(self, u, v, w=1.0):
+	def addEdge(self, u, v, w=1.0, addMissing = False):
 		""" Insert an undirected edge between the nodes `u` and `v`. If the graph is weighted you can optionally
 		set a weight for this edge. The default weight is 1.0.
+		If one or both end-points do not exists and addMissing is set, they are silently added.
 		Caution: It is not checked whether this edge already exists, thus it is possible to create multi-edges.
 
 	 	Parameters
@@ -778,7 +796,23 @@ cdef class Graph:
  			Endpoint of edge.
 		w : edgeweight, optional
 			Edge weight.
+		addMissing : optional, default: False
+			Add add missing endpoints if necessary (i.e., increase numberOfNodes).
 		"""
+		if not (self._this.hasNode(u) and self._this.hasNode(v)):
+			if not addMissing:
+				raise RuntimeError("Cannot create edge ({0}, {1}) as at least one end point does not exsists".format(u,v))
+
+			k = max(u, v)
+			if k >= self._this.upperNodeIdBound():
+				self._this.addNodes(k - self._this.upperNodeIdBound() + 1)
+
+			if not self._this.hasNode(u):
+				self._this.restoreNode(u)
+
+			if not self._this.hasNode(v):
+				self._this.restoreNode(v)
+
 		self._this.addEdge(u, v, w)
 		return self
 

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -540,20 +540,45 @@ node Graph::addNode() {
     // update per node data structures
     exists.push_back(true);
 
-    // update per node data structures
-    if (weighted) {
+    outEdges.emplace_back();
+    if (weighted) outEdgeWeights.emplace_back();
+    if (edgesIndexed) outEdgeIds.emplace_back();
 
-        std::vector<edgeweight> edgeWeight;
-        inEdgeWeights.push_back(edgeWeight);
-        outEdgeWeights.push_back(edgeWeight);
-    }
-
-    outEdges.push_back(std::vector<node>{});
     if (directed) {
-        inEdges.push_back(std::vector<node>{});
+        inEdges.emplace_back();
+        if (weighted) inEdgeWeights.emplace_back();
+        if (edgesIndexed) inEdgeIds.emplace_back();
     }
 
     return v;
+}
+
+node Graph::addNodes(count numberOfNewNodes) {
+    if (numberOfNewNodes < 10) {
+        // benchmarks suggested, it's cheaper to call 10 time emplace_back than resizing.
+        while (numberOfNewNodes--)
+            addNode();
+
+        return z - 1;
+    }
+
+    z += numberOfNewNodes;
+    n += numberOfNewNodes;
+
+    // update per node data structures
+    exists.resize(z, true);
+
+    outEdges.resize(z);
+    if (weighted) outEdgeWeights.resize(z);
+    if (edgesIndexed) outEdgeIds.resize(z);
+
+    if (directed) {
+        inEdges.resize(z);
+        if (weighted) inEdgeWeights.resize(z);
+        if (edgesIndexed) inEdgeIds.resize(z);
+    }
+
+    return z-1;
 }
 
 node Graph::addNode(float x, float y) {

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -385,6 +385,19 @@ TEST_P(GraphGTest, testAddNode) {
     ASSERT_EQ(4u, G2.numberOfNodes());
 }
 
+TEST_P(GraphGTest, testAddNodes) {
+    auto G = createGraph(5);
+    G.addNodes(5);
+
+    ASSERT_EQ(G.numberOfNodes(), 10);
+    ASSERT_TRUE(G.hasNode(9));
+
+    G.addNodes(90);
+
+    ASSERT_EQ(G.numberOfNodes(), 100);
+    ASSERT_TRUE(G.hasNode(99));
+}
+
 TEST_P(GraphGTest, testRemoveNode) {
     auto testGraph = [&](Graph &G) {
         count n = G.numberOfNodes();

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -231,7 +231,6 @@ class TestGraph(unittest.TestCase):
 			try:
 				while nbrs is not None:
 					nodeList.append(next(nbrs))
-					print(nodeList)
 			except StopIteration:
 				pass
 			return nodeList
@@ -241,6 +240,44 @@ class TestGraph(unittest.TestCase):
 			G.forInEdgesOf(node, nbrFunc)
 			nodeInNbrs = nodeInIter(node)
 			self.assertEqual(sorted(forEdgesNbrs), sorted(nodeInNbrs))
+
+	def testAddNodes(self):
+		G = nk.Graph(0)
+		G.addNodes(10)
+		self.assertEqual(G.numberOfNodes(), 10)
+		for u in range(G.numberOfNodes()):
+			self.assertTrue(G.hasNode(u))
+
+	def testAddEdgeWithMissingNodes(self):
+		G = nk.Graph(0)
+
+		with self.assertRaises(RuntimeError):
+			G.addEdge(0, 1)
+
+		self.assertEqual(G.numberOfNodes(), 0)
+		self.assertEqual(G.numberOfEdges(), 0)
+
+		G.addEdge(0, 2, addMissing = True)
+
+		self.assertEqual(G.numberOfNodes(), 3)
+		self.assertEqual(G.numberOfEdges(), 1)
+
+		G.removeNode(1)
+
+		self.assertEqual(G.numberOfNodes(), 2)
+		self.assertEqual(G.numberOfEdges(), 1)
+
+		G.addEdge(0, 1, addMissing = True)
+
+		self.assertEqual(G.numberOfNodes(), 3)
+		self.assertEqual(G.numberOfEdges(), 2)
+
+		G.removeNode(2)
+
+		G.addEdge(1, 2, addMissing = True)
+
+		self.assertEqual(G.numberOfNodes(), 3)
+		self.assertEqual(G.numberOfEdges(), 2)
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This PR includes three related changes:

- The logic of `Graph::addNode` was broken (e.g. it pushed to `inEdgeWeights` for undirected graphs) and inefficent (rather than using `outEdges.emplace_back()`, first an empty vector was created and then pushed). Both is fixed now.
- To add multiple nodes (required by next point), the method Graph::addNodes(k) was added which performs resizes rather than repeated emplace_backs.
- As discussed in #419, there are no boundary checks for Python's Graph.addEdge(u, v). Thus adding an edge to a non-existing node corrupts memory and (in the best-case) leads to a SegFault. While this is common for C++ interfaces, boundary checks are expected in Python interfaces. Hence, now an exception is thrown. Additionally `addEdge` has now the optional flag `addMissing=False` which will automatically add necessary nodes.