### PR TITLE
Deprecate Sampling

### DIFF
--- a/include/networkit/graph/Sampling.hpp
+++ b/include/networkit/graph/Sampling.hpp
@@ -11,6 +11,8 @@
 #include <networkit/graph/Graph.hpp>
 #include <networkit/graph/GraphTools.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -20,15 +22,15 @@ class Sampling {
 
 public:
 
-    static node randomNode(const Graph& G) {
+    static node TLX_DEPRECATED(randomNode(const Graph& G)) {
         return GraphTools::randomNode(G);
     }
 
-    static std::pair<node, node> randomEdge(const Graph& G);
+    static std::pair<node, node> TLX_DEPRECATED(randomEdge(const Graph& G)) {
         return GraphTools::randomEdge(G);
     }
 
-    static node randomNeighbor(const Graph& G, node u);
+    static node TLX_DEPRECATED(randomNeighbor(const Graph& G, node u)) {
         return GraphTools::randomNeighbor(G, u);
     }
 


### PR DESCRIPTION
`Sampling.hpp` defines three methods that are already implemented within GraphTools, and never used in NetworKit (after we merge #421). I think we should deprecate them now, and remove `Sampling` in future releases.