### PR TITLE
Fix graphio.readGraph / graphio.writeGraph

### DIFF
--- a/networkit/graphio.py
+++ b/networkit/graphio.py
@@ -24,67 +24,40 @@ except ImportError:
 	print("module 'scipy' not available - some functionality will be restricted")
 import fnmatch
 
-try:
-	from enum import Enum
+from enum import Enum
 
-	class __AutoNumber(Enum):
-		def __new__(cls):
-			value = len(cls.__members__) + 1
-			obj = object.__new__(cls)
-			obj._value_ = value
-			return obj
-
-
-	class Format(__AutoNumber):
-		""" Simple enumeration class to list supported file types. Currently supported
-		file types: SNAP, EdgeListSpaceZero, EdgeListSpaceOne, EdgeListTabZero, EdgeListTabOne,
-		METIS, GraphML, GEXF, GML, EdgeListCommaOne, GraphViz, DOT, EdgeList, LFR, KONEC, GraphToolBinary,
-                NetworkitBinary"""
-		SNAP = ()
-		EdgeListSpaceZero = ()
-		EdgeListSpaceOne = ()
-		EdgeListTabZero = ()
-		EdgeListTabOne = ()
-		METIS = ()
-		GraphML = ()
-		GEXF = ()
-		GML = ()
-		EdgeListCommaOne = ()
-		GraphViz = ()
-		DOT = ()
-		EdgeList = ()
-		LFR = ()
-		KONECT = ()
-		GraphToolBinary = ()
-		MAT = ()
-		ThrillBinary = ()
-		NetworkitBinary = ()
-
-except ImportError:
-	print("Update to Python >=3.4 recommended - support for < 3.4 may be discontinued in the future")
-	class Format:
-		SNAP = "snap"
-		EdgeListTabOne = "edgelist-t1"
-		EdgeListTabZero = "edgelist-t0"
-		EdgeListSpaceOne = "edgelist-s1"
-		EdgeListSpaceZero = "edgelist-s0"
-		METIS = "metis"
-		GraphML = "graphml"
-		GEXF = "gexf"
-		GML = "gml"
-		EdgeListCommaOne = "edgelist-cs1"
-		GraphViz = "dot"
-		DOT = "dot"
-		EdgeList = "edgelist"
-		LFR = "edgelist-t1"
-		KONECT = "konect"
-		GraphToolBinary = "gtbin"
-		MAT = "mat"
-		ThrillBinary = "thrillbinary"
-		NetworkitBinary = "networkitbinary"
+class __AutoNumber(Enum):
+	def __new__(cls):
+		value = len(cls.__members__) + 1
+		obj = object.__new__(cls)
+		obj._value_ = value
+		return obj
 
 
-
+class Format(__AutoNumber):
+	""" Simple enumeration class to list supported file types. Currently supported
+	file types: SNAP, EdgeListSpaceZero, EdgeListSpaceOne, EdgeListTabZero, EdgeListTabOne,
+	METIS, GraphML, GEXF, GML, EdgeListCommaOne, GraphViz, DOT, EdgeList, LFR, KONEC, GraphToolBinary,
+			NetworkitBinary"""
+	SNAP = ()
+	EdgeListSpaceZero = ()
+	EdgeListSpaceOne = ()
+	EdgeListTabZero = ()
+	EdgeListTabOne = ()
+	METIS = ()
+	GraphML = ()
+	GEXF = ()
+	GML = ()
+	EdgeListCommaOne = ()
+	GraphViz = ()
+	DOT = ()
+	EdgeList = ()
+	LFR = ()
+	KONECT = ()
+	GraphToolBinary = ()
+	MAT = ()
+	ThrillBinary = ()
+	NetworkitBinary = ()
 
 # reading
 

--- a/networkit/graphio.py
+++ b/networkit/graphio.py
@@ -61,41 +61,42 @@ class Format(__AutoNumber):
 
 # reading
 
-def getReader(fileformat, **kwargs):
+def getReader(fileformat, *kargs, **kwargs):
 	#define your [edgelist] reader here:
-	readers =	{
-			Format.METIS:			METISGraphReader(),
-			Format.GraphML:			GraphMLReader(),
-			Format.GEXF:			GEXFReader(),
-			Format.SNAP:			SNAPGraphReader(),
-			Format.EdgeListCommaOne:	EdgeListReader(',',1,),
-			Format.EdgeListSpaceOne:	EdgeListReader(' ',1),
-			Format.EdgeListSpaceZero:	EdgeListReader(' ',0),
-			Format.EdgeListTabOne:		EdgeListReader('\t',1),
-			Format.EdgeListTabZero:		EdgeListReader('\t',0),
-			Format.LFR:			EdgeListReader('\t',1),
-			Format.KONECT:			KONECTGraphReader(),
-			Format.GML:			GMLGraphReader(),
-			Format.GraphToolBinary:		GraphToolBinaryReader(),
-			Format.MAT:			MatReader(),
-			Format.ThrillBinary:		ThrillGraphBinaryReader(),
-			Format.NetworkitBinary:         NetworkitBinaryReader()
-			}
+	readers = {
+		Format.METIS:			METISGraphReader(),
+		Format.GraphML:			GraphMLReader(),
+		Format.GEXF:			GEXFReader(),
+		Format.SNAP:			SNAPGraphReader(),
+		Format.EdgeListCommaOne:	EdgeListReader(',',1,),
+		Format.EdgeListSpaceOne:	EdgeListReader(' ',1),
+		Format.EdgeListSpaceZero:	EdgeListReader(' ',0),
+		Format.EdgeListTabOne:		EdgeListReader('\t',1),
+		Format.EdgeListTabZero:		EdgeListReader('\t',0),
+		Format.LFR:			EdgeListReader('\t',1),
+		Format.KONECT:			KONECTGraphReader(),
+		Format.GML:			GMLGraphReader(),
+		Format.GraphToolBinary:		GraphToolBinaryReader(),
+		Format.MAT:			MatReader(),
+		Format.ThrillBinary:		ThrillGraphBinaryReader(),
+		Format.NetworkitBinary:         NetworkitBinaryReader()
+	}
 
-	try:
-		# special case for custom Edge Lists
-		if fileformat == Format.EdgeList:
-			if kwargs["continuous"] == False:
-				kwargs["firstNode"] = 0
-			reader = EdgeListReader(**kwargs)
-		else:
-			reader = readers[fileformat]#(**kwargs)
-	except Exception or KeyError:
-		raise Exception("unrecognized format/format not supported as input: {0}".format(fileformat))
+	# special case for custom Edge Lists
+	if fileformat == Format.EdgeList:
+		if "continuous" in kwargs and kwargs["continuous"] == False:
+			kwargs["firstNode"] = 0
+		reader = EdgeListReader(*kargs, **kwargs)
+
+	else:
+		if fileformat not in readers:
+			raise Exception("unrecognized format/format not supported as input: {0}".format(fileformat))
+		reader = readers[fileformat]#(**kwargs)
+
 	return reader
 
 
-def readGraph(path, fileformat, **kwargs):
+def readGraph(path, fileformat, *kargs, **kwargs):
 	""" Read graph file in various formats and return a NetworKit::Graph
 	    Parameters:
 		- fileformat: An element of the Format enumeration. Currently supported file types:
@@ -107,8 +108,7 @@ def readGraph(path, fileformat, **kwargs):
 			commentPrefix='#', continuous=True and directed=False are optional because of their default values;
 			firstNode is not needed when continuous=True.
 	"""
-	reader = getReader(fileformat,**kwargs)
-
+	reader = getReader(fileformat, *kargs, **kwargs)
 
 	if ("~" in path):
 		path = os.path.expanduser(path)
@@ -197,36 +197,37 @@ def writeMat(G, path, key="G"):
 
 
 # writing
-def getWriter(fileformat, **kwargs):
+def getWriter(fileformat, *kargs, **kwargs):
 	writers =	{
-			Format.METIS:			METISGraphWriter(),
-			Format.GraphML:			GraphMLWriter(),
-			Format.GEXF:			GEXFWriter(),
-			Format.SNAP:			SNAPGraphWriter(),
-			Format.EdgeListCommaOne:	EdgeListWriter(',',1,),
-			Format.EdgeListSpaceOne:	EdgeListWriter(' ',1),
-			Format.EdgeListSpaceZero:	EdgeListWriter(' ',0),
-			Format.EdgeListTabOne:		EdgeListWriter('\t',1),
-			Format.EdgeListTabZero:		EdgeListWriter('\t',0),
-			Format.GraphViz:		DotGraphWriter(),
-			Format.DOT:			DotGraphWriter(),
-			Format.GML:			GMLGraphWriter(),
-			Format.LFR:			EdgeListWriter('\t',1),
-			Format.GraphToolBinary:         GraphToolBinaryWriter(),
-			Format.ThrillBinary:		ThrillGraphBinaryWriter(),
-			Format.NetworkitBinary:         NetworkitBinaryWriter()
-			}
-	try:
-		# special case for custom Edge Lists
-		if fileformat == Format.EdgeList:
-			writer = EdgeListWriter(**kwargs)
-		else:
-			writer = writers[fileformat]#(**kwargs)
-	except KeyError:
-		raise Exception("format {0} currently not supported".format(fileformat))
-	return writer
+		Format.METIS:			METISGraphWriter(),
+		Format.GraphML:			GraphMLWriter(),
+		Format.GEXF:			GEXFWriter(),
+		Format.SNAP:			SNAPGraphWriter(),
+		Format.EdgeListCommaOne:	EdgeListWriter(',',1,),
+		Format.EdgeListSpaceOne:	EdgeListWriter(' ',1),
+		Format.EdgeListSpaceZero:	EdgeListWriter(' ',0),
+		Format.EdgeListTabOne:		EdgeListWriter('\t',1),
+		Format.EdgeListTabZero:		EdgeListWriter('\t',0),
+		Format.GraphViz:		DotGraphWriter(),
+		Format.DOT:			DotGraphWriter(),
+		Format.GML:			GMLGraphWriter(),
+		Format.LFR:			EdgeListWriter('\t',1),
+		Format.GraphToolBinary:         GraphToolBinaryWriter(),
+		Format.ThrillBinary:		ThrillGraphBinaryWriter(),
+		Format.NetworkitBinary:         NetworkitBinaryWriter()
+	}
 
