### PR TITLE
Jupyter-notebook for linkprediction module

### DIFF
--- a/notebooks/LinkPrediction.ipynb
+++ b/notebooks/LinkPrediction.ipynb
@@ -4,16 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# NetworKit Link Prediction"
+    "# Link Prediction with NetworKit"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Link prediction is concerned with estimating the probability of the existence of edges between nodes in a graph. The `linkprediction` module has sampling algorithms that provide methods to sample graphs as well link prediction algorithms. The results of the sampling algorithms can be passed to link prediction algorithms. \n",
+    "Link prediction is concerned with estimating the probability of the existence of edges between nodes in a graph. The `linkprediction` module in NetworKit provides sampling algorithms as well link prediction algorithms.\n",
     "\n",
-    "This notebook begins by briefly introducing a wide range of link predicition algorithms available in NetworKit and then demonstrates how to use the sampling algorithms together with the link prediction algorithms and then concludes with some metrics to evaluate the accuracy of the results of the link prediction."
+    "This notebook introduces a several link prediction algorithms available in NetworKit. It shows how to calculate link prediction measures, and how to use the sampling algorithms in combination with link prediction algorithms."
    ]
   },
   {
@@ -43,9 +43,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Adamic/Adar index predicts links in a social network according to the amount of shared links between two nodes. The index sums up the reciprocals of the logarithm of the degree of all common neighbors of u and v.\n",
+    "The Adamic/Adar Index predicts links in a graph according to the amount of shared links between two nodes. The index sums up the reciprocals of the logarithm of the degree of all common neighbors between two nodes `u` and `v`.\n",
     "\n",
-    "The constructor, [AdamicAdarIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=adamic#networkit.linkprediction.AdamicAdarIndex), expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the Adamic/Adar Index of the given node-pair (u, v)."
+    "The constructor, [AdamicAdarIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=adamic#networkit.linkprediction.AdamicAdarIndex) expects a graph as input. The `run(u, v)` method takes a pair of nodes `(u, v)` as input and returns the Adamic/Adar Index of the given pair of nodes."
    ]
   },
   {
@@ -55,28 +55,13 @@
    "outputs": [],
    "source": [
     "# Read graph\n",
-    "G = nk.graphio.readGraph(\"../input/karate.graph\", nk.Format.METIS)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "G = nk.graphio.readGraph(\"../input/karate.graph\", nk.Format.METIS)\n",
+    "\n",
     "# Initialize algorithm\n",
-    "aai = nk.linkprediction.AdamicAdarIndex(G)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get Adamic/Adar Index of 5 nodes\n",
-    "for i in range(5):\n",
-    "    print(\"Adamic/Adar of node {} and node {} = {}\" .format(i, i+1, aai.run(i, i+i)))"
+    "aai = nk.linkprediction.AdamicAdarIndex(G)\n",
+    "\n",
+    "# Get Adamic/Adar Index of two nodes\n",
+    "aai.run(14, 32)"
    ]
   },
   {
@@ -90,11 +75,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Algebraic distance index assigns a distance value to pairs of nodes according to their structural closeness in the graph.\n",
+    "The Algebraic Distance Index assigns a distance value to pairs of nodes according to their structural closeness in the graph.\n",
     "\n",
-    "The constructor, [AlgebraicDistanceIndex(G, numberSystems, numberIterations, omega=0.5, norm= 2)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=algeb#networkit.linkprediction.AlgebraicDistanceIndex) expects a graph followed by the number of systems to use for algebraic iteration and the  number of iterations in each system. `omega` is the overrelaxation parameter while `norm` is the norm factor of the extended algebraic distance. Maximum norm is realized by setting the norm to 0.\n",
+    "The constructor [AlgebraicDistanceIndex(G, numberSystems, numberIterations, omega=0.5, norm= 2)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=algeb#networkit.linkprediction.AlgebraicDistanceIndex) expects as inputs a graph, the number of systems to use for algebraic iteration, and the number of iterations in each system. `omega` is the over-relaxation parameter and `norm` is the norm factor of the extended algebraic distance. Maximum norm is realized by setting `norm` to 0.\n",
     "\n",
-    "After initializiation, the `preprocess()` method should be called before the run(u, v) is executed. `run` takes a pair of nodes (u, v) and returns the algebraic distance index of the given node-pair (u, v)."
+    "After initialization, call the `preprocess()` method. Afterwards, call the `run` method: it takes a pair of nodes `(u, v)` as input and returns the Algebraic Distance Index of the given pair of nodes."
    ]
   },
   {
@@ -103,20 +88,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize algorithm\n",
-    "adi = nk.linkprediction.AlgebraicDistanceIndex(G, 2, 200)\n",
-    "adi.preprocess()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get Algebraic distance index of first 5 nodes\n",
-    "for i in range(5):\n",
-    "    print(\"Algebraic distance index of node {} and node {} = {}\" .format(i, i+1, adi.run(i, i+i)))"
+    "# Initialize the algorithm\n",
+    "adi = nk.linkprediction.AlgebraicDistanceIndex(G, 30, 200)\n",
+    "adi.preprocess()\n",
+    "\n",
+    "# Get the algebraic distance index of two nodes\n",
+    "adi.run(1, 32)"
    ]
   },
   {
@@ -130,9 +107,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Common neighbors index calculates the number of common neighbors of a node-pair in a given graph. \n",
+    "The Common Neighbors Index calculates the number of common neighbors of a pair of nodes in a graph. \n",
     "\n",
-    "The constructor, [CommonNeighborsIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=common#networkit.linkprediction.CommonNeighborsIndex), expects a graph to work on. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the number of common neighbors between u and v."
+    "The constructor [CommonNeighborsIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=common#networkit.linkprediction.CommonNeighborsIndex), expects a graph as input. The `run(u, v)` method takes as input a pair of nodes `(u, v)` and returns the number of common neighbors between `u` and `v`."
    ]
   },
   {
@@ -141,19 +118,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize algorithm\n",
-    "cni = nk.linkprediction.CommonNeighborsIndex(G)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get common neighbors of the first 5 nodes\n",
-    "for i in range(5):\n",
-    "    print(\"Common neighbors between node {} and node {} = {}\" .format(i, i+1, cni.run(i, i+i)))"
+    "# Initialize the algorithm\n",
+    "cni = nk.linkprediction.CommonNeighborsIndex(G)\n",
+    "\n",
+    "# Calculate common neighbors between two nodes\n",
+    "cni.run(14, 15)"
    ]
   },
   {
@@ -167,9 +136,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Neighbors measure index returns the number of connections between neighbors of the given nodes u and v.\n",
+    "The Neighbors Measure Index returns the number of connections between neighbors of the given nodes `u` and `v`.\n",
     "\n",
-    "The [NeighborsMeasureIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=neighborsme#networkit.linkprediction.NeighborsMeasureIndex) constructor expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the neighbors measure index between nodes u and v."
+    "The constructor [NeighborsMeasureIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=neighborsme#networkit.linkprediction.NeighborsMeasureIndex) expects a graph as input. The `run(u, v)` takes a pair of nodes `(u, v)` as input and returns the neighbors measure index between `u` and `v`."
    ]
   },
   {
@@ -178,19 +147,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize algorithm\n",
-    "nmi = nk.linkprediction.NeighborsMeasureIndex(G)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get common neighbors of the first 5 nodes\n",
-    "for i in range(5):\n",
-    "    print(\"Neighbors measure index between node {} and node {} = {}\" .format(i, i+1, nmi.run(i, i+1)))"
+    "# Initialize the algorithm\n",
+    "nmi = nk.linkprediction.NeighborsMeasureIndex(G)\n",
+    "\n",
+    "# Calculate the neighbors measure index between two nodes\n",
+    "nmi.run(14, 32)"
    ]
   },
   {
@@ -204,9 +165,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Preferential attachment index suggests that the more connected a node is, the more likely it is to receive new links.\n",
+    "The Preferential Attachment Index suggests that the more connected a node is, the more likely it is to receive new links.\n",
     "\n",
-    "The [PreferentialAttachmentIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=preferential#networkit.linkprediction.PreferentialAttachmentIndex) constructor expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the product of the cardinalities of the neighborhoods regarding nodes u and v."
+    "The constructor [PreferentialAttachmentIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=preferential#networkit.linkprediction.PreferentialAttachmentIndex) expects a graph as input. The `run(u, v)` method takes a pair of nodes `(u, v)` as input and returns the product of the cardinalities of the neighborhoods of nodes `u` and `v`."
    ]
   },
   {
@@ -215,19 +176,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize algorithm\n",
-    "pai = nk.linkprediction.PreferentialAttachmentIndex(G)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get common neighbors of the first 5 nodes\n",
-    "for i in range(5):\n",
-    "    print(\"Preferential attachment index between node {} and node {} = {}\" .format(i, i+1, pai.run(i, i+1)))"
+    "# Initialize the algorithm\n",
+    "pai = nk.linkprediction.PreferentialAttachmentIndex(G)\n",
+    "\n",
+    "# Calculate the preferential attachment index between two nodes\n",
+    "pai.run(14, 32)"
    ]
   },
   {
@@ -241,7 +194,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The constructor, [ResourceAllocationIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=resource#networkit.linkprediction.ResourceAllocationIndex), expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the resource allocation index of the node-pair."
+    "The constructor [ResourceAllocationIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=resource#networkit.linkprediction.ResourceAllocationIndex) expects a graph as input. The `run(u, v)` method takes a pair of nodes `(u, v)` as input and returns the Resource Allocation Index between `u` and `v`."
    ]
   },
   {
@@ -250,19 +203,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize algorithm\n",
-    "rai = nk.linkprediction.ResourceAllocationIndex(G)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get common neighbors of the first 5 nodes\n",
-    "for i in range(5):\n",
-    "    print(\"Resource allocation index of node {} and node {} = {}\" .format(i, i+1, rai.run(i, i+1)))"
+    "# Initialize the algorithm\n",
+    "rai = nk.linkprediction.ResourceAllocationIndex(G)\n",
+    "\n",
+    "# Calculate the resource allocation index between two nodes\n",
+    "rai.run(14, 32)"
    ]
   },
   {
@@ -276,9 +221,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Same community index determines whether two nodes u and v are in the same community.\n",
+    "The Same Community Index determines whether two nodes `u` and `v` are in the same community.\n",
     "\n",
-    "The constructor, [SameCommunityIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=samecommunity#networkit.linkprediction.SameCommunityIndex), expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns `1` if the pair of nodes is in the same community."
+    "The constructor [SameCommunityIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=samecommunity#networkit.linkprediction.SameCommunityIndex) expects a graph as input. The `run(u, v)` method takes a pair of nodes `(u, v)` as input and returns `1` if `u` and `v` are in the same community, `0` otherwise."
    ]
   },
   {
@@ -287,19 +232,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize algorithm\n",
-    "sni = nk.linkprediction.SameCommunityIndex(G)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get same community index of some nodes\n",
-    "for i in range(5):\n",
-    "    print(\"Node {} and node {} community index = {}\" .format(i, i+1, sni.run(i, i+1)))"
+    "# Initialize the algorithm\n",
+    "sni = nk.linkprediction.SameCommunityIndex(G)\n",
+    "\n",
+    "# Compute the Same Community Index between two pairs of nodes\n",
+    "print(sni.run(14, 32))\n",
+    "print(sni.run(0, 32))"
    ]
   },
   {
@@ -313,9 +251,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Total neighbors index returns the number of nodes in the neighborhood-union of nodes u and v.\n",
+    "The Total Neighbors Index returns the number of nodes in the neighborhood-union of nodes `u` and `v`.\n",
     "\n",
-    "The [TotalNeighborsIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=totalneighb#networkit.linkprediction.TotalNeighborsIndex) constructor expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the total neighbors index between u and v."
+    "The constructor [TotalNeighborsIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=totalneighb#networkit.linkprediction.TotalNeighborsIndex) expects a graph as input. The `run(u, v)` method takes a pair of nodes `(u, v)` as input and returns the Total Neighbors Index between `u` and `v`."
    ]
   },
   {
@@ -324,19 +262,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize algorithm\n",
-    "tni = nk.linkprediction.TotalNeighborsIndex(G)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get total neighbors index of some nodes\n",
-    "for i in range(5):\n",
-    "    print(\"Total neighbors between node {} and node {} = {}\" .format(i, i+1, tni.run(i, i+1)))"
+    "# Initialize the algorithm\n",
+    "tni = nk.linkprediction.TotalNeighborsIndex(G)\n",
+    "\n",
+    "# Calculate the Total Neighbors Index between two nodes\n",
+    "tni.run(14, 32)"
    ]
   },
   {
@@ -350,22 +280,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This section shows how to use the training algorithms and the link prediction algorithms alongside each other, i.e, how to pass the results of the samplers to the link predictors. As an example, we shall use the Random Link Sampler, the Missing Links Finder and the Katz Index."
+    "This section shows how to use the training algorithms in combination with link prediction algorithms. In this example, we use the Random Link Sampler, the Missing Links Finder and the Katz Index algorithms."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Katz index assigns a pair of nodes a similarity score that is based on the sum of the weighted number of paths of length $l$ where $l$ is smaller than a given limit.\n",
+    "The Katz index assigns a similarity score to a pair of nodes. This score is based on the weighted sum of the number of paths with length $l$, where $l$ is smaller than a given limit.\n",
     "\n",
-    "The class has 2 [constructors](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=katzindex#networkit.linkprediction.KatzIndex) that each take different parameters:\n",
-    "   1. `KatzIndex(G, maxPathLength=5, dampingValue=0.005)` takes a graph, followed by the maximum length of paths to consider, and the damping value.\n",
-    "   2. `KatzIndex(maxPathLength=5, dampingValue=0.005)` only takes the maximum length of paths to consider and damping value.\n",
+    "[KatzIndex(G=None, maxPathLength=5, dampingValue=0.005)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=katzindex#networkit.linkprediction.KatzIndex) takes as inputs a graph (optional), the maximum length of paths to consider, and the damping value.\n",
     "   \n",
-    "The [RandomLinkSampler(G, numLinks)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=randomlinksampler#networkit.linkprediction.RandomLinkSampler) provides methods to randomly sample a number of edges from a given graph. `numLinks` defines the number of links the returned graph should consist of. The sampler returns a graph that contains `numLinks` links from the given graph.\n",
+    "[RandomLinkSampler(G, numLinks)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=randomlinksampler#networkit.linkprediction.RandomLinkSampler) provides methods to randomly sample a number of edges from a given graph. `numLinks` is the number of edges the returned graph should have.\n",
     "\n",
-    "The [MissingLinksFinder(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=missing#networkit.linkprediction.MissingLinksFinder) finds missing links in the given graph. The `findAtDistance(k)` function returns all missing links in the graph that have distance k."
+    "[MissingLinksFinder(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=missing#networkit.linkprediction.MissingLinksFinder) finds the missing edges in the given graph. The `findAtDistance(k)` function returns all missing links in the graph. The absent links to find are narrowed down by providing a distance that the nodes of the missing links should have. For example in case of distance 2 only node-pairs that would close a triangle in the given graph get returned."
    ]
   },
   {
@@ -375,52 +303,20 @@
    "outputs": [],
    "source": [
     "# Read graph\n",
-    "G = nk.graphio.readGraph(\"../input/jazz.graph\", nk.Format.METIS)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "G = nk.graphio.readGraph(\"../input/jazz.graph\", nk.Format.METIS)\n",
+    "\n",
     "# Sample graph\n",
-    "trainingGraph = nk.linkprediction.RandomLinkSampler.byPercentage(G, 0.7)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "trainingGraph = nk.linkprediction.RandomLinkSampler.byPercentage(G, 0.7)\n",
+    "\n",
     "# Find missing links\n",
-    "missingLinks = nk.linkprediction.MissingLinksFinder(trainingGraph).findAtDistance(2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "missingLinks = nk.linkprediction.MissingLinksFinder(trainingGraph).findAtDistance(5)\n",
+    "\n",
     "# Run link prediticion\n",
-    "predictions = nk.linkprediction.KatzIndex(G).runOn(missingLinks)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# Verify\n",
-    "for p in range(len(predictions)-1):\n",
-    "    a, b = predictions[p]\n",
-    "    c, d = predictions[p+1]\n",
-    "    assert (a < c or b < d)"
+    "predictions = nk.linkprediction.KatzIndex(G).runOn(missingLinks)\n",
+    "\n",
+    "# Print the first 5 predictions\n",
+    "for p in predictions[:5]:\n",
+    "    print(p)"
    ]
   }
  ],
