### PR TITLE
Refactor: CentralityGTest and fix in Closeness

### DIFF
--- a/include/networkit/centrality/Closeness.hpp
+++ b/include/networkit/centrality/Closeness.hpp
@@ -82,11 +82,11 @@ class Closeness : public Centrality {
         scoreData[u] =
             sum ? variant == ClosenessVariant::standard
                       ? 1.0 / sum
-                      : (reached - 1) / sum / (G.upperNodeIdBound() - 1)
+                      : (reached - 1) / sum / (G.numberOfNodes() - 1)
                 : 0.;
         if (normalized)
             scoreData[u] *=
-                (variant == ClosenessVariant::standard ? G.upperNodeIdBound()
+                (variant == ClosenessVariant::standard ? G.numberOfNodes()
                                                        : reached) -
                 1.;
     }

--- a/networkit/cpp/centrality/Closeness.cpp
+++ b/networkit/cpp/centrality/Closeness.cpp
@@ -129,13 +129,14 @@ void Closeness::dijkstra() {
 
         heap.push(u);
         dist_[u] = 0.;
-        double sum = 0.;
         visited_[u] = ts_;
+
+        double sumDist = 0.;
         count reached = 1;
 
         do {
-            node x = heap.extract_top();
-            sum += dist_[x];
+            const auto x = heap.extract_top();
+            sumDist += dist_[x];
             G.forNeighborsOf(x, [&](node y, edgeweight ew) {
                 if (ts_ != visited_[y]) {
                     ++reached;
@@ -148,7 +149,9 @@ void Closeness::dijkstra() {
                 }
             });
         } while (!heap.empty());
-        updateScoreData(u, reached, sum);
+
+        updateScoreData(u, reached, sumDist);
     }
 }
+
 } // namespace NetworKit

