### PR TITLE
Add local community detection algorithms

### DIFF
--- a/include/networkit/auxiliary/IncrementalUniformRandomSelector.hpp
+++ b/include/networkit/auxiliary/IncrementalUniformRandomSelector.hpp
@@ -1,0 +1,53 @@
+// networkit-format
+#ifndef NETWORKIT_AUXILIARY_INCREMENTAL_UNIFORM_RANDOM_SELECTOR_HPP_
+#define NETWORKIT_AUXILIARY_INCREMENTAL_UNIFORM_RANDOM_SELECTOR_HPP_
+
+#include <cstddef>
+
+#include <networkit/auxiliary/Random.hpp>
+
+namespace Aux {
+
+/**
+ * Select uniformly at random from a set of elements
+ * that is discovered incrementally. Every time you
+ * discover a new element, you tell the selector and
+ * it will tell if you should keep the new element or
+ * your old element. As more and more elements are
+ * discovered, it will be less and less likely that
+ * the new element is chosen in order to ensure that
+ * the selection is uniformly at random. The process
+ * can be reset when a new class of elements is found
+ * that shall be used instead.
+ */
+class IncrementalUniformRandomSelector {
+public:
+    /**
+     * Initialize the random select for one element.
+     */
+    IncrementalUniformRandomSelector() : counter(1){};
+
+    /**
+     * Add the next element.
+     *
+     * Note that this must not be called for the first element.
+     *
+     * @return If the new element shall be accepted/kept.
+     */
+    bool addElement() {
+        ++counter;
+        return (Random::real() < 1.0 / static_cast<double>(counter));
+    }
+
+    /**
+     * Reset the process to one element again.
+     */
+    void reset() { counter = 1; }
+
+private:
+    size_t counter;
+};
+
+} // namespace Aux
+
+#endif // NETWORKIT_AUXILIARY_INCREMENTAL_UNIFORM_RANDOM_SELECTOR_HPP_

