### PR TITLE
Refactor: Strongly Connected Components

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1769,25 +1769,7 @@ public:
     }
 
     /**
-     * Get i-th (outgoing) neighbor of @a u.
-     * WARNING: This function is deprecated or only temporary.
-     *
-     * @param u Node.
-     * @param i index; should be in [0, degreeOut(u))
-     * @return @a i -th (outgoing) neighbor of @a u, or @c none if no such
-     * neighbor exists.
-     */
-    template <bool graphIsDirected>
-    node getIthNeighbor(node u, index i) const {
-        node v = outEdges[u][i];
-        if (useEdgeInIteration<graphIsDirected>(u, v))
-            return v;
-        else
-            return none;
-    }
-
-    /**
-     * Get i-th (outgoing) neighbor of @a u.
+     * Return the i-th (outgoing) neighbor of @a u.
      *
      * @param u Node.
      * @param i index; should be in [0, degreeOut(u))

--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -78,14 +78,14 @@ void TopCloseness::computeReachableNodesDir() {
     // We compute the vector sccs_vec, where each component contains the list of
     // its nodes
     for (count v = 0; v < n; v++) {
-        sccs_vec[sccs.componentOfNode(v) - 1].push_back(v);
+        sccs_vec[sccs.componentOfNode(v)].push_back(v);
     }
 
     // We compute the SCC graph and store it in sccGraph
     for (count V = 0; V < N; V++) {
         for (count v : sccs_vec[V]) {
             G.forNeighborsOf(v, [&](node w) {
-                count W = sccs.componentOfNode(w) - 1;
+                count W = sccs.componentOfNode(w);
 
                 if (W != V && !found[W]) {
                     found[W] = true;
@@ -145,13 +145,13 @@ void TopCloseness::computeReachableNodesDir() {
     auto &reachL = *(reachLPtr.get());
     auto &reachU = *(reachUPtr.get());
     for (count v = 0; v < n; v++) {
-        reachL[v] = reachL_scc[sccs.componentOfNode(v) - 1];
-        reachU[v] = reachU_scc[sccs.componentOfNode(v) - 1];
-        if (false) { // MICHELE: used to check if the bounds are correct
-            count r = 0;
-            Traversal::BFSfrom(G, v, [&](node, count) { ++r; });
-            assert(reachL[v] <= r && reachU[v] >= r);
-        }
+        reachL[v] = reachL_scc[sccs.componentOfNode(v)];
+        reachU[v] = reachU_scc[sccs.componentOfNode(v)];
+#ifndef NDEBUG
+        count r = 0;
+        Traversal::BFSfrom(G, v, [&](node, count) { r++; });
+        assert(reachL[v] <= r && reachU[v] >= r);
+#endif
     }
 }
 

--- a/networkit/cpp/centrality/TopHarmonicCloseness.cpp
+++ b/networkit/cpp/centrality/TopHarmonicCloseness.cpp
@@ -464,14 +464,14 @@ void TopHarmonicCloseness::computeReachableNodesDirected() {
   // its nodes
   for (count v = 0; v < n; v++) {
     component[v] = sccs.componentOfNode(v);
-    sccs_vec[sccs.componentOfNode(v) - 1].push_back(v);
+    sccs_vec[sccs.componentOfNode(v)].push_back(v);
   }
 
   // We compute the SCC graph and store it in sccGraph
   for (count V = 0; V < N; V++) {
     for (node v : sccs_vec[V]) {
       G.forNeighborsOf(v, [&](node w) {
-        count W = sccs.componentOfNode(w) - 1;
+        count W = sccs.componentOfNode(w);
 
         if (W != V && !found[W]) {
           found[W] = true;
@@ -533,7 +533,7 @@ void TopHarmonicCloseness::computeReachableNodesDirected() {
   }
 
   for (count v = 0; v < n; v++) {
-    r[v] = reachU_scc[sccs.componentOfNode(v) - 1];
+    r[v] = reachU_scc[sccs.componentOfNode(v)];
   }
 }
 } // namespace NetworKit

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1220,6 +1220,7 @@ TEST_P(CentralityGTest, testTopCloseness) {
 TEST_F(CentralityGTest, testTopHarmonicClosenessDirected) {
     count size = 400;
     count k = 10;
+    Aux::Random::setSeed(42, false);
     Graph G1 = DorogovtsevMendesGenerator(size).generate();
     Graph G(G1.upperNodeIdBound(), false, true);
     G1.forEdges([&](node u, node v) {

--- a/networkit/cpp/components/StronglyConnectedComponents.cpp
+++ b/networkit/cpp/components/StronglyConnectedComponents.cpp
@@ -1,38 +1,142 @@
 /*
- * StrongConnectedComponents.cpp
+ * StronglyConnectedComponents.cpp
  *
  *  Created on: 01.06.2014
- *      Author: Klara Reichard (klara.reichard@gmail.com), Marvin Ritter (marvin.ritter@gmail.com)
- *
- *  [2016/07/14] Iterative variant avoiding stack-based recursion
- *  -- Obada Mahdi <omahdi@gmail.com>
+ *      Authors: Klara Reichard <klara.reichard@gmail.com>
+ *               Marvin Ritter <marvin.ritter@gmail.com>
+ *               Obada Mahdi <omahdi@gmail.com>
+ *               Eugenio Angriman <angrimae@hu-berlin.de>
  */
 
