### PR TITLE
Graph::addEdge: fix directed in-edge getting the wrong id

### DIFF
--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -693,7 +693,7 @@ void Graph::addEdge(node u, node v, edgeweight ew) {
         inEdges[v].push_back(u);
 
         if (edgesIndexed) {
-            inEdgeIds[v].push_back(id);
+            inEdgeIds[v].push_back(omega - 1);
         }
 
         if (weighted) {


### PR DESCRIPTION
Note that "id" is a member variable that contains the id of the graph.