-def writeGraph(G, path, fileformat, **kwargs):
+	# special case for custom Edge Lists
+	if fileformat == Format.EdgeList:
+		return EdgeListWriter(*kargs, **kwargs)
+
+	else:
+		if fileformat not in writers:
+			raise Exception("format {0} currently not supported".format(fileformat))
+
+		return writers[fileformat]#(**kwargs)
+
+def writeGraph(G, path, fileformat, *kargs, **kwargs):
 	""" Write graph to various output formats.
 
 	Paramaters:
@@ -250,7 +251,7 @@ def writeGraph(G, path, fileformat, **kwargs):
 			raise IOError("No permission to write")
 		else:
 			logging.warning("overriding given file")
-	writer = getWriter(fileformat, **kwargs)
+	writer = getWriter(fileformat, *kargs, **kwargs)
 	writer.write(G, path)
 	logging.info("wrote graph {0} to file {1}".format(G, path))
 

--- a/networkit/graphio.py
+++ b/networkit/graphio.py
@@ -179,11 +179,11 @@ def readMat(path, key="G"):
 	return G
 
 class MatWriter:
-	def __init__(self):
+	def __init__(self, key="G"):
 		self.key = key
 
 	def write(self, G, path, key="G"):
-		writeMat(path, key)
+		writeMat(G, path, key)
 
 def writeMat(G, path, key="G"):
 	""" Writes a NetworKit::Graph to a Matlab object file.
@@ -213,6 +213,7 @@ def getWriter(fileformat, *kargs, **kwargs):
 		Format.GML:			GMLGraphWriter(),
 		Format.LFR:			EdgeListWriter('\t',1),
 		Format.GraphToolBinary:         GraphToolBinaryWriter(),
+		Format.MAT:			MatWriter(),
 		Format.ThrillBinary:		ThrillGraphBinaryWriter(),
 		Format.NetworkitBinary:         NetworkitBinaryWriter()
 	}

--- a/networkit/test/test_graphio.py
+++ b/networkit/test/test_graphio.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import unittest
 import os
+import networkit as nk
 
 class TestGEXFIO(unittest.TestCase):
 	def setUp(self):
@@ -66,6 +67,35 @@ class TestGEXFIO(unittest.TestCase):
 		self.checkDynamic(self.events2, testEvents2)
 		self.checkDynamic(self.events3, testEvents3)
 		self.checkDynamic(self.events4, testEvents4)
+
+	def testWriteGraphReadGraph(self):
+		G = nk.generators.ErdosRenyiGenerator(100, 0.1).generate()
+		someFailed = False
+
+		for format in nk.Format:
+			if format == nk.Format.KONECT or format == nk.Format.DOT or format == nk.Format.GraphViz:
+				# format do not support both reading and writing
+				continue
+
+			filename = "output/testWriteGraphReadGraph." + str(format)
+			if format == nk.Format.MAT:
+				filename += ".mat" # suffix required
+
+			try:
+				if os.path.exists(filename):
+					os.remove(filename)
+
+				kargs = [' ', 0] if format == nk.Format.EdgeList else []
+				nk.graphio.writeGraph(G, filename, format, *kargs)
+				G1 = nk.graphio.readGraph(filename, format, *kargs)
+				self.checkStatic(G, G1)
+
+			except Exception as e:
+				someFailed = True
+				print("Test failed for format {0}".format(format))
+				print(e)
+
+		# assert(not someFailed)
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
As pointed out in the mailing list, Python's graphio interfaces `graphio.readGraph` and `graphio.writeGraph` require the user to provide arguments to the EdgeList reader/writer. Error messages get lost in an unnecessary `try ... except` block which is removed by this PR.

We also fix two bugs in the logic regarding `EdgeList`: While the `EdgeList` interface has to *optional* parameter `continuous`, it was required by the `readGraph` interface. This is not the case anymore. Additionally, the required `separator` and `firstNode` parameters have to be passed as positional arguments. Hence this PR add `*kargs` to readGraph/writeGraph.

It also adds a very simple unittest that tries for each format to write and read a graph again. This surprisingly failed for three Formats (SNAP, GEXF and MAT). I fixed MAT here.