### PR TITLE
Publish wheels

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -76,8 +76,11 @@ jobs:
           -w/app \
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
-            \$PYBIN/python setup.py build_ext install
-            \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64"
+            for PYBIN in /opt/python/*/bin; do
+              echo --> \$PYBIN
+              \$PYBIN/python setup.py build_ext install
+              \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
+            done"
     - name: Try to import on different python versions
       run: |
         docker run \

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,32 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: macOS-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install gcc
+      run: |
+        brew install gcc libomp
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install cython
+    - name: Build
+      run: |
+        CXX=g++-9 python setup.py install
+    - name: Smoke test
+      run: python -c "import networkit; networkit.Graph(5)"    
+  

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -76,7 +76,8 @@ jobs:
           -w/app \
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
-            for PYBIN in /opt/python/*/bin; do
+            set -e -x
+            for PYBIN in /opt/python/cp3*/bin; do
               echo '-->' \$PYBIN
               \$PYBIN/pip install cython
               \$PYBIN/python setup.py build_ext install
@@ -88,7 +89,8 @@ jobs:
           -v$(pwd):/app \
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
-            for PYBIN in /opt/python/*/bin; do
+            set -e -x
+            for PYBIN in /opt/python/cp3*/bin; do
               echo '-->' \$PYBIN
               \$PYBIN/pip install /app/python/dist/*-py3-none-manylinux2010_x86_64.whl
               \$PYBIN/python -c 'import networkit; networkit.Graph(5)'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: macOS-latest
+    runs-on: macOS-10.14
     strategy:
       max-parallel: 4
       matrix:
@@ -21,6 +21,7 @@ jobs:
       run: git submodule update --init
     - name: Install system dependencies
       run: |
+        brew update
         brew install libomp cmake
         brew reinstall gcc
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['cp35-cp35m', 'cp36-cp36m', 'cp37-cp37m', 'cp38-cp38']
+        python-version: ['cp35-cp35m', 'cp36-cp36m', 'cp37-cp37m']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,5 +32,7 @@ jobs:
     - name: Build
       run: CC=gcc-9 CXX=g++-9 python setup.py install
     - name: Smoke test
-      run: python -c "import networkit; networkit.Graph(5)"    
+      run: |
+        cd /tmp
+        python -c "import networkit; networkit.Graph(5)"    
   

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v1
@@ -66,18 +66,36 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install cython wheel twine
-    - name: Build
+    # - name: Build
+    #   run: |
+    #     python setup.py build_ext install
+    - name: Build with manylinux2010
       run: |
-        python setup.py build_ext install
+        docker run \
+          -v$(pwd):/app \
+          -w/app \
+          quay.io/pypa/manylinux2010_x86_64 \
+          bash -c "
+            \$PYBIN/python setup.py build_ext install
+            \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64"
+    - name: Try to import on different python versions
+      run: |
+        docker run \
+          -v$(pwd):/app \
+          quay.io/pypa/manylinux2010_x86_64 \
+          bash -c "
+            for PYBIN in /opt/python/*/bin; do
+              echo --> \$PYBIN
+              \$PYBIN/pip install /app/python/dist/*-py3-none-manylinux2010_x86_64.whl
+              \$PYBIN/python -c 'import networkit; networkit.Graph(5)'
+              \$PYBIN/python -m unittest discover -v networkit/test/
+            done"
     - name: Smoke test
       run: |
         cd /tmp
         python -c "import networkit; networkit.Graph(5)"
     - name: Tests
       run: python -m unittest discover -v networkit/test/
-    - name: Build wheel
-      run: |
-        python setup.py build_ext sdist bdist_wheel
     - name: Publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,8 +3,7 @@ name: Python package
 on: [push]
 
 jobs:
-  build:
-
+  build_mac:
     runs-on: macOS-10.14
     strategy:
       max-parallel: 4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,7 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install cython
     - name: Build
-      run: C=gcc-9 CXX=g++-9 python setup.py install
+      run: CC=gcc-9 CXX=g++-9 python setup.py install
     - name: Smoke test
       run: python -c "import networkit; networkit.Graph(5)"    
   

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7]
 
     steps:
     - uses: actions/checkout@v1
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install cython
+        pip install cython wheel
     - name: Build
       run: |
         CC=gcc-9 python setup.py build_ext install
@@ -38,4 +38,7 @@ jobs:
         python -c "import networkit; networkit.Graph(5)"
     - name: Tests
       run: python -m unittest discover -v networkit/test/
+    - name: Build wheel
+      run: |
+        CC=gcc-9 python setup.py build_ext bdist_wheel
       

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -62,13 +62,7 @@ jobs:
         python-version: 3.7
     - name: Pull submodules
       run: git submodule update --init
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install cython wheel twine
-    # - name: Build
-    #   run: |
-    #     python setup.py build_ext install
+
     - name: Build with manylinux2010
       run: |
         docker run \
@@ -87,6 +81,7 @@ jobs:
             \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
             \$PYBIN/python setup.py build_ext
             \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64"
+
     - name: Test with manylinux2010
       run: |
         docker run \
@@ -101,9 +96,12 @@ jobs:
             \$PYBIN/pip install dist/*${{ matrix.python-version }}-manylinux2010_x86_64.whl
             \$PYBIN/python -c 'import networkit; networkit.Graph(5)'
             \$PYBIN/python -m unittest discover -v networkit/test/"
+
     - name: Publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
+        python -m pip install --upgrade pip
+        pip install twine
         twine upload --repository-url https://pypi.scm.io/simple dist/*.whl

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -86,7 +86,7 @@ jobs:
             \$PYBIN/pip install cython
             \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
             \$PYBIN/python setup.py build_ext
-            \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
+            \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64"
     - name: Test with manylinux2010
       run: |
         docker run \

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,9 +30,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install cython
     - name: Build
-      run: CC=gcc-9 CXX=g++-9 python setup.py install
+      run: |
+        CC=gcc-9 CXX=g++-9 python setup.py build_ext
+        pip install -e .
     - name: Smoke test
       run: |
         cd /tmp
-        python -c "import networkit; networkit.Graph(5)"    
-  
+        python -c "import networkit; networkit.Graph(5)"
+    - name: Tests
+      run: python -m unittest discover -v networkit/test/
+      

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,16 +17,16 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install gcc
-      run: |
-        brew install gcc libomp cmake
+    - name: Pull submodules
+      run: git submodule update --init
+    - name: Install system dependencies
+      run: brew install gcc libomp cmake
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install cython
     - name: Build
-      run: |
-        C=gcc-9 CXX=g++-9 python setup.py install
+      run: C=gcc-9 CXX=g++-9 python setup.py install
     - name: Smoke test
       run: python -c "import networkit; networkit.Graph(5)"    
   

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build
       run: |
         CC=gcc-9 CXX=g++-9 python setup.py build_ext
-        pip install -e .
+        CC=gcc-9 CXX=g++-9 python setup.py install
     - name: Smoke test
       run: |
         cd /tmp

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,14 +52,14 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: ['cp35-cp35m', 'cp36-cp36m', 'cp37-cp37m', 'cp38-cp38']
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.7
     - name: Pull submodules
       run: git submodule update --init
     - name: Install dependencies
@@ -74,35 +74,33 @@ jobs:
         docker run \
           -v$(pwd):/app \
           -w/app \
+          --rm \
+          -e PYBIN=/opt/python/${{ matrix.python-version }}/bin \
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
             set -e -x
-            for PYBIN in /opt/python/cp3*/bin; do
-              echo '-->' \$PYBIN
-              \$PYBIN/pip install cython
-              \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
-              \$PYBIN/python setup.py build_ext install
-              \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
-            done"
-    - name: Try to import on different python versions
+            yum remove cmake -y
+            yum install cmake3 -y
+            ln -s /usr/bin/cmake3 /usr/bin/cmake
+            echo '-->' \$PYBIN
+            \$PYBIN/pip install cython
+            \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
+            \$PYBIN/python setup.py build_ext
+            \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
+    - name: Test with manylinux2010
       run: |
         docker run \
           -v$(pwd):/app \