--- a/include/networkit/scd/ApproximatePageRank.hpp
+++ b/include/networkit/scd/ApproximatePageRank.hpp
@@ -21,11 +21,11 @@ namespace NetworKit {
  * Computes an approximate PageRank vector from a given seed.
  */
 class ApproximatePageRank final {
-    const Graph *G;
+    const Graph *g;
     double alpha;
     double eps;
 
-    std::unordered_map<node, std::pair<double, double>> pr_res;
+    std::unordered_map<node, std::pair<double, double>> prRes;
 
 public:
     /**

--- a/include/networkit/scd/ApproximatePageRank.hpp
+++ b/include/networkit/scd/ApproximatePageRank.hpp
@@ -1,3 +1,4 @@
+// networkit-format
 /*
  * ApproximatePageRank.hpp
  *
@@ -20,7 +21,7 @@ namespace NetworKit {
  * Computes an approximate PageRank vector from a given seed.
  */
 class ApproximatePageRank final {
-    const Graph* G;
+    const Graph *G;
     double alpha;
     double eps;
 
@@ -32,7 +33,7 @@ public:
      * @param alpha Loop probability of random walk.
      * @param epsilon Error tolerance.
      */
-    ApproximatePageRank(const Graph& g, double alpha, double epsilon = 1e-12);
+    ApproximatePageRank(const Graph &g, double alpha, double epsilon = 1e-12);
 
     /**
      * @return Approximate PageRank vector from @a seeds with parameters

--- a/include/networkit/scd/ApproximatePageRank.hpp
+++ b/include/networkit/scd/ApproximatePageRank.hpp
@@ -8,6 +8,7 @@
 #ifndef NETWORKIT_SCD_APPROXIMATE_PAGE_RANK_HPP_
 #define NETWORKIT_SCD_APPROXIMATE_PAGE_RANK_HPP_
 
+#include <set>
 #include <unordered_map>
 #include <vector>
 
@@ -32,6 +33,12 @@ public:
      * @param epsilon Error tolerance.
      */
     ApproximatePageRank(const Graph& g, double alpha, double epsilon = 1e-12);
+
+    /**
+     * @return Approximate PageRank vector from @a seeds with parameters
+     *         specified in the constructor.
+     */
+    std::vector<std::pair<node, double>> run(const std::set<node> &seeds);
 
     /**
      * @return Approximate PageRank vector from @a seed with parameters

--- a/include/networkit/scd/CliqueDetect.hpp
+++ b/include/networkit/scd/CliqueDetect.hpp
@@ -1,0 +1,58 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_CLIQUE_DETECT_HPP_
+#define NETWORKIT_SCD_CLIQUE_DETECT_HPP_
+
+#include <networkit/scd/SelectiveCommunityDetector.hpp>
+
+namespace NetworKit {
+
+/**
+ * The CliqueDetect algorithm. It finds the largest clique in the seed node's neighborhood.
+ *
+ * The algorithm can handle weighted graphs. There, the clique with the highest sum of internal edge
+ * weights is returned. This sum includes edge weights to the seed node(s) to ensure that cliques
+ * that are well-connected to the seed node(s) are preferred.
+ *
+ * See also: Hamann, M.; Röhrs, E.; Wagner, D. Local Community Detection Based on Small Cliques.
+ * Algorithms 2017, 10, 90. https://doi.org/10.3390/a10030090
+ */
+class CliqueDetect : public SelectiveCommunityDetector {
+
+public:
+    /**
+     * Construct a Cliquedetect object.
+     *
+     * @param[in] G The graph to detect communities on
+     */
+    CliqueDetect(const Graph &g);
+
+    /**
+     * Expands a single seed node/vertex into a maximal clique.
+     *
+     * @param[in] s the seed node
+     * @return A community of the seed node
+     */
+    std::set<node> expandOneCommunity(node seed) override;
+
+    /**
+     * Detect a single clique for the given seed nodes.
+     *
+     * The resulting community is a clique iff the seeds form a clique.
+     * Otherwise, only the added nodes form a clique that is fully connected
+     * to the seed nodes.
+     *
+     * @param seeds The seeds for the community.
+     * @return The found community as set of nodes.
+     */
+    std::set<node> expandOneCommunity(const std::set<node> &seeds) override;
+
+protected:
+    std::vector<node> getMaximumWeightClique(const std::vector<node> &nodes,
+                                             const std::vector<edgeweight> &seedToNodeWeight) const;
+
+    Graph createSubgraphFromNodes(const std::vector<node> &nodes) const;
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_SCD_CLIQUE_DETECT_HPP_

--- a/include/networkit/scd/CombinedSCD.hpp
+++ b/include/networkit/scd/CombinedSCD.hpp
@@ -1,0 +1,52 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_COMBINED_SCD_HPP_
+#define NETWORKIT_SCD_COMBINED_SCD_HPP_
+
+#include <networkit/scd/SelectiveCommunityDetector.hpp>
+
+namespace NetworKit {
+/**
+ * Helper for combining two selective community detection algorithms.
+ *
+ * This allows to combine two SCD algorithms such that first the first
+ * algorithm is executed on the given seed(s) and then the result of
+ * the first algorithm is used as the seed set of the second algorithm.
+ * This is particularly useful for seeding an algorithm with a clique.
+ *
+ * @author Michael Hamann <michael.hamann@kit.edu>
+ */
+class CombinedSCD : public SelectiveCommunityDetector {
+public:
+    /**
+     * Initialize the combined algorithm with the given graph and the given two algorithms.
+     *
+     * @param G The graph to work on.
+     * @param first The first algorithm that is run with the given seed(s).
+     * @param secodn The second algorithm that is run with the result of the first algorithm.
+     */
+    CombinedSCD(const Graph &g, SelectiveCommunityDetector &first,
+                SelectiveCommunityDetector &second);
+
+    /**
+     * Expand a community with the given seed node using first and second algorithm.
+     *
+     * @param s The seed node to start with.
+     * @return The community found by the second algorithm.
+     */
+    std::set<node> expandOneCommunity(node s) override;
+
+    /**
+     * Expand a community with the given seed nodes using first and second algorithm.
+     *
+     * @param s The seed nodes to start with.
+     * @return The community found by the second algorithm.
+     */
+    std::set<node> expandOneCommunity(const std::set<node> &s) override;
+
+protected:
+    SelectiveCommunityDetector &first;
+    SelectiveCommunityDetector &second;
+};
+} // namespace NetworKit
+
+#endif // NETWORKIT_SCD_COMBINED_SCD_HPP_

--- a/include/networkit/scd/GCE.hpp
+++ b/include/networkit/scd/GCE.hpp
@@ -26,6 +26,16 @@ public:
 
     GCE(const Graph& G, std::string objective);
 
+    /**
+     * Expand a node into a community.
+     *
+     * Deprecated, use GCE::expandOneCommunity instead.
+     *
+     * @param seed Seed node for which a community is to be found.
+     *
+     * @return Set of nodes that makes up the best community found around the @a seed node.
+     */
+    std::set<node> TLX_DEPRECATED(expandSeed(node seed));
 
     /**
      * @param[in]  seeds  seed nodes

--- a/include/networkit/scd/GCE.hpp
+++ b/include/networkit/scd/GCE.hpp
@@ -26,14 +26,16 @@ public:
 
     GCE(const Graph& G, std::string objective);
 
-    std::map<node, std::set<node>> run(const std::set<node>& seeds) override;
 
     /**
-     * @param[in]  s  seed node
+     * @param[in]  seeds  seed nodes
      *
-     * @param[out]    community as a set of nodes
+     * @param[out]        community as a set of nodes
      */
-    std::set<node> expandSeed(node s);
+    std::set<node> expandOneCommunity(const std::set<node>& seeds) override;
+
+    // inherit method from parent class.
+    using SelectiveCommunityDetector::expandOneCommunity;
 
 private:
     std::string objective;    // name of objective function

--- a/include/networkit/scd/GCE.hpp
+++ b/include/networkit/scd/GCE.hpp
@@ -23,7 +23,7 @@ namespace NetworKit {
 class GCE : public SelectiveCommunityDetector {
 
 public:
-    GCE(const Graph &G, std::string objective);
+    GCE(const Graph &g, std::string objective);
 
     /**
      * Expand a node into a community.

--- a/include/networkit/scd/GCE.hpp
+++ b/include/networkit/scd/GCE.hpp
@@ -1,9 +1,9 @@
+// networkit-format
 /* GCE.hpp
  *
  * Created on: 06.05.2013
  * Author: cls
  */
-
 
 #ifndef NETWORKIT_SCD_GCE_HPP_
 #define NETWORKIT_SCD_GCE_HPP_
@@ -20,11 +20,10 @@ namespace NetworKit {
  *
  * Greedily adds nodes from the shell to improve community quality.
  */
-class GCE: public SelectiveCommunityDetector {
+class GCE : public SelectiveCommunityDetector {
 
 public:
-
-    GCE(const Graph& G, std::string objective);
+    GCE(const Graph &G, std::string objective);
 
     /**
      * Expand a node into a community.
@@ -42,14 +41,13 @@ public:
      *
      * @param[out]        community as a set of nodes
      */
-    std::set<node> expandOneCommunity(const std::set<node>& seeds) override;
+    std::set<node> expandOneCommunity(const std::set<node> &seeds) override;
 
     // inherit method from parent class.
     using SelectiveCommunityDetector::expandOneCommunity;
 
 private:
-    std::string objective;    // name of objective function
-
+    std::string objective; // name of objective function
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/scd/LFMLocal.hpp
+++ b/include/networkit/scd/LFMLocal.hpp
@@ -1,0 +1,55 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_LFM_LOCAL_HPP_
+#define NETWORKIT_SCD_LFM_LOCAL_HPP_
+
+#include <networkit/scd/SelectiveCommunityDetector.hpp>
+
+namespace NetworKit {
+
+/**
+ * Local version of the LFM algorithm
+ *
+ * This is the local community expansion as introduced in:
+ *
+ * Lancichinetti, A., Fortunato, S., & Kertész, J. (2009).
+ * Detecting the overlapping and hierarchical community structure in complex networks.
+ * New Journal of Physics, 11(3), 033015.
+ * https://doi.org/10.1088/1367-2630/11/3/033015
+ *
+ * Their algorithm detects overlapping communities by repeatedly
+ * executing this algorithm for a random seed node that has not yet
+ * been assigned to any community.
+ *
+ * The algorithm has a resolution parameter alpha. A natural choice
+ * for alpha is 1, the paper states that values below 0.5 usually
+ * give a community containing the whole graph while values larger
+ * than 2 recover the smallest communities.
+ */
+class LFMLocal : public SelectiveCommunityDetector {
+
+public:
+    /**
+     * Construct the LFMLocal algorithm.
+     *
+     * @param G The graph to find a community on.
+     * @param alpha The resolution parameter.
+     */
+    LFMLocal(const Graph &g, double alpha = 1.0);
+
+    using SelectiveCommunityDetector::expandOneCommunity;
+
+    /**
+     * Expand a set of nodes into a single community.
+     *
+     * @param s The set of seed nodes.
+     * @return The found community.
+     */
+    std::set<node> expandOneCommunity(const std::set<node> &s) override;
+
+protected:
+    const double alpha;
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_SCD_LFM_LOCAL_HPP_

--- a/include/networkit/scd/LocalT.hpp
+++ b/include/networkit/scd/LocalT.hpp
@@ -1,0 +1,41 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_LOCAL_T_HPP_
+#define NETWORKIT_SCD_LOCAL_T_HPP_
+
+#include <networkit/scd/SelectiveCommunityDetector.hpp>
+
+namespace NetworKit {
+
+/**
+ * The local community expansion algorithm optimizing the T measure.
+ *
+ * This implements the algorithm published in:
+ *
+ * Fagnan, J., Zaiane, O., & Barbosa, D. (2014).
+ * Using triads to identify local community structure in social networks.
+ * In 2014 IEEE/ACM International Conference on Advances in Social Networks Analysis and Mining
+ * (ASONAM) (pp. 108–112). https://doi.org/10.1109/ASONAM.2014.6921568
+ */
+class LocalT : public SelectiveCommunityDetector {
+public:
+    /**
+     * Constructs the Local T algorithm.
+     *
+     * @param[in] G The graph to detect communities on
+     */
+    LocalT(const Graph &g);
+
+    /**
+     * Expands a set of seed nodes into a community.
+     *
+     * @param[in] s The seed nodes
+     * @return A community of the seed nodes
+     */
+    std::set<node> expandOneCommunity(const std::set<node> &s) override;
+
+    using SelectiveCommunityDetector::expandOneCommunity;
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_SCD_LOCAL_T_HPP_

--- a/include/networkit/scd/LocalTightnessExpansion.hpp
+++ b/include/networkit/scd/LocalTightnessExpansion.hpp
@@ -1,0 +1,47 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_LOCAL_TIGHTNESS_EXPANSION_HPP_
+#define NETWORKIT_SCD_LOCAL_TIGHTNESS_EXPANSION_HPP_
+
+#include <networkit/scd/SelectiveCommunityDetector.hpp>
+
+namespace NetworKit {
+
+/**
+ * The Local Tightness Expansion (LTE) algorithm.
+ *
+ * The algorithm can handle weighted graphs.
+ *
+ * This is the local community expansion algorithm described in
+ *
+ * Huang, J., Sun, H., Liu, Y., Song, Q., & Weninger, T. (2011).
+ * Towards Online Multiresolution Community Detection in Large-Scale Networks.
+ * PLOS ONE, 6(8), e23829.
+ * https://doi.org/10.1371/journal.pone.0023829
+ */
+class LocalTightnessExpansion : public SelectiveCommunityDetector {
+private:
+    double alpha;
+
+public:
+    /**
+     * Constructs the Local Tightness Expansion algorithm.
+     *
+     * @param[in] G The graph to detect communities on
+     * @param[in] alpha Tightness coefficient - smaller values lead to larger communities
+     */
+    LocalTightnessExpansion(const Graph &g, double alpha = 1.0);
+
+    /**
+     * Expands a set of seed nodes into a community.
+     *
+     * @param[in] s The seed nodes
+     * @return A community of the seed nodes
+     */
+    std::set<node> expandOneCommunity(const std::set<node> &s) override;
+
+    using SelectiveCommunityDetector::expandOneCommunity;
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_SCD_LOCAL_TIGHTNESS_EXPANSION_HPP_

--- a/include/networkit/scd/PageRankNibble.hpp
+++ b/include/networkit/scd/PageRankNibble.hpp
@@ -1,3 +1,4 @@
+// networkit-format
 /*
  * PageRankNibble.hpp
  *
@@ -26,7 +27,7 @@ class PageRankNibble final : public SelectiveCommunityDetector {
     double alpha;
     double epsilon;
 
-    std::set<node> bestSweepSet(std::vector<std::pair<node, double>>& pr);
+    std::set<node> bestSweepSet(std::vector<std::pair<node, double>> &pr);
 
 public:
     /**
@@ -36,7 +37,7 @@ public:
      *        communities.
      * @param eps Tolerance threshold for approximation of PageRank vectors.
      */
-    PageRankNibble(const Graph& g, double alpha, double epsilon);
+    PageRankNibble(const Graph &g, double alpha, double epsilon);
 
     ~PageRankNibble() override = default;
 
@@ -56,11 +57,10 @@ public:
      *
      * @return Set of nodes that makes up the best community found around the @a seeds nodes.
      */
-    std::set<node> expandOneCommunity(const std::set<node>& seeds) override;
+    std::set<node> expandOneCommunity(const std::set<node> &seeds) override;
 
     // inherit method from parent class.
     using SelectiveCommunityDetector::expandOneCommunity;
-
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/scd/PageRankNibble.hpp
+++ b/include/networkit/scd/PageRankNibble.hpp
@@ -41,8 +41,19 @@ public:
     ~PageRankNibble() override = default;
 
     /**
-     * @param seed Seed nodes for which a community is to be found.
+     * Expand a node into a community.
+     *
+     * Deprecated, use PageRankNibble::expandOneCommunity instead.
+     *
+     * @param seed Seed node for which a community is to be found.
+     *
+     * @return Set of nodes that makes up the best community found around the @a seed node.
+     */
+    std::set<node> TLX_DEPRECATED(expandSeed(node seed));
 
+    /**
+     * @param seeds Seed nodes for which a community is to be found.
+     *
      * @return Set of nodes that makes up the best community found around the @a seeds nodes.
      */
     std::set<node> expandOneCommunity(const std::set<node>& seeds) override;

--- a/include/networkit/scd/PageRankNibble.hpp
+++ b/include/networkit/scd/PageRankNibble.hpp
@@ -40,15 +40,16 @@ public:
 
     ~PageRankNibble() override = default;
 
-    std::map<node, std::set<node>> run(const std::set<node>& seeds) override;
-
     /**
-     * @param seed Seed node for which a community is to be found.
+     * @param seed Seed nodes for which a community is to be found.
 
-     * @return Set of nodes that makes up the best community found around node @a seed.
-     *   If target conductance or target size are not fulfilled, an empty set is returned.
+     * @return Set of nodes that makes up the best community found around the @a seeds nodes.
      */
-    std::set<node> expandSeed(node seed);
+    std::set<node> expandOneCommunity(const std::set<node>& seeds) override;
+
+    // inherit method from parent class.
+    using SelectiveCommunityDetector::expandOneCommunity;
+
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/scd/RandomBFS.hpp
+++ b/include/networkit/scd/RandomBFS.hpp
@@ -1,0 +1,34 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_RANDOM_BFS_HPP_
+#define NETWORKIT_SCD_RANDOM_BFS_HPP_
+
+#include <networkit/scd/SelectiveCommunityDetector.hpp>
+#include <networkit/structures/Cover.hpp>
+
+namespace NetworKit {
+
+/*
+ * The random BFS community detection baseline:
+ * finds a community around a seed node with a given size using a prefix of a
+ * BFS order that is selected at random among all possible prefixes.
+ */
+class RandomBFS : public SelectiveCommunityDetector {
+
+public:
+    RandomBFS(const Graph &g, const Cover &c);
+
+    /**
+     * @param[in]	s	seed node
+     *
+     * @param[out]		community as a set of nodes
+     */
+    std::set<node> expandOneCommunity(const std::set<node> &s) override;
+    using SelectiveCommunityDetector::expandOneCommunity;
+
+protected:
+    const Cover *c; // ground truth communities
+    std::map<index, count> subsetSizes;
+};
+
+} /* namespace NetworKit */
+#endif // NETWORKIT_SCD_RANDOM_BFS_HPP_

--- a/include/networkit/scd/SCDGroundTruthComparison.hpp
+++ b/include/networkit/scd/SCDGroundTruthComparison.hpp
@@ -1,0 +1,122 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_SCD_GROUND_TRUTH_COMPARISON_HPP_
+#define NETWORKIT_SCD_SCD_GROUND_TRUTH_COMPARISON_HPP_
+
+#include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/structures/Cover.hpp>
+
+#include <map>
+#include <set>
+
+namespace NetworKit {
+
+/**
+ * This class evaluates a set found communities against a ground truth cover. Each found community
+ * is compared against the communities of the seed node in the ground truth cover.
+ *
+ * For each score, the ground truth community is chosen as comparison that maximizes the score.
+ * If seeds are not ignored (a parameter of the constructor), then only ground truth communities
+ * that contain the given seed are used to compare against.
+ *
+ * The calculated scores are:
+ *
+ * Precision: the size of the intersection of found and ground truth community divided by the
+ * size of the found community, i.e., how much of the found community was an actual match.
+ *
+ * Recall: the size of the intersection of found and ground truth community divided by the
+ * size of the ground truth community, i.e., how much of the ground truth community was found.
+ *
+ * F1 score: the harmonic mean of precision and recall.
+ *
+ * Jaccard index: the size of the intersection of found and ground truth community divided by the
+ * size of the union of found and ground truth community.
+ *
+ * For each score, the range of values is between 0 and 1, where 0 is the worst and 1 the best
+ * score.
+ */
+class SCDGroundTruthComparison final : public Algorithm {
+public:
+    /**
+     * Construct the SCD evaluation for the given graph, ground truth and found communities.
+     *
+     * @param G The graph to compare on
+     * @param groundTruth The ground truth cover
+     * @param found The found communities
+     * @param ignoreSeeds If the seeds shall be ignored, i.e. any ground truth community is a match
+     */
+    SCDGroundTruthComparison(const Graph &g, const Cover &groundTruth,
+                             const std::map<node, std::set<node>> &found, bool ignoreSeeds = false);
+
+    /**
+     * Calculate all measures.
+     */
+    void run() override;
+
+    /**
+     * Get the Jaccard index of every found community.
+     *
+     * @return A map between seed node and the jaccard index of the seed's community.
+     */
+    const std::map<index, double> &getIndividualJaccard() const;
+
+    /**
+     * Get the precision of every found community.
+     *
+     * @return A map between seed node and the precision of the seed's community.
+     */
+    const std::map<index, double> &getIndividualPrecision() const;
+
+    /**
+     * Get the recall of every found community.
+     *
+     * @return A map between seed node and the recall of the seed's community.
+     */
+    const std::map<index, double> &getIndividualRecall() const;
+
+    /**
+     * Get the F1 score of every found community.
+     *
+     * @return A map between seed node and the F1 score of the seed's community.
+     */
+    const std::map<index, double> &getIndividualF1() const;
+
+    /**
+     * Get the (unweighted) average of the jaccard indices of every found community.
+     */
+    double getAverageJaccard() const;
+
+    /**
+     * Get the (unweighted) average of the F1 score of every found community.
+     */
+    double getAverageF1() const;
+
+    /**
+     * Get the (unweighted) average of the precision of every found community.
+     */
+    double getAveragePrecision() const;
+
+    /**
+     * Get the (unweighted) average of the recall of every found community.
+     */
+    double getAverageRecall() const;
+
+private:
+    const Graph *g;
+    const Cover *groundTruth;
+    const std::map<node, std::set<node>> *found;
+    bool ignoreSeeds;
+
+    std::map<index, double> jaccardScores;
+    double averageJaccard;
+    std::map<index, double> f1Scores;
+    double averageF1;
+    std::map<index, double> precisionScores;
+    double averagePrecision;
+    std::map<index, double> recallScores;
+    double averageRecall;
+};
+
+} /* namespace NetworKit */
+
+#endif // NETWORKIT_SCD_SCD_GROUND_TRUTH_COMPARISON_HPP_

--- a/include/networkit/scd/SelectiveCommunityDetector.hpp
+++ b/include/networkit/scd/SelectiveCommunityDetector.hpp
@@ -16,22 +16,57 @@
 
 namespace NetworKit {
 
+/**
+ * Base class for selective community detection algorithms, i.e., algorithms
+ * that detect communities around a single node.
+ */
 class SelectiveCommunityDetector {
 
 public:
+    /**
+     * Construct a selective community detector. This should only be called by child classes.
+     *
+     * @param G The graph for which communities shall be detected.
+     */
+    SelectiveCommunityDetector(const Graph& G);
 
     /**
-     * @param[in] G the input graph.
+     * Virtual default destructor to allow safe destruction of child classes.
      */
-    SelectiveCommunityDetector(const Graph& G) : G(&G) {}
     virtual ~SelectiveCommunityDetector() = default;
 
     /**
-     * Detect communities for given seed nodes.
+     * Detect one community for each of the given seed nodes.
+     *
+     * The default implementation calls expandOneCommunity() for each of the seeds.
+     *
+     * @param seeds The list of seeds for which communities shall be detected.
      * @return a mapping from seed node to community (as a set of nodes)
      */
-    virtual std::map<node, std::set<node>> run(const std::set<node>& seeds) = 0;
+    virtual std::map<node, std::set<node> >  run(const std::set<node>& seeds);
 
+    /**
+     * Detect a community for the given seed node.
+     *
+     * The default implementation calls expandOneCommunity(const
+     * std::set<node>&) with a set of one node.
+     *
+     * @param seed The seed to find the community for.
+     * @return The found community as set of node.
+     */
+    virtual std::set<node> expandOneCommunity(node seed);
+
+    /**
+     * Detect a single community for the given seed nodes.
+     *
+     * This is useful if you know multiple nodes that should be part of the
+     * community. This method may throw an exception if the particular algorithm
+     * does not support multiple seeds.
+     *
+     * @param seeds The seeds for the community.
+     * @return The found community as set of nodes.
+     */
+    virtual std::set<node> expandOneCommunity(const std::set<node>& seeds) = 0;
 protected:
     const Graph* G;
 };

--- a/include/networkit/scd/SelectiveCommunityDetector.hpp
+++ b/include/networkit/scd/SelectiveCommunityDetector.hpp
@@ -29,7 +29,7 @@ public:
      *
      * @param G The graph for which communities shall be detected.
      */
-    SelectiveCommunityDetector(const Graph &G);
+    SelectiveCommunityDetector(const Graph &g);
 
     /**
      * Virtual default destructor to allow safe destruction of child classes.
@@ -70,7 +70,7 @@ public:
     virtual std::set<node> expandOneCommunity(const std::set<node> &seeds) = 0;
 
 protected:
-    const Graph *G;
+    const Graph *g;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/scd/SelectiveCommunityDetector.hpp
+++ b/include/networkit/scd/SelectiveCommunityDetector.hpp
@@ -1,3 +1,4 @@
+// networkit-format
 /*
  * SelectiveCommunityDetector.hpp
  *
@@ -28,7 +29,7 @@ public:
      *
      * @param G The graph for which communities shall be detected.
      */
-    SelectiveCommunityDetector(const Graph& G);
+    SelectiveCommunityDetector(const Graph &G);
 
     /**
      * Virtual default destructor to allow safe destruction of child classes.
@@ -43,7 +44,7 @@ public:
      * @param seeds The list of seeds for which communities shall be detected.
      * @return a mapping from seed node to community (as a set of nodes)
      */
-    virtual std::map<node, std::set<node> >  run(const std::set<node>& seeds);
+    virtual std::map<node, std::set<node>> run(const std::set<node> &seeds);
 
     /**
      * Detect a community for the given seed node.
@@ -66,9 +67,10 @@ public:
      * @param seeds The seeds for the community.
      * @return The found community as set of nodes.
      */
-    virtual std::set<node> expandOneCommunity(const std::set<node>& seeds) = 0;
+    virtual std::set<node> expandOneCommunity(const std::set<node> &seeds) = 0;
+
 protected:
-    const Graph* G;
+    const Graph *G;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/scd/SetConductance.hpp
+++ b/include/networkit/scd/SetConductance.hpp
@@ -1,0 +1,48 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_SET_CONDUCTANCE_HPP_
+#define NETWORKIT_SCD_SET_CONDUCTANCE_HPP_
+
+#include <set>
+
+#include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+/**
+ * Calculates the conductance of a set of nodes, i.e., the weight of all edges
+ * between the set and the rest of the graph divided by the minimum
+ * of the volume (the sum of the weighted degrees) of the community and the rest
+ * of the graph.
+ */
+class SetConductance : public Algorithm {
+public:
+    /**
+     * Construct the SetConductance with the given graph and community.
+     *
+     * @param G The graph
+     * @param community The set of nodes to examine.
+     */
+    SetConductance(const Graph &g, const std::set<node> &community);
+
+    /**
+     * Calculate the conductance.
+     */
+    void run() override;
+
+    /**
+     * Get the calculated conductance score.
+     *
+     * @return The conductance.
+     */
+    double getConductance() const;
+
+private:
+    const Graph *g;
+    const std::set<node> *community;
+    double conductance;
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_SCD_SET_CONDUCTANCE_HPP_

--- a/include/networkit/scd/TCE.hpp
+++ b/include/networkit/scd/TCE.hpp
@@ -1,0 +1,42 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_TCE_HPP_
+#define NETWORKIT_SCD_TCE_HPP_
+
+#include <networkit/scd/SelectiveCommunityDetector.hpp>
+
+namespace NetworKit {
+
+/**
+ * Triangle-based community expansion
+ *
+ * The algorithm can handle weighted graphs.
+ */
+class TCE : public SelectiveCommunityDetector {
+private:
+    bool refine;
+    bool useJaccard;
+
+public:
+    /**
+     * Construct a TCE object.
+     *
+     * @param[in] G The graph to detect communities on
+     * @param[in] refine If nodes shall be removed again if this makes the community better
+     * @param[in] useJaccard use jaccard index for weight calculation.
+     */
+    TCE(const Graph &g, bool refine = false, bool useJaccard = false);
+
+    /**
+     * Expands a set of seed nodes into a community.
+     *
+     * @param[in] s The seed nodes
+     * @return A community of the seed nodes
+     */
+    std::set<node> expandOneCommunity(const std::set<node> &s) override;
+
+    using SelectiveCommunityDetector::expandOneCommunity;
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_SCD_TCE_HPP_

--- a/include/networkit/scd/TwoPhaseL.hpp
+++ b/include/networkit/scd/TwoPhaseL.hpp
@@ -1,0 +1,41 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_TWO_PHASE_L_HPP_
+#define NETWORKIT_SCD_TWO_PHASE_L_HPP_
+
+#include <networkit/scd/SelectiveCommunityDetector.hpp>
+
+namespace NetworKit {
+
+/**
+ * The two-phase local community detection algorithm optimizing the L-measure.
+ *
+ * This is an implementation of the algorithm proposed in:
+ *
+ * Chen, J., Zaïane, O., & Goebel, R. (2009).
+ * Local Community Identification in Social Networks.
+ * In 2009 International Conference on Advances in Social Network Analysis and Mining (pp. 237–242).
+ * https://doi.org/10.1109/ASONAM.2009.14
+ */
+class TwoPhaseL : public SelectiveCommunityDetector {
+
+public:
+    /**
+     * Construct the algorithm class.
+     *
+     * @param G The graph on which communities shall be found.
+     */
+    TwoPhaseL(const Graph &g);
+
+    /**
+     * @param[in]	seeds	seed nodes
+     *
+     * @param[out]		community as a set of nodes
+     */
+    std::set<node> expandOneCommunity(const std::set<node> &s) override;
+
+    // inherit method from parent class.
+    using SelectiveCommunityDetector::expandOneCommunity;
+};
+
+} /* namespace NetworKit */
+#endif // NETWORKIT_SCD_TWO_PHASE_L_HPP_

--- a/include/networkit/structures/LocalCommunity.hpp
+++ b/include/networkit/structures/LocalCommunity.hpp
@@ -1,0 +1,364 @@
+// networkit-format
+#ifndef NETWORKIT_STRUCTURES_LOCAL_COMMUNITY_HPP_
+#define NETWORKIT_STRUCTURES_LOCAL_COMMUNITY_HPP_
+
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+/**
+ * Class for maintaining some measures for a local community while expanding it.
+ *
+ * Depending on the template parameters, different values are maintained. By
+ * default, it stores the shell of the community (i.e., all external neighbors)
+ * and the volume and cut of the community. Further, for every node in the shell,
+ * the number of internal neighbors is maintained. Optionally, also the number of
+ * external neighbors can be maintained for every node in the shell (@a ShellMaintainsExtDeg).
+ * Additionally, also the boundary, i.e., all nodes in the community that have
+ * a neighbor in the shell are maintained (@a MaintainBoundary).
+ */
+template <bool ShellMaintainsExtDeg, bool MaintainBoundary = false, bool AllowRemoval = false>
+class LocalCommunity {
+    static_assert(!MaintainBoundary || ShellMaintainsExtDeg,
+                  "boundary cannot be maintained without maintaining the external degree");
+
+public:
+    template <typename ValueType, bool used>
+    struct OptionalValue {
+        ValueType &get() { throw std::runtime_error("Getting value that is missing"); }
+
+        const ValueType &get() const { throw std::runtime_error("Getting value that is missing"); }
+
+        ValueType &operator*() { throw std::runtime_error("Getting value that is missing"); }
+
+        const ValueType &operator*() const {
+            throw std::runtime_error("Getting value that is missing");
+        }
+
+        ValueType *operator->() { throw std::runtime_error("Getting value that is missing"); }
+
+        const ValueType *operator->() const {
+            throw std::runtime_error("Getting value that is missing");
+        }
+
+        void set(ValueType) { throw std::runtime_error("Setting value that is missing"); }
+
+        OptionalValue &operator+=(ValueType) {
+            throw std::runtime_error("Increasing value that is missing");
+        }
+
+        OptionalValue &operator-=(ValueType) {
+            throw std::runtime_error("Decreasing value that is missing");
+        }
+
+        OptionalValue(const ValueType &){};
+
+        OptionalValue(){};
+    };
+
+    template <typename ValueType>
+    struct OptionalValue<ValueType, true> {
+        ValueType &get() { return value; }
+
+        const ValueType &get() const { return value; }
+
+        ValueType &operator*() { return value; }
+
+        const ValueType &operator*() const { return value; }
+
+        ValueType *operator->() { return &value; }
+
+        const ValueType *operator->() const { return &value; }
+
+        void set(ValueType v) { value = v; }
+
+        template <typename SecondValue,
+                  typename std::enable_if<std::is_scalar<SecondValue>::value, int>::type = 0>
+        OptionalValue &operator+=(SecondValue v) {
+            value += v;
+            return *this;
+        }
+
+        template <typename SecondValue,
+                  typename std::enable_if<std::is_scalar<SecondValue>::value, int>::type = 0>
+        OptionalValue &operator-=(SecondValue v) {
+            value -= v;
+            return *this;
+        }
+
+        OptionalValue(const ValueType &v) : value(v){};
+
+        OptionalValue() : value(){};
+
+        ValueType value;
+    };
+
+    struct ShellInfo {
+        /**
+         * Number of neighbors in the community.
+         */
+        OptionalValue<double, true> intDeg;
+
+        /**
+         * Number of neighbors outside the community.
+         */
+        OptionalValue<double, ShellMaintainsExtDeg> extDeg;
+
+        /**
+         * Number of nodes in the boundary whose only outside neighbor is this node.
+         */
+        OptionalValue<count, MaintainBoundary> numExclusiveBoundaryMembers;
+
+        /**
+         * Calculate how much the boundary size would change if the node
+         * was added to the community.
+         */
+        int64_t boundaryChange() const {
+            int64_t boundary_diff = -1 * numExclusiveBoundaryMembers.get();
+
+            if (extDeg.get() > 0) {
+                boundary_diff += 1;
+            }
+
+            return boundary_diff;
+        }
+
+        ShellInfo() : intDeg(0), extDeg(0), numExclusiveBoundaryMembers(0) {}
+    };
+
+    struct CommunityInfo {
+        /**
+         * Number of neighbors in the community.
+         */
+        OptionalValue<double, AllowRemoval> intDeg;
+
+        /**
+         * Number of neighbors outside the community.
+         */
+        OptionalValue<double, ShellMaintainsExtDeg && AllowRemoval> extDeg;
+
+        /**
+         * The only neighbor outside the community if there is only one.
+         */
+        OptionalValue<node, MaintainBoundary && AllowRemoval> exclusiveOutsideNeighbor;
+
+        /**
+         * The number of neighbors that have no internal neighbors.
+         */
+        OptionalValue<count, MaintainBoundary && AllowRemoval> numFullyInternalNeighbors;
+
+        /**
+         * Calculate how much the boundary size would change if the node
+         * was removed from the community.
+         */
+        int64_t boundaryChange() const {
+            int64_t boundary_diff = numFullyInternalNeighbors.get();
+
+            if (extDeg.get() > 0) {
+                boundary_diff -= 1;
+            }
+
+            return boundary_diff;
+        }
+
+        CommunityInfo()
+            : intDeg(0), extDeg(0), exclusiveOutsideNeighbor(none), numFullyInternalNeighbors(0) {}
+    };
+
+    /**
+     * Initialize an empty community for the given graph.
+     *
+     * @param G The graph.
+     */
+    LocalCommunity(const Graph &G);
+
+    /**
+     * Add the given node to the community.
+     *
+     * This needs O(deg(u)) time in expectation. If the boundary
+     * is maintained, the complexity can be higher but this is amortized
+     * if nodes are only added to the community.
+     *
+     * @param u The node to add.
+     */
+    void addNode(node u);
+
+    /**
+     * Removes the given node form the community
+     *
+     * This needs O(deg(u)) time in expectation. If the boundary
+     * is maintained, the complexity can be higher but this is amortized
+     * if nodes are only added to the community.
+     *
+     * @param u The node to add.
+     */
+    void removeNode(node u);
+
+    /**
+     * Check if a given node @a u is in the community.
+     *
+     * @param u The node to check.
+     *
+     * @return If @a u is in the community.
+     */
+    bool contains(node u) const;
+
+    /**
+     * Return the community as a std::set<node>.
+     *
+     * @return The community as std::set<node>
+     */
+    std::set<node> toSet() const;
+
+    /**
+     * Execute a callback for every node in the shell.
+     *
+     * The complexity is linear in the size of the shell.
+     * The callback should accept a node and a ShellInfo
+     * object as parameters. Note that only the enabled
+     * properties of the ShellInfo object may be accessed.
+     *
+     * @param callback The callback to call.
+     */
+    template <typename F>
+    void forShellNodes(F callback) {
+        for (const auto &it : shell) {
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+            auto intExtDeg = calculateIntExtDeg(it.first);
+            assert(*it.second.intDeg == intExtDeg.first);
+            if (ShellMaintainsExtDeg) {
+                assert(*it.second.extDeg == intExtDeg.second);
+            }
+
+            if (MaintainBoundary) {
+                int64_t boundary_diff_debug = 0;
+                bool v_in_boundary = false;
+                G->forNeighborsOf(it.first, [&](node x) {
+                    auto it = currentBoundary->find(x);
+                    if (it != currentBoundary->end()) {
+                        if (it->second == 1) {
+                            boundary_diff_debug -= 1;
+                        }
+                    } else if (!v_in_boundary) {
+                        boundary_diff_debug += 1;
+                        v_in_boundary = true;
+                    }
+                });
+
+                assert(it.second.boundaryChange() == boundary_diff_debug);
+            }
+#endif // NDEBUG
+#endif // NETWORKIT_SANITY_CHECKS
+
+            callback(it.first, it.second);
+        }
+    }
+
+    /**
+     * Execute a callback for every node in the community.
+     *
+     * The complexity is linear in the size of the community.
+     * The callback should accept a node and a CommunityInfo
+     * object as parameters. Note that only the enabled
+     * properties of the CommunityInfo object may be accessed.
+     *
+     * Note that unless AllowRemoval is set, the CommunityInfo object is empty.
+     *
+     * @param callback The callback to call.
+     */
+    template <typename F>
+    void forCommunityNodes(F callback) {
+        for (auto it = community.cbegin(); it != community.cend();) {
+            // advance the iterator so the current element may be deleted
+            const auto cit = it++;
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+            if (AllowRemoval) {
+                auto intExtDeg = calculateIntExtDeg(cit->first);
+                assert(*cit->second.intDeg == intExtDeg.first);
+                if (ShellMaintainsExtDeg) {
+                    assert(*cit->second.extDeg == intExtDeg.second);
+                }
+
+                if (MaintainBoundary) {
+                    int64_t boundary_diff_debug = 0;
+                    bool v_in_boundary = false;
+                    G->forNeighborsOf(cit->first, [&](node x) {
+                        if (community.find(x) == community.end()) {
+                            if (!v_in_boundary) {
+                                boundary_diff_debug -= 1;
+                                v_in_boundary = true;
+                            }
+                        } else if (currentBoundary->find(x) == currentBoundary->end()) {
+                            boundary_diff_debug += 1;
+                        }
+                    });
+
+                    assert(cit->second.boundaryChange() == boundary_diff_debug);
+                }
+            }
+#endif // NDEBUG
+#endif // NETWORKIT_SANITY_CHECKS
+
+            callback(cit->first, cit->second);
+        }
+    }
+
+    /**
+     * Get the size of the community.
+     *
+     * @return The size of the community.
+     */
+    size_t size() const { return community.size(); }
+
+    /**
+     * Get the internal edge weight.
+     * This is the sum of the weights of all internal edges, i.e.,
+     * the weight of every internal edge is counted once.
+     *
+     * @return The internal edge weight of the community.
+     */
+    double internalEdgeWeight() const { return intWeight; }
+
+    /**
+     * Get the cut of the community.
+     *
+     * @return The cut of the community.
+     */
+    double cut() const { return extWeight; }
+
+    /**
+     * Get the size of the boundary of the community.
+     *
+     * @return The size of the boundary.
+     */
+    count boundarySize() const { return currentBoundary->size(); }
+
+private:
+    const Graph *G;
+    std::unordered_map<node, CommunityInfo> community;
+    std::unordered_map<node, ShellInfo> shell;
+    double intWeight;
+    double extWeight;
+    OptionalValue<std::unordered_map<node, count>, MaintainBoundary> currentBoundary;
+
+    // The boundary is defined as all nodes of C that have a neighbor not in C
+    std::unordered_set<node> calculateBoundary();
+
+    /**
+     * internal and external weighted degree of a node with respect to the community
+     */
+    std::pair<double, double> calculateIntExtDeg(node v);
+
+    std::pair<double, double> calculateVolumeCut();
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_STRUCTURES_LOCAL_COMMUNITY_HPP_

--- a/networkit/cpp/scd/ApproximatePageRank.cpp
+++ b/networkit/cpp/scd/ApproximatePageRank.cpp
@@ -12,34 +12,34 @@
 
 namespace NetworKit {
 
-ApproximatePageRank::ApproximatePageRank(const Graph &g, double alpha_, double epsilon)
-    : G(&g), alpha(alpha_), eps(epsilon) {}
+ApproximatePageRank::ApproximatePageRank(const Graph &g, double alpha, double epsilon)
+    : g(&g), alpha(alpha), eps(epsilon) {}
 
 std::vector<std::pair<node, double>> ApproximatePageRank::run(const std::set<node> &seeds) {
-    double init_res = 1.0 / seeds.size();
+    double initRes = 1.0 / seeds.size();
     std::queue<node> activeNodes;
     for (node s : seeds) {
-        pr_res[s] = std::make_pair(0.0, init_res);
+        prRes[s] = std::make_pair(0.0, initRes);
         activeNodes.push(s);
     }
 
     auto push = [&](const node u, std::queue<node> &activeNodes) {
-        double res = pr_res[u].second;
-        double volume = G->weightedDegree(u, true);
+        double res = prRes[u].second;
+        double volume = g->weightedDegree(u, true);
 
-        G->forNeighborsOf(u, [&](node, const node v, const edgeweight w) {
+        g->forNeighborsOf(u, [&](node, const node v, const edgeweight w) {
             double mass = (1.0 - alpha) * res * w / (2.0 * volume);
-            double vol_v = G->weightedDegree(v, true);
+            double volV = g->weightedDegree(v, true);
             // the first check is for making sure the node is not added twice.
             // the second check ensures that enough residual is left.
-            if (pr_res[v].second < vol_v * eps && (pr_res[v].second + mass) >= eps * vol_v) {
+            if (prRes[v].second < volV * eps && (prRes[v].second + mass) >= eps * volV) {
                 activeNodes.push(v);
             }
-            pr_res[v].second += mass;
+            prRes[v].second += mass;
         });
 
-        pr_res[u] = std::make_pair(pr_res[u].first + alpha * res, (1.0 - alpha) * res / 2);
-        if ((pr_res[u].second / volume) >= eps) {
+        prRes[u] = std::make_pair(prRes[u].first + alpha * res, (1.0 - alpha) * res / 2);
+        if ((prRes[u].second / volume) >= eps) {
             activeNodes.push(u);
         }
     };
@@ -51,9 +51,9 @@ std::vector<std::pair<node, double>> ApproximatePageRank::run(const std::set<nod
     }
 
     std::vector<std::pair<node, double>> pr;
-    pr.reserve(pr_res.size());
+    pr.reserve(prRes.size());
 
-    for (auto it = pr_res.begin(); it != pr_res.end(); it++) {
+    for (auto it = prRes.begin(); it != prRes.end(); it++) {
         pr.emplace_back(it->first, it->second.first);
     }
 

--- a/networkit/cpp/scd/ApproximatePageRank.cpp
+++ b/networkit/cpp/scd/ApproximatePageRank.cpp
@@ -14,10 +14,13 @@ namespace NetworKit {
 ApproximatePageRank::ApproximatePageRank(const Graph& g, double alpha_, double epsilon):
         G(&g), alpha(alpha_), eps(epsilon) {}
 
-std::vector<std::pair<node, double>> ApproximatePageRank::run(node seed) {
-    pr_res[seed] = std::make_pair(0.0, 1.0);
+std::vector<std::pair<node, double>> ApproximatePageRank::run(const std::set<node>& seeds) {
+    double init_res = 1.0 / seeds.size();
     std::queue<node> activeNodes;
-    activeNodes.push(seed);
+    for (node s : seeds) {
+        pr_res[s] = std::make_pair(0.0, init_res);
+        activeNodes.push(s);
+    }
 
     auto push = [&](const node u, std::queue<node> &activeNodes) {
         double res = pr_res[u].second;
@@ -41,7 +44,7 @@ std::vector<std::pair<node, double>> ApproximatePageRank::run(node seed) {
     };
 
     while (!activeNodes.empty()) {
-        node v =  activeNodes.front();
+        node v = activeNodes.front();
         activeNodes.pop();
         push(v, activeNodes);
     }
@@ -54,6 +57,10 @@ std::vector<std::pair<node, double>> ApproximatePageRank::run(node seed) {
     }
 
     return pr;
+}
+
+std::vector<std::pair<node, double>> ApproximatePageRank::run(node seed) {
+    return run(std::set<node>{seed});
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/scd/ApproximatePageRank.cpp
+++ b/networkit/cpp/scd/ApproximatePageRank.cpp
@@ -1,3 +1,4 @@
+// networkit-format
 /*
  * ApproximatePageRank.cpp
  *
@@ -11,10 +12,10 @@
 
 namespace NetworKit {
 
-ApproximatePageRank::ApproximatePageRank(const Graph& g, double alpha_, double epsilon):
-        G(&g), alpha(alpha_), eps(epsilon) {}
+ApproximatePageRank::ApproximatePageRank(const Graph &g, double alpha_, double epsilon)
+    : G(&g), alpha(alpha_), eps(epsilon) {}
 
-std::vector<std::pair<node, double>> ApproximatePageRank::run(const std::set<node>& seeds) {
+std::vector<std::pair<node, double>> ApproximatePageRank::run(const std::set<node> &seeds) {
     double init_res = 1.0 / seeds.size();
     std::queue<node> activeNodes;
     for (node s : seeds) {
@@ -31,7 +32,7 @@ std::vector<std::pair<node, double>> ApproximatePageRank::run(const std::set<nod
             double vol_v = G->weightedDegree(v, true);
             // the first check is for making sure the node is not added twice.
             // the second check ensures that enough residual is left.
-            if ( pr_res[v].second < vol_v * eps && (pr_res[v].second + mass) >= eps * vol_v ) {
+            if (pr_res[v].second < vol_v * eps && (pr_res[v].second + mass) >= eps * vol_v) {
                 activeNodes.push(v);
             }
             pr_res[v].second += mass;

--- a/networkit/cpp/scd/CMakeLists.txt
+++ b/networkit/cpp/scd/CMakeLists.txt
@@ -1,6 +1,7 @@
 networkit_add_module(scd
     ApproximatePageRank.cpp
     CliqueDetect.cpp
+    CombinedSCD.cpp
     GCE.cpp
     LFMLocal.cpp
     PageRankNibble.cpp

--- a/networkit/cpp/scd/CMakeLists.txt
+++ b/networkit/cpp/scd/CMakeLists.txt
@@ -2,10 +2,10 @@ networkit_add_module(scd
     ApproximatePageRank.cpp
     GCE.cpp
     PageRankNibble.cpp
+    SCDGroundTruthComparison.cpp
     )
 
 networkit_module_link_modules(scd
     auxiliary graph)
 
 add_subdirectory(test)
-

--- a/networkit/cpp/scd/CMakeLists.txt
+++ b/networkit/cpp/scd/CMakeLists.txt
@@ -2,6 +2,7 @@ networkit_add_module(scd
     ApproximatePageRank.cpp
     CliqueDetect.cpp
     GCE.cpp
+    LFMLocal.cpp
     PageRankNibble.cpp
     SCDGroundTruthComparison.cpp
     SelectiveCommunityDetector.cpp

--- a/networkit/cpp/scd/CMakeLists.txt
+++ b/networkit/cpp/scd/CMakeLists.txt
@@ -5,6 +5,7 @@ networkit_add_module(scd
     GCE.cpp
     LFMLocal.cpp
     PageRankNibble.cpp
+    RandomBFS.cpp
     SCDGroundTruthComparison.cpp
     SelectiveCommunityDetector.cpp
     SetConductance.cpp

--- a/networkit/cpp/scd/CMakeLists.txt
+++ b/networkit/cpp/scd/CMakeLists.txt
@@ -9,6 +9,7 @@ networkit_add_module(scd
     SCDGroundTruthComparison.cpp
     SelectiveCommunityDetector.cpp
     SetConductance.cpp
+    TwoPhaseL.cpp
     )
 
 networkit_module_link_modules(scd

--- a/networkit/cpp/scd/CMakeLists.txt
+++ b/networkit/cpp/scd/CMakeLists.txt
@@ -4,12 +4,15 @@ networkit_add_module(scd
     CombinedSCD.cpp
     GCE.cpp
     LFMLocal.cpp
+    LocalT.cpp
+    LocalTightnessExpansion.cpp
     PageRankNibble.cpp
     RandomBFS.cpp
     SCDGroundTruthComparison.cpp
     SelectiveCommunityDetector.cpp
     SetConductance.cpp
     TwoPhaseL.cpp
+    TCE.cpp
     )
 
 networkit_module_link_modules(scd

--- a/networkit/cpp/scd/CMakeLists.txt
+++ b/networkit/cpp/scd/CMakeLists.txt
@@ -3,6 +3,7 @@ networkit_add_module(scd
     GCE.cpp
     PageRankNibble.cpp
     SCDGroundTruthComparison.cpp
+    SetConductance.cpp
     )
 
 networkit_module_link_modules(scd

--- a/networkit/cpp/scd/CMakeLists.txt
+++ b/networkit/cpp/scd/CMakeLists.txt
@@ -3,6 +3,7 @@ networkit_add_module(scd
     GCE.cpp
     PageRankNibble.cpp
     SCDGroundTruthComparison.cpp
+    SelectiveCommunityDetector.cpp
     SetConductance.cpp
     )
 

--- a/networkit/cpp/scd/CMakeLists.txt
+++ b/networkit/cpp/scd/CMakeLists.txt
@@ -1,5 +1,6 @@
 networkit_add_module(scd
     ApproximatePageRank.cpp
+    CliqueDetect.cpp
     GCE.cpp
     PageRankNibble.cpp
     SCDGroundTruthComparison.cpp
@@ -8,6 +9,6 @@ networkit_add_module(scd
     )
 
 networkit_module_link_modules(scd
-    auxiliary graph)
+    auxiliary clique graph)
 
 add_subdirectory(test)

--- a/networkit/cpp/scd/CliqueDetect.cpp
+++ b/networkit/cpp/scd/CliqueDetect.cpp
@@ -1,0 +1,183 @@
+// networkit-format
+#include <unordered_map>
+
+#include <networkit/auxiliary/IncrementalUniformRandomSelector.hpp>
+#include <networkit/clique/MaximalCliques.hpp>
+#include <networkit/graph/GraphBuilder.hpp>
+#include <networkit/scd/CliqueDetect.hpp>
+
+namespace NetworKit {
+
+CliqueDetect::CliqueDetect(const Graph &g) : SelectiveCommunityDetector(g) {
+    if (g.numberOfSelfLoops() > 0)
+        throw std::runtime_error("CliqueDetect works only with simple graphs.");
+    if (g.isDirected())
+        throw std::runtime_error("CliqueDetect work only with undirected graphs.");
+}
+
+std::set<node> CliqueDetect::expandOneCommunity(node s) {
+    // 1. get the maximum clique in neighbors(s) + s
+    std::set<node> result;
+    result.insert(s);
+
+    std::vector<node> sn(g->neighborRange(s).begin(), g->neighborRange(s).end());
+    std::vector<edgeweight> neighborWeights;
+    if (g->isWeighted()) {
+        neighborWeights.reserve(sn.size());
+
+        for (auto it : g->weightNeighborRange(s)) {
+            neighborWeights.push_back(it.second);
+        }
+    }
+
+    if (!sn.empty()) {
+        for (node u : getMaximumWeightClique(sn, neighborWeights)) {
+            result.insert(sn[u]);
+        }
+    }
+
+    return result;
+}
+
+std::set<node> CliqueDetect::expandOneCommunity(const std::set<node> &seeds) {
+    std::set<node> result(seeds);
+
+    if (!seeds.empty()) {
+        // Find neighbors of the seeds that are neighbors of all seed nodes
+        // First, candidates are neighbors of the first seed node
+        std::unordered_map<node, std::pair<count, edgeweight>> sn;
+        g->forNeighborsOf(*seeds.begin(), [&](node v, edgeweight weight) {
+            if (seeds.find(v) == seeds.end()) {
+                sn.insert({v, {1u, weight}});
+            }
+        });
+
+        // Count for each neighbor to how many other seed nodes it is adjacent
+        for (auto it = ++seeds.begin(); it != seeds.end(); ++it) {
+            g->forNeighborsOf(*it, [&](node v, edgeweight weight) {
+                auto it = sn.find(v);
+                if (it != sn.end()) {
+                    ++it->second.first;
+                    it->second.second += weight;
+                }
+            });
+        }
+
+        // Take those neighbors that are adjacent to all seed nodes
+        std::vector<node> neighbors;
+        std::vector<edgeweight> neighborWeights;
+        neighbors.reserve(sn.size());
+        if (g->isWeighted()) {
+            neighborWeights.reserve(sn.size());
+        }
+
+        for (auto it : sn) {
+            assert(it.second.first <= seeds.size() && "Graph has probably multi-edges!");
+            if (it.second.first == seeds.size()) {
+                neighbors.push_back(it.first);
+                if (g->isWeighted()) {
+                    neighborWeights.push_back(it.second.second);
+                }
+            }
+        }
+
+        if (!neighbors.empty()) {
+            const std::vector<node> clique = getMaximumWeightClique(neighbors, neighborWeights);
+
+            for (node u : clique) {
+                result.insert(neighbors[u]);
+            }
+        }
+    }
+
+    return result;
+}
+
+std::vector<node>
+CliqueDetect::getMaximumWeightClique(const std::vector<node> &nodes,
+                                     const std::vector<edgeweight> &seedToNodeWeight) const {
+
+    Graph s = createSubgraphFromNodes(nodes);
+    std::vector<node> maxClique;
+
+    Aux::IncrementalUniformRandomSelector selector;
+    if (!g->isWeighted()) {
+        // Select a maximum clique uniformly at random
+        MaximalCliques mc(s, [&](const std::vector<node> &clique) {
+            if (clique.size() < maxClique.size())
+                return;
+            if (clique.size() > maxClique.size()) {
+                maxClique = clique;
+                selector.reset();
+            } else {
+                if (selector.addElement()) {
+                    maxClique = clique;
+                }
+            }
+        });
+        mc.run();
+    } else {
+        // Select a maximum weight clique uniformly at random
+        double maxWeight = 0.0;
+        assert(s.numberOfNodes() == s.upperNodeIdBound());
+        std::vector<bool> inClique(s.upperNodeIdBound(), false);
+
+        // clique with the greatest sum of its edgeweights
+        MaximalCliques mc(s, [&](const std::vector<node> &clique) {
+            double cliqueWeight = 0.0;
+
+            for (node u : clique) {
+                inClique[u] = true;
+            }
+
+            for (node u : clique) {
+                for (auto neighborIt : s.weightNeighborRange(u)) {
+                    cliqueWeight += inClique[neighborIt.first] * neighborIt.second;
+                }
+
+                // Add the weight from u to the seed node(s)
+                cliqueWeight += seedToNodeWeight[u];
+
+                // Reset inClique[u] to avoid counting edges twice
+                inClique[u] = false;
+            }
+
+            if (cliqueWeight > maxWeight) {
+                maxWeight = cliqueWeight;
+                maxClique = clique;
+                selector.reset();
+            } else if (cliqueWeight == maxWeight) {
+                if (selector.addElement()) {
+                    maxClique = clique;
+                }
+            }
+        });
+
+        mc.run();
+    }
+
+    return maxClique;
+}
+
+Graph CliqueDetect::createSubgraphFromNodes(const std::vector<node> &nodes) const {
+    GraphBuilder gbuilder(nodes.size(), g->isWeighted());
+    std::unordered_map<node, node> reverseMapping;
+
+    node i = 0;
+    for (node u : nodes) {
+        reverseMapping[u] = i;
+        i += 1;
+    }
+    for (node u : nodes) {
+        node lu = reverseMapping[u];
+        g->forNeighborsOf(u, [&](node v, edgeweight weight) {
+            auto lv = reverseMapping.find(v);
+            if (lv != reverseMapping.end())
+                gbuilder.addHalfEdge(lu, lv->second, weight);
+        });
+    }
+
+    return gbuilder.toGraph(false);
+}
+
+} /* namespace NetworKit */

--- a/networkit/cpp/scd/CombinedSCD.cpp
+++ b/networkit/cpp/scd/CombinedSCD.cpp
@@ -1,0 +1,18 @@
+// networkit-format
+#include <networkit/scd/CombinedSCD.hpp>
+
+namespace NetworKit {
+
+CombinedSCD::CombinedSCD(const Graph &g, SelectiveCommunityDetector &first,
+                         SelectiveCommunityDetector &second)
+    : SelectiveCommunityDetector(g), first(first), second(second) {}
+
+std::set<node> CombinedSCD::expandOneCommunity(node s) {
+    return second.expandOneCommunity(first.expandOneCommunity(s));
+}
+
+std::set<node> CombinedSCD::expandOneCommunity(const std::set<node> &s) {
+    return second.expandOneCommunity(first.expandOneCommunity(s));
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/scd/GCE.cpp
+++ b/networkit/cpp/scd/GCE.cpp
@@ -1,3 +1,4 @@
+// networkit-format
 /* GCE.cpp
  *
  * Created on: 06.05.2013
@@ -5,11 +6,11 @@
  */
 
 #include <unordered_map>
-
 #include <utility>
+
+#include <networkit/auxiliary/IncrementalUniformRandomSelector.hpp>
 #include <networkit/scd/GCE.hpp>
 #include <networkit/structures/LocalCommunity.hpp>
-#include <networkit/auxiliary/IncrementalUniformRandomSelector.hpp>
 
 namespace NetworKit {
 
@@ -26,7 +27,7 @@ std::set<node> GCE::expandSeed(node seed) {
 }
 
 template <bool objectiveIsM>
-std::set<node> expandseed_internal(const Graph&G, const std::set<node>& seeds) {
+std::set<node> expandseed_internal(const Graph &G, const std::set<node> &seeds) {
     double currentQ = 0.0; // current community quality
 
     LocalCommunity<true, !objectiveIsM> com(G);
@@ -44,8 +45,9 @@ std::set<node> expandseed_internal(const Graph&G, const std::set<node>& seeds) {
      * objective function M
      * @return quality difference for the move of v to C
      */
-    auto deltaM = [&](const shell_info_t& info){
-        double delta = (com.internalEdgeWeight() + (*info.intDeg)) / (double) (com.cut() - (*info.intDeg) + (*info.extDeg));
+    auto deltaM = [&](const shell_info_t &info) {
+        double delta = (com.internalEdgeWeight() + (*info.intDeg))
+                       / (double)(com.cut() - (*info.intDeg) + (*info.extDeg));
         return delta - currentQ;
     };
 
@@ -53,27 +55,27 @@ std::set<node> expandseed_internal(const Graph&G, const std::set<node>& seeds) {
      * objective function L
      * @return quality difference for the move of v to C
      */
-    auto deltaL = [&](const shell_info_t& info){
+    auto deltaL = [&](const shell_info_t &info) {
         // Compute difference in boundary size: for each neighbor where we are the last
         // external neighbor decrease by 1, if v has an external neighbor increase by 1
         int64_t boundary_diff = info.boundaryChange();
 
         TRACE("boundary diff: ", boundary_diff);
 
-        double numerator = 2.0 * (com.internalEdgeWeight() + (*info.intDeg)) * (com.boundarySize() + boundary_diff);
+        double numerator = 2.0 * (com.internalEdgeWeight() + (*info.intDeg))
+                           * (com.boundarySize() + boundary_diff);
         double denominator = (com.size() + 1) * (com.cut() - (*info.intDeg) + (*info.extDeg));
         return (numerator / denominator) - currentQ;
     };
 
     // select quality objective
-    auto deltaQ = [&](const shell_info_t& info) -> double {
+    auto deltaQ = [&](const shell_info_t &info) -> double {
         if (objectiveIsM) {
             return deltaM(info);
         } else {
             return deltaL(info);
         }
     };
-
 
     if (objectiveIsM) {
         currentQ = com.internalEdgeWeight() / com.cut();
@@ -86,11 +88,11 @@ std::set<node> expandseed_internal(const Graph&G, const std::set<node>& seeds) {
     node vMax;
     do {
         // scan shell for node with maximum quality improvement
-        double dQMax = 0.0; 	// maximum quality improvement
+        double dQMax = 0.0; // maximum quality improvement
         vMax = none;
         Aux::IncrementalUniformRandomSelector selector;
 
-        com.forShellNodes([&](const node v, const shell_info_t& info) {
+        com.forShellNodes([&](const node v, const shell_info_t &info) {
             // get values for current node
             double dQ = deltaQ(info);
 
@@ -108,15 +110,15 @@ std::set<node> expandseed_internal(const Graph&G, const std::set<node>& seeds) {
         TRACE("vMax: ", vMax);
         TRACE("dQMax: ", dQMax);
         if (vMax != none) {
-            com.addNode(vMax);	// add best node to community
-            currentQ += dQMax;	 // update current community quality
+            com.addNode(vMax); // add best node to community
+            currentQ += dQMax; // update current community quality
         }
     } while (vMax != none);
 
     return com.toSet();
 }
 
-std::set<node> GCE::expandOneCommunity(const std::set<node>& s) {
+std::set<node> GCE::expandOneCommunity(const std::set<node> &s) {
     if (objective == "M") {
         return expandseed_internal<true>(*G, s);
     } else if (objective == "L") {

--- a/networkit/cpp/scd/GCE.cpp
+++ b/networkit/cpp/scd/GCE.cpp
@@ -8,29 +8,8 @@
 
 #include <utility>
 #include <networkit/scd/GCE.hpp>
-
-namespace {
-    template <bool> struct ConditionalCount {
-        void increaseNumBoundaryNeighbors() {}
-        void decreaseNumBoundaryNeighbors() {}
-        NetworKit::count getNumBoundaryNeighbors() {
-            throw std::logic_error("Error, num boundary neighbors not available in false branch");
-        }
-    };
-    template <> struct ConditionalCount<true> {
-        NetworKit::count numBoundaryNeighbors;
-        void increaseNumBoundaryNeighbors() {
-            numBoundaryNeighbors += 1;
-        }
-        void decreaseNumBoundaryNeighbors() {
-            assert(numBoundaryNeighbors > 0);
-            numBoundaryNeighbors -= 1;
-        }
-        NetworKit::count getNumBoundaryNeighbors() {
-            return numBoundaryNeighbors;
-        }
-    };
-}
+#include <networkit/structures/LocalCommunity.hpp>
+#include <networkit/auxiliary/IncrementalUniformRandomSelector.hpp>
 
 namespace NetworKit {
 
@@ -48,235 +27,93 @@ std::set<node> GCE::expandSeed(node seed) {
 
 template <bool objectiveIsM>
 std::set<node> expandseed_internal(const Graph&G, const std::set<node>& seeds) {
-    /**
-    * Check if set contains node.
-    */
-    auto in = [](const std::set<node>& A, node x) {
-        return (A.find(x) != A.end());
-    };
-
-    std::set<node> community;
-
-    // values per community
-    double intWeight = 0;
-    double extWeight = 0;
-
-    struct node_property_t : ConditionalCount<!objectiveIsM> {
-        double degInt;
-        double degExt;
-    };
-
-    std::unordered_map<node, node_property_t> currentShell;
-
     double currentQ = 0.0; // current community quality
 
-    // Current boundary. Stores for every node in the boundary how many neighbors it has outside the community.
-    std::unordered_map<node, count> currentBoundary;
-
-#ifndef NDEBUG
-    // The boundary is defined as all nodes of C that have a neighbor not in C
-    auto boundary = [&](const std::set<node>& C) {
-        std::set<node> sh;
-        for (node u : C) {
-            G.forNeighborsOf(u, [&](node v){
-                if (!in(C, v)) {
-                    sh.insert(u);
-                }
-            });
-        }
-        return sh;
-    };
-
-    /**
-     * internal and external weighted degree of a node with respect to the community
-     */
-    auto intExtDeg = [&](node v, const std::set<node>& C) {
-        double degInt = 0;
-        double degExt = 0;
-        G.forNeighborsOf(v, [&](node, node u, edgeweight ew) {
-            if (in(C, u)) {
-                degInt += ew;
-            } else {
-                degExt += ew;
-            }
-        });
-        return std::make_pair(degInt, degExt);
-    };
-
-    auto intExtWeight = [&](const std::set<node>& community) {
-        double internal = 0;
-        double external = 0;
-        for (node u : community) {
-            G.forEdgesOf(u, [&](node, node v, edgeweight ew) {
-                if (in(community, v)) {
-                    internal += ew;
-                } else {
-                    external += ew;
-                }
-            });
-        }
-        internal = internal / 2;	// internal edges were counted twice
-        return std::make_pair(internal, external);
-    };
-#endif
-
-    auto addNodeToCommunity = [&](node u) {
-        community.insert(u); 	// add node to community
-
-        currentShell.erase(u);	// remove node from shell
-
-        node boundaryNeighbor = none; // for L: if u is in the boundary and has only one neighbor outside of the community, store it here.
-        auto boundaryIt = currentBoundary.end();
-
-        G.forNeighborsOf(u, [&](node, node v, edgeweight ew) { // insert external neighbors of u into shell
-            if (!in(community, v)) {
-                auto it = currentShell.find(v);
-                if (it == currentShell.end()) {
-                    std::tie(it, std::ignore) = currentShell.insert({v, node_property_t {}});
-                    it->second.degExt = G.weightedDegree(v);
-                }
-
-                it->second.degInt += ew;
-                it->second.degExt -= ew;
-
-                extWeight += ew;
-                if (!objectiveIsM) {
-                    if (boundaryIt == currentBoundary.end()) {
-                        std::tie(boundaryIt, std::ignore) = currentBoundary.insert({u, 0});
-                        boundaryNeighbor = v;
-                    }
-
-                    ++boundaryIt->second;
-                }
-
-                assert(intExtDeg(v, community) == std::make_pair(currentShell[v].degInt, currentShell[v].degExt));
-            } else {
-                if (!objectiveIsM) {
-                    auto it = currentBoundary.find(v);
-                    assert(it != currentBoundary.end());
-                    it->second -= 1;
-                    if (it->second == 0) {
-                        currentBoundary.erase(it);
-                    } else if (it->second == 1) {
-                        G.forNeighborsOf(v, [&](node x) {
-                            auto it = currentShell.find(x);
-                            if (it != currentShell.end()) {
-                                it->second.increaseNumBoundaryNeighbors();
-                            }
-                        });
-                    }
-                }
-
-                intWeight += ew;
-                extWeight -= ew;
-            }
-        });
-
-        if (!objectiveIsM && boundaryIt != currentBoundary.end() && boundaryIt->second == 1) {
-            assert(boundaryNeighbor != none);
-            currentShell[boundaryNeighbor].increaseNumBoundaryNeighbors();
-        }
-
-        assert(objectiveIsM || boundary(community).size() == currentBoundary.size());
-    };
+    LocalCommunity<true, !objectiveIsM> com(G);
 
     for (node s : seeds) {
-        addNodeToCommunity(s);
+        com.addNode(s);
+#ifdef NETWORKIT_SANITY_CHECKS
+        assert(com.contains(s));
+#endif
     }
 
+    using shell_info_t = typename decltype(com)::ShellInfo;
 
     /*
      * objective function M
      * @return quality difference for the move of v to C
      */
-    auto deltaM = [&](node, double degInt, double degExt, const std::set<node> &){
-        double delta = (intWeight + degInt) / (double) (extWeight - degInt + degExt);
+    auto deltaM = [&](const shell_info_t& info){
+        double delta = (com.internalEdgeWeight() + (*info.intDeg)) / (double) (com.cut() - (*info.intDeg) + (*info.extDeg));
         return delta - currentQ;
     };
-
 
     /*
      * objective function L
      * @return quality difference for the move of v to C
      */
-    auto deltaL = [&](node v, double degInt, double degExt, std::set<node>& C){
-    // Compute difference in boundary size: for each neighbor where we are the last
-    // external neighbor decrease by 1, if v has an external neighbor increase by 1
-    int64_t boundary_diff = 0;
-    if (degExt > 0) {
-        boundary_diff += 1;
-    }
+    auto deltaL = [&](const shell_info_t& info){
+        // Compute difference in boundary size: for each neighbor where we are the last
+        // external neighbor decrease by 1, if v has an external neighbor increase by 1
+        int64_t boundary_diff = info.boundaryChange();
 
-    boundary_diff -= currentShell[v].getNumBoundaryNeighbors();
+        TRACE("boundary diff: ", boundary_diff);
 
-#ifndef NDEBUG
-    int64_t boundary_diff_debug = 0;
-    bool v_in_boundary = false;
-    G.forNeighborsOf(v, [&](node x) {
-        auto it = currentBoundary.find(x);
-        if (it != currentBoundary.end()) {
-            if (it->second == 1) {
-                boundary_diff_debug -= 1;
-            }
-        } else if (!v_in_boundary) {
-            boundary_diff_debug += 1;
-            v_in_boundary = true;
-        }
-    });
-
-    assert(boundary_diff == boundary_diff_debug);
-#endif
-    double numerator = 2.0 * (intWeight + degInt) * static_cast<double>(currentBoundary.size() + boundary_diff);
-    double denominator = static_cast<double>(C.size() + 1) * (extWeight - degInt + degExt);
+        double numerator = 2.0 * (com.internalEdgeWeight() + (*info.intDeg)) * (com.boundarySize() + boundary_diff);
+        double denominator = (com.size() + 1) * (com.cut() - (*info.intDeg) + (*info.extDeg));
         return (numerator / denominator) - currentQ;
     };
 
     // select quality objective
-    auto deltaQ = [&](node v, double degInt, double degExt, std::set<node>& C) -> double {
+    auto deltaQ = [&](const shell_info_t& info) -> double {
         if (objectiveIsM) {
-            return deltaM(v, degInt, degExt, C);
+            return deltaM(info);
         } else {
-            return deltaL(v, degInt, degExt, C);
+            return deltaL(info);
         }
     };
 
 
     if (objectiveIsM) {
-        currentQ = deltaM(0, 0, 0, community);
+        currentQ = com.internalEdgeWeight() / com.cut();
     } else {
-        double numerator = 2.0 * (intWeight) * currentBoundary.size();
-        double denominator = community.size() * (extWeight);
+        double numerator = 2.0 * com.internalEdgeWeight() * com.boundarySize();
+        double denominator = com.size() * com.cut();
         currentQ = numerator / denominator;
     }
 
     node vMax;
     do {
-        // get values for current community
-        assert(std::make_pair(intWeight, extWeight) == intExtWeight(community));
         // scan shell for node with maximum quality improvement
         double dQMax = 0.0; 	// maximum quality improvement
         vMax = none;
-        for (const auto& vs : currentShell) {
-            // get values for current node
-            assert(intExtDeg(vs.first, community) == std::make_pair(vs.second.degInt, vs.second.degExt));
+        Aux::IncrementalUniformRandomSelector selector;
 
-            double dQ = deltaQ(vs.first, vs.second.degInt, vs.second.degExt, community);
+        com.forShellNodes([&](const node v, const shell_info_t& info) {
+            // get values for current node
+            double dQ = deltaQ(info);
+
             TRACE("dQ: ", dQ);
-            if (dQ >= dQMax) {
-                vMax = vs.first;
+
+            if (dQ > dQMax) {
+                vMax = v;
                 dQMax = dQ;
+                selector.reset();
+            } else if (dQ == dQMax && selector.addElement()) {
+                vMax = v;
             }
-        }
+        });
+
         TRACE("vMax: ", vMax);
         TRACE("dQMax: ", dQMax);
         if (vMax != none) {
-            addNodeToCommunity(vMax);  // add best node to community
-            currentQ += dQMax;   // update current community quality
-            TRACE("community: ", community);
+            com.addNode(vMax);	// add best node to community
+            currentQ += dQMax;	 // update current community quality
         }
     } while (vMax != none);
 
-    return community;
+    return com.toSet();
 }
 
 std::set<node> GCE::expandOneCommunity(const std::set<node>& s) {

--- a/networkit/cpp/scd/GCE.cpp
+++ b/networkit/cpp/scd/GCE.cpp
@@ -14,9 +14,9 @@
 
 namespace NetworKit {
 
-GCE::GCE(const Graph &G, std::string objective)
-    : SelectiveCommunityDetector(G), objective(std::move(objective)) {
-    if (G.numberOfSelfLoops()) {
+GCE::GCE(const Graph &g, std::string objective)
+    : SelectiveCommunityDetector(g), objective(std::move(objective)) {
+    if (g.numberOfSelfLoops()) {
         throw std::runtime_error("Graphs with self-loops are not supported in GCE");
     }
 }
@@ -27,10 +27,10 @@ std::set<node> GCE::expandSeed(node seed) {
 }
 
 template <bool objectiveIsM>
-std::set<node> expandseed_internal(const Graph &G, const std::set<node> &seeds) {
+std::set<node> expandseedInternal(const Graph &g, const std::set<node> &seeds) {
     double currentQ = 0.0; // current community quality
 
-    LocalCommunity<true, !objectiveIsM> com(G);
+    LocalCommunity<true, !objectiveIsM> com(g);
 
     for (node s : seeds) {
         com.addNode(s);
@@ -58,12 +58,12 @@ std::set<node> expandseed_internal(const Graph &G, const std::set<node> &seeds) 
     auto deltaL = [&](const shell_info_t &info) {
         // Compute difference in boundary size: for each neighbor where we are the last
         // external neighbor decrease by 1, if v has an external neighbor increase by 1
-        int64_t boundary_diff = info.boundaryChange();
+        int64_t boundaryDiff = info.boundaryChange();
 
-        TRACE("boundary diff: ", boundary_diff);
+        TRACE("boundary diff: ", boundaryDiff);
 
-        double numerator = 2.0 * (com.internalEdgeWeight() + (*info.intDeg))
-                           * (com.boundarySize() + boundary_diff);
+        double numerator =
+            2.0 * (com.internalEdgeWeight() + (*info.intDeg)) * (com.boundarySize() + boundaryDiff);
         double denominator = (com.size() + 1) * (com.cut() - (*info.intDeg) + (*info.extDeg));
         return (numerator / denominator) - currentQ;
     };
@@ -120,9 +120,9 @@ std::set<node> expandseed_internal(const Graph &G, const std::set<node> &seeds) 
 
 std::set<node> GCE::expandOneCommunity(const std::set<node> &s) {
     if (objective == "M") {
-        return expandseed_internal<true>(*G, s);
+        return expandseedInternal<true>(*g, s);
     } else if (objective == "L") {
-        return expandseed_internal<false>(*G, s);
+        return expandseedInternal<false>(*g, s);
     } else {
         throw std::runtime_error("unknown objective function");
     }

--- a/networkit/cpp/scd/GCE.cpp
+++ b/networkit/cpp/scd/GCE.cpp
@@ -41,6 +41,11 @@ GCE::GCE(const Graph &G, std::string objective)
     }
 }
 
+std::set<node> GCE::expandSeed(node seed) {
+    WARN("GCE::expandSeed is deprecated, use GCE::expandOneCommunity instead");
+    return expandOneCommunity(seed);
+}
+
 template <bool objectiveIsM>
 std::set<node> expandseed_internal(const Graph&G, const std::set<node>& seeds) {
     /**

--- a/networkit/cpp/scd/LFMLocal.cpp
+++ b/networkit/cpp/scd/LFMLocal.cpp
@@ -1,0 +1,101 @@
+// networkit-format
+#include <cmath>
+#include <unordered_map>
+
+#include <networkit/auxiliary/IncrementalUniformRandomSelector.hpp>
+#include <networkit/scd/LFMLocal.hpp>
+#include <networkit/structures/LocalCommunity.hpp>
+
+namespace NetworKit {
+
+LFMLocal::LFMLocal(const Graph &g, double alpha) : SelectiveCommunityDetector(g), alpha(alpha) {}
+
+std::set<node> LFMLocal::expandOneCommunity(const std::set<node> &seeds) {
+    LocalCommunity<true, false, true> community(*g);
+    using shell_info_t = LocalCommunity<true, false, true>::ShellInfo;
+    using community_info_t = LocalCommunity<true, false, true>::CommunityInfo;
+
+    for (node u : seeds) {
+        community.addNode(u);
+    }
+
+    if (community.internalEdgeWeight() + community.cut() == 0)
+        return community.toSet();
+
+    auto quality = [this](double internalEdgeWeight, double cut) {
+        return (2 * internalEdgeWeight)
+               / std::pow(static_cast<double>(2 * internalEdgeWeight + cut), alpha);
+    };
+
+    node uMax;
+    double qMax, currentQ = quality(community.internalEdgeWeight(), community.cut());
+    do {
+        assert(std::abs(currentQ - quality(community.internalEdgeWeight(), community.cut()))
+               < 0.00001);
+        uMax = none;
+        qMax = 0.0;
+
+        // find node with max score
+
+        Aux::IncrementalUniformRandomSelector selector;
+        community.forShellNodes([&](node u, const shell_info_t &uInfo) {
+            double uQ = quality(community.internalEdgeWeight() + uInfo.intDeg.get(),
+                                community.cut() - uInfo.intDeg.get() + uInfo.extDeg.get())
+                        - currentQ;
+
+            assert(!std::isnan(uQ) && !std::isinf(uQ));
+            TRACE(u, " diff: ", uQ);
+            if (uQ > qMax) {
+                qMax = uQ;
+                uMax = u;
+                selector.reset();
+            } else if (uQ == qMax && selector.addElement()) {
+                uMax = u;
+            }
+        });
+
+        if (uMax != none) {
+            community.addNode(uMax);
+            currentQ += qMax;
+
+            // delete nodes from result with neg. score (except node s)
+            Aux::IncrementalUniformRandomSelector removalSelector;
+            node uMin;
+            do {
+                uMin = none;
+                double qMin = 0;
+
+                assert(std::abs(currentQ - quality(community.internalEdgeWeight(), community.cut()))
+                       < 0.00001);
+
+                community.forCommunityNodes([&](node u, const community_info_t &uInfo) {
+                    double uQ =
+                        currentQ
+                        - quality(community.internalEdgeWeight() - uInfo.intDeg.get(),
+                                  community.cut() + uInfo.intDeg.get() - uInfo.extDeg.get());
+
+                    TRACE(u, " diff removal: ", uQ);
+
+                    if (uQ < qMin && seeds.find(u) == seeds.end()) {
+                        uMin = u;
+                        qMin = uQ;
+                        removalSelector.reset();
+                    } else if (uQ == qMin && seeds.find(u) == seeds.end()
+                               && removalSelector.addElement()) {
+                        uMin = u;
+                    }
+                });
+
+                if (uMin != none) {
+                    currentQ -= qMin;
+                    community.removeNode(uMin);
+                }
+            } while (uMin != none);
+        }
+
+    } while (uMax != none);
+
+    return community.toSet();
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/scd/LocalDegreeDirectedGraph.hpp
+++ b/networkit/cpp/scd/LocalDegreeDirectedGraph.hpp
@@ -1,0 +1,329 @@
+// networkit-format
+#ifndef NETWORKIT_SCD_LOCALDEGREEDIRECTEDGRAPH_HPP
+#define NETWORKIT_SCD_LOCALDEGREEDIRECTEDGRAPH_HPP
+
+#include <unordered_map>
+#include <vector>
+
+#include <networkit/Globals.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+/**
+ * Graph for local community detection that stores edges in directed
+ * form in just one direction depending on the node's degrees and
+ * thus allows efficient triangle listing.
+ */
+template <bool IsWeighted, typename NodeAddedCallbackType>
+class LocalDegreeDirectedGraph {
+protected:
+    // local to global (input graph) id mapping
+    std::vector<node> localToGlobalId;
+    // map from input graph to local id
+    std::unordered_map<node, node> globalToLocalId;
+
+    // for the local graph: outgoing neighbors
+    std::vector<node> head;
+    // for the local graph: weight of outgoing edges, only used for weighted graphs (otherwise
+    // empty)
+    std::vector<double> headWeight;
+
+    struct LocalNode {
+        /** first index in head where neighbors of the node are stored */
+        size_t firstHead;
+        /** index after the last index in head where neighbors of the node are stored */
+        size_t lastHead;
+    };
+
+    // stores for every local node the information where the outgoing neighbors begins and ends
+    std::vector<LocalNode> headInfo;
+    // stores the degree of every local node in the local graph
+    std::vector<count> degree;
+
+    std::vector<node> currentLocalNeighborIds;
+
+    const Graph &g;
+
+    // data structures only for neighbors of a node
+    std::vector<bool> isNeighbor;
+    std::vector<double> neighborWeight;
+
+    // callback to call whenever a node is added
+    NodeAddedCallbackType nodeAddedCallback;
+
+public:
+    /**
+     * Initialize the local graph as empty graph.
+     *
+     * @param g The graph from which nodes can be added
+     * @param node_added_callback Callback that is called whenever a node is added
+     */
+    LocalDegreeDirectedGraph(const Graph &g, NodeAddedCallbackType nodeAddedCallback)
+        : g(g), nodeAddedCallback(nodeAddedCallback) {
+        if (g.isDirected()) {
+            throw std::runtime_error("Directed graphs are not supported");
+        }
+    }
+
+    ~LocalDegreeDirectedGraph() = default;
+
+    /**
+     * Map a local node id to a global one
+     */
+    node toGlobal(node lu) const { return localToGlobalId[lu]; }
+
+    /**
+     * Check if the given node exists.
+     */
+    bool hasNode(node u) const { return globalToLocalId.find(u) != globalToLocalId.end(); }
+
+    /**
+     * Ensure that the given global node id exists in the local graph
+     *
+     * @param u The global node id to check
+     * @return The local node id
+     */
+    node ensureNodeExists(node u) {
+        auto gtlIt = globalToLocalId.find(u);
+
+        if (gtlIt == globalToLocalId.end()) {
+            node localId = localToGlobalId.size();
+            localToGlobalId.push_back(u);
+            globalToLocalId[u] = localId;
+
+            double weightedDegree = 0;
+
+            size_t myDegree = 0;
+
+            index myBegin = head.size();
+            index myEnd = myBegin;
+            index nh = myEnd; // next head if all potential out neighbors were inserted
+
+            g.forEdgesOf(u, [&](node, node v, edgeweight weight) {
+                auto it = globalToLocalId.find(v);
+
+                if (it != globalToLocalId.end()) {
+                    ++myDegree;
+
+                    auto &nDegree = degree[it->second];
+                    ++nDegree;
+
+                    head.push_back(it->second);
+                    if (IsWeighted) {
+                        headWeight.push_back(weight);
+                    }
+
+                    ++myEnd;
+                }
+
+                weightedDegree += weight;
+                ++nh;
+            });
+
+            assert(myEnd == head.size());
+            assert(!IsWeighted || myEnd == headWeight.size());
+            assert(nh >= myEnd);
+
+            head.resize(nh);
+            if (IsWeighted) {
+                headWeight.resize(nh);
+            }
+
+            degree.push_back(myDegree);
+
+            // Iterate over all neighbors in the local graph
+            for (index i = myBegin; i < myEnd;) {
+                node ln = head[i];
+                edgeweight weight = IsWeighted ? headWeight[i] : defaultEdgeWeight;
+
+                auto &nDegree = degree[ln];
+                auto &nInfo = headInfo[ln];
+
+                // Before into the neighbors of ln, check if it can get rid of any
+                // neighbors due to being a higher-degree node now.
+                for (index ni = nInfo.firstHead; ni < nInfo.lastHead;) {
+                    node nn = head[ni];
+                    if (nDegree <= degree[nn]) {
+                        ++ni;
+                    } else {
+                        // Move edge to node nn
+                        // Store last neighbor of ln at position ni instead, i.e., remove nn
+                        head[ni] = head[--nInfo.lastHead];
+
+                        if (IsWeighted) {
+                            // Copy weight to neighbor list of nn
+                            headWeight[headInfo[nn].lastHead] = headWeight[ni];
+                            // Copy weight of last neighbor of nn at position ni
+                            headWeight[ni] = headWeight[nInfo.lastHead];
+                        }
+
+                        // Store ln as neighbor at the last position of the neighbor list of nn
+                        head[headInfo[nn].lastHead++] = ln;
+                    }
+                }
+
+                if (myDegree < nDegree) {
+                    ++i;
+                } else {
+                    // Add local_id to ln as neighbor instead of adding ln as neighbor here
+                    if (IsWeighted) {
+                        headWeight[nInfo.lastHead] = weight;
+                    }
+
+                    head[nInfo.lastHead++] = localId;
+
+                    // This removes one neighbor
+                    --myEnd;
+                    // Move the last neighbor at the current position
+                    head[i] = head[myEnd];
+                    if (IsWeighted) {
+                        headWeight[i] = headWeight[myEnd];
+                    }
+
+                    assert(ln + 1 == localId
+                           || headInfo[ln].lastHead <= headInfo[ln + 1].firstHead);
+                }
+            }
+
+            headInfo.emplace_back(LocalNode{myBegin, myEnd});
+
+            isNeighbor.push_back(false);
+
+            if (IsWeighted)
+                neighborWeight.push_back(0);
+
+            nodeAddedCallback(u, localId, weightedDegree);
+
+            validateEdgesExist();
+
+            return localId;
+        } else {
+            return gtlIt->second;
+        }
+    }
+
+    /**
+     * Iterate over all triangles that include the global node @a u
+     *
+     * @param u The node from which triangles shall be listed
+     * @param callback The callback to call. Must take two node ids of the triangle as well as three
+     * edge weights as parameters.
+     */
+    template <typename F>
+    void forTrianglesOf(node u, F callback) {
+        forTrianglesOf(
+            u, [](node, edgeweight) {}, callback);
+    }
+
+    /**
+     * Iterate over all triangles that include the global node @a u
+     *
+     * @param u The node from which triangles shall be listed
+     * @param initNeighborsCallback The callback to call for every local neighbor (local id) as they
+     * are collected
+     * @param triangleCallback The callback to call for each
+     * triangle. Must take two node ids of the triangle as well as
+     * three edge weights as parameters.
+     */
+    template <typename Fi, typename Ft>
+    void forTrianglesOf(node u, Fi initNeighborsCallback, Ft triangleCallback) {
+        if (g.degree(u) == 0)
+            return;
+
+        currentLocalNeighborIds.clear();
+        currentLocalNeighborIds.reserve(g.degree(u));
+
+        g.forNeighborsOf(u, [&](node, node v, edgeweight weight) {
+            node localId = ensureNodeExists(v);
+            currentLocalNeighborIds.emplace_back(localId);
+            isNeighbor[localId] = true;
+
+            if (IsWeighted) {
+                neighborWeight[localId] = weight;
+            }
+
+            initNeighborsCallback(localId, weight);
+        });
+
+        for (node lv : currentLocalNeighborIds) {
+            for (index ti = headInfo[lv].firstHead; ti < headInfo[lv].lastHead; ++ti) {
+                node y = head[ti];
+
+                if (isNeighbor[y]) {
+                    edgeweight weightUv = defaultEdgeWeight;
+                    edgeweight weightUy = defaultEdgeWeight;
+                    edgeweight weightVy = defaultEdgeWeight;
+                    if (IsWeighted) {
+                        weightUv = neighborWeight[lv];
+                        weightUy = neighborWeight[y];
+                        weightVy = headWeight[ti];
+                    }
+
+                    triangleCallback(lv, y, weightUv, weightUy, weightVy);
+                }
+            }
+        }
+
+        for (node v : currentLocalNeighborIds) {
+            isNeighbor[v] = false;
+        }
+    }
+
+    void validateEdgesExist() {
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+        g.forNodes([&](node gu) {
+            auto gtlIt = globalToLocalId.find(gu);
+            if (gtlIt != globalToLocalId.end()) {
+                node lu = gtlIt->second;
+
+                g.forNeighborsOf(gu, [&](node gv) {
+                    auto gtlV = globalToLocalId.find(gv);
+                    if (gtlV != globalToLocalId.end()) {
+                        node lv = gtlV->second;
+
+                        bool foundU = false;
+                        for (size_t i = headInfo[lu].firstHead; i < headInfo[lu].lastHead; ++i) {
+                            if (head[i] == lv) {
+                                foundU = true;
+                                break;
+                            }
+                        }
+                        bool foundV = false;
+                        for (size_t i = headInfo[lv].firstHead; i < headInfo[lv].lastHead; ++i) {
+                            if (head[i] == lu) {
+                                foundV = true;
+                                break;
+                            }
+                        }
+
+                        assert(foundU != foundV);
+                    }
+                });
+            }
+        });
+#endif
+#endif
+    }
+
+    /**
+     * Iterate over local neighbors of the node previously passed to forTrianglesOf
+     *
+     * @param callback The call back that shall be called for each neighbor, needs to take a node
+     * and an edgeweight.
+     */
+    template <typename F>
+    void forLocalNeighbors(F callback) {
+        for (node v : currentLocalNeighborIds) {
+            if (IsWeighted) {
+                callback(v, neighborWeight[v]);
+            } else {
+                callback(v, defaultEdgeWeight);
+            }
+        }
+    }
+};
+
+} // namespace NetworKit
+#endif

--- a/networkit/cpp/scd/LocalT.cpp
+++ b/networkit/cpp/scd/LocalT.cpp
@@ -1,0 +1,196 @@
+// networkit-format
+#include <algorithm>
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <networkit/scd/LocalT.hpp>
+
+#include "LocalDegreeDirectedGraph.hpp"
+
+namespace NetworKit {
+
+LocalT::LocalT(const Graph &g) : SelectiveCommunityDetector(g) {}
+
+std::set<node> LocalT::expandOneCommunity(const std::set<node> &s) {
+    // global data structures
+    // result community
+    std::set<node> result;
+
+    // This algorithm creates a local graph. It contains the community and its shell.
+    // stores the sum of the similarities of all nodes to nodes in the community
+    std::vector<double> nodeInternalTriangles;
+    std::vector<double> nodeExternalTriangles;
+    std::vector<double> nodeSemiInternalTriangles;
+
+    // indicates for every local node if it is in the community (true) or in the shell (false)
+    std::vector<bool> inResult;
+
+    std::vector<bool> inShell;
+
+    count internalTriangles = 0, externalTriangles = 0;
+
+    auto addNode = [&](node, node, double) {
+        nodeInternalTriangles.push_back(0);
+        nodeExternalTriangles.push_back(0);
+        nodeSemiInternalTriangles.push_back(0);
+        inResult.push_back(false);
+        inShell.push_back(false);
+    };
+
+    LocalDegreeDirectedGraph<false, decltype(addNode)> localGraph(*g, addNode);
+
+    std::unordered_set<node> shell;
+
+    auto updateShell = [&](node u) {
+        localGraph.forTrianglesOf(u, [&](node lv, node lw, edgeweight, edgeweight, edgeweight) {
+            // collect counts and compute scores
+            // new completely internal triangle, was not counted
+            // previously
+            if (inResult[lv] && inResult[lw]) {
+                ++nodeInternalTriangles[lv];
+                ++nodeInternalTriangles[lw];
+                ++internalTriangles;
+            } else if (inResult[lv] || inResult[lw]) {
+                --externalTriangles;
+
+                if (inResult[lv]) {
+                    ++nodeInternalTriangles[lw];
+                    --nodeSemiInternalTriangles[lw];
+                } else {
+                    ++nodeInternalTriangles[lv];
+                    --nodeSemiInternalTriangles[lv];
+                }
+            } else {
+                ++externalTriangles;
+                if (inShell[lv]) {
+                    --nodeExternalTriangles[lv];
+                }
+                ++nodeSemiInternalTriangles[lv];
+
+                if (inShell[lw]) {
+                    --nodeExternalTriangles[lw];
+                }
+                ++nodeSemiInternalTriangles[lw];
+            }
+        });
+
+        g->forNeighborsOf(u, [&](node v) {
+            node s = localGraph.ensureNodeExists(v);
+
+            if (!inShell[s] && !inResult[s]) {
+                shell.insert(s);
+                inShell[s] = true;
+
+                localGraph.forTrianglesOf(localGraph.toGlobal(s), [&](node lv, node lw, edgeweight,
+                                                                      edgeweight, edgeweight) {
+                    if (!inResult[lv] && !inResult[lw]) {
+                        ++nodeExternalTriangles[s];
+                    }
+                });
+            }
+        });
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+        count debugExternalTriangles = 0;
+        count debugInternalTriangles = 0;
+        for (node u : result) {
+            count uExternal = 0, uInternal = 0;
+            localGraph.forTrianglesOf(u, [&](node lv, node lw, edgeweight, edgeweight, edgeweight) {
+                if (inResult[lv] && inResult[lw]) {
+                    ++uInternal;
+                } else if (!inResult[lv] && !inResult[lw]) {
+                    ++uExternal;
+                }
+            });
+
+            node lu = localGraph.ensureNodeExists(u);
+
+            assert(uInternal == nodeInternalTriangles[lu]);
+            assert(uInternal == nodeInternalTriangles[lu]);
+
+            debugExternalTriangles += uExternal;
+            debugInternalTriangles += uInternal;
+        }
+
+        assert(debugExternalTriangles == externalTriangles);
+        assert(debugInternalTriangles / 3 == internalTriangles);
+
+        for (node ls : shell) {
+            count sExternal = 0, sInternal = 0, sSemiInternal = 0;
+            localGraph.forTrianglesOf(localGraph.toGlobal(ls),
+                                      [&](node lv, node lw, edgeweight, edgeweight, edgeweight) {
+                                          if (inResult[lv] && inResult[lw]) {
+                                              ++sInternal;
+                                          } else if (inResult[lv] || inResult[lw]) {
+                                              ++sSemiInternal;
+                                          } else {
+                                              ++sExternal;
+                                          }
+                                      });
+
+            assert(sSemiInternal == nodeSemiInternalTriangles[ls]);
+            assert(sInternal == nodeInternalTriangles[ls]);
+            assert(sExternal == nodeExternalTriangles[ls]);
+        }
+#endif
+#endif
+    };
+
+    // init community with seed set
+    for (node u : s) {
+        node lu = localGraph.ensureNodeExists(u);
+        result.insert(u);
+        shell.erase(lu);
+        inResult[lu] = true;
+        updateShell(u);
+    }
+
+    auto getScore = [](count intTriangles, count extTriangles) -> count {
+        return std::max<int64_t>(
+            0, intTriangles
+                   * (static_cast<int64_t>(intTriangles) - static_cast<int64_t>(extTriangles)));
+    };
+
+    // expand (main loop)
+    node uMax = none;
+    do {
+
+        uMax = none;
+        count bestScore = getScore(internalTriangles, externalTriangles);
+        count bestExternalTriangles = none;
+
+        for (node lv : shell) {
+            count newInternalTriangles = internalTriangles + nodeInternalTriangles[lv];
+            count newExternalTriangles =
+                externalTriangles + nodeExternalTriangles[lv] - nodeSemiInternalTriangles[lv];
+
+            count newScore = getScore(newInternalTriangles, newExternalTriangles);
+
+            if (newScore > bestScore
+                || (newScore == bestScore && newExternalTriangles < bestExternalTriangles)) {
+                uMax = lv;
+                bestScore = newScore;
+                bestExternalTriangles = newExternalTriangles;
+            }
+        }
+
+        if (uMax != none) {
+#ifdef NETWORKIT_SANITY_CHECKS
+            assert(result.find(uMax) == result.end());
+#endif
+            node gUMax = localGraph.toGlobal(uMax);
+            result.insert(gUMax);
+            shell.erase(uMax);
+            inResult[uMax] = true;
+            updateShell(gUMax);
+            assert(externalTriangles == bestExternalTriangles);
+            assert(getScore(internalTriangles, externalTriangles) == bestScore);
+        }
+
+    } while (uMax != none);
+    return result;
+}
+
+} /* namespace NetworKit */

--- a/networkit/cpp/scd/LocalTightnessExpansion.cpp
+++ b/networkit/cpp/scd/LocalTightnessExpansion.cpp
@@ -1,0 +1,345 @@
+// networkit-format
+#include <algorithm>
+#include <limits>
+#include <unordered_map>
+
+#include <tlx/container/d_ary_addressable_int_heap.hpp>
+#include <tlx/unused.hpp>
+
+#include <networkit/scd/LocalTightnessExpansion.hpp>
+
+#include "LocalDegreeDirectedGraph.hpp"
+
+namespace NetworKit {
+
+LocalTightnessExpansion::LocalTightnessExpansion(const Graph &g, double alpha)
+    : SelectiveCommunityDetector(g), alpha(alpha) {}
+
+namespace {
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+/*
+ * Only used for debugging.
+ */
+double weightedEdgeScore(const Graph &g, node u, node v, edgeweight ew, double uDegree,
+                         const std::unordered_map<node, double> &uNeighbors) {
+    double vDegree = 1.0; // w(u, u) = 1 per their definition
+    double nom = ew;      // w(v, v) * w(v, u)
+
+    g.forNeighborsOf(v, [&](node, node w, edgeweight vwWeight) {
+        vDegree += vwWeight * vwWeight;
+        auto uw = uNeighbors.find(w);
+        if (uw != uNeighbors.end())
+            nom += vwWeight * uw->second;
+        else if (w == u)
+            nom += vwWeight; // w(u, u) * w(u, v)
+    });
+
+    vDegree = std::sqrt(vDegree);
+
+    double denom = vDegree * uDegree;
+
+    return nom / denom;
+}
+#endif
+#endif
+
+template <typename NodeAddedCallbackType>
+struct InnerNodeAddedCallback {
+    NodeAddedCallbackType nodeAddedCallback;
+    std::vector<double> &triangleSum;
+
+    void operator()(node u, node localId, double weightedDegree) {
+        nodeAddedCallback(u, localId, weightedDegree);
+        triangleSum.push_back(0);
+    }
+};
+
+template <bool is_weighted, typename NodeAddedCallbackType>
+class LocalGraph
+    : public LocalDegreeDirectedGraph<is_weighted, InnerNodeAddedCallback<NodeAddedCallbackType>> {
+private:
+    // data structures only for neighbors of a node
+    std::vector<double> triangleSum;
+
+public:
+    LocalGraph(const Graph &g, NodeAddedCallbackType nodeAddedCallback)
+        : LocalDegreeDirectedGraph<is_weighted, InnerNodeAddedCallback<NodeAddedCallbackType>>(
+            g, InnerNodeAddedCallback<NodeAddedCallbackType>{nodeAddedCallback, triangleSum}) {
+        if (g.isWeighted() != is_weighted) {
+            throw std::runtime_error("Error, weighted/unweighted status of input graph does not "
+                                     "match is_weighted template parameter");
+        }
+    }
+
+    template <typename F>
+    void forNeighborsWithTrianglesOf(node u, F callback) {
+        if (this->g.degree(u) == 0)
+            return;
+
+        this->forTrianglesOf(
+            u, [&](node ln, edgeweight w) { triangleSum[ln] = 2 * w; },
+            [&](node lv, node y, edgeweight weightUv, edgeweight weightUy, edgeweight weightVy) {
+                if (is_weighted) {
+                    triangleSum[y] += weightUv * weightVy;
+                    triangleSum[lv] += weightUy * weightVy;
+                } else {
+                    triangleSum[y] += 1;
+                    triangleSum[lv] += 1;
+                }
+            });
+
+        this->forLocalNeighbors([&](node v, edgeweight w) { callback(v, w, triangleSum[v]); });
+    }
+};
+
+template <bool is_weighted>
+std::set<node> expandSeedSetInternal(const Graph &g, const std::set<node> &s, double alpha) {
+    // global data structures
+    // result community
+    std::set<node> result;
+
+    // This algorithm creates a local graph. It contains the community and its shell.
+    // stores sqrt{sum_{v \in N(u)} w(u, v)^2} for every local node u
+    std::vector<double> weightedDegree;
+
+    // stores the sum of the similarities of all nodes to nodes in the community
+    std::vector<double> nodeInternalSimilarity;
+    std::vector<double> nodeExternalSimilarity;
+
+    // indicates for every local node if it is in the community (true) or in the shell (false)
+    std::vector<bool> inResult;
+
+    std::vector<bool> inShell;
+
+    // heap that contains the nodes of the shell that still need to be considered
+    class Compare {
+        const std::vector<double> &similarity;
+
+    public:
+        Compare(const std::vector<double> &similarity) : similarity(similarity) {}
+
+        bool operator()(node u, node v) { return similarity[u] > similarity[v]; }
+    };
+
+    tlx::d_ary_addressable_int_heap<node, 4, Compare> shell((Compare(nodeInternalSimilarity)));
+
+    double internalSimilarity = 0;
+    double externalSimilarity = 0;
+
+    auto addNode = [&](node u, node, double) {
+        double wd = 1;
+        if (is_weighted) {
+            g.forNeighborsOf(u, [&](node, node, edgeweight w) { wd += w * w; });
+        } else {
+            wd += g.degree(u);
+        }
+
+        weightedDegree.push_back(std::sqrt(wd));
+
+        nodeInternalSimilarity.push_back(.0);
+        nodeExternalSimilarity.push_back(.0);
+        inResult.push_back(false);
+        inShell.push_back(false);
+    };
+
+    LocalGraph<is_weighted, decltype(addNode)> localGraph(g, addNode);
+
+    auto updateShell = [&](node u, node lu) {
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+        std::unordered_map<node, double> uNeighbors;
+        g.forNeighborsOf(
+            u, [&](node, node v, edgeweight ew) { uNeighbors.insert(std::make_pair(v, ew)); });
+
+        if (inShell[lu]) {
+            double debugUExternalSimilarity = .0;
+            double debugUInternalSimilarity = .0;
+            localGraph.forNeighborsWithTrianglesOf(u, [&](node lv, edgeweight, double triangleSum) {
+                double scoreUv = 0.0;
+                double denom = weightedDegree[lv] * weightedDegree[lu];
+                if (denom > 0.0) {
+                    scoreUv = triangleSum / denom;
+                }
+
+                if (inResult[lv]) {
+                    debugUInternalSimilarity += scoreUv;
+                } else {
+                    debugUExternalSimilarity += scoreUv;
+                }
+            });
+
+            assert(std::abs(debugUExternalSimilarity - nodeExternalSimilarity[lu]) < 0.000001);
+            assert(std::abs(debugUInternalSimilarity - nodeInternalSimilarity[lu]) < 0.000001);
+        }
+#endif
+#endif
+
+        std::vector<node> newShellNodes;
+
+        localGraph.forNeighborsWithTrianglesOf(
+            u, [&](node lv, edgeweight weight, double triangleSum) {
+                // collect counts and compute scores
+                double denom = weightedDegree[lv] * weightedDegree[lu];
+                double scoreUv = triangleSum / denom;
+
+#if defined(NETWORKIT_SANITY_CHECKS) && !defined(NDEBUG)
+                {
+                    double debugScore = weightedEdgeScore(g, u, localGraph.toGlobal(lv), weight,
+                                                          weightedDegree[lu], uNeighbors);
+                    assert(scoreUv == debugScore);
+                }
+#else
+                tlx::unused(weight); // needed for assert above
+#endif
+
+                nodeInternalSimilarity[lv] += scoreUv;
+
+                if (inResult[lv]) {
+#ifdef NETWORKIT_SANITY_CHECKS
+                    assert(!shell.contains(lv));
+#endif
+                    externalSimilarity -= scoreUv;
+                    internalSimilarity += 2 * scoreUv;
+                    if (!inShell[lu]) {
+#ifdef NETWORKIT_SANITY_CHECKS
+                        assert(!shell.contains(lu));
+#endif
+                        nodeInternalSimilarity[lu] += scoreUv;
+                    }
+                    nodeExternalSimilarity[lv] -= scoreUv;
+                } else {
+                    externalSimilarity += scoreUv;
+
+                    if (!inShell[lu]) {
+                        nodeExternalSimilarity[lu] += scoreUv;
+                    }
+
+                    shell.update(lv);
+
+                    if (!inShell[lv]) {
+                        inShell[lv] = true;
+                        newShellNodes.push_back(lv);
+                    } else {
+                        nodeExternalSimilarity[lv] -= scoreUv;
+                    }
+                }
+            });
+
+        for (node s : newShellNodes) {
+            localGraph.forNeighborsWithTrianglesOf(
+                localGraph.toGlobal(s), [&](node lv, edgeweight, double triangleSum) {
+                    if (!inResult[lv]) {
+                        double scoreUv = 0.0;
+                        double denom = weightedDegree[lv] * weightedDegree[s];
+                        if (denom > 0.0) {
+                            scoreUv = triangleSum / denom;
+                        }
+
+                        nodeExternalSimilarity[s] += scoreUv;
+                    }
+                });
+        }
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+        g.forNodes([&](node u) {
+            if (localGraph.hasNode(u)) {
+                node lu = localGraph.ensureNodeExists(u);
+                if (inShell[lu]) {
+                    double debugUExternalSimilarity = .0;
+                    double debugUInternalSimilarity = .0;
+                    localGraph.forNeighborsWithTrianglesOf(
+                        u, [&](node lv, edgeweight, double triangleSum) {
+                            double scoreUv = 0.0;
+                            double denom = weightedDegree[lv] * weightedDegree[lu];
+                            if (denom > 0.0) {
+                                scoreUv = triangleSum / denom;
+                            }
+
+                            if (inResult[lv]) {
+                                debugUInternalSimilarity += scoreUv;
+                            } else {
+                                debugUExternalSimilarity += scoreUv;
+                            }
+                        });
+
+                    assert(std::abs(debugUExternalSimilarity - nodeExternalSimilarity[lu])
+                           < 0.000001);
+                    assert(std::abs(debugUInternalSimilarity - nodeInternalSimilarity[lu])
+                           < 0.000001);
+                }
+            }
+        });
+#endif
+#endif
+    };
+
+    // init community with seed set
+    for (node u : s) {
+        node lu = localGraph.ensureNodeExists(u);
+        // Ensure that u is not added again during the expansion step
+        if (shell.contains(lu)) {
+            shell.remove(lu);
+        }
+        result.insert(u);
+        inResult[lu] = true;
+        updateShell(u, lu);
+    }
+
+    // expand (main loop)
+    while (!shell.empty()) {
+        node uMax = shell.extract_top();
+        node gUMax = localGraph.toGlobal(uMax);
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+        assert(result.find(gUMax) == result.end());
+        double internalSimilarityNew = internalSimilarity + 2 * nodeInternalSimilarity[uMax];
+        double externalSimilarityNew =
+            externalSimilarity - nodeInternalSimilarity[uMax] + nodeExternalSimilarity[uMax];
+
+        {
+            double debugInternalSimilarity = .0;
+            double debugExternalSimilarity = .0;
+            for (node u : result) {
+                node lu = localGraph.ensureNodeExists(u);
+                debugInternalSimilarity += nodeInternalSimilarity[lu];
+                debugExternalSimilarity += nodeExternalSimilarity[lu];
+            }
+
+            assert(std::abs(debugInternalSimilarity - internalSimilarity) < 0.000001);
+            assert(std::abs(debugExternalSimilarity - externalSimilarity) < 0.000001);
+        }
+#endif
+#endif
+
+        // if conductance decreases (i.e., improves)
+        if (externalSimilarity / internalSimilarity
+                - (alpha * nodeExternalSimilarity[uMax] - nodeInternalSimilarity[uMax])
+                      / (2 * nodeInternalSimilarity[uMax])
+            > 0) {
+            result.insert(gUMax);
+            inResult[uMax] = true;
+            updateShell(gUMax, uMax);
+
+#ifdef NETWORKIT_SANITY_CHECKS
+            assert(std::abs(internalSimilarity - internalSimilarityNew) < 0.000001);
+            assert(std::abs(externalSimilarity - externalSimilarityNew) < 0.000001);
+#endif
+        }
+    }
+    return result;
+}
+
+} // namespace
+
+std::set<node> LocalTightnessExpansion::expandOneCommunity(const std::set<node> &s) {
+    if (g->isWeighted()) {
+        return expandSeedSetInternal<true>(*g, s, alpha);
+    } else {
+        return expandSeedSetInternal<false>(*g, s, alpha);
+    }
+}
+
+} /* namespace NetworKit */

--- a/networkit/cpp/scd/PageRankNibble.cpp
+++ b/networkit/cpp/scd/PageRankNibble.cpp
@@ -17,6 +17,11 @@ namespace NetworKit {
 
 PageRankNibble::PageRankNibble(const Graph& g, double alpha, double epsilon): SelectiveCommunityDetector(g), alpha(alpha), epsilon(epsilon) {}
 
+std::set<node> PageRankNibble::expandSeed(node seed) {
+    WARN("PageRankNibble::expandSeed is deprecated, use PageRankNibble::expandOneCommunity instead");
+    return expandOneCommunity(seed);
+}
+
 std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>>& pr) {
     TRACE("Finding best sweep set. Support size: ",  pr.size());
 

--- a/networkit/cpp/scd/PageRankNibble.cpp
+++ b/networkit/cpp/scd/PageRankNibble.cpp
@@ -79,20 +79,12 @@ std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>>
     return bestSweepSet;
 }
 
-std::set<node> PageRankNibble::expandSeed(node seed) {
+
+std::set<node> PageRankNibble::expandOneCommunity(const std::set<node>& seeds) {
     DEBUG("APR(G, ", alpha, ", ", epsilon, ")");
     ApproximatePageRank apr(*G, alpha, epsilon);
-    std::vector<std::pair<node, double>> pr = apr.run(seed);
+    std::vector<std::pair<node, double>> pr = apr.run(seeds);
     return bestSweepSet(pr);
-}
-
-std::map<node, std::set<node> >  PageRankNibble::run(const std::set<node>& seeds) {
-    std::map<node, std::set<node> > result;
-    for (auto seed : seeds) {
-        auto community = expandSeed(seed);
-        result[seed] = community;
-    }
-    return result;
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/scd/PageRankNibble.cpp
+++ b/networkit/cpp/scd/PageRankNibble.cpp
@@ -31,7 +31,7 @@ std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>>
     // order vertices
     TRACE("Before sorting");
     for (size_t i = 0; i < pr.size(); i++) {
-        pr[i].second = pr[i].second / G->weightedDegree(pr[i].first, true);
+        pr[i].second = pr[i].second / g->weightedDegree(pr[i].first, true);
     }
     auto comp([&](const std::pair<node, double> &a, const std::pair<node, double> &b) {
         return a.second > b.second;
@@ -54,13 +54,13 @@ std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>>
     std::vector<node> currentSweepSet;
 
     // generate total volume.
-    double totalVolume = G->totalEdgeWeight() * 2;
+    double totalVolume = g->totalEdgeWeight() * 2;
 
     for (auto it = pr.begin(); it != pr.end(); it++) {
         // update sweep set
         node v = it->first;
         double wDegree = 0.0;
-        G->forNeighborsOf(v, [&](node, node neigh, edgeweight w) {
+        g->forNeighborsOf(v, [&](node, node neigh, edgeweight w) {
             wDegree += w;
             if (withinSweepSet.find(neigh) == withinSweepSet.end()) {
                 cut += w;
@@ -75,7 +75,7 @@ std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>>
         // compute conductance
         double cond = cut / std::min(volume, totalVolume - volume);
 
-        if ((cond < bestCond) && (currentSweepSet.size() < G->numberOfNodes())) {
+        if ((cond < bestCond) && (currentSweepSet.size() < g->numberOfNodes())) {
             bestCond = cond;
             bestSweepSetIndex = currentSweepSet.size();
         }
@@ -89,8 +89,8 @@ std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>>
 }
 
 std::set<node> PageRankNibble::expandOneCommunity(const std::set<node> &seeds) {
-    DEBUG("APR(G, ", alpha, ", ", epsilon, ")");
-    ApproximatePageRank apr(*G, alpha, epsilon);
+    DEBUG("APR(g, ", alpha, ", ", epsilon, ")");
+    ApproximatePageRank apr(*g, alpha, epsilon);
     std::vector<std::pair<node, double>> pr = apr.run(seeds);
     return bestSweepSet(pr);
 }

--- a/networkit/cpp/scd/PageRankNibble.cpp
+++ b/networkit/cpp/scd/PageRankNibble.cpp
@@ -1,3 +1,4 @@
+// networkit-format
 /*
  * PageRankNibble.cpp
  *
@@ -15,32 +16,34 @@
 
 namespace NetworKit {
 
-PageRankNibble::PageRankNibble(const Graph& g, double alpha, double epsilon): SelectiveCommunityDetector(g), alpha(alpha), epsilon(epsilon) {}
+PageRankNibble::PageRankNibble(const Graph &g, double alpha, double epsilon)
+    : SelectiveCommunityDetector(g), alpha(alpha), epsilon(epsilon) {}
 
 std::set<node> PageRankNibble::expandSeed(node seed) {
-    WARN("PageRankNibble::expandSeed is deprecated, use PageRankNibble::expandOneCommunity instead");
+    WARN(
+        "PageRankNibble::expandSeed is deprecated, use PageRankNibble::expandOneCommunity instead");
     return expandOneCommunity(seed);
 }
 
-std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>>& pr) {
-    TRACE("Finding best sweep set. Support size: ",  pr.size());
+std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>> &pr) {
+    TRACE("Finding best sweep set. Support size: ", pr.size());
 
     // order vertices
     TRACE("Before sorting");
     for (size_t i = 0; i < pr.size(); i++) {
         pr[i].second = pr[i].second / G->weightedDegree(pr[i].first, true);
     }
-    auto comp([&](const std::pair<node, double>& a, const std::pair<node, double>& b) {
+    auto comp([&](const std::pair<node, double> &a, const std::pair<node, double> &b) {
         return a.second > b.second;
     });
     Aux::Parallel::sort(pr.begin(), pr.end(), comp);
     TRACE("After sorting");
 
-    #ifndef NDEBUG
+#ifndef NDEBUG
     for (auto it = pr.begin(); it != pr.end(); it++) {
         TRACE("(", it->first, ", ", it->second, ")");
     }
-    #endif
+#endif
 
     // find best sweep set w.r.t. conductance
     double bestCond = std::numeric_limits<double>::max();
@@ -80,12 +83,12 @@ std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>>
 
     DEBUG("Best conductance: ", bestCond, "\n");
 
-    std::set<node> bestSweepSet(currentSweepSet.begin(), currentSweepSet.begin() + bestSweepSetIndex);
+    std::set<node> bestSweepSet(currentSweepSet.begin(),
+                                currentSweepSet.begin() + bestSweepSetIndex);
     return bestSweepSet;
 }
 
-
-std::set<node> PageRankNibble::expandOneCommunity(const std::set<node>& seeds) {
+std::set<node> PageRankNibble::expandOneCommunity(const std::set<node> &seeds) {
     DEBUG("APR(G, ", alpha, ", ", epsilon, ")");
     ApproximatePageRank apr(*G, alpha, epsilon);
     std::vector<std::pair<node, double>> pr = apr.run(seeds);

--- a/networkit/cpp/scd/PageRankNibble.cpp
+++ b/networkit/cpp/scd/PageRankNibble.cpp
@@ -39,7 +39,7 @@ std::set<node> PageRankNibble::bestSweepSet(std::vector<std::pair<node, double>>
     Aux::Parallel::sort(pr.begin(), pr.end(), comp);
     TRACE("After sorting");
 
-#ifndef NDEBUG
+#ifndef NETWORKIT_RELEASE_LOGGING
     for (auto it = pr.begin(); it != pr.end(); it++) {
         TRACE("(", it->first, ", ", it->second, ")");
     }

--- a/networkit/cpp/scd/RandomBFS.cpp
+++ b/networkit/cpp/scd/RandomBFS.cpp
@@ -1,0 +1,82 @@
+// networkit-format
+#include <iterator>
+
+#include <networkit/auxiliary/Random.hpp>
+#include <networkit/scd/RandomBFS.hpp>
+
+namespace NetworKit {
+
+RandomBFS::RandomBFS(const Graph &g, const Cover &c)
+    : SelectiveCommunityDetector(g), c(&c), subsetSizes(c.subsetSizeMap()) {}
+
+std::set<node> RandomBFS::expandOneCommunity(const std::set<node> &s) {
+    // allow as many nodes in the community as seeds are given
+    count comSize = s.size();
+
+    { // select a random community of s and get its size
+        std::set<index> gs(c->subsetsOf(*s.begin()));
+
+        for (auto it = ++s.begin(); it != s.end(); ++it) {
+            const std::set<index> additionalComs(c->subsetsOf(*it));
+            for (auto it = gs.begin(); it != gs.end();) {
+                if (additionalComs.find(*it) == additionalComs.end()) {
+                    it = gs.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+        }
+
+        if (!gs.empty()) {
+            index i = Aux::Random::index(gs.size());
+            auto it = gs.begin();
+            std::advance(it, i);
+            comSize = subsetSizes[*it];
+        }
+    }
+
+    std::set<node> result;
+
+    std::vector<node> currentLevel, nextLevel;
+
+    for (node u : s) {
+        currentLevel.push_back(u);
+    }
+
+    while (result.size() < comSize && !currentLevel.empty()) {
+        nextLevel.clear();
+
+        if (currentLevel.size() + result.size() < comSize) {
+            for (node u : currentLevel) {
+                result.insert(u);
+            }
+        } else {
+            std::shuffle(currentLevel.begin(), currentLevel.end(), Aux::Random::getURNG());
+
+            for (auto it = currentLevel.begin(); result.size() < comSize; ++it) {
+                assert(it != currentLevel.end());
+                result.insert(*it);
+            }
+
+            break;
+        }
+
+        for (node u : currentLevel) {
+            g->forNeighborsOf(u, [&](node v) {
+                if (result.count(v) == 0) {
+                    nextLevel.push_back(v);
+                }
+            });
+        }
+
+        std::sort(nextLevel.begin(), nextLevel.end());
+        auto last = std::unique(nextLevel.begin(), nextLevel.end());
+        nextLevel.erase(last, nextLevel.end());
+
+        std::swap(currentLevel, nextLevel);
+    }
+
+    return result;
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/scd/SCDGroundTruthComparison.cpp
+++ b/networkit/cpp/scd/SCDGroundTruthComparison.cpp
@@ -1,0 +1,177 @@
+// networkit-format
+#include <string>
+#include <networkit/auxiliary/SignalHandling.hpp>
+#include <networkit/scd/SCDGroundTruthComparison.hpp>
+
+namespace NetworKit {
+SCDGroundTruthComparison::SCDGroundTruthComparison(const Graph &g, const Cover &groundTruth,
+                                                   const std::map<node, std::set<node>> &found,
+                                                   bool ignoreSeeds)
+    : g(&g), groundTruth(&groundTruth), found(&found), ignoreSeeds(ignoreSeeds) {}
+
+void SCDGroundTruthComparison::run() {
+    Aux::SignalHandler handler;
+
+    hasRun = false;
+
+    jaccardScores.clear();
+    f1Scores.clear();
+    precisionScores.clear();
+    recallScores.clear();
+
+    std::vector<std::vector<node>> groundTruthSets(groundTruth->upperBound());
+    std::vector<count> foundSizes(g->upperNodeIdBound(), 0),
+        truthSizes(groundTruth->upperBound(), 0);
+
+    g->forNodes([&](node u) {
+        for (index s : (*groundTruth)[u]) {
+            groundTruthSets[s].emplace_back(u);
+            ++truthSizes[s];
+        }
+    });
+
+    for (const auto &it : *found) {
+        for (node u : it.second) {
+            if (g->hasNode(u)) {
+                ++foundSizes[it.first];
+            }
+        }
+    }
+
+    handler.assureRunning();
+
+    std::map<index, count> overlap;
+
+    for (const auto &foundIt : *found) {
+        handler.assureRunning();
+
+        node seed = foundIt.first;
+
+        if (!ignoreSeeds && !g->hasNode(seed)) {
+            throw std::runtime_error("Error, the graph does not contain the seed node "
+                                     + std::to_string(seed));
+        }
+
+        overlap.clear();
+
+        const auto &foundNodes = foundIt.second;
+
+        std::set<node> allowedSubsets;
+
+        if (!ignoreSeeds) {
+            allowedSubsets = groundTruth->subsetsOf(seed);
+        }
+
+        for (node u : foundNodes) {
+            if (g->hasNode(u)) {
+                for (index s : (*groundTruth)[u]) {
+                    if (ignoreSeeds || allowedSubsets.count(s) > 0) {
+                        ++overlap[s];
+                    }
+                }
+            }
+        }
+
+        handler.assureRunning();
+
+        double bestJaccard = 0;
+        double bestF1 = 0;
+        double bestPrecision = 0;
+        double bestRecall = 0;
+
+        for (auto o : overlap) {
+            double currentj =
+                static_cast<double>(o.second)
+                / static_cast<double>(foundSizes[seed] + truthSizes[o.first] - overlap[o.first]);
+
+            double recall = o.second * 1.0 / truthSizes[o.first];
+            double precision = o.second * 1.0 / foundSizes[seed];
+
+            double currentf1 = 0;
+            if (precision > 0 && recall > 0) {
+                currentf1 = 2 * (precision * recall) / (precision + recall);
+            }
+
+            if (currentj > bestJaccard) {
+                bestJaccard = currentj;
+            }
+
+            if (currentf1 > bestF1) {
+                bestF1 = currentf1;
+            }
+
+            if (recall > bestRecall) {
+                bestRecall = recall;
+            }
+
+            if (precision > bestPrecision) {
+                bestPrecision = precision;
+            }
+        }
+
+        jaccardScores[seed] = bestJaccard;
+        f1Scores[seed] = bestF1;
+        precisionScores[seed] = bestPrecision;
+        recallScores[seed] = bestRecall;
+    }
+
+    handler.assureRunning();
+
+    auto avgScore = [](const std::map<index, double> &scores) -> double {
+        double scoreSum = 0;
+        for (auto a : scores) {
+            scoreSum += a.second;
+        }
+
+        return scoreSum / scores.size();
+    };
+
+    averageJaccard = avgScore(jaccardScores);
+    averageF1 = avgScore(f1Scores);
+    averageRecall = avgScore(recallScores);
+    averagePrecision = avgScore(precisionScores);
+
+    handler.assureRunning();
+    hasRun = true;
+}
+
+const std::map<index, double> &SCDGroundTruthComparison::getIndividualJaccard() const {
+    assureFinished();
+    return jaccardScores;
+}
+
+const std::map<index, double> &SCDGroundTruthComparison::getIndividualF1() const {
+    assureFinished();
+    return f1Scores;
+}
+
+const std::map<index, double> &SCDGroundTruthComparison::getIndividualRecall() const {
+    assureFinished();
+    return recallScores;
+}
+
+const std::map<index, double> &SCDGroundTruthComparison::getIndividualPrecision() const {
+    assureFinished();
+    return precisionScores;
+}
+
+double SCDGroundTruthComparison::getAverageJaccard() const {
+    assureFinished();
+    return averageJaccard;
+}
+
+double SCDGroundTruthComparison::getAverageF1() const {
+    assureFinished();
+    return averageF1;
+}
+
+double SCDGroundTruthComparison::getAverageRecall() const {
+    assureFinished();
+    return averageRecall;
+}
+
+double SCDGroundTruthComparison::getAveragePrecision() const {
+    assureFinished();
+    return averagePrecision;
+}
+} // namespace NetworKit

--- a/networkit/cpp/scd/SelectiveCommunityDetector.cpp
+++ b/networkit/cpp/scd/SelectiveCommunityDetector.cpp
@@ -1,0 +1,28 @@
+/*
+ * SelectiveCommunityDetector.cpp
+ *
+ *  Created on: 15.05.2013
+ *      Author: cls, Yassine Marrakchi
+ */
+
+#include <networkit/scd/SelectiveCommunityDetector.hpp>
+
+namespace NetworKit {
+
+SelectiveCommunityDetector::SelectiveCommunityDetector(const Graph &G) : G(&G) {}
+
+std::map<node, std::set<node>> SelectiveCommunityDetector::run(const std::set<node> &seeds) {
+    std::map<node, std::set<node>> result;
+
+    for (node s : seeds) {
+        result[s] = expandOneCommunity(s);
+    }
+
+    return result;
+}
+
+std::set<node> SelectiveCommunityDetector::expandOneCommunity(node s) {
+    return expandOneCommunity(std::set<node>({s}));
+}
+
+} /* namespace NetworKit */

--- a/networkit/cpp/scd/SelectiveCommunityDetector.cpp
+++ b/networkit/cpp/scd/SelectiveCommunityDetector.cpp
@@ -10,7 +10,7 @@
 
 namespace NetworKit {
 
-SelectiveCommunityDetector::SelectiveCommunityDetector(const Graph &G) : G(&G) {}
+SelectiveCommunityDetector::SelectiveCommunityDetector(const Graph &g) : g(&g) {}
 
 std::map<node, std::set<node>> SelectiveCommunityDetector::run(const std::set<node> &seeds) {
     std::map<node, std::set<node>> result;

--- a/networkit/cpp/scd/SelectiveCommunityDetector.cpp
+++ b/networkit/cpp/scd/SelectiveCommunityDetector.cpp
@@ -1,3 +1,4 @@
+// networkit-format
 /*
  * SelectiveCommunityDetector.cpp
  *

--- a/networkit/cpp/scd/SetConductance.cpp
+++ b/networkit/cpp/scd/SetConductance.cpp
@@ -1,0 +1,55 @@
+// networkit-format
+#include <networkit/auxiliary/SignalHandling.hpp>
+#include <networkit/scd/SetConductance.hpp>
+
+namespace NetworKit {
+SetConductance::SetConductance(const Graph &g, const std::set<node> &community)
+    : g(&g), community(&community) {
+    if (g.isDirected()) {
+        throw std::runtime_error("SetConductance only supports undirected graphs.");
+    }
+}
+
+void SetConductance::run() {
+    hasRun = false;
+
+    Aux::SignalHandler handler;
+
+    double cut = 0;
+    double comVolume = 0;
+
+    for (node u : *community) {
+        if (g->hasNode(u)) {
+            g->forEdgesOf(u, [&](node, node v, edgeweight ew) {
+                if (community->count(v) == 0) {
+                    cut += ew;
+                }
+                comVolume += ew;
+
+                // count loops twice
+                if (u == v) {
+                    comVolume += ew;
+                }
+            });
+        }
+    }
+
+    double totalVolume = g->totalEdgeWeight() * 2;
+
+    double restVolume = totalVolume - comVolume;
+
+    conductance = 1.0;
+
+    if (comVolume > 0 && restVolume > 0) {
+        conductance = cut / std::min(comVolume, restVolume);
+    }
+
+    hasRun = true;
+}
+
+double SetConductance::getConductance() const {
+    assureFinished();
+    return conductance;
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/scd/TCE.cpp
+++ b/networkit/cpp/scd/TCE.cpp
@@ -1,0 +1,316 @@
+// networkit-format
+#include <algorithm>
+#include <limits>
+#include <unordered_map>
+
+#include <tlx/container/d_ary_addressable_int_heap.hpp>
+#include <tlx/unused.hpp>
+
+#include <networkit/scd/TCE.hpp>
+
+#include "LocalDegreeDirectedGraph.hpp"
+
+namespace NetworKit {
+
+TCE::TCE(const Graph &g, bool refine, bool useJaccard)
+    : SelectiveCommunityDetector(g), refine(refine), useJaccard(useJaccard) {}
+
+namespace {
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+/*
+ * Only used for debugging.
+ */
+double weightedEdgeScore(const Graph &g, node, node v, edgeweight uvWeight, double uDegree,
+                         const std::unordered_map<node, double> &uNeighbors, bool useJaccard) {
+    double nom = uvWeight;
+    double vDegree = 0.0;
+
+    g.forNeighborsOf(v, [&](node, node w, edgeweight vwWeight) {
+        vDegree += vwWeight;
+        auto uw = uNeighbors.find(w);
+        if (uw != uNeighbors.end())
+            nom += std::min(vwWeight, uw->second);
+    });
+
+    if (vDegree == 0.0)
+        return 0.0;
+
+    double denom = useJaccard ? (uDegree + vDegree - nom) : std::min(uDegree, vDegree);
+    return nom / (denom * g.degree(v));
+}
+#endif
+#endif
+
+template <bool isWeighted>
+std::set<node> expandSeedSetInternal(const Graph &g, const std::set<node> &s, bool refine,
+                                     bool useJaccard) {
+    // global data structures
+    std::set<node> result = s;
+
+    std::vector<double> weightedDegrees;
+    std::vector<double> nodeScore;
+
+    std::vector<double> cutEdges;
+    std::vector<bool> inResult;
+
+    // heap that contains the nodes of the shell that still need to be considered
+    class Compare {
+        const std::vector<double> &similarity;
+
+    public:
+        Compare(const std::vector<double> &similarity) : similarity(similarity) {}
+
+        bool operator()(node u, node v) const { return similarity[u] > similarity[v]; }
+    };
+
+    tlx::d_ary_addressable_int_heap<node, 4, Compare> shell((Compare(nodeScore)));
+
+    // data structures only for neighbors of a node
+    std::vector<double> triangleSum;
+
+    auto nodeAdded = [&](node, node, double weightedDegree) {
+        weightedDegrees.push_back(weightedDegree);
+        nodeScore.push_back(0);
+        cutEdges.push_back(0);
+
+        inResult.push_back(false);
+        triangleSum.push_back(0);
+    };
+
+    LocalDegreeDirectedGraph<isWeighted, decltype(nodeAdded)> localGraph(g, nodeAdded);
+
+    auto updateShell = [&](node u, node lu, bool noverify) -> double {
+#if defined(NDEBUG) || !defined(NETWORKIT_SANITY_CHECKS)
+        tlx::unused(noverify); // only used in debug mode
+#endif
+        if (g.degree(u) == 0)
+            return 0.0;
+
+        double xDegree = weightedDegrees[lu];
+
+        localGraph.forTrianglesOf(
+            u, [&](node lv, node y, double weightUv, double weightUy, double weightVy) {
+                if (isWeighted) {
+                    triangleSum[y] += std::min(weightUv, weightVy);
+                    triangleSum[lv] += std::min(weightUy, weightVy);
+                } else {
+                    triangleSum[y] += 1;
+                    triangleSum[lv] += 1;
+                }
+            });
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+        std::unordered_map<node, double> uNeighbors;
+        g.forNeighborsOf(
+            u, [&](node, node v, edgeweight ew) { uNeighbors.insert(std::make_pair(v, ew)); });
+#endif
+#endif
+
+        // collect counts and compute scores
+        localGraph.forLocalNeighbors([&](node v, edgeweight weight) {
+            if (!inResult[v]) {
+                double nom = weight + triangleSum[v];
+                double wd = weightedDegrees[v];
+
+                double scoreUv = 0.0;
+                if (wd > 0.0) {
+                    double denom = useJaccard ? (wd + xDegree - nom) : std::min(wd, xDegree);
+                    scoreUv = nom / (denom * g.degree(localGraph.toGlobal(v)));
+                }
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+                assert(scoreUv
+                       == weightedEdgeScore(g, u, localGraph.toGlobal(v), weight, xDegree,
+                                            uNeighbors, useJaccard));
+#endif
+#endif
+                nodeScore[v] += scoreUv;
+                shell.update(v);
+
+                cutEdges[v] += weight;
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+                if (!noverify) {
+                    double debugWeight = 0;
+                    g.forNeighborsOf(localGraph.toGlobal(v), [&](node, node y, edgeweight ew) {
+                        if (result.count(y)) {
+                            debugWeight += ew;
+                        }
+                    });
+                    assert(debugWeight == cutEdges[v]);
+                }
+#endif
+#endif
+            }
+
+            // reset triangle_sum
+            triangleSum[v] = 0;
+        });
+
+#ifdef NETWORKIT_SANITY_CHECKS
+        assert(
+            std::all_of(triangleSum.begin(), triangleSum.end(), [](double s) { return s == 0; }));
+#endif
+
+        return xDegree;
+    };
+
+    // init community with seed set
+    double volume = 0.0;
+    double numCutEdges = 0.0;
+
+    for (auto u : result) {
+        node lu = localGraph.ensureNodeExists(u);
+        inResult[lu] = true;
+    }
+
+    for (auto u : result) {
+        volume += updateShell(u, localGraph.ensureNodeExists(u), true);
+    }
+
+    for (const auto &vv : cutEdges) {
+        numCutEdges += vv;
+    }
+
+    // expand (main loop)
+    while (!shell.empty()) {
+        node uMax = shell.extract_top();
+        node gUMax = localGraph.toGlobal(uMax);
+        double uMaxVol = weightedDegrees[uMax];
+
+        double numCutEdgesNew = numCutEdges + uMaxVol - (2 * cutEdges[uMax]);
+        double volumeNew = volume + uMaxVol;
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+        {
+            double debugVolumeOld = 0.0;
+            double debugCutsizeOld = 0.0;
+
+            double debugVolumeNew = 0.0;
+            double debugCutsizeNew = 0.0;
+
+            for (auto u : result) {
+                g.forEdgesOf(u, [&](node, node v, edgeweight ew) {
+                    debugVolumeOld += ew;
+                    debugVolumeNew += ew;
+                    if (!result.count(v)) {
+                        debugCutsizeOld += ew;
+
+                        if (v != gUMax) {
+                            debugCutsizeNew += ew;
+                        }
+                    }
+                });
+            }
+            g.forEdgesOf(gUMax, [&](node, node v, edgeweight ew) {
+                debugVolumeNew += ew;
+                if (!result.count(v)) {
+                    debugCutsizeNew += ew;
+                }
+            });
+
+            assert(debugVolumeOld == volume);
+            assert(debugVolumeNew == volumeNew);
+            assert(debugCutsizeNew == numCutEdgesNew);
+            assert(debugCutsizeOld == numCutEdges);
+        }
+#endif
+#endif
+
+        // if conductance decreases (i.e., improves)
+        if ((numCutEdgesNew / volumeNew) < (numCutEdges / volume)) {
+            result.insert(gUMax);
+            inResult[uMax] = true;
+            updateShell(gUMax, uMax, false);
+
+            numCutEdges = numCutEdgesNew;
+            volume = volumeNew;
+        }
+    }
+
+    if (refine) {
+        for (auto it = result.begin(); it != result.end();) {
+            node u = *it;
+            double uVol = 0;
+            double uCutChange = 0;
+
+            g.forNeighborsOf(u, [&](node, node v, edgeweight ew) {
+                uVol += ew;
+                if (result.count(v) > 0) {
+                    uCutChange += ew;
+                } else {
+                    uCutChange -= ew;
+                }
+            });
+
+            double numCutEdgesNew = numCutEdges + uCutChange;
+            double volumeNew = volume - uVol;
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+            {
+                double debugVolumeOld = 0.0;
+                double debugCutsizeOld = 0.0;
+
+                double debugVolumeNew = 0.0;
+                double debugCutsizeNew = 0.0;
+
+                for (auto v : result) {
+                    g.forEdgesOf(v, [&](node, node x, edgeweight ew) {
+                        debugVolumeOld += ew;
+                        if (v != u) {
+                            debugVolumeNew += ew;
+                        }
+                        if (!result.count(x)) {
+                            debugCutsizeOld += ew;
+                            if (v != u) {
+                                debugCutsizeNew += ew;
+                            }
+                        }
+                        if (x == u) {
+                            debugCutsizeNew += ew;
+                        }
+                    });
+                }
+
+                assert(debugVolumeOld == volume);
+                assert(debugVolumeNew == volumeNew);
+                assert(debugCutsizeNew == numCutEdgesNew);
+                assert(debugCutsizeOld == numCutEdges);
+            }
+#endif
+#endif
+
+            if ((numCutEdgesNew / volumeNew) < (numCutEdges / volume)) {
+                numCutEdges = numCutEdgesNew;
+                volume = volumeNew;
+
+                TRACE("Removing ", u, " again");
+
+                it = result.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    return result;
+}
+
+} // namespace
+
+std::set<node> TCE::expandOneCommunity(const std::set<node> &s) {
+    if (g->isWeighted()) {
+        return expandSeedSetInternal<true>(*g, s, refine, useJaccard);
+    } else {
+        return expandSeedSetInternal<false>(*g, s, refine, useJaccard);
+    }
+}
+
+} /* namespace NetworKit */

--- a/networkit/cpp/scd/TwoPhaseL.cpp
+++ b/networkit/cpp/scd/TwoPhaseL.cpp
@@ -1,0 +1,117 @@
+// networkit-format
+#include <networkit/auxiliary/IncrementalUniformRandomSelector.hpp>
+#include <networkit/scd/TwoPhaseL.hpp>
+#include <networkit/structures/LocalCommunity.hpp>
+
+namespace NetworKit {
+
+TwoPhaseL::TwoPhaseL(const Graph &g) : SelectiveCommunityDetector(g) {
+    if (g.numberOfSelfLoops() > 0) {
+        throw std::runtime_error("Graphs with self-loops are not supported in TwoPhaseL");
+    }
+}
+
+std::set<node> TwoPhaseL::expandOneCommunity(const std::set<node> &seeds) {
+    LocalCommunity<true, true, true> com(*g);
+
+    for (node s : seeds) {
+        com.addNode(s);
+#ifdef NETWORKIT_SANITY_CHECKS
+        assert(com.contains(s));
+#endif
+    }
+
+    using shell_info_t = typename decltype(com)::ShellInfo;
+    using community_info_t = typename decltype(com)::CommunityInfo;
+
+    auto newLinAdd = [&](const shell_info_t &info) {
+        return 2.0 * (com.internalEdgeWeight() + (*info.intDeg))
+               / static_cast<double>(com.size() + 1);
+    };
+
+    auto newLexAdd = [&](const shell_info_t &info) {
+        return (com.cut() - (*info.intDeg) + (*info.extDeg))
+               / static_cast<double>(com.boundarySize() + info.boundaryChange());
+    };
+
+    auto newLinRemove = [&](const community_info_t &info) {
+        return 2.0 * (com.internalEdgeWeight() - (*info.intDeg))
+               / static_cast<double>(com.size() - 1);
+    };
+
+    auto newLexRemove = [&](const community_info_t &info) {
+        return (com.cut() + (*info.intDeg) - (*info.extDeg))
+               / static_cast<double>(com.boundarySize() + info.boundaryChange());
+    };
+
+    double currentLin = 2.0 * com.internalEdgeWeight() / com.size();
+    double currentLex = com.cut() / com.boundarySize();
+    double currentL = currentLin / currentLex;
+
+    // first phase: add possible candidates
+    node vMax;
+    do {
+        // scan shell for node with maximum quality improvement
+        double lMax = currentL; // maximum quality improvement
+        vMax = none;
+        Aux::IncrementalUniformRandomSelector selector;
+
+        com.forShellNodes([&](const node v, const shell_info_t &info) {
+            // get values for current node
+            double nLin = newLinAdd(info);
+            double nLex = newLexAdd(info);
+            double nL = nLin / nLex;
+
+            TRACE("nLin: ", nLin);
+            TRACE("nLex: ", nLex);
+
+            if (nLin > currentLin) {
+                if (nL > lMax) {
+                    vMax = v;
+                    lMax = nL;
+                    selector.reset();
+                } else if (nL == lMax && selector.addElement()) {
+                    vMax = v;
+                }
+            }
+        });
+
+        TRACE("vMax: ", vMax);
+        TRACE("LMax: ", lMax);
+        if (vMax != none) {
+            com.addNode(vMax); // add best node to community
+            // update current community quality
+            currentLin = 2.0 * com.internalEdgeWeight() / com.size();
+            currentLex = com.cut() / com.boundarySize();
+            currentL = currentLin / currentLex;
+        }
+    } while (vMax != none);
+
+    // second phase: remove unwanted nodes
+    com.forCommunityNodes([&](const node v, const community_info_t &info) {
+        double nLin = newLinRemove(info);
+        double nLex = newLexRemove(info);
+
+        if (!(currentLin > nLin && currentLex < nLex)) {
+            TRACE("Removing ", v);
+            com.removeNode(v);
+            if (com.size() == 0)
+                return;
+            currentLin = 2.0 * com.internalEdgeWeight() / com.size();
+            currentLex = com.cut() / com.boundarySize();
+            currentL = currentLin / currentLex;
+            assert(std::abs(currentLin - nLin) < 0.0001);
+            assert(std::abs(currentLex - nLex) < 0.0001);
+        }
+    });
+
+    for (node s : seeds) {
+        if (!com.contains(s)) {
+            return {};
+        }
+    }
+
+    return com.toSet();
+}
+
+} /* namespace NetworKit */

--- a/networkit/cpp/scd/test/CMakeLists.txt
+++ b/networkit/cpp/scd/test/CMakeLists.txt
@@ -1,3 +1,2 @@
 networkit_add_test(scd SelectiveCDGTest
-    auxiliary community graph io)
-
+    auxiliary clique community graph io)

--- a/networkit/cpp/scd/test/CMakeLists.txt
+++ b/networkit/cpp/scd/test/CMakeLists.txt
@@ -1,2 +1,2 @@
 networkit_add_test(scd SelectiveCDGTest
-    auxiliary clique community graph io)
+    auxiliary clique coarsening community graph io)

--- a/networkit/cpp/scd/test/CMakeLists.txt
+++ b/networkit/cpp/scd/test/CMakeLists.txt
@@ -1,2 +1,2 @@
 networkit_add_test(scd SelectiveCDGTest
-    auxiliary clique coarsening community graph io)
+    auxiliary clique coarsening community components graph io structures)

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -12,7 +12,10 @@
 #include <networkit/scd/LFMLocal.hpp>
 #include <networkit/scd/PageRankNibble.hpp>
 #include <networkit/scd/ApproximatePageRank.hpp>
+#include <networkit/scd/LocalT.hpp>
+#include <networkit/scd/LocalTightnessExpansion.hpp>
 #include <networkit/scd/SelectiveCommunityDetector.hpp>
+#include <networkit/scd/TCE.hpp>
 #include <networkit/scd/TwoPhaseL.hpp>
 
 namespace NetworKit {
@@ -42,6 +45,10 @@ TEST_F(SCDGTest2, testSCD) {
     algorithms.emplace_back(std::make_pair(std::string("GCE M"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "M"))));
     algorithms.emplace_back(std::make_pair(std::string("LFM"), std::unique_ptr<SelectiveCommunityDetector>(new LFMLocal(G, 0.8))));
     algorithms.emplace_back(std::make_pair(std::string("TwoPhaseL"), std::unique_ptr<SelectiveCommunityDetector>(new TwoPhaseL(G))));
+    algorithms.emplace_back(std::make_pair(std::string("TCE"), std::unique_ptr<SelectiveCommunityDetector>(new TCE(G))));
+    algorithms.emplace_back(std::make_pair(std::string("LTE"), std::unique_ptr<SelectiveCommunityDetector>(new LocalTightnessExpansion(G))));
+    algorithms.emplace_back(std::make_pair(std::string("LocalT"), std::unique_ptr<SelectiveCommunityDetector>(new LocalT(G))));
+
 
     count idBound = G.upperNodeIdBound();
 
@@ -55,7 +62,7 @@ TEST_F(SCDGTest2, testSCD) {
         EXPECT_GT(cluster.size(), 0u);
         Partition partition(idBound);
         partition.allToOnePartition();
-        partition.toSingleton(50);
+        partition.toSingleton(seed);
         index id = partition[seed];
         for (auto entry: cluster) {
             partition.moveToSubset(id, entry);
@@ -124,5 +131,95 @@ TEST_F(SCDGTest2, testGCE) {
     }
 }
 
+TEST_F(SCDGTest2, testSCDWeighted) {
+    Aux::Random::setSeed(23, false);
+    METISGraphReader reader;
+    Graph G = reader.read("input/lesmis.graph");
+    // parameters
+    node seed = 20;
+    std::set<node> seeds;
+    G.forNodes([&](node u) { seeds.insert(u); });
+    double alpha = 0.1; // loop (or teleport) probability, changed due to DGleich from: // phi * phi / (225.0 * log(100.0 * sqrt(m)));
+    double epsilon = 1e-5; // changed due to DGleich from: pow(2, exponent) / (48.0 * B);
+
+    std::vector<std::pair<std::string, std::unique_ptr<SelectiveCommunityDetector>>> algorithms;
+    algorithms.emplace_back(std::make_pair(std::string("PageRankNibble"), std::unique_ptr<SelectiveCommunityDetector>(new PageRankNibble(G, alpha, epsilon))));
+    algorithms.emplace_back(std::make_pair(std::string("GCE L"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "L"))));
+    algorithms.emplace_back(std::make_pair(std::string("GCE M"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "M"))));
+    algorithms.emplace_back(std::make_pair(std::string("LTE"), std::unique_ptr<SelectiveCommunityDetector>(new LocalTightnessExpansion(G))));
+    algorithms.emplace_back(std::make_pair(std::string("TCE"), std::unique_ptr<SelectiveCommunityDetector>(new TCE(G))));
+
+    count idBound = G.upperNodeIdBound();
+
+    for (auto &algIt : algorithms) {
+        // run SCD algorithm and partition the graph accordingly
+        DEBUG("Call ", algIt.first, "(", seed, ")");
+        auto result = algIt.second->run(seeds);
+        auto cluster = result[seed];
+
+        // prepare result
+        EXPECT_GT(cluster.size(), 0u);
+        Partition partition(idBound);
+        partition.allToOnePartition();
+        partition.toSingleton(seed);
+        index id = partition[seed];
+        for (auto entry: cluster) {
+            partition.moveToSubset(id, entry);
+        }
+
+        // evaluate result
+        Conductance conductance;
+        double targetCond = 0.5;
+        double cond = conductance.getQuality(partition, G);
+        EXPECT_LT(cond, targetCond);
+        INFO("Conductance of ", algIt.first, ": ", cond, "; cluster size: ", cluster.size());
+    }
+}
+
+TEST_F(SelectiveCDGTest, testWeightedCliqueDetect) {
+    Graph G(4, true, false);
+
+    G.addEdge(0, 1, 2);
+    G.addEdge(0, 2, 1);
+
+    CliqueDetect cliqueDetect(G);
+
+    {
+        auto result = cliqueDetect.expandOneCommunity(0);
+        EXPECT_EQ(result.size(), 2);
+        EXPECT_EQ(result.count(0), 1);
+        EXPECT_EQ(result.count(1), 1);
+    }
+
+    G.setWeight(0, 2, 3);
+
+    {
+        auto result = cliqueDetect.expandOneCommunity(0);
+        EXPECT_EQ(result.size(), 2);
+        EXPECT_EQ(result.count(0), 1);
+        EXPECT_EQ(result.count(2), 1);
+    }
+
+    G.setWeight(0, 2, 1);
+    G.addEdge(0, 3, 0.5);
+    G.addEdge(2, 3, 0.4);
+
+    {
+        auto result = cliqueDetect.expandOneCommunity(0);
+        EXPECT_EQ(result.size(), 2);
+        EXPECT_EQ(result.count(0), 1);
+        EXPECT_EQ(result.count(1), 1);
+    }
+
+    G.setWeight(2, 3, 0.6);
+
+    {
+        auto result = cliqueDetect.expandOneCommunity(0);
+        EXPECT_EQ(result.size(), 3);
+        EXPECT_EQ(result.count(0), 1);
+        EXPECT_EQ(result.count(2), 1);
+        EXPECT_EQ(result.count(3), 1);
+    }
+}
 
 } /* namespace NetworKit */

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -7,6 +7,7 @@
 #include <networkit/graph/Graph.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/io/SNAPGraphReader.hpp>
+#include <networkit/scd/CliqueDetect.hpp>
 #include <networkit/scd/GCE.hpp>
 #include <networkit/scd/PageRankNibble.hpp>
 #include <networkit/scd/ApproximatePageRank.hpp>

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -58,7 +58,7 @@ TEST_F(SCDGTest2, testSCD) {
 
         // evaluate result
         Conductance conductance;
-        double targetCond = 0.4;
+        double targetCond = 1.0;
         double cond = conductance.getQuality(partition, G);
         EXPECT_LT(cond, targetCond);
         INFO("Conductance of ", algIt.first, ": ", cond, "; cluster size: ", cluster.size());
@@ -70,10 +70,12 @@ TEST_F(SCDGTest2, testGCE) {
     Graph G = reader.read("input/hep-th.graph");
 
     node seed = 50;
-    GCE gce(G, "L");
+    // Use the "M" score to ensure that the conductance we measure below can only improve
+    GCE gce(G, "M");
     auto cluster = gce.expandOneCommunity(seed);
 
     EXPECT_GT(cluster.size(), 0u);
+    double cond1;
 
     {
         Partition partition(G.upperNodeIdBound());
@@ -86,10 +88,10 @@ TEST_F(SCDGTest2, testGCE) {
 
         // evaluate result
         Conductance conductance;
-        double targetCond = 0.4;
-        double cond = conductance.getQuality(partition, G);
-        EXPECT_LT(cond, targetCond);
-        INFO("Conductance of GCE: ", cond, "; cluster size: ", cluster.size());
+        double targetCond = 1.0;
+        cond1 = conductance.getQuality(partition, G);
+        EXPECT_LT(cond1, targetCond);
+        INFO("Conductance of GCE: ", cond1, "; cluster size: ", cluster.size());
     }
 
     auto cluster2 = gce.expandOneCommunity(cluster);
@@ -105,12 +107,16 @@ TEST_F(SCDGTest2, testGCE) {
 
         // evaluate result
         Conductance conductance;
-        double targetCond = 0.4;
+        // The quality should only improve
         double cond = conductance.getQuality(partition, G);
-        EXPECT_LT(cond, targetCond);
+        EXPECT_LE(cond, cond1);
         INFO("Conductance of GCE2: ", cond, "; cluster size: ", cluster2.size());
     }
-    EXPECT_EQ(cluster, cluster2);
+
+    // The cluster should only grow
+    for (node u : cluster) {
+        EXPECT_NE(cluster2.find(u), cluster2.end());
+    }
 }
 
 

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -1,5 +1,6 @@
-#include <gtest/gtest.h>
+// networkit-format
 #include <memory>
+#include <gtest/gtest.h>
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/community/Conductance.hpp>
@@ -7,20 +8,20 @@
 #include <networkit/graph/Graph.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/io/SNAPGraphReader.hpp>
+#include <networkit/scd/ApproximatePageRank.hpp>
 #include <networkit/scd/CliqueDetect.hpp>
 #include <networkit/scd/GCE.hpp>
 #include <networkit/scd/LFMLocal.hpp>
-#include <networkit/scd/PageRankNibble.hpp>
-#include <networkit/scd/ApproximatePageRank.hpp>
 #include <networkit/scd/LocalT.hpp>
 #include <networkit/scd/LocalTightnessExpansion.hpp>
+#include <networkit/scd/PageRankNibble.hpp>
 #include <networkit/scd/SelectiveCommunityDetector.hpp>
 #include <networkit/scd/TCE.hpp>
 #include <networkit/scd/TwoPhaseL.hpp>
 
 namespace NetworKit {
 
-class SelectiveCDGTest: public testing::Test {};
+class SelectiveCDGTest : public testing::Test {};
 
 TEST_F(SelectiveCDGTest, testRunApproximatePageRank) {
     SNAPGraphReader reader;
@@ -37,19 +38,31 @@ TEST_F(SelectiveCDGTest, testSCD) {
     // parameters
     node seed = 50;
     std::set<node> seeds = {seed};
-    double alpha = 0.1; // loop (or teleport) probability, changed due to DGleich from: // phi * phi / (225.0 * log(100.0 * sqrt(m)));
+    double alpha = 0.1; // loop (or teleport) probability, changed due to DGleich from: // phi * phi
+                        // / (225.0 * log(100.0 * sqrt(m)));
     double epsilon = 1e-5; // changed due to DGleich from: pow(2, exponent) / (48.0 * B);
 
     std::vector<std::pair<std::string, std::unique_ptr<SelectiveCommunityDetector>>> algorithms;
-    algorithms.emplace_back(std::make_pair(std::string("PageRankNibble"), std::unique_ptr<SelectiveCommunityDetector>(new PageRankNibble(G, alpha, epsilon))));
-    algorithms.emplace_back(std::make_pair(std::string("GCE L"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "L"))));
-    algorithms.emplace_back(std::make_pair(std::string("GCE M"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "M"))));
-    algorithms.emplace_back(std::make_pair(std::string("LFM"), std::unique_ptr<SelectiveCommunityDetector>(new LFMLocal(G, 0.8))));
-    algorithms.emplace_back(std::make_pair(std::string("TwoPhaseL"), std::unique_ptr<SelectiveCommunityDetector>(new TwoPhaseL(G))));
-    algorithms.emplace_back(std::make_pair(std::string("TCE"), std::unique_ptr<SelectiveCommunityDetector>(new TCE(G))));
-    algorithms.emplace_back(std::make_pair(std::string("LTE"), std::unique_ptr<SelectiveCommunityDetector>(new LocalTightnessExpansion(G))));
-    algorithms.emplace_back(std::make_pair(std::string("LocalT"), std::unique_ptr<SelectiveCommunityDetector>(new LocalT(G))));
-
+    algorithms.emplace_back(std::make_pair(
+        std::string("PageRankNibble"),
+        std::unique_ptr<SelectiveCommunityDetector>(new PageRankNibble(G, alpha, epsilon))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("GCE L"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "L"))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("GCE M"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "M"))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("LFM"), std::unique_ptr<SelectiveCommunityDetector>(new LFMLocal(G, 0.8))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("TwoPhaseL"), std::unique_ptr<SelectiveCommunityDetector>(new TwoPhaseL(G))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("TCE"), std::unique_ptr<SelectiveCommunityDetector>(new TCE(G))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("LTE"),
+        std::unique_ptr<SelectiveCommunityDetector>(new LocalTightnessExpansion(G))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("LocalT"), std::unique_ptr<SelectiveCommunityDetector>(new LocalT(G))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("Clique"), std::unique_ptr<SelectiveCommunityDetector>(new CliqueDetect(G))));
 
     count idBound = G.upperNodeIdBound();
 
@@ -65,7 +78,7 @@ TEST_F(SelectiveCDGTest, testSCD) {
         partition.allToOnePartition();
         partition.toSingleton(seed);
         index id = partition[seed];
-        for (auto entry: cluster) {
+        for (auto entry : cluster) {
             partition.moveToSubset(id, entry);
         }
 
@@ -95,7 +108,7 @@ TEST_F(SelectiveCDGTest, testGCE) {
         partition.allToOnePartition();
         partition.toSingleton(50);
         index id = partition[seed];
-        for (auto entry: cluster) {
+        for (auto entry : cluster) {
             partition.moveToSubset(id, entry);
         }
 
@@ -114,7 +127,7 @@ TEST_F(SelectiveCDGTest, testGCE) {
         partition.allToOnePartition();
         partition.toSingleton(50);
         index id = partition[seed];
-        for (auto entry: cluster2) {
+        for (auto entry : cluster2) {
             partition.moveToSubset(id, entry);
         }
 
@@ -140,15 +153,25 @@ TEST_F(SelectiveCDGTest, testSCDWeighted) {
     node seed = 20;
     std::set<node> seeds;
     G.forNodes([&](node u) { seeds.insert(u); });
-    double alpha = 0.1; // loop (or teleport) probability, changed due to DGleich from: // phi * phi / (225.0 * log(100.0 * sqrt(m)));
+    double alpha = 0.1; // loop (or teleport) probability, changed due to DGleich from: // phi * phi
+                        // / (225.0 * log(100.0 * sqrt(m)));
     double epsilon = 1e-5; // changed due to DGleich from: pow(2, exponent) / (48.0 * B);
 
     std::vector<std::pair<std::string, std::unique_ptr<SelectiveCommunityDetector>>> algorithms;
-    algorithms.emplace_back(std::make_pair(std::string("PageRankNibble"), std::unique_ptr<SelectiveCommunityDetector>(new PageRankNibble(G, alpha, epsilon))));
-    algorithms.emplace_back(std::make_pair(std::string("GCE L"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "L"))));
-    algorithms.emplace_back(std::make_pair(std::string("GCE M"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "M"))));
-    algorithms.emplace_back(std::make_pair(std::string("LTE"), std::unique_ptr<SelectiveCommunityDetector>(new LocalTightnessExpansion(G))));
-    algorithms.emplace_back(std::make_pair(std::string("TCE"), std::unique_ptr<SelectiveCommunityDetector>(new TCE(G))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("PageRankNibble"),
+        std::unique_ptr<SelectiveCommunityDetector>(new PageRankNibble(G, alpha, epsilon))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("GCE L"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "L"))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("GCE M"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "M"))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("LTE"),
+        std::unique_ptr<SelectiveCommunityDetector>(new LocalTightnessExpansion(G))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("TCE"), std::unique_ptr<SelectiveCommunityDetector>(new TCE(G))));
+    algorithms.emplace_back(std::make_pair(
+        std::string("Clique"), std::unique_ptr<SelectiveCommunityDetector>(new CliqueDetect(G))));
 
     count idBound = G.upperNodeIdBound();
 
@@ -164,7 +187,7 @@ TEST_F(SelectiveCDGTest, testSCDWeighted) {
         partition.allToOnePartition();
         partition.toSingleton(seed);
         index id = partition[seed];
-        for (auto entry: cluster) {
+        for (auto entry : cluster) {
             partition.moveToSubset(id, entry);
         }
 

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -31,6 +31,7 @@ TEST_F(SelectiveCDGTest, testRunApproximatePageRank) {
 }
 
 TEST_F(SelectiveCDGTest, testSCD) {
+    Aux::Random::setSeed(32, false);
     METISGraphReader reader;
     Graph G = reader.read("input/hep-th.graph");
     // parameters

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -21,7 +21,7 @@ TEST_F(SCDGTest2, testRunApproximatePageRank) {
     auto G = reader.read("./input/wiki-Vote.txt");
 
     ApproximatePageRank apr(G, 0.4);
-    const auto prVector= apr.run(0);
+    const auto prVector = apr.run(0);
 }
 
 TEST_F(SCDGTest2, testSCD) {
@@ -63,6 +63,54 @@ TEST_F(SCDGTest2, testSCD) {
         EXPECT_LT(cond, targetCond);
         INFO("Conductance of ", algIt.first, ": ", cond, "; cluster size: ", cluster.size());
     }
+}
+
+TEST_F(SCDGTest2, testGCE) {
+    METISGraphReader reader;
+    Graph G = reader.read("input/hep-th.graph");
+
+    node seed = 50;
+    GCE gce(G, "L");
+    auto cluster = gce.expandOneCommunity(seed);
+
+    EXPECT_GT(cluster.size(), 0u);
+
+    {
+        Partition partition(G.upperNodeIdBound());
+        partition.allToOnePartition();
+        partition.toSingleton(50);
+        index id = partition[seed];
+        for (auto entry: cluster) {
+            partition.moveToSubset(id, entry);
+        }
+
+        // evaluate result
+        Conductance conductance;
+        double targetCond = 0.4;
+        double cond = conductance.getQuality(partition, G);
+        EXPECT_LT(cond, targetCond);
+        INFO("Conductance of GCE: ", cond, "; cluster size: ", cluster.size());
+    }
+
+    auto cluster2 = gce.expandOneCommunity(cluster);
+
+    {
+        Partition partition(G.upperNodeIdBound());
+        partition.allToOnePartition();
+        partition.toSingleton(50);
+        index id = partition[seed];
+        for (auto entry: cluster2) {
+            partition.moveToSubset(id, entry);
+        }
+
+        // evaluate result
+        Conductance conductance;
+        double targetCond = 0.4;
+        double cond = conductance.getQuality(partition, G);
+        EXPECT_LT(cond, targetCond);
+        INFO("Conductance of GCE2: ", cond, "; cluster size: ", cluster2.size());
+    }
+    EXPECT_EQ(cluster, cluster2);
 }
 
 

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -20,9 +20,9 @@
 
 namespace NetworKit {
 
-class SCDGTest2: public testing::Test {};
+class SelectiveCDGTest: public testing::Test {};
 
-TEST_F(SCDGTest2, testRunApproximatePageRank) {
+TEST_F(SelectiveCDGTest, testRunApproximatePageRank) {
     SNAPGraphReader reader;
     auto G = reader.read("./input/wiki-Vote.txt");
 
@@ -30,7 +30,7 @@ TEST_F(SCDGTest2, testRunApproximatePageRank) {
     const auto prVector = apr.run(0);
 }
 
-TEST_F(SCDGTest2, testSCD) {
+TEST_F(SelectiveCDGTest, testSCD) {
     METISGraphReader reader;
     Graph G = reader.read("input/hep-th.graph");
     // parameters
@@ -77,7 +77,7 @@ TEST_F(SCDGTest2, testSCD) {
     }
 }
 
-TEST_F(SCDGTest2, testGCE) {
+TEST_F(SelectiveCDGTest, testGCE) {
     METISGraphReader reader;
     Graph G = reader.read("input/hep-th.graph");
 
@@ -131,7 +131,7 @@ TEST_F(SCDGTest2, testGCE) {
     }
 }
 
-TEST_F(SCDGTest2, testSCDWeighted) {
+TEST_F(SelectiveCDGTest, testSCDWeighted) {
     Aux::Random::setSeed(23, false);
     METISGraphReader reader;
     Graph G = reader.read("input/lesmis.graph");

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -9,6 +9,7 @@
 #include <networkit/io/SNAPGraphReader.hpp>
 #include <networkit/scd/CliqueDetect.hpp>
 #include <networkit/scd/GCE.hpp>
+#include <networkit/scd/LFMLocal.hpp>
 #include <networkit/scd/PageRankNibble.hpp>
 #include <networkit/scd/ApproximatePageRank.hpp>
 #include <networkit/scd/SelectiveCommunityDetector.hpp>
@@ -38,6 +39,7 @@ TEST_F(SCDGTest2, testSCD) {
     algorithms.emplace_back(std::make_pair(std::string("PageRankNibble"), std::unique_ptr<SelectiveCommunityDetector>(new PageRankNibble(G, alpha, epsilon))));
     algorithms.emplace_back(std::make_pair(std::string("GCE L"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "L"))));
     algorithms.emplace_back(std::make_pair(std::string("GCE M"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "M"))));
+    algorithms.emplace_back(std::make_pair(std::string("LFM"), std::unique_ptr<SelectiveCommunityDetector>(new LFMLocal(G, 0.8))));
 
     count idBound = G.upperNodeIdBound();
 

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -13,6 +13,7 @@
 #include <networkit/scd/PageRankNibble.hpp>
 #include <networkit/scd/ApproximatePageRank.hpp>
 #include <networkit/scd/SelectiveCommunityDetector.hpp>
+#include <networkit/scd/TwoPhaseL.hpp>
 
 namespace NetworKit {
 
@@ -40,6 +41,7 @@ TEST_F(SCDGTest2, testSCD) {
     algorithms.emplace_back(std::make_pair(std::string("GCE L"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "L"))));
     algorithms.emplace_back(std::make_pair(std::string("GCE M"), std::unique_ptr<SelectiveCommunityDetector>(new GCE(G, "M"))));
     algorithms.emplace_back(std::make_pair(std::string("LFM"), std::unique_ptr<SelectiveCommunityDetector>(new LFMLocal(G, 0.8))));
+    algorithms.emplace_back(std::make_pair(std::string("TwoPhaseL"), std::unique_ptr<SelectiveCommunityDetector>(new TwoPhaseL(G))));
 
     count idBound = G.upperNodeIdBound();
 

--- a/networkit/cpp/structures/CMakeLists.txt
+++ b/networkit/cpp/structures/CMakeLists.txt
@@ -1,5 +1,6 @@
 networkit_add_module(structures
     Cover.cpp
+    LocalCommunity.cpp
     Partition.cpp
     UnionFind.cpp
     )

--- a/networkit/cpp/structures/LocalCommunity.cpp
+++ b/networkit/cpp/structures/LocalCommunity.cpp
@@ -1,0 +1,333 @@
+// networkit-format
+#include <networkit/structures/LocalCommunity.hpp>
+
+namespace NetworKit {
+template <bool ShellMaintainsExtDeg, bool MaintainBoundary, bool AllowRemoval>
+LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::LocalCommunity(const Graph &G)
+    : G(&G), intWeight(0), extWeight(0) {
+    if (G.isDirected()) {
+        throw std::runtime_error("Directed graphs are not supported");
+    }
+}
+
+template <bool ShellMaintainsExtDeg, bool MaintainBoundary, bool AllowRemoval>
+void LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::addNode(node u) {
+    typename decltype(community)::iterator uIt;
+    std::tie(uIt, std::ignore) = community.insert({u, CommunityInfo()});
+    shell.erase(u);
+
+    node boundaryNeighbor = none; // if u is in the boundary and has only one neighbor outside of
+                                  // the community, store it here.
+    std::unordered_map<node, count>::iterator boundaryIt;
+
+    if (MaintainBoundary) {
+        boundaryIt = currentBoundary->end();
+    }
+
+    G->forNeighborsOf(
+        u, [&](node, node v, edgeweight ew) { // insert external neighbors of u into shell
+            auto vIt = community.find(v);
+            if (vIt != community.end()) {
+                if (MaintainBoundary) {
+                    auto it = currentBoundary->find(v);
+                    assert(it != currentBoundary->end());
+                    it->second -= 1;
+                    if (it->second == 0) {
+                        currentBoundary->erase(it);
+
+                        if (AllowRemoval) {
+                            // u was v's only external neighbor
+                            *vIt->second.exclusiveOutsideNeighbor = none;
+
+                            // v is now fully internal! -> inform neighbors!
+                            G->forNeighborsOf(v, [&](node x) {
+                                auto it = community.find(x);
+                                assert(it != community.end());
+
+                                it->second.numFullyInternalNeighbors += 1;
+                            });
+                        }
+                    } else if (it->second == 1) {
+                        G->forNeighborsOf(v, [&](node x) {
+                            auto it = shell.find(x);
+                            if (it != shell.end()) {
+                                it->second.numExclusiveBoundaryMembers += 1;
+                                if (AllowRemoval) {
+                                    *uIt->second.exclusiveOutsideNeighbor = it->first;
+                                }
+                            }
+                        });
+                    }
+                }
+
+                intWeight += ew;
+                extWeight -= ew;
+
+                if (AllowRemoval) {
+                    uIt->second.intDeg += ew;
+
+                    vIt->second.intDeg += ew;
+                    if (ShellMaintainsExtDeg) {
+                        vIt->second.extDeg -= ew;
+                    }
+                }
+            } else {
+                auto it = shell.find(v);
+                if (it == shell.end()) {
+                    std::tie(it, std::ignore) = shell.insert({v, ShellInfo()});
+                    if (ShellMaintainsExtDeg) {
+                        it->second.extDeg.set(G->weightedDegree(v));
+                    }
+                }
+
+                it->second.intDeg += ew;
+                if (ShellMaintainsExtDeg) {
+                    it->second.extDeg -= ew;
+                }
+
+                extWeight += ew;
+
+                if (AllowRemoval && ShellMaintainsExtDeg) {
+                    uIt->second.extDeg += ew;
+                }
+
+                if (MaintainBoundary) {
+                    if (boundaryIt == currentBoundary->end()) {
+                        std::tie(boundaryIt, std::ignore) = currentBoundary->insert({u, 0});
+                        boundaryNeighbor = v;
+                    }
+
+                    ++boundaryIt->second;
+                }
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+                {
+                    auto intExtDeg = calculateIntExtDeg(v);
+                    assert(*shell[v].intDeg == intExtDeg.first);
+                    if (ShellMaintainsExtDeg) {
+                        assert(*shell[v].extDeg == intExtDeg.second);
+                    }
+                }
+#endif
+#endif
+            }
+        });
+
+    if (MaintainBoundary && boundaryIt != currentBoundary->end() && boundaryIt->second == 1) {
+        assert(boundaryNeighbor != none);
+        shell[boundaryNeighbor].numExclusiveBoundaryMembers += 1;
+    }
+
+    if (MaintainBoundary && AllowRemoval && boundaryIt == currentBoundary->end()) {
+        // this node is a fully internal node! -> inform neighbors
+        G->forNeighborsOf(u, [&](node v) {
+            auto it = community.find(v);
+            assert(it != community.end());
+
+            it->second.numFullyInternalNeighbors += 1;
+        });
+    }
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+    if (AllowRemoval) {
+        auto intExtDeg = calculateIntExtDeg(u);
+        assert(*community[u].intDeg == intExtDeg.first);
+        if (ShellMaintainsExtDeg) {
+            assert(*community[u].extDeg == intExtDeg.second);
+        }
+    }
+
+    assert(!MaintainBoundary || calculateBoundary().size() == currentBoundary->size());
+#endif
+#endif
+}
+
+template <bool ShellMaintainsExtDeg, bool MaintainBoundary, bool AllowRemoval>
+void LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::removeNode(node u) {
+    typename decltype(shell)::iterator uIt;
+    std::tie(uIt, std::ignore) = shell.insert({u, ShellInfo()});
+    community.erase(u);
+    bool wasFullyInternal = false;
+
+    if (MaintainBoundary) {
+        auto buIt = currentBoundary->find(u);
+        if (buIt != currentBoundary->end()) {
+            currentBoundary->erase(buIt);
+        } else {
+            // we are removing a completely internal node!!! (not really a good idea, but okay...)
+            wasFullyInternal = true;
+        }
+    }
+
+    G->forNeighborsOf(
+        u, [&](node, node v, edgeweight ew) { // insert external neighbors of u into shell
+            auto vIt = community.find(v);
+            if (vIt != community.end()) {
+                if (MaintainBoundary) {
+                    if (wasFullyInternal) {
+                        vIt->second.numFullyInternalNeighbors -= 1;
+                    }
+
+                    auto it = currentBoundary->find(v);
+                    // v was a fully internal node
+                    if (it == currentBoundary->end()) {
+                        std::tie(it, std::ignore) = currentBoundary->insert({v, 0});
+                    }
+
+                    assert(it != currentBoundary->end());
+
+                    it->second += 1;
+
+                    if (it->second == 1) {
+                        // v was a fully internal node
+                        // therefore, u is now the exclusive outside neighbor of v
+                        *vIt->second.exclusiveOutsideNeighbor = u;
+
+                        // inform all neighbors of v that they now have one fully
+                        // internal neighbor less
+                        G->forNeighborsOf(v, [&](node x) {
+                            auto comIt = community.find(x);
+                            if (comIt != community.end()) {
+                                comIt->second.numFullyInternalNeighbors -= 1;
+                            } else {
+                                assert(x == u);
+                            }
+                        });
+
+                        // u has now a neighbor that is only in the boundary
+                        // becuase of u
+                        uIt->second.numExclusiveBoundaryMembers += 1;
+                    } else if (it->second == 2) {
+                        *vIt->second.exclusiveOutsideNeighbor = none;
+
+                        uIt->second.numExclusiveBoundaryMembers -= 1;
+                    }
+                }
+
+                intWeight -= ew;
+                extWeight += ew;
+
+                vIt->second.intDeg -= ew;
+                uIt->second.intDeg += ew;
+
+                if (ShellMaintainsExtDeg) {
+                    vIt->second.extDeg += ew;
+                }
+            } else {
+                auto it = shell.find(v);
+                assert(it != shell.end());
+
+                it->second.intDeg -= ew;
+                if (ShellMaintainsExtDeg) {
+                    it->second.extDeg += ew;
+                    uIt->second.extDeg += ew;
+                }
+
+                extWeight -= ew;
+
+                if (*it->second.intDeg == 0) {
+                    shell.erase(it);
+                } else {
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+                    {
+                        auto intExtDeg = calculateIntExtDeg(v);
+                        assert(*shell[v].intDeg == intExtDeg.first);
+                        if (ShellMaintainsExtDeg) {
+                            assert(*shell[v].extDeg == intExtDeg.second);
+                        }
+                    }
+#endif
+#endif
+                }
+            }
+        });
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+    {
+        auto intExtDeg = calculateIntExtDeg(u);
+        assert(*uIt->second.intDeg == intExtDeg.first);
+        if (ShellMaintainsExtDeg) {
+            assert(*uIt->second.extDeg == intExtDeg.second);
+        }
+    }
+
+    assert(!MaintainBoundary || calculateBoundary().size() == currentBoundary->size());
+#endif
+#endif
+}
+
+template <bool ShellMaintainsExtDeg, bool MaintainBoundary, bool AllowRemoval>
+bool LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::contains(node u) const {
+    return community.find(u) != community.end();
+}
+
+template <bool ShellMaintainsExtDeg, bool MaintainBoundary, bool AllowRemoval>
+std::set<node> LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::toSet() const {
+    std::set<node> result;
+
+    for (const auto &it : community) {
+        result.insert(it.first);
+    }
+
+    return result;
+}
+
+template <bool ShellMaintainsExtDeg, bool MaintainBoundary, bool AllowRemoval>
+std::unordered_set<node>
+LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::calculateBoundary() {
+    std::unordered_set<node> sh;
+    for (const auto &it : community) {
+        G->forNeighborsOf(it.first, [&](node v) {
+            if (!contains(v)) {
+                sh.insert(it.first);
+            }
+        });
+    }
+    return sh;
+}
+
+template <bool ShellMaintainsExtDeg, bool MaintainBoundary, bool AllowRemoval>
+std::pair<double, double>
+LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::calculateIntExtDeg(node v) {
+    double degInt = 0;
+    double degExt = 0;
+    G->forNeighborsOf(v, [&](node, node u, edgeweight ew) {
+        if (contains(u)) {
+            degInt += ew;
+        } else {
+            degExt += ew;
+        }
+    });
+    return std::make_pair(degInt, degExt);
+}
+
+template <bool ShellMaintainsExtDeg, bool MaintainBoundary, bool AllowRemoval>
+std::pair<double, double>
+LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::calculateVolumeCut() {
+    double internal = 0;
+    double external = 0;
+    for (const auto &it : community) {
+        G->forEdgesOf(it.first, [&](node, node v, edgeweight ew) {
+            if (contains(v)) {
+                internal += ew;
+            } else {
+                external += ew;
+            }
+        });
+    }
+    internal = internal / 2; // internal edges were counted twice
+    return std::make_pair(internal, external);
+}
+
+template class LocalCommunity<false, false, false>;
+template class LocalCommunity<true, false, false>;
+template class LocalCommunity<true, true, false>;
+template class LocalCommunity<false, false, true>;
+template class LocalCommunity<true, false, true>;
+template class LocalCommunity<true, true, true>;
+
+} // namespace NetworKit

--- a/networkit/scd.pyx
+++ b/networkit/scd.pyx
@@ -78,3 +78,117 @@ cdef class GCE:
 		"""
 		return self._this.run(seeds)
 
+cdef extern from "<networkit/scd/SCDGroundTruthComparison.hpp>":
+	cdef cppclass _SCDGroundTruthComparison "NetworKit::SCDGroundTruthComparison"(_Algorithm):
+		_SCDGroundTruthComparison(_Graph G, _Cover groundTruth, map[node, set[node]] found, bool_t ignoreSeeds) except +
+		map[index, double] getIndividualJaccard() except +
+		map[index, double] getIndividualPrecision() except +
+		map[index, double] getIndividualRecall() except +
+		map[index, double] getIndividualF1() except +
+
+		double getAverageJaccard() except +
+		double getAverageF1() except +
+		double getAveragePrecision() except +
+		double getAverageRecall() except +
+
+cdef class SCDGroundTruthComparison(Algorithm):
+	"""
+	This class evaluates a set found communities against a ground truth cover. Each found community
+	is compared against the communities of the seed node in the ground truth cover.
+
+	For each score, the ground truth community is chosen as comparison that maximizes the score.
+	If seeds are not ignored (a parameter of the constructor), then only ground truth communities
+	that contain the given seed are used to compare against.
+
+	The calculated scores are:
+
+	Precision: the size of the intersection of found and ground truth community divided by the
+	size of the found community, i.e., how much of the found community was an actual match.
+
+	Recall: the size of the intersection of found and ground truth community divided by the
+	size of the ground truth community, i.e., how much of the ground truth community was found.
+
+	F1 score: the harmonic mean of precision and recall.
+
+	Jaccard index: the size of the intersection of found and ground truth community divided by the
+	size of the union of found and ground truth community.
+
+	For each score, the range of values is between 0 and 1, where 0 is the worst and 1 the best score.
+
+	Parameters:
+	-----------
+	G : Graph
+		The graph to compare on
+	groundTruth : Cover
+		The ground truth cover
+	found : dict
+		The found communities, where the keys are the seed nodes and the values are the found nodes.
+	ignoreSeeds : bool
+		If the seed values shall be ignored, i.e. if any ground truth community is a match
+	"""
+	cdef Graph _G
+	cdef Cover _groundTruth
+	cdef map[node, set[node]] _found
+
+	def __cinit__(self, Graph G not None, Cover groundTruth not None, map[node, set[node]] found, bool_t ignoreSeeds):
+		self._found = found
+		self._G = G
+		self._groundTruth = groundTruth
+		self._this = new _SCDGroundTruthComparison(G._this, groundTruth._this, self._found, ignoreSeeds)
+
+	def getIndividualJaccard(self):
+		"""
+		Get the Jaccard index of every found community.
+
+		Returns
+		-------
+		A dict between seed node and the jaccard index of the seed's community.
+		"""
+		return (<_SCDGroundTruthComparison*>(self._this)).getIndividualJaccard()
+	def getIndividualPrecision(self):
+		"""
+		Get the precision of every found community.
+
+		Returns
+		-------
+		A dict between seed node and the precision of the seed's community.
+		"""
+		return (<_SCDGroundTruthComparison*>(self._this)).getIndividualPrecision()
+	def getIndividualRecall(self):
+		"""
+		Get the recall of every found community.
+
+		Returns
+		-------
+		A dict between seed node and the recall of the seed's community.
+		"""
+		return (<_SCDGroundTruthComparison*>(self._this)).getIndividualRecall()
+	def getIndividualF1(self):
+		"""
+		Get the F1 score of every found community.
+
+		Returns
+		-------
+		A dict between seed node and the F1 score of the seed's community.
+		"""
+		return (<_SCDGroundTruthComparison*>(self._this)).getIndividualF1()
+	def getAverageJaccard(self):
+		"""
+		Get the (unweighted) average of the jaccard indices of every found community.
+		"""
+		return (<_SCDGroundTruthComparison*>(self._this)).getAverageJaccard()
+	def getAverageF1(self):
+		"""
+		Get the (unweighted) average of the F1 score of every found community.
+		"""
+		return (<_SCDGroundTruthComparison*>(self._this)).getAverageF1()
+	def getAveragePrecision(self):
+		"""
+		Get the (unweighted) average of the precision of every found community.
+		"""
+		return (<_SCDGroundTruthComparison*>(self._this)).getAveragePrecision()
+	def getAverageRecall(self):
+		"""
+		Get the (unweighted) average of the recall of every found community.
+		"""
+		return (<_SCDGroundTruthComparison*>(self._this)).getAverageRecall()

--- a/networkit/scd.pyx
+++ b/networkit/scd.pyx
@@ -402,3 +402,78 @@ cdef class TwoPhaseL(SelectiveCommunityDetector):
 	def __cinit__(self, Graph G):
 		self._G = G
 		self._this = new _TwoPhaseL(G._this)
+
+cdef extern from "<networkit/scd/LocalTightnessExpansion.hpp>":
+
+	cdef cppclass _LocalTightnessExpansion "NetworKit::LocalTightnessExpansion"(_SelectiveCommunityDetector):
+		_LocalTightnessExpansion(_Graph G, double alpha) except +
+
+cdef class LocalTightnessExpansion(SelectiveCommunityDetector):
+	"""
+	The Local Tightness Expansion (LTE) algorithm.
+
+	The algorithm can handle weighted graphs.
+
+	This is the local community expansion algorithm described in
+
+	Huang, J., Sun, H., Liu, Y., Song, Q., & Weninger, T. (2011).
+	Towards Online Multiresolution Community Detection in Large-Scale Networks.
+	PLOS ONE, 6(8), e23829.
+	https://doi.org/10.1371/journal.pone.0023829
+
+	Parameters:
+	-----------
+	G : Graph
+		graph in which the community shell be found
+	alpha : float
+		Tightness coefficient - smaller values lead to larger communities
+	"""
+	def __cinit__(self, Graph G, double alpha = 1.0):
+		self._G = G
+		self._this = new _LocalTightnessExpansion(G._this, alpha)
+
+cdef extern from "<networkit/scd/TCE.hpp>":
+
+	cdef cppclass _TCE "NetworKit::TCE"(_SelectiveCommunityDetector):
+		_TCE(_Graph G, bool_t refine, bool_t useJaccard) except +
+
+cdef class TCE(SelectiveCommunityDetector):
+	"""
+	The Triangle-based community expansion algorithm.
+
+	Parameters:
+	-----------
+	G : Graph
+		graph in which the community shell be found
+	refine : bool
+		If nodes shall be removed again if this improves the quality
+	useJaccard : bool
+		If the jaccard index shall be used for weights
+	"""
+	def __cinit__(self, Graph G, bool_t refine = True, bool_t useJaccard = False):
+		self._G = G
+		self._this = new _TCE(G._this, refine, useJaccard)
+
+cdef extern from "<networkit/scd/LocalT.hpp>":
+	cdef cppclass _LocalT "NetworKit::LocalT"(_SelectiveCommunityDetector):
+		_LocalT(_Graph G) except +
+
+cdef class LocalT(SelectiveCommunityDetector):
+	"""
+	The local community expansion algorithm optimizing the T measure.
+
+	This implements the algorithm published in:
+
+	Fagnan, J., Zaiane, O., & Barbosa, D. (2014).
+	Using triads to identify local community structure in social networks.
+	In 2014 IEEE/ACM International Conference on Advances in Social Networks Analysis and Mining (ASONAM) (pp. 108–112).
+	https://doi.org/10.1109/ASONAM.2014.6921568
+
+	Parameters:
+	-----------
+	G : Graph
+		graph in which the community shell be found
+	"""
+	def __cinit__(self, Graph G):
+		self._G = G
+		self._this = new _LocalT(G._this)

--- a/networkit/scd.pyx
+++ b/networkit/scd.pyx
@@ -121,6 +121,37 @@ cdef class GCE(SelectiveCommunityDetector):
 		self._G = G
 		self._this = new _GCE(G._this, stdstring(quality))
 
+cdef extern from "<networkit/scd/CliqueDetect.hpp>":
+	cdef cppclass _CliqueDetect "NetworKit::CliqueDetect"(_SelectiveCommunityDetector):
+		_CliqueDetect(_Graph G) except +
+
+cdef class CliqueDetect(SelectiveCommunityDetector):
+	"""
+	The CliqueDetect algorithm. It finds the largest clique in the
+	seed node's neighborhood.
+
+	The algorithm can handle weighted graphs. There, the clique
+	with the highest sum of internal edge weights is
+	returned. This sum includes edge weights to the seed node(s)
+	to ensure that cliques that are well-connected to the seed
+	node(s) are preferred.
+
+	For multiple seed nodes, the resulting community is a clique
+	iff the seeds form a clique. Otherwise, only the added nodes
+	form a clique that is fully connected to the seed nodes.
+
+	See also: Hamann, M.; Röhrs, E.; Wagner, D.
+	Local Community Detection Based on Small Cliques.
+	Algorithms 2017, 10, 90. https://doi.org/10.3390/a10030090
+
+	Parameters:
+	-----------
+	G : graph in which communities shall be detected.
+	"""
+	def __cinit__(self, Graph G):
+		self._G = G
+		self._this = new _CliqueDetect(G._this)
+
 
 cdef extern from "<networkit/scd/SCDGroundTruthComparison.hpp>":
 	cdef cppclass _SCDGroundTruthComparison "NetworKit::SCDGroundTruthComparison"(_Algorithm):

--- a/networkit/scd.pyx
+++ b/networkit/scd.pyx
@@ -2,6 +2,8 @@ from libc.stdint cimport uint64_t
 from libcpp cimport bool as bool_t
 from libcpp.map cimport map
 from libcpp.set cimport set
+from libcpp.utility cimport pair
+from libcpp.vector cimport vector
 from libcpp.string cimport string
 
 ctypedef uint64_t index
@@ -82,6 +84,56 @@ cdef class SelectiveCommunityDetector:
 		except TypeError:
 			return self._this.expandOneCommunity(<node?>seeds)
 
+cdef extern from "<networkit/scd/ApproximatePageRank.hpp>":
+	cdef cppclass _ApproximatePageRank "NetworKit::ApproximatePageRank":
+		_ApproximatePageRank(_Graph g, double alpha, double epsilon) except +
+		vector[pair[node, double]] run(set[node] seeds) except +
+		vector[pair[node, double]] run(node seed) except +
+
+cdef class ApproximatePageRank:
+	"""
+	Computes an approximate PageRank vector from a given seed.
+
+	Parameters:
+	-----------
+	G : Graph
+		Graph in which an APR is computed
+	alpha : float
+		Loop probability of random walk
+	epsilon: float
+		Error tolerance
+	"""
+	cdef _ApproximatePageRank *_this
+	cdef Graph _G
+
+	def __cinit__(self, Graph G not None, double alpha, double epsilon):
+		self._G = G
+		self._this = new _ApproximatePageRank(G._this, alpha, epsilon)
+
+	def __dealloc__(self):
+		if self._this != NULL:
+			del self._this
+		self._this = NULL
+
+	def run(self, seeds):
+		"""
+		Approximate PageRank vector from seeds with parameters
+		specified in the constructor.
+
+		Parameters:
+		-----------
+		seeds : node or iterable of nodes
+			The seed node or list of seed nodes
+
+		Returns:
+		--------
+		list[node, float]
+			List of pairs of nodes and scores with positive PageRank
+		"""
+		try:
+			return self._this.run(<set[node]?>seeds)
+		except TypeError:
+			return self._this.run(<node?>seeds)
 
 cdef extern from "<networkit/scd/PageRankNibble.hpp>":
 

--- a/networkit/scd.pyx
+++ b/networkit/scd.pyx
@@ -357,3 +357,28 @@ cdef class SetConductance(Algorithm):
 		The conductance.
 		"""
 		return (<_SetConductance*>(self._this)).getConductance()
+
+cdef extern from "<networkit/scd/RandomBFS.hpp>":
+
+	cdef cppclass _RandomBFS "NetworKit::RandomBFS"(_SelectiveCommunityDetector):
+		_RandomBFS(_Graph G, _Cover C) except +
+
+cdef class RandomBFS(SelectiveCommunityDetector):
+	"""
+	The random BFS community detection baseline:
+	finds a community around a seed node with a given size using a prefix of a
+	BFS order that is selected at random among all possible prefixes.
+
+	Parameters:
+	-----------
+	G : Graph
+		Graph in which the community shall be found
+	C : Cover
+		Ground truth communities to get size information from
+	"""
+	cdef Cover _C
+
+	def __cinit__(self, Graph G, Cover C):
+		self._G = G
+		self._C = C
+		self._this = new _RandomBFS(G._this, C._this)

--- a/networkit/scd.pyx
+++ b/networkit/scd.pyx
@@ -152,6 +152,41 @@ cdef class CliqueDetect(SelectiveCommunityDetector):
 		self._G = G
 		self._this = new _CliqueDetect(G._this)
 
+cdef extern from "<networkit/scd/LFMLocal.hpp>":
+
+	cdef cppclass _LFMLocal "NetworKit::LFMLocal"(_SelectiveCommunityDetector):
+		_LFMLocal(_Graph G, double alpha) except +
+
+cdef class LFMLocal(SelectiveCommunityDetector):
+	"""
+	Local version of the LFM algorithm
+
+	This is the local community expansion as introduced in:
+
+	Lancichinetti, A., Fortunato, S., & Kertész, J. (2009).
+	Detecting the overlapping and hierarchical community structure in complex networks.
+	New Journal of Physics, 11(3), 033015.
+	https://doi.org/10.1088/1367-2630/11/3/033015
+
+	Their algorithm detects overlapping communities by repeatedly
+	executing this algorithm for a random seed node that has not yet
+	been assigned to any community.
+
+	The algorithm has a resolution parameter alpha. A natural choice
+	for alpha is 1, the paper states that values below 0.5 usually
+	give a community containing the whole graph while values larger
+	than 2 recover the smallest communities.
+
+	Parameters:
+	-----------
+	G : Graph
+		graph in which the community shall be found.
+	alpha : float
+		The resolution parameter
+	"""
+	def __cinit__(self, Graph G, double alpha = 1.0):
+		self._G = G
+		self._this = new _LFMLocal(G._this, alpha)
 
 cdef extern from "<networkit/scd/SCDGroundTruthComparison.hpp>":
 	cdef cppclass _SCDGroundTruthComparison "NetworKit::SCDGroundTruthComparison"(_Algorithm):

--- a/networkit/scd.pyx
+++ b/networkit/scd.pyx
@@ -382,3 +382,23 @@ cdef class RandomBFS(SelectiveCommunityDetector):
 		self._G = G
 		self._C = C
 		self._this = new _RandomBFS(G._this, C._this)
+
+cdef extern from "<networkit/scd/TwoPhaseL.hpp>":
+
+	cdef cppclass _TwoPhaseL "NetworKit::TwoPhaseL"(_SelectiveCommunityDetector):
+		_TwoPhaseL(_Graph G) except +
+
+cdef class TwoPhaseL(SelectiveCommunityDetector):
+	"""
+	The two-phase local community detection algorithm optimizing the L-measure.
+
+	This is an implementation of the algorithm proposed in:
+
+	Chen, J., Zaïane, O., & Goebel, R. (2009).
+	Local Community Identification in Social Networks.
+	In 2009 International Conference on Advances in Social Network Analysis and Mining (pp. 237–242).
+	https://doi.org/10.1109/ASONAM.2009.14
+	"""
+	def __cinit__(self, Graph G):
+		self._G = G
+		self._this = new _TwoPhaseL(G._this)

--- a/networkit/scd.pyx
+++ b/networkit/scd.pyx
@@ -7,6 +7,8 @@ from libcpp.string cimport string
 ctypedef uint64_t index
 ctypedef index node
 
+from cython.operator import dereference
+
 from .graph cimport _Graph, Graph
 from .base cimport _Algorithm, Algorithm
 from .structures cimport _Cover, Cover
@@ -187,6 +189,20 @@ cdef class LFMLocal(SelectiveCommunityDetector):
 	def __cinit__(self, Graph G, double alpha = 1.0):
 		self._G = G
 		self._this = new _LFMLocal(G._this, alpha)
+
+cdef extern from "<networkit/scd/CombinedSCD.hpp>":
+	cdef cppclass _CombinedSCD "NetworKit::CombinedSCD"(_SelectiveCommunityDetector):
+		_CombinedSCD(_Graph G, _SelectiveCommunityDetector first, _SelectiveCommunityDetector second) except +
+
+cdef class CombinedSCD(SelectiveCommunityDetector):
+	cdef SelectiveCommunityDetector _first
+	cdef SelectiveCommunityDetector _second
+
+	def __cinit__(self, Graph G, SelectiveCommunityDetector first not None, SelectiveCommunityDetector second not None):
+		self._G = G
+		self._first = first
+		self._second = second
+		self._this = new _CombinedSCD(G._this, dereference(first._this), dereference(second._this))
 
 cdef extern from "<networkit/scd/SCDGroundTruthComparison.hpp>":
 	cdef cppclass _SCDGroundTruthComparison "NetworKit::SCDGroundTruthComparison"(_Algorithm):

--- a/networkit/test/test_scd.py
+++ b/networkit/test/test_scd.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import unittest
+
+import networkit as nk
+
+
+class Test_SCD(unittest.TestCase):
+
+	def setUp(self):
+		self.G = nk.readGraph("input/PGPgiantcompo.graph", nk.Format.METIS)
+
+	def testApproximatePageRank(self):
+		epsilon = 1e-12
+		result = dict(nk.scd.ApproximatePageRank(self.G, 0.1, epsilon).run(0))
+
+		result2 = dict(nk.scd.ApproximatePageRank(self.G, 0.1, epsilon).run([0]))
+
+		self.assertGreaterEqual(len(result), 1)
+		self.assertEqual(len(result), len(result2))
+
+		for u, score in result.items():
+			self.assertTrue(self.G.hasNode(u))
+			self.assertGreaterEqual(score, 0)
+			self.assertTrue(u in result2)
+			self.assertAlmostEqual(score, result2[u])
+
+	def testSCD(self):
+		nk.setSeed(42, False)
+		seed = 20
+		seeds = [seed]
+		for name, algo in [
+				("PageRankNibble", nk.scd.PageRankNibble(self.G, 0.1, 1e-12)),
+				("GCE L", nk.scd.GCE(self.G, "L")),
+				("GCE M", nk.scd.GCE(self.G, "M")),
+				("LFM", nk.scd.LFMLocal(self.G, 0.8)),
+				("TwoPhaseL", nk.scd.TwoPhaseL(self.G)),
+				("TCE", nk.scd.TCE(self.G)),
+				("LTE", nk.scd.LocalTightnessExpansion(self.G)),
+				("LocalT", nk.scd.LocalT(self.G)),
+				("Clique", nk.scd.CliqueDetect(self.G))]:
+			result = algo.run(seeds)[seed]
+
+			self.assertGreaterEqual(len(result), 1, "{} has empty community".format(name))
+
+			cond = nk.scd.SetConductance(self.G, result).run().getConductance()
+
+			self.assertLessEqual(cond, 0.5, "{} has too large conductance".format(name))
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
This is the code that I have developed for our paper on local community detection:

Hamann, Michael; Röhrs, Eike; Wagner, Dorothea. 2017. "[Local Community Detection based on Small Cliques](http://www.mdpi.com/1999-4893/10/3/90)." Algorithms 10, no. 3: 90.

The scripts that are based on this code can be found at https://github.com/kit-algo/LCD-cliques-experiments

Apart from adding many local community detection algorithms, this also adds a class for evaluating the results of local community detection algorithms with respect to a ground truth cover. Further, some helper classes have been added.

I have rebased this code on the current NetworKit master branch and applied clang-format to all new files.

All algorithms try to be really local in the sense that they (should) never allocate memory proportional to the graph size (apart from `RandomBFS` maybe, which is just a baseline). To detect many communities, it would definitely be faster to instead use global data structures, and if the graph is not too large compared to a found community, this would most likely also speed up even finding a single community.