### PR TITLE
Refactor components module

### DIFF
--- a/include/networkit/components/BiconnectedComponents.hpp
+++ b/include/networkit/components/BiconnectedComponents.hpp
@@ -65,7 +65,7 @@ private:
   void init();
   void newComponent(std::pair<node, node> e);
 
-  const Graph &G;
+  const Graph *G;
   count n;
   count idx;
   count nComp;

--- a/include/networkit/components/ConnectedComponents.hpp
+++ b/include/networkit/components/ConnectedComponents.hpp
@@ -22,7 +22,7 @@ namespace NetworKit {
  * @ingroup components
  * Determines the connected components of an undirected graph.
  */
-class ConnectedComponents : public Algorithm {
+class ConnectedComponents final : public Algorithm {
 public:
     /**
      * Create ConnectedComponents class for Graph @a G.
@@ -78,7 +78,7 @@ public:
     static Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph = false);
 
 private:
-    const Graph& G;
+    const Graph* G;
     Partition component;
     count numComponents;
 };

--- a/include/networkit/components/DynConnectedComponents.hpp
+++ b/include/networkit/components/DynConnectedComponents.hpp
@@ -23,7 +23,7 @@ namespace NetworKit {
     * @ingroup components
     * Determines and updates the connected components of an undirected graph.
     */
-    class DynConnectedComponents : public Algorithm, public DynAlgorithm {
+    class DynConnectedComponents final : public Algorithm, public DynAlgorithm {
 
     public:
         /**
@@ -95,7 +95,7 @@ namespace NetworKit {
         std::pair<bool, edgeid> updateMapAfterAddition(node u, node v);
         void init();
         std::pair<node, node> makePair(node u, node v);
-        const Graph& G;
+        const Graph* G;
         std::vector<bool> isTree;
         std::vector<index> components;
         std::map<index, count> compSize;
@@ -106,7 +106,7 @@ namespace NetworKit {
     };
 
     inline count DynConnectedComponents::componentOfNode(node u) {
-        assert(u <= G.upperNodeIdBound());
+        assert(u <= G->upperNodeIdBound());
         assert (components[u] != none);
         assureFinished();
         return components[u];

--- a/include/networkit/components/DynWeaklyConnectedComponents.hpp
+++ b/include/networkit/components/DynWeaklyConnectedComponents.hpp
@@ -23,7 +23,7 @@ namespace NetworKit {
     * Determines and updates the weakly connected components of a directed
     * graph.
     */
-    class DynWeaklyConnectedComponents : public Algorithm, public DynAlgorithm {
+    class DynWeaklyConnectedComponents final : public Algorithm, public DynAlgorithm {
 
     public:
         /**
@@ -107,7 +107,7 @@ namespace NetworKit {
         std::pair<node, node> makePair(node u, node v);
 
         // Pointer to the graph
-        const Graph& G;
+        const Graph* G;
 
         // This vector associates each node to a component
         std::vector<index> components;

--- a/include/networkit/components/ParallelConnectedComponents.hpp
+++ b/include/networkit/components/ParallelConnectedComponents.hpp
@@ -18,7 +18,7 @@ namespace NetworKit {
  * @ingroup components
  * Determines the connected components of an undirected graph.
  */
-class ParallelConnectedComponents : public Algorithm {
+class ParallelConnectedComponents final : public Algorithm {
 public:
 
     /**
@@ -39,7 +39,7 @@ public:
     /**
      * This method determines the connected components for the graph g.
      */
-    void run();
+    void run() override;
 
     /**
      * This method returns the number of connected components.
@@ -61,7 +61,7 @@ public:
 
 
 private:
-    const Graph& G;
+    const Graph* G;
     Partition component;
     bool coarsening;
 };

--- a/include/networkit/components/RandomSpanningForest.hpp
+++ b/include/networkit/components/RandomSpanningForest.hpp
@@ -18,17 +18,17 @@ namespace NetworKit {
  * Time complexity: cover time of G.
  * @ingroup graph
  */
-class RandomSpanningForest: public SpanningForest {
+class RandomSpanningForest final : public SpanningForest {
 public:
     RandomSpanningForest(const Graph& G);
-    virtual ~RandomSpanningForest() = default;
+    ~RandomSpanningForest() = default;
 
     /**
      * Computes for each component a random spanning tree.
      * Uses simple random-walk based algorithm.
      * Time complexity: cover time of G.
      */
-    virtual void run() override;
+    void run() override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/components/StronglyConnectedComponents.hpp
+++ b/include/networkit/components/StronglyConnectedComponents.hpp
@@ -59,7 +59,7 @@ public:
 
 
 private:
-    const Graph& G;
+    const Graph* G;
     bool iterativeAlgo;
     Partition component;
 };

--- a/networkit/cpp/components/BiconnectedComponents.cpp
+++ b/networkit/cpp/components/BiconnectedComponents.cpp
@@ -12,7 +12,7 @@
 
 namespace NetworKit {
 
-BiconnectedComponents::BiconnectedComponents(const Graph &G) : G(G) {
+BiconnectedComponents::BiconnectedComponents(const Graph &G) : G(&G) {
   if (G.isDirected()) {
     throw std::runtime_error(
         "Error, biconnected components cannot be computed on directed graphs.");
@@ -20,7 +20,7 @@ BiconnectedComponents::BiconnectedComponents(const Graph &G) : G(G) {
 }
 
 void BiconnectedComponents::init() {
-  n = G.numberOfNodes();
+  n = G->numberOfNodes();
   idx = 0;
   nComp = 0;
   level.assign(n, 0);
@@ -45,13 +45,13 @@ void BiconnectedComponents::run() {
 
   std::stack<std::pair<node, Graph::NeighborIterator>> stack;
   std::vector<std::pair<node, node>> edgeStack;
-  G.forNodes([&](node v) {
+  G->forNodes([&](node v) {
     if (visited[v]) {
       return;
     }
 
     isRoot[v] = true;
-    stack.push(std::make_pair(v, G.neighborRange(v).begin()));
+    stack.push(std::make_pair(v, G->neighborRange(v).begin()));
 
     do {
       node u = stack.top().first;
@@ -60,12 +60,12 @@ void BiconnectedComponents::run() {
         visitNode(u);
       }
 
-      for (; iter != G.neighborRange(u).end(); ++iter) {
+      for (; iter != G->neighborRange(u).end(); ++iter) {
         node neighbor = *iter;
         if (!visited[neighbor]) {
           visitNode(neighbor);
           parent[neighbor] = u;
-          stack.push(std::make_pair(neighbor, G.neighborRange(neighbor).begin()));
+          stack.push(std::make_pair(neighbor, G->neighborRange(neighbor).begin()));
           edgeStack.push_back(std::make_pair(u, neighbor));
           break;
         } else if (neighbor != parent[u] && level[neighbor] < level[u]) {
@@ -74,7 +74,7 @@ void BiconnectedComponents::run() {
         }
       }
 
-      if (iter == G.neighborRange(u).end()) {
+      if (iter == G->neighborRange(u).end()) {
         stack.pop();
 
         if (isRoot[u]) {

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -15,7 +15,7 @@
 
 namespace NetworKit {
 
-ConnectedComponents::ConnectedComponents(const Graph& G) : G(G) {
+ConnectedComponents::ConnectedComponents(const Graph& G) : G(&G) {
     if (G.isDirected()) {
         throw std::runtime_error("Error, connected components of directed graphs cannot be computed, use StronglyConnectedComponents for them.");
     }
@@ -23,13 +23,13 @@ ConnectedComponents::ConnectedComponents(const Graph& G) : G(G) {
 
 void ConnectedComponents::run() {
     DEBUG("initializing labels");
-    component = Partition(G.upperNodeIdBound(), none);
+    component = Partition(G->upperNodeIdBound(), none);
     numComponents = 0;
 
     std::queue<node> q;
 
     // perform breadth-first searches
-    G.forNodes([&](node u) {
+    G->forNodes([&](node u) {
         if (component[u] == none) {
             component.setUpperBound(numComponents+1);
             index c = numComponents;
@@ -41,7 +41,7 @@ void ConnectedComponents::run() {
                 node u = q.front();
                 q.pop();
                 // enqueue neighbors, set component
-                G.forNeighborsOf(u, [&](node v) {
+                G->forNeighborsOf(u, [&](node v) {
                     if (component[v] == none) {
                         q.push(v);
                         component[v] = c;
@@ -69,7 +69,7 @@ std::vector<std::vector<node> > ConnectedComponents::getComponents() const {
     // transform partition into vector of unordered_set
     std::vector<std::vector<node> > result(numComponents);
 
-    G.forNodes([&](node u) {
+    G->forNodes([&](node u) {
         result[component[u]].push_back(u);
     });
 

--- a/networkit/cpp/components/DynConnectedComponents.cpp
+++ b/networkit/cpp/components/DynConnectedComponents.cpp
@@ -10,7 +10,7 @@
 namespace NetworKit {
 
     DynConnectedComponents::DynConnectedComponents(const Graph& G) :
-    G(G) {
+    G(&G) {
         if (G.isDirected()) {
             throw std::runtime_error("Error, connected components of directed graphs cannot be computed, use StronglyConnectedComponents instead.");
         }
@@ -20,8 +20,8 @@ namespace NetworKit {
     void DynConnectedComponents::init() {
         edgesMap.clear();
         compSize.clear();
-        components.assign(G.upperNodeIdBound(), none);
-        tmpDistances.assign(G.upperNodeIdBound(), none);
+        components.assign(G->upperNodeIdBound(), none);
+        tmpDistances.assign(G->upperNodeIdBound(), none);
         indexEdges();
         isTree.assign(edgesMap.size(), false);
         hasRun = false;
@@ -33,7 +33,7 @@ namespace NetworKit {
         std::queue<node> q;
 
         // Perform breadth-first searches
-        G.forNodes([&](node u) {
+        G->forNodes([&](node u) {
             if (components[u] == none) {
                 index c = compSize.size();
                 q.push(u);
@@ -43,7 +43,7 @@ namespace NetworKit {
                 do {
                     node u = q.front();
                     q.pop();
-                    G.forNeighborsOf(u, [&](node v) {
+                    G->forNeighborsOf(u, [&](node v) {
                         if (components[v] == none) {
                             q.push(v);
                             components[v] = c;
@@ -63,7 +63,7 @@ namespace NetworKit {
 
     void DynConnectedComponents::indexEdges() {
         edgeid eid = 0;
-        G.forEdges([&](node u, node v) {
+        G->forEdges([&](node u, node v) {
             if (edgesMap.find(makePair(u, v)) == edgesMap.end()) {
                 insertEdgeIntoMap(u, v, eid);
                 ++eid;
@@ -132,7 +132,7 @@ namespace NetworKit {
 
         // In the other case, we can merge the two components in an undirected
         // graph merge components
-        G.parallelForNodes([&](node w) {
+        G->parallelForNodes([&](node w) {
             if (components[w] == maxComp) {
                 components[w] = minComp;
             }
@@ -182,7 +182,7 @@ namespace NetworKit {
             count d = tmpDistances[s] + 1;
 
             // Enqueue not visited neighbors
-            G.forNeighborsOf(s, [&](node w) {
+            G->forNeighborsOf(s, [&](node w) {
                 if (!connected) {
                     if (tmpDistances[w] == none) {
                         tmpDistances[w] = d;
@@ -229,7 +229,7 @@ namespace NetworKit {
             q.pop();
 
             bool nextEdgeFound = false;
-            G.forNeighborsOf(s, [&](node w) {
+            G->forNeighborsOf(s, [&](node w) {
                 if (!nextEdgeFound) {
 
                     if (w == u) {
@@ -282,7 +282,7 @@ namespace NetworKit {
             }
         }
 
-        G.forNodes([&](node u) {
+        G->forNodes([&](node u) {
             result[compIndex.find(components[u])->second].push_back(u);
         });
 

--- a/networkit/cpp/components/StronglyConnectedComponents.cpp
+++ b/networkit/cpp/components/StronglyConnectedComponents.cpp
@@ -18,7 +18,7 @@
 
 namespace NetworKit {
 
-StronglyConnectedComponents::StronglyConnectedComponents(const Graph& G, bool iterativeAlgo) : G(G), iterativeAlgo(iterativeAlgo) {
+StronglyConnectedComponents::StronglyConnectedComponents(const Graph& G, bool iterativeAlgo) : G(&G), iterativeAlgo(iterativeAlgo) {
 
 }
 
@@ -31,7 +31,7 @@ void StronglyConnectedComponents::run() {
 }
 
 void StronglyConnectedComponents::runRecursively() {
-    count z = G.upperNodeIdBound();
+    count z = G->upperNodeIdBound();
     component = Partition(z);
 
     index nextIndex = 0;
@@ -46,7 +46,7 @@ void StronglyConnectedComponents::runRecursively() {
         stx.push(v);
         onStack[v] = true;
 
-        G.forNeighborsOf(v, [&](node w) {
+        G->forNeighborsOf(v, [&](node w) {
             if (nodeIndex[w] == none) {
                 strongConnect(w);
                 nodeLowLink[v] = std::min(nodeLowLink[v], nodeLowLink[w]);
@@ -69,7 +69,7 @@ void StronglyConnectedComponents::runRecursively() {
         }
     };
 
-    G.forNodes([&](node v) {
+    G->forNodes([&](node v) {
         if (nodeIndex[v] == none) {
             strongConnect(v);
         }
@@ -77,7 +77,7 @@ void StronglyConnectedComponents::runRecursively() {
 }
 
 void StronglyConnectedComponents::runIteratively() {
-    count z = G.upperNodeIdBound();
+    count z = G->upperNodeIdBound();
     component = Partition(z);
 
     index nextIndex = 0;
@@ -99,7 +99,7 @@ void StronglyConnectedComponents::runIteratively() {
     dfss.reserve(z);
     //auto max_stack_size = dfss.size();
 
-    G.forNodes([&](node _v) {
+    G->forNodes([&](node _v) {
         if (nodes[_v].i != none)
             return;
         DEBUG("DFS init: dfss.emplace(", _v, ", none, -1)");
@@ -119,7 +119,7 @@ void StronglyConnectedComponents::runIteratively() {
                 nextIndex++;
                 stx.push_back(u);
                 onStack[u] = true;
-                j = G.degreeOut(u);
+                j = G->degreeOut(u);
                 DEBUG("j <- ", j, ", nextIndex=", nextIndex);
             }
             if (j == 0) {
@@ -145,7 +145,7 @@ void StronglyConnectedComponents::runIteratively() {
                 // manually to allow constant-time lookup of the i-th neighbor
                 // (see networkit/cpp/graph/Graph.h)
                 // Note: Neighbors in reverse order compared to original impl
-                auto v = G.getIthNeighbor<true>(u, j-1);
+                auto v = G->getIthNeighbor<true>(u, j-1);
                 // Unoptimised version that works with the public API only:
                 //auto v = G.neighbors(u)[G.degreeOut(u)-j];
                 if (v == none) {


### PR DESCRIPTION
This PR brings some improvements to the C++ code of the components module. The changes include:
 - All classes that are not inherited from are made final.
- The `virtual` keyword is removed from any non-base classes.
- All __member__ variables are changed from references to pointers. The point of this is to make classes assignable.
- The `override` keyword is added to functions accordingly.