+          -w/app \
+          --rm \
+          -e PYBIN=/opt/python/${{ matrix.python-version }}/bin \
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
             set -e -x
-            for PYBIN in /opt/python/cp3*/bin; do
-              echo '-->' \$PYBIN
-              \$PYBIN/pip install /app/python/dist/*-py3-none-manylinux2010_x86_64.whl
-              \$PYBIN/python -c 'import networkit; networkit.Graph(5)'
-              \$PYBIN/python -m unittest discover -v networkit/test/
-            done"
-    - name: Smoke test
-      run: |
-        cd /tmp
-        python -c "import networkit; networkit.Graph(5)"
-    - name: Tests
-      run: python -m unittest discover -v networkit/test/
+            echo '-->' \$PYBIN
+            \$PYBIN/pip install dist/*${{ matrix.python-version }}-manylinux2010_x86_64.whl
+            \$PYBIN/python -c 'import networkit; networkit.Graph(5)'
+            \$PYBIN/python -m unittest discover -v networkit/test/"
     - name: Publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,7 +26,7 @@ jobs:
         pip install cython
     - name: Build
       run: |
-        CXX=g++-9 python setup.py install
+        C=gcc-9 CXX=g++-9 python setup.py install
     - name: Smoke test
       run: python -c "import networkit; networkit.Graph(5)"    
   

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -80,6 +80,7 @@ jobs:
             for PYBIN in /opt/python/cp3*/bin; do
               echo '-->' \$PYBIN
               \$PYBIN/pip install cython