-#include <stack>
-#include <functional>
-#include <tuple>
+// networkit-format
 
+#include <stack>
+
+#include <networkit/auxiliary/Log.hpp>
 #include <networkit/components/StronglyConnectedComponents.hpp>
 #include <networkit/structures/Partition.hpp>
-#include <networkit/auxiliary/Log.hpp>
 
 namespace NetworKit {
 
-StronglyConnectedComponents::StronglyConnectedComponents(const Graph& G, bool iterativeAlgo) : G(&G), iterativeAlgo(iterativeAlgo) {
+StronglyConnectedComponents::StronglyConnectedComponents(const Graph &G)
+    : G(&G), iterativeAlgo(true) {
+    if (!G.isDirected())
+        WARN("The input graph is undirected, use ConnectedComponents for more efficiency.");
+}
 
+StronglyConnectedComponents::StronglyConnectedComponents(const Graph &G, bool iterativeAlgo)
+    : G(&G), iterativeAlgo(iterativeAlgo) {
+    if (!iterativeAlgo)
+        WARN("Running deprecated recursive algorithm.");
 }
 
 void StronglyConnectedComponents::run() {
-    if (iterativeAlgo) {
-        runIteratively();
-    } else {
+    if (!iterativeAlgo) {
         runRecursively();
+        return;
     }
+
+    const auto n = G->upperNodeIdBound();
+
+    // The component of every node is initially undefined.
+    component.clear();
+    component.resize(n, none);
+
+    // Stack used to determine the strongly connected components from the root nodes.
+    std::vector<node> stack;
+    stack.reserve(n);
+    std::vector<unsigned char> onStack(n, 0);
+
+    // Depth of a node in the dfs
+    std::vector<count> depth(n, none);
+    // At index `u`: smallest id among reachable nodes.
+    std::vector<node> lowLink(n, none);
+    // Last visited child during the dfs.
+    std::vector<node> lastVisited(n, none);
+
+    count curDepth = 0, visitedNodes = 0;
+    componentIndex = 0;
+
+    std::stack<std::pair<node, Graph::NeighborIterator>> dfsStack;
+
+    // Set the depth of node v and push it onto the stacks.
+    auto visit = [&](const node v) -> void {
+        depth[v] = curDepth;
+        lowLink[v] = curDepth;
+        ++curDepth;
+        stack.emplace_back(v);
+        onStack[v] = 1;
+        dfsStack.push({v, G->neighborRange(v).begin()});
+    };
+
+    auto strongConnect = [&](const node u) -> void {
+        visit(u);
+
+        do {
+            const auto v = dfsStack.top().first;
+            if (lastVisited[v] != none) {
+                lowLink[v] = std::min(lowLink[v], lowLink[lastVisited[v]]);
+                lastVisited[v] = none;
+            }
+
+            // Iter points to the first neighbor of v, or to the last visited dfs child of v.
+            auto &iter = dfsStack.top().second;
+
+            // Iterate over the neighbors of v from either the first, or the last visited one.
+            for (; iter != G->neighborRange(v).end(); ++iter) {
+                const auto w = *iter;
+
+                // w not visited yet, visit it and continue the exploration from w.
+                if (depth[w] == none) {
+                    visit(w);
+                    lastVisited[v] = w;
+                    break;
+                }
+                // w already visited, if it is on the stack is part of the same component.
+                if (onStack[w] && depth[w] < lowLink[v]) {
+                    lowLink[v] = depth[w];
+                }
+            }
+
+            // Check if all neighbors of v have been visited.
+            if (iter == G->neighborRange(v).end()) {
+                // All neighbors of v have been visited, pop v.
+                dfsStack.pop();
+
+                // v is a root node, generate new component.
+                if (lowLink[v] == depth[v]) {
+
+                    const auto stackSize = stack.size();
+                    node w = none;
+                    do {
+                        w = stack.back();
+                        stack.pop_back();
+                        onStack[w] = 0;
+                        component[w] = componentIndex;
+                    } while (w != v);
+
+                    ++componentIndex;
+                    visitedNodes += (stackSize - stack.size());
+                }
+            }
+        } while (!dfsStack.empty());
+    };
+
+    for (node u = 0; u < n; ++u) {
+        if (depth[u] != none)
+            continue;
+        strongConnect(u);
+        // Check if all nodes have been assigned to a component.
+        if (visitedNodes == G->numberOfNodes())
+            break;
+    }
+
+    hasRun = true;
 }
 
 void StronglyConnectedComponents::runRecursively() {
     count z = G->upperNodeIdBound();
-    component = Partition(z);
+    Partition partition(z);
 
     index nextIndex = 0;
     std::vector<index> nodeIndex(z, none);
@@ -56,7 +160,7 @@ void StronglyConnectedComponents::runRecursively() {
         });
 
         if (nodeLowLink[v] == nodeIndex[v]) {
-            component.toSingleton(v);
+            partition.toSingleton(v);
             while (true) {
                 node w = stx.top();
                 stx.pop();
@@ -64,7 +168,7 @@ void StronglyConnectedComponents::runRecursively() {
                 if (w == v) {
                     break;
                 }
-                component[w] = component[v];
+                partition[w] = partition[v];
             }
         }
     };
@@ -74,107 +178,16 @@ void StronglyConnectedComponents::runRecursively() {
             strongConnect(v);
         }
     });
+
+    component.clear();
+    component.resize(z, none);
+    partition.forEntries([&](const node u, const index i) { component[u] = i; });
+
+    hasRun = true;
 }
 
 void StronglyConnectedComponents::runIteratively() {
-    count z = G->upperNodeIdBound();
-    component = Partition(z);
-
-    index nextIndex = 0;
-    struct node_info {
-        index i, lowLink;
-    };
-    std::vector<node_info> nodes(z, node_info {none, none});
-    std::vector<node> stx {};
-    stx.reserve(z);
-    std::vector<bool> onStack(z, false);
-    using state_type = typename std::tuple<node, node, int>;
-    using container_type = typename std::vector<state_type>;
-    //std::stack<state_type, container_type> dfss {};
-    //
-    // For performance tests: reserve enough memory to prevent online resizing
-    // of dfss (memory-intensive operation!). Does not work easily with
-    // std:stack wrapper, hence using std::vector directly.
-    container_type dfss {};
-    dfss.reserve(z);
-    //auto max_stack_size = dfss.size();
-
-    G->forNodes([&](node _v) {
-        if (nodes[_v].i != none)
-            return;
-        DEBUG("DFS init: dfss.emplace(", _v, ", none, -1)");
-        dfss.emplace_back(_v, none, -1L);
-        while (!dfss.empty()) {
-            //if (dfss.size() > max_stack_size)
-            //	max_stack_size = dfss.size();
-            node u, pred;
-            int j;
-            std::tie(u, pred, j) = dfss.back();
-            DEBUG("(u=", u, ", pred=", pred, ", j=", j, ") = dfss.top()");
-            dfss.pop_back();
-            if (j == -1) {
-                DEBUG("* new DFS branch at node u=", u, " (pred=", pred, "), index=", nextIndex);
-                nodes[u].i = nextIndex;
-                nodes[u].lowLink = nextIndex;
-                nextIndex++;
-                stx.push_back(u);
-                onStack[u] = true;
-                j = G->degreeOut(u);
-                DEBUG("j <- ", j, ", nextIndex=", nextIndex);
-            }
-            if (j == 0) {
-                DEBUG("< backtracking at u=", u, " (pred=", pred, ")");
-                if (nodes[u].lowLink == nodes[u].i) {
-                    component.toSingleton(u);
-                    node w = none;
-                    do {
-                        w = stx.back();
-                        stx.pop_back();
-                        DEBUG(" - ", w, " <- stx.pop()");
-                        onStack[w] = false;
-                        component[w] = component[u];
-                    } while (u != w);
-                }
-                if (pred != none) {
-                    DEBUG("  ", pred, " -> ", u, ": testing pred lowlink (lowlink[pred]=", nodes[pred].lowLink, ", lowlink[u]=", nodes[u].lowLink, ")");
-                    nodes[pred].lowLink = std::min(nodes[pred].lowLink, nodes[u].lowLink);
-                }
-            } else {
-                dfss.emplace_back(u, pred, j-1);
-                // getIthNeighbor() is not part of the public API; hacked in
-                // manually to allow constant-time lookup of the i-th neighbor
-                // (see networkit/cpp/graph/Graph.h)
-                // Note: Neighbors in reverse order compared to original impl
-                auto v = G->getIthNeighbor<true>(u, j-1);
-                // Unoptimised version that works with the public API only:
-                //auto v = G.neighbors(u)[G.degreeOut(u)-j];
-                if (v == none) {
-                    throw std::runtime_error("StronglyConnectedComponents::runIteratively(): unexpected value 'none' for neighbor, try the recursive implementation");
-                }
-                if (nodes[v].i == none) {
-                    DEBUG("  ", u, " -> ", v, ": descending (current pred=", pred, ")");
-                    dfss.emplace_back(v, u, -1L);
-                } else if (onStack[v]) {
-                    DEBUG("  ", u, " -> ", v, ": testing lowlink (lowlink=", nodes[u].lowLink, ", index at arc head is ", nodes[v].i, ")");
-                    nodes[u].lowLink = std::min(nodes[u].lowLink, nodes[v].i);
-                }
-            }
-        }
-    });
-    //DEBUG("max_stack_size = ", max_stack_size, ", node count = ", z);
+    run();
 }
 
