### PR TITLE
Add GraphTools to Graph Notebook and update other notebooks

### DIFF
--- a/notebooks/Distance.ipynb
+++ b/notebooks/Distance.ipynb
@@ -39,7 +39,7 @@
     "# Read a graph\n",
     "G = nk.readGraph(\"../input/foodweb-baydry.konect\", nk.Format.KONECT)\n",
     "GDir = G\n",
-    "G = G.toUndirected()\n",
+    "G = nk.graphtools.toUndirected(G)\n",
     "source = 0\n",
     "target = 27\n",
     "G.indexEdges()"
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "GUnweighted = GDir.toUnweighted()"
+    "GUnweighted = nk.graphtools.toUnweighted(GDir)"
    ]
   },
   {

--- a/notebooks/GraphNotebook.ipynb
+++ b/notebooks/GraphNotebook.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook we will cover the most important things on the `Networkit.Graph`, the central class in in Networkit, to get you started. The first step is to import NetworKit."
+    "In this notebook we will cover the main functionalities of `networkit.Graph`, the central class in NetworKit. The first step is to import NetworKit."
    ]
   },
   {
@@ -27,7 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We start by creating the core object, a `Networkit.Graph`. The [networkit.Graph](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=graph#networkit.Graph) constructor expects the `number of nodes` as an unsigned integer, a Boolean value stating if the graph is weighted or not followed by another Boolean value stating the directedness of the graph. The latter two are set to false by default. If the graph is unweighted, all edge weights are set to `1.0`."
+    "We start by creating the core object, a `networkit.Graph`. The [networkit.Graph](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=graph#networkit.Graph) constructor expects the `number of nodes` as an integer, a boolean value stating if the graph is weighted or not followed by another boolean value stating whether the graph is directed or not. The latter two are set to false by default. If the graph is unweighted, all edge weights are set to `1.0`."
    ]
   },
   {
@@ -37,10 +37,8 @@
    "outputs": [],
    "source": [
     "G = nk.Graph(5)\n",
-    "print(G.numberOfNodes())\n",
-    "print(G.numberOfEdges())\n",
-    "print(G.isDirected())\n",
-    "print(G.isDirected())"
+    "print(G.numberOfNodes(), G.numberOfEdges())\n",
+    "print(G.isWeighted(), G.isDirected())"
    ]
   },
   {
@@ -56,19 +54,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G.addEdge(1,3)\n",
-    "G.addEdge(2,4)\n",
-    "G.addEdge(1,2)\n",
-    "G.addEdge(3,4)\n",
-    "G.addEdge(2,3)\n",
-    "G.addEdge(4,0)"
+    "G.addEdge(1, 3)\n",
+    "G.addEdge(2, 4)\n",
+    "G.addEdge(1, 2)\n",
+    "G.addEdge(3, 4)\n",
+    "G.addEdge(2, 3)\n",
+    "G.addEdge(4, 0)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Node IDs in NetworKit are integer indices that start at 0 through to `G.upperNodeIdBound()`-1. Hence, `G.addEdge(*,5)` is an illegal operation in NetworKit. The same goes for edge IDs. If we need to, for example, add an edge betwen node 0 and node 5, we first need to add a sixth node to the graph using `G.addNode()`."
+    "Node IDs in NetworKit are integer indices that start at 0 through to `G.upperNodeIdBound() - 1`. Hence, for this graph `G.addEdge(1,5)` would an illegal operation as node `5` does not exist. The same goes for edge IDs. If we need to add an edge between node 0 and node 5, we first need to add a sixth node to the graph using `G.addNode()`."
    ]
   },
   {
@@ -85,7 +83,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hereafter, we can add the new edge."
+    "Now we can add the new edge."
    ]
   },
   {
@@ -101,7 +99,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the method [overview(G)](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=overview#networkit.overview), we can take a look at the graph we have created so far."
+    "Using the method [overview(G)](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=overview#networkit.overview), we can take a look at the main properties of the graph we have created."
    ]
   },
   {
@@ -117,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have created a graph we can start to play around with it. Say we want to remove the node with the node ID 2, so the third node, from `G`, we can easily do so using [Graph.removeNode(node u)](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=remove%20node#networkit.graph.Graph.removeNode). "
+    "Now that we have created a graph we can start to play around with it. Say we want to remove the node with the node ID 2, so the third node. We can easily do so using [Graph.removeNode(node u)](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=remove%20node#networkit.graph.Graph.removeNode). "
    ]
   },
   {
@@ -135,7 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Check if it's really gone\n",
+    "# 2 has been deleted\n",
     "print(G.hasNode(2))"
    ]
   },