+              \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
               \$PYBIN/python setup.py build_ext install
               \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
             done"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,7 +22,8 @@ jobs:
     - name: Install system dependencies
       run: |
         brew update
-        brew install libomp cmake
+        brew install libomp
+        brew upgrade cmake
         brew reinstall gcc
     - name: Install dependencies
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,5 +39,10 @@ jobs:
       run: python -m unittest discover -v networkit/test/
     - name: Build wheel
       run: |
-        CC=gcc-9 python setup.py build_ext bdist_wheel
-      
+        CC=gcc-9 python setup.py build_ext sdist bdist_wheel
+    - name: Publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        twine upload --repository-url https://pypi.scm.io/simple dist/*

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -45,7 +45,7 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        twine upload --repository-url https://pypi.scm.io/simple dist/*
+        twine upload --repository-url https://pypi.scm.io/simple dist/*.whl
         
   build_linux:
     runs-on: ubuntu-latest
@@ -83,4 +83,4 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        twine upload --repository-url https://pypi.scm.io/simple dist/*
+        twine upload --repository-url https://pypi.scm.io/simple dist/*.whl

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -46,3 +46,41 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         twine upload --repository-url https://pypi.scm.io/simple dist/*
+        
+  build_linux:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Pull submodules
+      run: git submodule update --init
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install cython wheel twine
+    - name: Build
+      run: |
+        python setup.py build_ext install
+    - name: Smoke test
+      run: |
+        cd /tmp
+        python -c "import networkit; networkit.Graph(5)"
+    - name: Tests
+      run: python -m unittest discover -v networkit/test/
+    - name: Build wheel
+      run: |
+        python setup.py build_ext sdist bdist_wheel
+    - name: Publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        twine upload --repository-url https://pypi.scm.io/simple dist/*

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,8 +31,7 @@ jobs:
         pip install cython
     - name: Build
       run: |
-        CC=gcc-9 CXX=g++-9 python setup.py build_ext
-        CC=gcc-9 CXX=g++-9 python setup.py install
+        CC=gcc-9 python setup.py build_ext install
     - name: Smoke test
       run: |
         cd /tmp

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,9 @@ jobs:
     - name: Pull submodules
       run: git submodule update --init
     - name: Install system dependencies
-      run: brew install gcc libomp cmake
+      run: |
+        brew install libomp cmake
+        brew reinstall gcc
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -77,7 +77,8 @@ jobs:
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
             for PYBIN in /opt/python/*/bin; do
-              echo --> \$PYBIN
+              echo '-->' \$PYBIN
+              \$PYBIN/pip install cython
               \$PYBIN/python setup.py build_ext install
               \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
             done"
@@ -88,7 +89,7 @@ jobs:
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
             for PYBIN in /opt/python/*/bin; do
-              echo --> \$PYBIN
+              echo '-->' \$PYBIN
               \$PYBIN/pip install /app/python/dist/*-py3-none-manylinux2010_x86_64.whl
               \$PYBIN/python -c 'import networkit; networkit.Graph(5)'
               \$PYBIN/python -m unittest discover -v networkit/test/

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build_mac:
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install gcc
       run: |
-        brew install gcc libomp
+        brew install gcc libomp cmake
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install cython wheel
+        pip install cython wheel twine
     - name: Build
       run: |
         CC=gcc-9 python setup.py build_ext install


### PR DESCRIPTION
We need to pre-compile wheels for linux and mac, because we can't compile the library on our target machines. Therefore, I implemented building and publishing of the wheels as Github Actions (free for open-source). Essentially, this could replace the current travis builds.

Currently, we are publishing the wheels to our custom registry, but could easily be switched to the official pypi.org (with your credentials).

Please let me know if you find this PR useful. Thanks!