-Partition StronglyConnectedComponents::getPartition() {
-    return this->component;
-}
-
-count StronglyConnectedComponents::numberOfComponents() {
-    return this->component.numberOfSubsets();
-}
-
-count StronglyConnectedComponents::componentOfNode(node u) {
-    assert (component[u] != none);
-    return component[u];
-}
-
-}
+} // namespace NetworKit

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -434,6 +434,22 @@ class TestSelfLoops(unittest.TestCase):
 		for i in range(G.numberOfNodes()):
 			self.assertEqual(G2.hasNode(i), (4 <= i <= 9))
 
+	def test_components_StronglyConnectedComponents(self):
+		g = nk.readGraph("input/MIT8.edgelist",
+				nk.Format.EdgeList, separator='\t', firstNode=0, continuous=False, directed=True)
+		scc = nk.components.StronglyConnectedComponents(g)
+		scc.run()
+		self.assertNotEqual(scc.componentOfNode(0), None)
+		nComponents = scc.numberOfComponents()
+		compSizes = scc.getComponentSizes()
+		self.assertEqual(nComponents, len(compSizes))
+
+		comps = scc.getComponents()
+		for idx, size in compSizes.items():
+			self.assertEqual(len(comps[idx]), size)
+
+		_=scc.getPartition()
+
 	def testComponentsBiconnectedComponents(self):
 		bcc = nk.components.BiconnectedComponents(self.LL)
 		bcc.run()