--- a/networkit/cpp/centrality/Closeness.cpp
+++ b/networkit/cpp/centrality/Closeness.cpp
@@ -130,6 +130,7 @@ void Closeness::dijkstra() {
         heap.push(u);
         dist_[u] = 0.;
         double sum = 0.;
+        visited_[u] = ts_;
         count reached = 1;
 
         do {

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1623,10 +1623,11 @@ TEST_F(CentralityGTest, testKadabraAbsoluteDeterministic) {
     }
 }
 
-TEST_F(CentralityGTest, testDynTopHarmonicClosenessUndirected) {
-    Graph G = DorogovtsevMendesGenerator(500).generate();
+TEST_P(CentralityGTest, testDynTopHarmonicCloseness) {
+    auto G1 = DorogovtsevMendesGenerator(500).generate();
+    Graph G(G1, false, isDirected());
 
-    count k = 10;
+    constexpr count k = 10;
 
     DynTopHarmonicCloseness centrality(G, k, false);
     centrality.run();
@@ -1665,11 +1666,11 @@ TEST_F(CentralityGTest, testDynTopHarmonicClosenessUndirected) {
         G.addEdge(u, v);
     }
 
-    for (auto e : insertions) {
+    for (auto &e : insertions) {
         G.removeEdge(e.u, e.v);
     }
 
-    for (GraphEvent edgeAddition : insertions) {
+    for (auto &edgeAddition : insertions) {
 
         node u = edgeAddition.u;
         node v = edgeAddition.v;
@@ -1687,7 +1688,7 @@ TEST_F(CentralityGTest, testDynTopHarmonicClosenessUndirected) {
         }
     }
 
-    for (GraphEvent edgeDeletion : deletions) {
+    for (auto &edgeDeletion : deletions) {
         node u = edgeDeletion.u;
         node v = edgeDeletion.v;
 
@@ -1704,7 +1705,7 @@ TEST_F(CentralityGTest, testDynTopHarmonicClosenessUndirected) {
         }
     }
 
-    for (GraphEvent edgeInsertion : insertions) {
+    for (auto &edgeInsertion : insertions) {
         G.addEdge(edgeInsertion.u, edgeInsertion.v);
     }
 
@@ -1719,99 +1720,4 @@ TEST_F(CentralityGTest, testDynTopHarmonicClosenessUndirected) {
     }
 }
 
-TEST_F(CentralityGTest, testDynTopHarmonicClosenessDirected) {
-    Graph G = ErdosRenyiGenerator(300, 0.1, true).generate();
-
-    count k = 10;
-
-    DynTopHarmonicCloseness centrality(G, k, false);
-    centrality.run();
-
-    HarmonicCloseness reference(G, false);
-    reference.run();
-
-    auto scores = centrality.ranking();
-    auto refScores = reference.ranking();
-    for (count j = 0; j < k; ++j) {
-        EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-    }
-
-    count numInsertions = 1;
-
-    std::vector<GraphEvent> deletions;
-    std::vector<GraphEvent> insertions;
-
-    for (count i = 0; i < numInsertions; i++) {
-
-        node u = G.upperNodeIdBound();
-        node v = G.upperNodeIdBound();
-
-        do {
-            u = G.randomNode();
-            v = G.randomNode();
-        } while (G.hasEdge(u, v));
-
-        GraphEvent edgeAddition(GraphEvent::EDGE_ADDITION, u, v);
-        insertions.insert(insertions.begin(), edgeAddition);
-
-        GraphEvent edgeDeletion(GraphEvent::EDGE_REMOVAL, u, v);
-        deletions.push_back(edgeDeletion);
-
-        G.addEdge(u, v);
-    }
-
-    for (auto e : insertions) {
-        G.removeEdge(e.u, e.v);
-    }
-
-    for (GraphEvent edgeAddition : insertions) {
-
-        node u = edgeAddition.u;
-        node v = edgeAddition.v;
-
-        G.addEdge(u, v);
-
-        centrality.update(edgeAddition);
-        reference.run();
-
-        scores = centrality.ranking();
-        refScores = reference.ranking();
-
-        for (count j = 0; j < k; ++j) {
-            EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-        }
-    }
-
-    for (GraphEvent edgeDeletion : deletions) {
-
-        node u = edgeDeletion.u;
-        node v = edgeDeletion.v;
-
-        G.removeEdge(u, v);
-
-        centrality.update(edgeDeletion);
-        reference.run();
-
-        scores = centrality.ranking();
-        refScores = reference.ranking();
-
-        for (count j = 0; j < k; ++j) {
-            EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-        }
-    }
-
-    for (GraphEvent edgeInsertion : insertions) {
-        G.addEdge(edgeInsertion.u, edgeInsertion.v);
-    }
-
-    reference.run();
-    centrality.updateBatch(insertions);
-
-    scores = centrality.ranking();
-    refScores = reference.ranking();
-
-    for (count j = 0; j < k; ++j) {
-        EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-    }
-}
 } /* namespace NetworKit */

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -45,7 +45,20 @@
 
 namespace NetworKit {
 
-class CentralityGTest : public testing::Test {};
+class CentralityGTest : public testing::TestWithParam<std::pair<bool, bool>> {
+protected:
+    bool isDirected() const noexcept;
+    bool isWeighted() const noexcept;
+};
+
+INSTANTIATE_TEST_CASE_P(InstantiationName, CentralityGTest,
+        testing::Values(std::make_pair(false, false), std::make_pair(true, false),
+                        std::make_pair(false, true),
+                        std::make_pair(true, true)), ); // comma required for variadic macro
+
+bool CentralityGTest::isWeighted() const noexcept { return GetParam().first; }
+
+bool CentralityGTest::isDirected() const noexcept { return GetParam().second; }
 
 TEST_F(CentralityGTest, testBetweennessCentrality) {
     /* Graph:


### PR DESCRIPTION
This PR brings the following changes:

- Parametrization of `CentralityGTests` for weighted/directed graphs: the code for some tests was copy-pasted to test directed/undirected, weighted/unweighted graphs. With parametrization we can use the same code once for all of those cases.
- Additional tests for all `TopCloseness` heuristics.
- Fix a bug in `Closeness` for weighted graphs (wrong scores were not detected due to lack of tests).