@@ -152,9 +150,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#restore node with ID 2\n",
+    "# Restore node with ID 2\n",
     "G.restoreNode(2)\n",
-    "#Check if it is back in G\n",
+    "\n",
+    "# Check if it is back in G\n",
     "print(G.hasNode(2))"
    ]
   },
@@ -162,23 +161,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In case, you permanently want to delete a node, and remap the node IDs so as to have continues IDs, Networkit provides functions from the [GraphTools](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=graph%20tools#networkit.graph.GraphTools) module that do just that."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "newGraph = nk.graphtools.getCompactedGraph(G, nk.graphtools.getContinuousNodeIds(G))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Networkit provides a few special itertors that enable iterating over all nodes or edges in a simple manner. These iterators accept callback functions that are passed to the iterators as parameters. More information can be found in the Networkit documentation [here](https://networkit.github.io/dev-docs/python_api/graph.html). Let's start by using the [forNodes](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=fornodes#networkit.graph.Graph.forNodes) iterator. It expects a callback function which accepts one parameter, i.e., a node. Firstly, we define such a function."
+    "NetworKit provides iterators that enable iterating over all nodes or edges in a simple manner. These iterators accept callback functions that are passed to the iterators as parameters. More information can be found in the NetworKit documentation [here](https://networkit.github.io/dev-docs/python_api/graph.html). Let's start by using the [forNodes](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=fornodes#networkit.graph.Graph.forNodes) iterator. It expects a callback function which accepts one parameter, i.e., a node. First, we define such a function."
    ]
   },
   {
@@ -208,6 +191,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The same can be achieved using a lambda function\n",
+    "G.forNodes(lambda u: print(\"Node id\", u))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -220,8 +213,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First define callback function\n",
-    "# To iterate over edges it must accept 4 parameters\n",
+    "# First define callback function,\n",
+    "# to iterate over the edges it must accept 4 parameters\n",
     "def edgeFunc(u, v, weight, edgeId):\n",
     "    print(\"Edge from {} to {} has weight {} and id {}\".format(u, v, weight, edgeId))"
    ]
@@ -239,7 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Using iterator with callback function\n",
+    "# Using iterator with callback function.\n",
     "G.forEdges(edgeFunc)"
    ]
   },