@@ -440,7 +336,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/LinkPrediction.ipynb
+++ b/notebooks/LinkPrediction.ipynb
@@ -1,0 +1,448 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NetworKit Link Prediction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Link prediction is concerned with estimating the probability of the existence of edges between nodes in a graph. The `linkprediction` module has sampling algorithms that provide methods to sample graphs as well link prediction algorithms. The results of the sampling algorithms can be passed to link prediction algorithms. \n",
+    "\n",
+    "This notebook begins by briefly introducing a wide range of link predicition algorithms available in NetworKit and then demonstrates how to use the sampling algorithms together with the link prediction algorithms and then concludes with some metrics to evaluate the accuracy of the results of the link prediction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import networkit as nk"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Link prediction algorithms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adamic/Adar Index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Adamic/Adar index predicts links in a social network according to the amount of shared links between two nodes. The index sums up the reciprocals of the logarithm of the degree of all common neighbors of u and v.\n",
+    "\n",
+    "The constructor, [AdamicAdarIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=adamic#networkit.linkprediction.AdamicAdarIndex), expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the Adamic/Adar Index of the given node-pair (u, v)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read graph\n",
+    "G = nk.graphio.readGraph(\"../input/karate.graph\", nk.Format.METIS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize algorithm\n",
+    "aai = nk.linkprediction.AdamicAdarIndex(G)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get Adamic/Adar Index of 5 nodes\n",
+    "for i in range(5):\n",
+    "    print(\"Adamic/Adar of node {} and node {} = {}\" .format(i, i+1, aai.run(i, i+i)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Algebraic Distance Index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Algebraic distance index assigns a distance value to pairs of nodes according to their structural closeness in the graph.\n",
+    "\n",
+    "The constructor, [AlgebraicDistanceIndex(G, numberSystems, numberIterations, omega=0.5, norm= 2)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=algeb#networkit.linkprediction.AlgebraicDistanceIndex) expects a graph followed by the number of systems to use for algebraic iteration and the  number of iterations in each system. `omega` is the overrelaxation parameter while `norm` is the norm factor of the extended algebraic distance. Maximum norm is realized by setting the norm to 0.\n",
+    "\n",
+    "After initializiation, the `preprocess()` method should be called before the run(u, v) is executed. `run` takes a pair of nodes (u, v) and returns the algebraic distance index of the given node-pair (u, v)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize algorithm\n",
+    "adi = nk.linkprediction.AlgebraicDistanceIndex(G, 2, 200)\n",
+    "adi.preprocess()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get Algebraic distance index of first 5 nodes\n",
+    "for i in range(5):\n",
+    "    print(\"Algebraic distance index of node {} and node {} = {}\" .format(i, i+1, adi.run(i, i+i)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Common Neighbors Index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Common neighbors index calculates the number of common neighbors of a node-pair in a given graph. \n",
+    "\n",
+    "The constructor, [CommonNeighborsIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=common#networkit.linkprediction.CommonNeighborsIndex), expects a graph to work on. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the number of common neighbors between u and v."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize algorithm\n",
+    "cni = nk.linkprediction.CommonNeighborsIndex(G)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get common neighbors of the first 5 nodes\n",
+    "for i in range(5):\n",
+    "    print(\"Common neighbors between node {} and node {} = {}\" .format(i, i+1, cni.run(i, i+i)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Neighbors Measure Index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Neighbors measure index returns the number of connections between neighbors of the given nodes u and v.\n",
+    "\n",
+    "The [NeighborsMeasureIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=neighborsme#networkit.linkprediction.NeighborsMeasureIndex) constructor expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the neighbors measure index between nodes u and v."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize algorithm\n",
+    "nmi = nk.linkprediction.NeighborsMeasureIndex(G)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get common neighbors of the first 5 nodes\n",
+    "for i in range(5):\n",
+    "    print(\"Neighbors measure index between node {} and node {} = {}\" .format(i, i+1, nmi.run(i, i+1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preferential Attachment Index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Preferential attachment index suggests that the more connected a node is, the more likely it is to receive new links.\n",
+    "\n",
+    "The [PreferentialAttachmentIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=preferential#networkit.linkprediction.PreferentialAttachmentIndex) constructor expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the product of the cardinalities of the neighborhoods regarding nodes u and v."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize algorithm\n",
+    "pai = nk.linkprediction.PreferentialAttachmentIndex(G)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get common neighbors of the first 5 nodes\n",
+    "for i in range(5):\n",
+    "    print(\"Preferential attachment index between node {} and node {} = {}\" .format(i, i+1, pai.run(i, i+1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Resource Allocation Index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The constructor, [ResourceAllocationIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=resource#networkit.linkprediction.ResourceAllocationIndex), expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the resource allocation index of the node-pair."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize algorithm\n",
+    "rai = nk.linkprediction.ResourceAllocationIndex(G)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get common neighbors of the first 5 nodes\n",
+    "for i in range(5):\n",
+    "    print(\"Resource allocation index of node {} and node {} = {}\" .format(i, i+1, rai.run(i, i+1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Same Community Index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Same community index determines whether two nodes u and v are in the same community.\n",
+    "\n",
+    "The constructor, [SameCommunityIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=samecommunity#networkit.linkprediction.SameCommunityIndex), expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns `1` if the pair of nodes is in the same community."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize algorithm\n",
+    "sni = nk.linkprediction.SameCommunityIndex(G)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get same community index of some nodes\n",
+    "for i in range(5):\n",
+    "    print(\"Node {} and node {} community index = {}\" .format(i, i+1, sni.run(i, i+1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Total Neighbors Index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Total neighbors index returns the number of nodes in the neighborhood-union of nodes u and v.\n",
+    "\n",
+    "The [TotalNeighborsIndex(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=totalneighb#networkit.linkprediction.TotalNeighborsIndex) constructor expects a graph. After initializiation, the `run(u, v)` method should be called. It takes a pair of nodes (u, v) and returns the total neighbors index between u and v."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize algorithm\n",
+    "tni = nk.linkprediction.TotalNeighborsIndex(G)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get total neighbors index of some nodes\n",
+    "for i in range(5):\n",
+    "    print(\"Total neighbors between node {} and node {} = {}\" .format(i, i+1, tni.run(i, i+1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Link sampling and link prediction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section shows how to use the training algorithms and the link prediction algorithms alongside each other, i.e, how to pass the results of the samplers to the link predictors. As an example, we shall use the Random Link Sampler, the Missing Links Finder and the Katz Index."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Katz index assigns a pair of nodes a similarity score that is based on the sum of the weighted number of paths of length $l$ where $l$ is smaller than a given limit.\n",
+    "\n",
+    "The class has 2 [constructors](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=katzindex#networkit.linkprediction.KatzIndex) that each take different parameters:\n",
+    "   1. `KatzIndex(G, maxPathLength=5, dampingValue=0.005)` takes a graph, followed by the maximum length of paths to consider, and the damping value.\n",
+    "   2. `KatzIndex(maxPathLength=5, dampingValue=0.005)` only takes the maximum length of paths to consider and damping value.\n",
+    "   \n",
+    "The [RandomLinkSampler(G, numLinks)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=randomlinksampler#networkit.linkprediction.RandomLinkSampler) provides methods to randomly sample a number of edges from a given graph. `numLinks` defines the number of links the returned graph should consist of. The sampler returns a graph that contains `numLinks` links from the given graph.\n",
+    "\n",
+    "The [MissingLinksFinder(G)](https://networkit.github.io/dev-docs/python_api/linkprediction.html?highlight=missing#networkit.linkprediction.MissingLinksFinder) finds missing links in the given graph. The `findAtDistance(k)` function returns all missing links in the graph that have distance k."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read graph\n",
+    "G = nk.graphio.readGraph(\"../input/jazz.graph\", nk.Format.METIS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sample graph\n",
+    "trainingGraph = nk.linkprediction.RandomLinkSampler.byPercentage(G, 0.7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find missing links\n",
+    "missingLinks = nk.linkprediction.MissingLinksFinder(trainingGraph).findAtDistance(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run link prediticion\n",
+    "predictions = nk.linkprediction.KatzIndex(G).runOn(missingLinks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Verify\n",
+    "for p in range(len(predictions)-1):\n",
+    "    a, b = predictions[p]\n",
+    "    c, d = predictions[p+1]\n",
+    "    assert (a < c or b < d)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a new jupyter-notebook for the `linkprediction` module.