### PR TITLE
Fix deprecation warnings with GCC 9.2

### DIFF
--- a/include/networkit/viz/Octree.hpp
+++ b/include/networkit/viz/Octree.hpp
@@ -39,7 +39,7 @@ public:
     /**
      *
      */
-    BoundingBox(const BoundingBox<T>& other) : center(other.center), sideLength(other.sideLength), halfSideLength(other.halfSideLength), sqSideLength(other.sqSideLength), dimension(other.dimension) {}
+    BoundingBox(const BoundingBox<T>& other) = default;
 
     /**
      * Sets the center of the bounding box.

--- a/include/networkit/viz/Point.hpp
+++ b/include/networkit/viz/Point.hpp
@@ -58,7 +58,7 @@ public:
     bool operator==(const Point<T>& other) const;
     bool operator!=(const Point<T>& other) const;
 
-    void operator=(const Point<T>& other);
+    Point<T>& operator=(const Point<T>& other) = default;
 
     T length() const;
     T squaredLength() const;
@@ -185,12 +185,6 @@ template<typename T>
 bool Point<T>::operator!=(const Point<T>& other) const {
     return !(*this == other);
 }
-
-template<typename T>
-void Point<T>::operator=(const Point& other) {
-    this->data = other.data;
-}
-
 
 template<class T>
 Point<T>& Point<T>::scale(const T factor) {


### PR DESCRIPTION
This removes implementations of a copy constructor and an assignment
operator in viz/Octree and Point because if one implementation is
provided, the other (assignment operator/copy constructor) must be
provided, too. As far as I can see, none of the implementations did
anything non-default, so I reverted both to default implementations.