@@ -247,7 +240,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Although we did not add any indexes to our edges, our edges all have indexes of 0. This is because Networkit by default indexes all edges with 0. However, sometimes it makes sense to have indexed edges. If you decide to index the edges of your graph after creating it, you can use the [Graph.indexEdges(bool force = False)](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=indexedges#networkit.graph.Graph.indexEdges) method. The `force` parameter forces re-indexing of edges if they had already been indexed."
+    "Although we did not add any indexes to our edges, our edges all have indexes of 0. This is because NetworKit by default indexes all edges with 0. However, sometimes it makes sense to have indexed edges. If you decide to index the edges of your graph after creating it, you can use the [Graph.indexEdges(bool force = False)](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=indexedges#networkit.graph.Graph.indexEdges) method. The `force` parameter forces re-indexing of edges if they had already been indexed."
    ]
   },
   {
@@ -270,7 +263,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sometimes you also need to iterate over specific edges, for example all nodes' edges. This calls for nested iterations. Using an ordinary for loop and the [forEdgesOf](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=foredges#networkit.graph.Graph.forEdges) iterator we can do so."
+    "Sometimes you also need to iterate over specific edges, for example the ones connecting a node `u` to its neighbors. Using the [forNodes](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=foredges#networkit.graph.Graph.forNodes) iterator and the [forEdgesOf](https://networkit.github.io/dev-docs/python_api/graph.html?highlight=foredges#networkit.graph.Graph.forEdges) iterator we can do so."
    ]
   },
   {
@@ -279,8 +272,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i in range ((G.upperNodeIdBound())-1):\n",
-    "    G.forEdgesOf(i, edgeFunc)"
+    "G.forNodes(lambda u: G.forEdgesOf(u, edgeFunc))"
    ]
   },
   {
@@ -301,14 +293,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Some useful methods that give information on graphs or change graphs are implemented in `networkit.graphtools`. The following section demonstrates some of the GraphTools functionalities."
+    "`networkit.graphtools` implements some useful functions to get information or modify graphs. The following section shows some of the GraphTools functionalities."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The function `toWeighted(G)` takes an unweighted graph `G` as input, and returns a weighted copy of `G`. All the edge weights are set to a default weight of 1.0."
+    "`toWeighted(G)` takes an unweighted graph `G` as input, and returns a weighted copy of `G`. All the edge weights are set to a default value of 1.0."
    ]
   },
   {
@@ -319,21 +311,22 @@
    "source": [
     "weightedG = nk.graphtools.toWeighted(G)\n",
     "assert(weightedG.numberOfNodes() == G.numberOfNodes())\n",
-    "assert(weightedG.numberOfEdges() == G.numberOfEdges())"
+    "assert(weightedG.numberOfEdges() == G.numberOfEdges())\n",
+    "assert(weightedG.isWeighted())"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The function `toUnweighted(G)` does the inverse of the one above: it takes a weighted graph `G` as input, and returns an unweighted copy of `G` as output."
+    "`toUnweighted(G)` does the inverse of the one above: it takes a weighted graph `G` as input, and returns an unweighted copy of `G` as output."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The function`randomNeighbor(G, u)` returns a random neighbor of node `u` in the graph `G`."
+    "`randomNode(G)` returns a node of `G` selected uniformly at random."
    ]
   },
   {
@@ -342,8 +335,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "random = nk.graphtools.randomNeighbor(G, 0)\n",
-    "print(random)"
+    "nk.graphtools.randomNode(G)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`randomNeighbor(G, u)` returns a random (out) neighbor of node `u` in the graph `G`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nk.graphtools.randomNeighbor(G, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`randomEdge(G, uniformDistribution=False)` returns a random edge of graph `G`. If `uniformDistribution` is set to `True`, the edge is selected uniformly at random."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nk.graphtools.randomEdge(G, True)"
    ]
   },
   {
@@ -397,6 +421,29 @@
     "assert(compGraph.numberOfNodes() == G.numberOfNodes())\n",
     "assert(compGraph.numberOfEdges() == G.numberOfEdges())"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`maxDegree(G)` returns the highest (out) degree of `G`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nk.graphtools.maxDegree(G)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`maxInDegree(G)` returns the highest in-degree of a directed graph `G`. `maxWeightedDegree(G)` returns the highest sum of the (out) edge weights of `G`, while `maxWeightedInDegree(G)` returns the highest sum of the in-edge weights of a directed graph `G`."
+   ]
   }
  ],
  "metadata": {
@@ -415,7 +462,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/GraphNotebook.ipynb
+++ b/notebooks/GraphNotebook.ipynb
@@ -38,7 +38,9 @@
    "source": [
     "G = nk.Graph(5)\n",
     "print(G.numberOfNodes())\n",
-    "print(G.numberOfEdges())"
+    "print(G.numberOfEdges())\n",
+    "print(G.isDirected())\n",
+    "print(G.isDirected())"
    ]
   },
   {
@@ -287,6 +289,114 @@
    "source": [
     "Note, in an undirected graph, like we have here, the [forEdgesOf](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=foredgesof#networkit.Graph.forEdgesOf) iterator returns all edges of a node. When dealing with a directed graph only the out edges are returned. The rest of the edges can be accessed using the [forInEdgesOf](https://networkit.github.io/dev-docs/python_api/networkit.html?highlight=forinedges#networkit.Graph.forInEdgesOf) iterator."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GraphTools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some useful methods that give information on graphs or change graphs are implemented in `networkit.graphtools`. The following section demonstrates some of the GraphTools functionalities."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function `toWeighted(G)` takes an unweighted graph `G` as input, and returns a weighted copy of `G`. All the edge weights are set to a default weight of 1.0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weightedG = nk.graphtools.toWeighted(G)\n",
+    "assert(weightedG.numberOfNodes() == G.numberOfNodes())\n",
+    "assert(weightedG.numberOfEdges() == G.numberOfEdges())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function `toUnweighted(G)` does the inverse of the one above: it takes a weighted graph `G` as input, and returns an unweighted copy of `G` as output."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function`randomNeighbor(G, u)` returns a random neighbor of node `u` in the graph `G`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "random = nk.graphtools.randomNeighbor(G, 0)\n",
+    "print(random)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sometimes it makes sense to compact the graph, e.g., after deleting nodes. The method `getCompactedGraph(G, nodeIdMap)` does just that by designating continuous node ids. `nodeIdMap` maps each node id of graph `G` to their new ids.\n",
+    "\n",
+    "First, we delete a node from `G`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.removeNode(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then, we use `getContinuousNodeIds(G)` to get a map from the original nodes ids of G, to their new ids."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nodeIdMap = nk.graphtools.getContinuousNodeIds(G)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we get a new graph with compacted node ids."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compGraph = nk.graphtools.getCompactedGraph(G, nodeIdMap)\n",
+    "assert(compGraph.numberOfNodes() == G.numberOfNodes())\n",
+    "assert(compGraph.numberOfEdges() == G.numberOfEdges())"
+   ]
   }
  ],
  "metadata": {
@@ -305,7 +415,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/User-Guide.ipynb
+++ b/notebooks/User-Guide.ipynb
@@ -189,9 +189,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n = G.numberOfNodes()\n",
-    "m = G.numberOfEdges()\n",
-    "print(n, m)"
+    "print(G.numberOfNodes(), G.numberOfEdges())"
    ]
   },
   {
@@ -207,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G.hasEdge(42,11)"
+    "G.hasEdge(42, 11)"
    ]
   },
   {
@@ -223,7 +221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G.weight(42,11)"
+    "G.weight(42, 11)"
    ]
   },
   {
@@ -911,8 +909,7 @@
    "outputs": [],
    "source": [
     "ERD = nk.generators.ErdosRenyiGenerator(200, 0.2).generate()\n",
-    "print(ERD.numberOfNodes())\n",
-    "print(ERD.numberOfEdges())"
+    "print(ERD.numberOfNodes(), ERD.numberOfEdges())"
    ]
   },
   {
@@ -1100,7 +1097,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/User-Guide.ipynb
+++ b/notebooks/User-Guide.ipynb
@@ -195,31 +195,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "G.toString()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Nodes are simply integer indices, and edges are pairs of such indices."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "V = G.nodes()\n",
-    "print(V[:10])\n",
-    "E = G.edges()\n",
-    "print(E[:10])"
    ]
   },
   {
@@ -832,7 +811,7 @@
    "outputs": [],
    "source": [
     "c2 = communities.getMembers(2)\n",
-    "g2 = G.subgraphFromNodes(c2)"
+    "g2 = nk.graphtools.subgraphFromNodes(G, c2)"
    ]
   },
   {
@@ -932,7 +911,8 @@
    "outputs": [],
    "source": [
     "ERD = nk.generators.ErdosRenyiGenerator(200, 0.2).generate()\n",
-    "print(ERD.toString())"
+    "print(ERD.numberOfNodes())\n",
+    "print(ERD.numberOfEdges())"
    ]
   },
   {
@@ -1120,7 +1100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds some examples for the `GraphTools` class in the Graph notebook.
While at it, I updated the notebooks that were using the newly deprecated functions.