--- a/notebooks/Components.ipynb
+++ b/notebooks/Components.ipynb
@@ -227,7 +227,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A [StronglyConnectedComponent(G, iterativeAlgo=True)](https://networkit.github.io/dev-docs/python_api/components.html?highlight=strongly#networkit.components.StronglyConnectedComponents) of a directed graph G is a maximal strongly connected subgraph. A directed graph is strongly connected if there is a path between all pairs of vertices in the graph. The constructor expects a directed [networkit.Graph](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=graph#networkit.Graph) as a mandatory parameter. The parameter `iterativeAlgo` specifies which implementation to use; either iterative or recursive. By default the iterative implementation is used. Set `iterativeAlgo` to false to use the recursive implementation."
+    "A [StronglyConnectedComponent(G)](https://networkit.github.io/dev-docs/python_api/components.html?highlight=strongly#networkit.components.StronglyConnectedComponents) of a directed graph G is a maximal strongly connected subgraph. A directed graph is strongly connected if there is a path between all pairs of vertices in the graph. The constructor expects a directed [networkit.Graph](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=graph#networkit.Graph) as a mandatory parameter."
    ]
   },
   {
@@ -246,8 +246,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use recursive implementaion\n",
-    "scc = nk.components.StronglyConnectedComponents(G, iterativeAlgo=False)"
+    "scc = nk.components.StronglyConnectedComponents(G)"
    ]
   },
   {
@@ -257,7 +256,7 @@
    "outputs": [],
    "source": [
     "#Run recursively\n",
-    "scc.runRecursively()\n",
+    "scc.run()\n",
     "print(\"number of components: \", scc.numberOfComponents())"
    ]
   },
@@ -293,7 +292,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR brings a cleaner implementation of Tarjan's algorithm for strongly connected components.
It also removes the deprecated method `getIthNeighbor` in Graph that was designed specifically for StronglyConnectedComponents to return the (deg(v) - i)-th neighbor of a node v (using neighbor iterators this operation is not needed anymore).

Furthermore, it includes more extensive C++ tests, and basic Python tests.