### PR TITLE
Refactor algebraic module

### DIFF
--- a/include/networkit/algebraic/CSRMatrix.hpp
+++ b/include/networkit/algebraic/CSRMatrix.hpp
@@ -1,5 +1,5 @@
 /*
- * CSRMatrix.h
+ * CSRMatrix.hpp
  *
  *  Created on: May 6, 2015
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
@@ -9,6 +9,7 @@
 #define NETWORKIT_ALGEBRAIC_CSR_MATRIX_HPP_
 
 #include <vector>
+
 #include <networkit/Globals.hpp>
 #include <networkit/algebraic/AlgebraicGlobals.hpp>
 #include <networkit/algebraic/Vector.hpp>
@@ -97,7 +98,7 @@ public:
      * @param zero The zero element (default is 0.0).
      * @param isSorted True, if the triplets are sorted per row. Default is false.
      */
-    CSRMatrix(count nRows, const count nCols, const std::vector<Triplet>& triplets, double zero = 0.0, bool isSorted = false);
+    CSRMatrix(count nRows, count nCols, const std::vector<Triplet>& triplets, double zero = 0.0, bool isSorted = false);
 
     /**
      * Constructs the @a nRows x @a nCols Matrix from the elements stored in @a columnIdx and @a values. @a columnIdx and @a values store the colums and values by row.
@@ -557,7 +558,7 @@ template<typename L> inline CSRMatrix CSRMatrix::binaryOperator(const CSRMatrix 
 }
 
 template<typename F>
-void CSRMatrix::apply(const F unaryElementFunction) {
+void CSRMatrix::apply(F unaryElementFunction) {
 #pragma omp parallel for
     for (omp_index k = 0; k < static_cast<omp_index>(nonZeros.size()); ++k) {
         nonZeros[k] = unaryElementFunction(nonZeros[k]);

--- a/include/networkit/algebraic/CSRMatrix.hpp
+++ b/include/networkit/algebraic/CSRMatrix.hpp
@@ -23,7 +23,7 @@ namespace NetworKit {
  * The CSRMatrix class represents a sparse matrix stored in CSR-Format (i.e. compressed sparse row).
  * If speed is important, use this CSRMatrix instead of the Matrix class.
  */
-class CSRMatrix {
+class CSRMatrix final {
 private:
     std::vector<index> rowIdx;
     std::vector<index> columnIdx;
@@ -70,7 +70,7 @@ public:
      * @param dimension Defines how many rows and columns this matrix has.
      * @param zero The zero element (default = 0.0).
      */
-    CSRMatrix(const count dimension, const double zero = 0.0);
+    CSRMatrix(count dimension, double zero = 0.0);
 
     /**
      * Constructs the CSRMatrix with size @a nRows x @a nCols.
@@ -78,7 +78,7 @@ public:
      * @param nCols Number of columns.
      * @param zero The zero element (default = 0.0).
      */
-    CSRMatrix(const count nRows, const count nCols, const double zero = 0.0);
+    CSRMatrix(count nRows, count nCols, double zero = 0.0);
 
     /**
      * Constructs the @a dimension x @a dimension Matrix from the elements at position @a positions with values @values.
@@ -87,7 +87,7 @@ public:
      * @param zero The zero element (default is 0.0).
      * @param isSorted True, if the triplets are sorted per row. Default is false.
      */
-    CSRMatrix(const count dimension, const std::vector<Triplet>& triplets, const double zero = 0.0, bool isSorted = false);
+    CSRMatrix(count dimension, const std::vector<Triplet>& triplets, double zero = 0.0, bool isSorted = false);
 
     /**
      * Constructs the @a nRows x @a nCols Matrix from the elements at position @a positions with values @values.
@@ -97,7 +97,7 @@ public:
      * @param zero The zero element (default is 0.0).
      * @param isSorted True, if the triplets are sorted per row. Default is false.
      */
-    CSRMatrix(const count nRows, const count nCols, const std::vector<Triplet>& triplets, const double zero = 0.0, bool isSorted = false);
+    CSRMatrix(count nRows, const count nCols, const std::vector<Triplet>& triplets, double zero = 0.0, bool isSorted = false);
 
     /**
      * Constructs the @a nRows x @a nCols Matrix from the elements stored in @a columnIdx and @a values. @a columnIdx and @a values store the colums and values by row.
@@ -108,7 +108,7 @@ public:
      * @param zero The zero element (default is 0.0).
      * @param isSorted True if the column indices in @a columnIdx are sorted in every row.
      */
-    CSRMatrix(const count nRows, const count nCols, const std::vector<std::vector<index>> &columnIdx, const std::vector<std::vector<double>> &values, const double zero = 0.0, bool isSorted = false);
+    CSRMatrix(count nRows, count nCols, const std::vector<std::vector<index>> &columnIdx, const std::vector<std::vector<double>> &values, double zero = 0.0, bool isSorted = false);
 
     /**
      * Constructs the @a nRows x @a nCols Matrix from the elements at position @a positions with values @values.
@@ -120,7 +120,7 @@ public:
      * @param zero The zero element (default is 0.0).
      * @param isSorted True, if the triplets are sorted per row. Default is false.
      */
-    CSRMatrix(const count nRows, const count nCols, const std::vector<index>& rowIdx, const std::vector<index>& columnIdx, const std::vector<double>& nonZeros, const double zero = 0.0, bool isSorted = false);
+    CSRMatrix(count nRows, count nCols, const std::vector<index>& rowIdx, const std::vector<index>& columnIdx, const std::vector<double>& nonZeros, double zero = 0.0, bool isSorted = false);
 
     /** Default copy constructor */
     CSRMatrix (const CSRMatrix &other) = default;
@@ -129,7 +129,7 @@ public:
     CSRMatrix (CSRMatrix &&other) = default;
 
     /** Default destructor */
-    virtual ~CSRMatrix() = default;
+    ~CSRMatrix() = default;
 
     /** Default move assignment operator */
     CSRMatrix& operator=(CSRMatrix &&other) = default;
@@ -190,7 +190,7 @@ public:
      * @param i The row index.
      * @return Number of non-zeros in row @a i.
      */
-    count nnzInRow(const index i) const;
+    count nnzInRow(index i) const;
 
     /**
      * @return Number of non-zeros in this matrix.
@@ -200,13 +200,13 @@ public:
     /**
      * @return Value at matrix position (i,j).
      */
-    double operator()(const index i, const index j) const;
+    double operator()(index i, index j) const;
 
     /**
      * Set the matrix at position (@a i, @a j) to @a value.
      * @note This operation can be linear in the number of non-zeros due to vector element movements
      */
-    void setValue(const index i, const index j, const double value);
+    void setValue(index i, index j, double value);
 
     /**
      * Sorts the column indices in each row for faster access.
@@ -221,12 +221,12 @@ public:
     /**
      * @return Row @a i of this matrix as vector.
      */
-    Vector row(const index i) const;
+    Vector row(index i) const;
 
     /**
      * @return Column @a j of this matrix as vector.
      */
-    Vector column(const index j) const;
+    Vector column(index j) const;
 
     /**
      * @return The main diagonal of this matrix.

--- a/include/networkit/algebraic/CSRMatrix.hpp
+++ b/include/networkit/algebraic/CSRMatrix.hpp
@@ -262,13 +262,13 @@ public:
      * Multiplies this matrix with a scalar specified in @a scalar and returns the result.
      * @return The result of multiplying this matrix with @a scalar.
      */
-    CSRMatrix operator*(const double &scalar) const;
+    CSRMatrix operator*(double scalar) const;
 
     /**
      * Multiplies this matrix with a scalar specified in @a scalar.
      * @return Reference to this matrix.
      */
-    CSRMatrix& operator*=(const double &scalar);
+    CSRMatrix& operator*=(double scalar);
 
     /**
      * Multiplies this matrix with @a vector and returns the result.
@@ -286,13 +286,13 @@ public:
      * Divides this matrix by a divisor specified in @a divisor and returns the result in a new matrix.
      * @return The result of dividing this matrix by @a divisor.
      */
-    CSRMatrix operator/(const double &divisor) const;
+    CSRMatrix operator/(double divisor) const;
 
     /**
      * Divides this matrix by a divisor specified in @a divisor.
      * @return Reference to this matrix.
      */
-    CSRMatrix& operator/=(const double &divisor);
+    CSRMatrix& operator/=(double divisor);
 
     /**
      * Computes @a A @a binaryOp @a B on the elements of matrix @a A and matrix @a B.

--- a/include/networkit/algebraic/DenseMatrix.hpp
+++ b/include/networkit/algebraic/DenseMatrix.hpp
@@ -179,13 +179,13 @@ public:
      * Multiplies this matrix with a scalar specified in @a scalar and returns the result.
      * @return The result of multiplying this matrix with @a scalar.
      */
-    DenseMatrix operator*(const double &scalar) const;
+    DenseMatrix operator*(double scalar) const;
 
     /**
      * Multiplies this matrix with a scalar specified in @a scalar.
      * @return Reference to this matrix.
      */
-    DenseMatrix& operator*=(const double &scalar);
+    DenseMatrix& operator*=(double scalar);
 
     /**
      * Multiplies this matrix with @a vector and returns the result.
@@ -203,13 +203,13 @@ public:
      * Divides this matrix by a divisor specified in @a divisor and returns the result in a new matrix.
      * @return The result of dividing this matrix by @a divisor.
      */
-    DenseMatrix operator/(const double &divisor) const;
+    DenseMatrix operator/(double divisor) const;
 
     /**
      * Divides this matrix by a divisor specified in @a divisor.
      * @return Reference to this matrix.
      */
-    DenseMatrix& operator/=(const double &divisor);
+    DenseMatrix& operator/=(double divisor);
 
     /**
      * Transposes this matrix and returns it.

--- a/include/networkit/algebraic/DenseMatrix.hpp
+++ b/include/networkit/algebraic/DenseMatrix.hpp
@@ -21,7 +21,7 @@ namespace NetworKit {
  * Represents a dense matrix. Use this matrix to run LU decompositions and LU solves.
  * Note that most matrices are rather sparse s.t. CSRMatrix might be a better representation.
  */
-class DenseMatrix {
+class DenseMatrix final {
 private:
     count nRows;
     count nCols;
@@ -37,7 +37,7 @@ public:
      * @param dimension Defines how many rows and columns this matrix has.
      * @param zero The zero element (default is 0.0).
      */
-    DenseMatrix(const count dimension, double zero = 0.0);
+    DenseMatrix(count dimension, double zero = 0.0);
 
     /**
      * Constructs the DenseMatrix with size @a nRows x @a nCols.
@@ -45,7 +45,7 @@ public:
      * @param nCols Number of columns.
      * @param zero The zero element (default is 0.0).
      */
-    DenseMatrix(const count nRows, const count nCols, double zero = 0.0);
+    DenseMatrix(count nRows, count nCols, double zero = 0.0);
 
     /**
      * Constructs the @a dimension x @a dimension DenseMatrix from the elements at position @a positions with values @values.
@@ -53,7 +53,7 @@ public:
      * @param triplets The nonzero elements.
      * @param zero The zero element (default is 0.0).
      */
-    DenseMatrix(const count dimension, const std::vector<Triplet>& triplets, double zero = 0.0);
+    DenseMatrix(count dimension, const std::vector<Triplet>& triplets, double zero = 0.0);
 
     /**
      * Constructs the @a nRows x @a nCols DenseMatrix from the elements at position @a positions with values @values.
@@ -62,7 +62,7 @@ public:
      * @param triplets The nonzero elements.
      * @param zero The zero element (default is 0.0).
      */
-    DenseMatrix(const count nRows, const count nCols, const std::vector<Triplet>& triplets, double zero = 0.0);
+    DenseMatrix(count nRows,count nCols, const std::vector<Triplet>& triplets, double zero = 0.0);
 
     /**
      * Constructs an instance of DenseMatrix given the number of rows (@a nRows) and the number of columns (@a nCols) and its
@@ -73,10 +73,10 @@ public:
      * @param zero The zero element (default is 0.0).
      * @note The size of the @a entries vector should be equal to @a nRows * @a nCols.
      */
-    DenseMatrix(const count nRows, const count nCols, const std::vector<double>& entries, double zero = 0.0);
+    DenseMatrix(count nRows, count nCols, const std::vector<double>& entries, double zero = 0.0);
 
     /** Default destructor */
-    virtual ~DenseMatrix() = default;
+    ~DenseMatrix() = default;
 
     /** Default copy constructor */
     DenseMatrix (const DenseMatrix &other) = default;
@@ -116,7 +116,7 @@ public:
      * @return Number of non-zeros in row @a i.
      * @note This function is linear in the number of columns of the matrix.
      */
-    count nnzInRow(const index i) const;
+    count nnzInRow(index i) const;
 
     /**
      * @return Number of non-zeros in this matrix.
@@ -127,23 +127,23 @@ public:
     /**
      * @return Value at matrix position (i,j).
      */
-    double operator()(const index i, const index j) const;
+    double operator()(index i, index j) const;
 
     /**
      * Set the matrix at position (@a i, @a j) to @a value.
      */
-    void setValue(const index i, const index j, const double value);
+    void setValue(index i, index j, double value);
 
 
     /**
      * @return Row @a i of this matrix as vector.
      */
-    Vector row(const index i) const;
+    Vector row(index i) const;
 
     /**
      * @return Column @a j of this matrix as vector.
      */
-    Vector column(const index j) const;
+    Vector column(index j) const;
 
     /**
      * @return The main diagonal of this matrix.

--- a/include/networkit/algebraic/DenseMatrix.hpp
+++ b/include/networkit/algebraic/DenseMatrix.hpp
@@ -1,5 +1,5 @@
 /*
- * DenseMatrix.h
+ * DenseMatrix.hpp
  *
  *  Created on: Nov 25, 2015
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
@@ -8,11 +8,12 @@
 #ifndef NETWORKIT_ALGEBRAIC_DENSE_MATRIX_HPP_
 #define NETWORKIT_ALGEBRAIC_DENSE_MATRIX_HPP_
 
+#include <cassert>
+#include <vector>
+
 #include <networkit/Globals.hpp>
 #include <networkit/algebraic/AlgebraicGlobals.hpp>
 #include <networkit/algebraic/Vector.hpp>
-#include <cassert>
-#include <vector>
 
 namespace NetworKit {
 
@@ -242,7 +243,7 @@ public:
      * @param unaryElementFunction
      */
     template<typename F>
-    void apply(const F unaryElementFunction);
+    void apply(F unaryElementFunction);
 
     /**
      * Decomposes the given @a matrix into lower L and upper U matrix (in-place).
@@ -318,7 +319,7 @@ public:
 };
 
 template<typename F>
-void DenseMatrix::apply(const F unaryElementFunction) {
+void DenseMatrix::apply(F unaryElementFunction) {
 #pragma omp parallel for
     for (omp_index k = 0; k < static_cast<omp_index>(entries.size()); ++k) {
         entries[k] = unaryElementFunction(entries[k]);

--- a/include/networkit/algebraic/DynamicMatrix.hpp
+++ b/include/networkit/algebraic/DynamicMatrix.hpp
@@ -20,7 +20,7 @@ namespace NetworKit {
  * The DynamicMatrix class represents a matrix that is optimized for sparse matrices and internally uses a graph data structure.
  * DynamicMatrix should be used when changes to the structure of the matrix are frequent.
  */
-class DynamicMatrix {
+class DynamicMatrix final {
 protected:
     Graph graph;
 
@@ -38,7 +38,7 @@ public:
      * @param dimension Defines how many rows and columns this matrix has.
      * @param zero The zero element (default is 0.0).
      */
-    DynamicMatrix(const count dimension, const double zero = 0.0);
+    DynamicMatrix(count dimension, double zero = 0.0);
 
 
     /**
@@ -47,7 +47,7 @@ public:
      * @param nCols Number of columns.
      * @param zero The zero element (default is 0.0).
      */
-    DynamicMatrix(const count nRows, const count nCols, const double zero = 0.0);
+    DynamicMatrix(count nRows, count nCols, double zero = 0.0);
 
     /**
      * Constructs the @a dimension x @a dimension Matrix from the elements at position @a positions with values @values.
@@ -55,7 +55,7 @@ public:
      * @param triplets The nonzero elements.
      * @param zero The zero element (default is 0.0).
      */
-    DynamicMatrix(const count dimension, const std::vector<Triplet>& triplets, const double zero = 0.0);
+    DynamicMatrix(count dimension, const std::vector<Triplet>& triplets, double zero = 0.0);
 
     /**
      * Constructs the @a nRows x @a nCols Matrix from the elements at position @a positions with values @values.
@@ -64,7 +64,7 @@ public:
      * @param triplets The nonzero elements.
      * @param zero The zero element (default is 0.0).
      */
-    DynamicMatrix(const count nRows, const count nCols, const std::vector<Triplet>& triplets, const double zero = 0.0);
+    DynamicMatrix(count nRows, count nCols, const std::vector<Triplet>& triplets, double zero = 0.0);
 
     /** Default copy constructor */
     DynamicMatrix(const DynamicMatrix &other) = default;
@@ -73,7 +73,7 @@ public:
     DynamicMatrix(DynamicMatrix &&other) = default;
 
     /** Default destructor */
-    virtual ~DynamicMatrix() = default;
+     ~DynamicMatrix() = default;
 
     /** Default move assignment operator */
     DynamicMatrix& operator=(DynamicMatrix &&other) = default;
@@ -134,7 +134,7 @@ public:
      * @param i The row index.
      * @return Number of non-zeros in row @a i.
      */
-    count nnzInRow(const index i) const;
+    count nnzInRow(index i) const;
 
     /**
      * @return Number of non-zeros in this matrix.
@@ -144,22 +144,22 @@ public:
     /**
      * @return Value at matrix position (i,j).
      */
-    double operator()(const index i, const index j) const;
+    double operator()(index i, index j) const;
 
     /**
      * Set the matrix at position (@a i, @a j) to @a value.
      */
-    void setValue(const index i, const index j, const double value);
+    void setValue(index i, index j, double value);
 
     /**
      * @return Row @a i of this matrix as vector.
      */
-    Vector row(const index i) const;
+    Vector row(index i) const;
 
     /**
      * @return Column @a j of this matrix as vector.
      */
-    Vector column(const index j) const;
+    Vector column(index j) const;
 
     /**
      * @return The main diagonal of this matrix.
@@ -195,13 +195,13 @@ public:
      * Multiplies this matrix with a scalar specified in @a scalar and returns the result.
      * @return The result of multiplying this matrix with @a scalar.
      */
-    DynamicMatrix operator*(const double scalar) const;
+    DynamicMatrix operator*(double scalar) const;
 
     /**
      * Multiplies this matrix with a scalar specified in @a scalar.
      * @return Reference to this matrix.
      */
-    DynamicMatrix& operator*=(const double scalar);
+    DynamicMatrix& operator*=(double scalar);
 
     /**
      * Multiplies this matrix with @a vector and returns the result.
@@ -219,13 +219,13 @@ public:
      * Divides this matrix by a divisor specified in @a divisor and returns the result in a new matrix.
      * @return The result of dividing this matrix by @a divisor.
      */
-    DynamicMatrix operator/(const double divisor) const;
+    DynamicMatrix operator/(double divisor) const;
 
     /**
      * Divides this matrix by a divisor specified in @a divisor.
      * @return Reference to this matrix.
      */
-    DynamicMatrix& operator/=(const double divisor);
+    DynamicMatrix& operator/=(double divisor);
 
     /**
      * Computes A^T * B.

--- a/include/networkit/algebraic/DynamicMatrix.hpp
+++ b/include/networkit/algebraic/DynamicMatrix.hpp
@@ -1,5 +1,5 @@
 /*
- * DynamicMatrix.h
+ * DynamicMatrix.hpp
  *
  *  Created on: 13.03.2014
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
@@ -8,10 +8,10 @@
 #ifndef NETWORKIT_ALGEBRAIC_DYNAMIC_MATRIX_HPP_
 #define NETWORKIT_ALGEBRAIC_DYNAMIC_MATRIX_HPP_
 
-#include <networkit/graph/Graph.hpp>
-#include <networkit/algebraic/Vector.hpp>
-#include <networkit/algebraic/SparseAccumulator.hpp>
 #include <networkit/algebraic/AlgebraicGlobals.hpp>
+#include <networkit/algebraic/SparseAccumulator.hpp>
+#include <networkit/algebraic/Vector.hpp>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
@@ -279,7 +279,7 @@ public:
      * @param unaryElementFunction
      */
     template<typename F>
-    void apply(const F unaryElementFunction);
+    void apply(F unaryElementFunction);
 
     /**
      * Returns the (weighted) adjacency matrix of the (weighted) Graph @a graph.
@@ -337,7 +337,7 @@ public:
 } /* namespace NetworKit */
 
 template<typename F>
-void NetworKit::DynamicMatrix::apply(const F unaryElementFunction) {
+void NetworKit::DynamicMatrix::apply(F unaryElementFunction) {
     forNonZeroElementsInRowOrder([&](index i, index j, double value) {
         setValue(i,j, unaryElementFunction(value));
     });

--- a/include/networkit/algebraic/Semirings.hpp
+++ b/include/networkit/algebraic/Semirings.hpp
@@ -22,10 +22,10 @@
  * one: 1
  * codomain = (-infty, +infty)
  */
-class ArithmeticSemiring {
+class ArithmeticSemiring final {
 public:
     ArithmeticSemiring() = default;
-    virtual ~ArithmeticSemiring() = default;
+    ~ArithmeticSemiring() = default;
 
     inline static double add(double a, double b) {
         return a + b;
@@ -48,10 +48,10 @@ public:
  * one: 0
  * codomain = (-infty, +infty]
  */
-class MinPlusSemiring {
+class MinPlusSemiring final {
 public:
     MinPlusSemiring() = default;
-    virtual ~MinPlusSemiring() = default;
+    ~MinPlusSemiring() = default;
 
     inline static double add(double a, double b) {
         return std::min(a,b);
@@ -74,10 +74,10 @@ public:
  * one: 0
  * codomain = [-infty, +infty)
  */
-class MaxPlusSemiring {
+class MaxPlusSemiring final {
 public:
     MaxPlusSemiring() = default;
-    virtual ~MaxPlusSemiring() = default;
+    ~MaxPlusSemiring() = default;
 
     inline static double add(double a, double b) {
         return std::max(a,b);
@@ -100,10 +100,10 @@ public:
  * one: -infty
  * codomain = [-infty, +infty]
  */
-class MinMaxSemiring {
+class MinMaxSemiring final {
 public:
     MinMaxSemiring() = default;
-    virtual ~MinMaxSemiring() = default;
+    ~MinMaxSemiring() = default;
 
     inline static double add(double a, double b) {
         return std::min(a,b);
@@ -126,10 +126,10 @@ public:
  * one: +infty
  * codomain = [-infty, +infty]
  */
-class MaxMinSemiring{
+class MaxMinSemiring final {
 public:
     MaxMinSemiring() = default;
-    virtual ~MaxMinSemiring() = default;
+    ~MaxMinSemiring() = default;
 
     inline static double add(double a, double b) {
         return std::max(a,b);
@@ -152,10 +152,10 @@ public:
  * one: 1
  * codomain = [-infty, +infty]
  */
-class IntLogicalSemiring {
+class IntLogicalSemiring final {
 public:
     IntLogicalSemiring() = default;
-    virtual ~IntLogicalSemiring() = default;
+    ~IntLogicalSemiring() = default;
 
     inline static double add(double a, double b) {
         return (int) a || (int) b;
@@ -178,10 +178,10 @@ public:
  * one: 1
  * codomain = [0, 1]
  */
-class GaloisFieldSemiring {
+class GaloisFieldSemiring final {
 public:
     GaloisFieldSemiring() = default;
-    virtual ~GaloisFieldSemiring() = default;
+    ~GaloisFieldSemiring() = default;
 
     inline static double add(double a, double b) {
         return (int) a ^ (int) b;

--- a/include/networkit/algebraic/Semirings.hpp
+++ b/include/networkit/algebraic/Semirings.hpp
@@ -1,5 +1,5 @@
 /*
- * Semirings.h
+ * Semirings.hpp
  *
  *  Created on: May 31, 2016
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)

--- a/include/networkit/algebraic/SparseAccumulator.hpp
+++ b/include/networkit/algebraic/SparseAccumulator.hpp
@@ -19,12 +19,11 @@ namespace NetworKit {
  * The SparseAccumulator class represents the sparse accumulator datastructure as described in Kepner, Jeremy, and John Gilbert, eds.
  * Graph algorithms in the language of linear algebra. Vol. 22. SIAM, 2011. It is used as temporal storage for efficient computations on matrices.
  */
-class SparseAccumulator {
+class SparseAccumulator final {
 private:
     /** row indicator used to avoid resetting the occupied vector */
     count row;
 
-protected:
     /** dense vector of doubles which stores the computed values */
     std::vector<double> values; // w
 

--- a/include/networkit/algebraic/SparseAccumulator.hpp
+++ b/include/networkit/algebraic/SparseAccumulator.hpp
@@ -1,5 +1,5 @@
 /*
- * SparseAccumulator.h
+ * SparseAccumulator.hpp
  *
  *  Created on: 14.05.2014
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
@@ -8,9 +8,10 @@
 #ifndef NETWORKIT_ALGEBRAIC_SPARSE_ACCUMULATOR_HPP_
 #define NETWORKIT_ALGEBRAIC_SPARSE_ACCUMULATOR_HPP_
 
-#include <vector>
 #include <algorithm>
 #include <cassert>
+#include <vector>
+
 #include <networkit/Globals.hpp>
 
 namespace NetworKit {
@@ -86,7 +87,7 @@ public:
         std::sort(indices.begin(), indices.end());
         for (index idx : indices) {
             handle(row - 1, idx, values[idx]);
-            nonZeros++;
+            ++nonZeros;
         }
 
         return nonZeros;
@@ -96,7 +97,7 @@ public:
      * Sets the SparseAccumulator to the next row which invalidates all currently stored data.
      */
     void increaseRow() {
-        row++;
+        ++row;
         indices.clear();
     }
 };

--- a/include/networkit/algebraic/Vector.hpp
+++ b/include/networkit/algebraic/Vector.hpp
@@ -182,26 +182,26 @@ public:
      * Multiplies this vector with a scalar specified in @a scalar and returns the result in a new vector.
      * @return The result of multiplying this vector with @a scalar.
      */
-    Vector operator*(const double &scalar) const;
+    Vector operator*(double scalar) const;
 
     /**
      * Multiplies this vector with a scalar specified in @a scalar.
      * @return Reference to this vector.
      */
-    Vector& operator*=(const double &scalar);
+    Vector& operator*=(double scalar);
 
 
     /**
      * Divides this vector by a divisor specified in @a divisor and returns the result in a new vector.
      * @return The result of dividing this vector by @a divisor.
      */
-    Vector operator/(const double &divisor) const;
+    Vector operator/(double divisor) const;
 
     /**
      * Divides this vector by a divisor specified in @a divisor.
      * @return Reference to this vector.
      */
-    Vector& operator/=(const double &divisor);
+    Vector& operator/=(double divisor);
 
     /**
      * Adds this vector to @a other and returns the result.

--- a/include/networkit/algebraic/Vector.hpp
+++ b/include/networkit/algebraic/Vector.hpp
@@ -26,7 +26,7 @@ class DynamicMatrix;
  * @ingroup algebraic
  * The Vector class represents a basic vector with double coefficients.
  */
-class Vector {
+class Vector final {
 private:
     std::vector<double> values;
     bool transposed;
@@ -41,14 +41,14 @@ public:
      * @param initialValue All coefficients will be initialized to @a initialValue.
      * @param transpose Indicates whether this vector is transposed (row vector) or not (column vector).
      */
-    Vector(const count dimension, const double initialValue = 0, const bool transpose = false);
+    Vector(count dimension, double initialValue = 0, bool transpose = false);
 
     /**
      * Constructs the Vector with the contents of @a values.
      * @param values The values of this Vector.
      * @param transpose Indicates whether this vector is transposed (row vector) or not (column vector).
      */
-    Vector(const std::vector<double> &values, const bool transpose = false);
+    Vector(const std::vector<double> &values, bool transpose = false);
 
     /**
      * Constructs the Vector from the contents of the initializer list @a list.
@@ -63,7 +63,7 @@ public:
     Vector(Vector &&other) = default;
 
     /** Default destructor */
-    virtual ~Vector() = default;
+    ~Vector() = default;
 
     /** Default copy assignment operator */
     Vector& operator=(const Vector &other) = default;
@@ -109,7 +109,7 @@ public:
      * @param idx The index of the element.
      * @return Reference to the element at index @a idx.
      */
-    inline double& operator[](const index idx) {
+    inline double& operator[](index idx) {
         assert(idx < values.size());
         return values[idx];
     }
@@ -119,7 +119,7 @@ public:
      * @a idx The index of the element.
      * @return Constant reference to the element at index @a idx.
      */
-    inline const double& operator[](const index idx) const {
+    inline const double& operator[](index idx) const {
         assert(idx < values.size());
         return values[idx];
     }
@@ -129,7 +129,7 @@ public:
      * @param idx The index of the element.
      * @return Reference to the element at index @a idx.
      */
-    double &at(const index idx) {
+    double &at(index idx) {
         if (idx >= values.size()) {
             throw std::runtime_error("index out of range");
         } else {
@@ -184,7 +184,7 @@ public:
      */
     Vector operator*(double scalar) const;
 
-    /**
+    /*
      * Multiplies this vector with a scalar specified in @a scalar.
      * @return Reference to this vector.
      */
@@ -213,7 +213,7 @@ public:
     /**
      * Adds @a value to each element of this vector and returns the result.
      */
-    Vector operator+(const double value) const;
+    Vector operator+(double value) const;
 
     /**
      * Adds @a other to this vector.
@@ -225,7 +225,7 @@ public:
     /**
      * Adds @a value to each element of this vector.
      */
-    Vector& operator+=(const double value);
+    Vector& operator+=(double value);
 
     /**
      * Subtracts @a other from this vector and returns the result.
@@ -238,7 +238,7 @@ public:
     /**
      * Subtracts @a value from each element of this vector and returns the result.
      */
-    Vector operator-(const double value) const;
+    Vector operator-(double value) const;
 
     /**
      * Subtracts @a other from this vector.
@@ -250,7 +250,7 @@ public:
     /**
      * Subtracts @a value from each element of this vector.
      */
-    Vector& operator-=(const double value);
+    Vector& operator-=(double value);
 
     /**
      * Applies the unary function @a unaryElementFunction to each value in the Vector. Note that it must hold that the

--- a/include/networkit/algebraic/Vector.hpp
+++ b/include/networkit/algebraic/Vector.hpp
@@ -5,6 +5,8 @@
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_ALGEBRAIC_VECTOR_HPP_
 #define NETWORKIT_ALGEBRAIC_VECTOR_HPP_
 
@@ -15,7 +17,6 @@
 
 #include <networkit/Globals.hpp>
 #include <networkit/algebraic/AlgebraicGlobals.hpp>
-
 
 namespace NetworKit {
 
@@ -39,14 +40,16 @@ public:
      * Constructs the Vector with @a dimension elements with value @a initialValue.
      * @param dimension The dimension of this vector.
      * @param initialValue All coefficients will be initialized to @a initialValue.
-     * @param transpose Indicates whether this vector is transposed (row vector) or not (column vector).
+     * @param transpose Indicates whether this vector is transposed (row vector) or not (column
+     * vector).
      */
     Vector(count dimension, double initialValue = 0, bool transpose = false);
 
     /**
      * Constructs the Vector with the contents of @a values.
      * @param values The values of this Vector.
-     * @param transpose Indicates whether this vector is transposed (row vector) or not (column vector).
+     * @param transpose Indicates whether this vector is transposed (row vector) or not (column
+     * vector).
      */
     Vector(const std::vector<double> &values, bool transpose = false);
 
@@ -66,18 +69,15 @@ public:
     ~Vector() = default;
 
     /** Default copy assignment operator */
-    Vector& operator=(const Vector &other) = default;
+    Vector &operator=(const Vector &other) = default;
 
     /** Default move assignment operator */
-    Vector& operator=(Vector &&other) = default;
-
+    Vector &operator=(Vector &&other) = default;
 
     /**
      * @return dimension of vector
      */
-    inline count getDimension() const {
-        return values.size();
-    }
+    inline count getDimension() const { return values.size(); }
 
     /**
      * A transposed vector is a row vector.
@@ -90,13 +90,11 @@ public:
      */
     Vector transpose() const;
 
-
     /**
      * Calculates and returns the Euclidean length of this vector
      * @return The Euclidean length of this vector.
      */
     double length() const;
-
 
     /**
      * Calculates and returns the arithmetic mean of this vector
@@ -109,7 +107,7 @@ public:
      * @param idx The index of the element.
      * @return Reference to the element at index @a idx.
      */
-    inline double& operator[](index idx) {
+    inline double &operator[](index idx) {
         assert(idx < values.size());
         return values[idx];
     }
@@ -125,7 +123,8 @@ public:
     }
 
     /**
-     * Returns a reference to the element at index @a idx. If @a idx is not a valid index an exception is thrown.
+     * Returns a reference to the element at index @a idx. If @a idx is not a valid index an
+     * exception is thrown.
      * @param idx The index of the element.
      * @return Reference to the element at index @a idx.
      */
@@ -149,15 +148,14 @@ public:
      */
     bool operator!=(const Vector &other) const;
 
-
     /**
      * Computes the outer product of @a v1 and @a v2.
      * @param v1 First Vector.
      * @param v2 Second Vector.
      * @return The resulting matrix from the outer product.
      */
-    template<class Matrix = DynamicMatrix>
-    static Matrix outerProduct(const Vector& v1, const Vector& v2);
+    template <class Matrix = DynamicMatrix>
+    static Matrix outerProduct(const Vector &v1, const Vector &v2);
 
     /**
      * Computes the inner product (dot product) of the vectors @a v1 and @a v2.
@@ -175,11 +173,12 @@ public:
      * Multiplies this vector with @a matrix and returns the result.
      * @return The result of multiplying this vector with @a matrix.
      */
-    template<typename Matrix = DynamicMatrix>
-    Vector operator*(const Matrix& matrix) const;
+    template <typename Matrix = DynamicMatrix>
+    Vector operator*(const Matrix &matrix) const;
 
     /**
-     * Multiplies this vector with a scalar specified in @a scalar and returns the result in a new vector.
+     * Multiplies this vector with a scalar specified in @a scalar and returns the result in a new
+     * vector.
      * @return The result of multiplying this vector with @a scalar.
      */
     Vector operator*(double scalar) const;
@@ -188,11 +187,11 @@ public:
      * Multiplies this vector with a scalar specified in @a scalar.
      * @return Reference to this vector.
      */
-    Vector& operator*=(double scalar);
-
+    Vector &operator*=(double scalar);
 
     /**
-     * Divides this vector by a divisor specified in @a divisor and returns the result in a new vector.
+     * Divides this vector by a divisor specified in @a divisor and returns the result in a new
+     * vector.
      * @return The result of dividing this vector by @a divisor.
      */
     Vector operator/(double divisor) const;
@@ -201,7 +200,7 @@ public:
      * Divides this vector by a divisor specified in @a divisor.
      * @return Reference to this vector.
      */
-    Vector& operator/=(double divisor);
+    Vector &operator/=(double divisor);
 
     /**
      * Adds this vector to @a other and returns the result.
@@ -220,12 +219,12 @@ public:
      * Note that the dimensions of the vectors have to be the same.
      * @return Reference to this vector.
      */
-    Vector& operator+=(const Vector &other);
+    Vector &operator+=(const Vector &other);
 
     /**
      * Adds @a value to each element of this vector.
      */
-    Vector& operator+=(double value);
+    Vector &operator+=(double value);
 
     /**
      * Subtracts @a other from this vector and returns the result.
@@ -245,42 +244,46 @@ public:
      * Note that the dimensions of the vectors have to be the same.
      * @return Reference to this vector.
      */
-    Vector& operator-=(const Vector &other);
+    Vector &operator-=(const Vector &other);
 
     /**
      * Subtracts @a value from each element of this vector.
      */
-    Vector& operator-=(double value);
+    Vector &operator-=(double value);
 
     /**
-     * Applies the unary function @a unaryElementFunction to each value in the Vector. Note that it must hold that the
-     * function applied to the zero element of this matrix returns the zero element.
+     * Applies the unary function @a unaryElementFunction to each value in the Vector. Note that it
+     * must hold that the function applied to the zero element of this matrix returns the zero
+     * element.
      * @param unaryElementFunction
      */
-    template<typename F>
+    template <typename F>
     void apply(F unaryElementFunction);
 
     /**
      * Iterate over all elements of the vector and call handler (lambda closure).
      */
-    template<typename L> void forElements(L handle);
+    template <typename L>
+    void forElements(L handle);
 
     /**
      * Iterate over all elements of the vector and call handler (lambda closure).
      */
-    template<typename L> void forElements(L handle) const;
+    template <typename L>
+    void forElements(L handle) const;
 
     /**
      * Iterate in parallel over all elements of the vector and call handler (lambda closure).
      *
      */
-    template<typename L> void parallelForElements(L handle);
+    template <typename L>
+    void parallelForElements(L handle);
 
     /**
      * Iterate in parallel over all elements of the vector and call handler (lambda closure).
      */
-    template<typename L> void parallelForElements(L handle) const;
-
+    template <typename L>
+    void parallelForElements(L handle) const;
 };
 
 /**
@@ -291,15 +294,15 @@ inline Vector operator*(double scalar, const Vector &v) {
     return v.operator*(scalar);
 }
 
-template<class Matrix>
-Matrix Vector::outerProduct(const Vector& v1, const Vector& v2) {
+template <class Matrix>
+Matrix Vector::outerProduct(const Vector &v1, const Vector &v2) {
     std::vector<Triplet> triplets;
 
     for (index i = 0; i < v1.getDimension(); ++i) {
         for (index j = 0; j < v2.getDimension(); ++j) {
             double result = v1[i] * v2[j];
             if (fabs(result) >= FLOAT_EPSILON) {
-                triplets.push_back({i,j,result});
+                triplets.push_back({i, j, result});
             }
         }
     }
@@ -307,9 +310,9 @@ Matrix Vector::outerProduct(const Vector& v1, const Vector& v2) {
     return Matrix(v1.getDimension(), v2.getDimension(), triplets);
 }
 
-template<class Matrix>
-Vector Vector::operator*(const Matrix& matrix) const {
-    assert(isTransposed()); // vector must be of the form 1xn
+template <class Matrix>
+Vector Vector::operator*(const Matrix &matrix) const {
+    assert(isTransposed());                          // vector must be of the form 1xn
     assert(getDimension() == matrix.numberOfRows()); // dimensions of vector and matrix must match
 
     Vector result(matrix.numberOfColumns(), 0.0, true);
@@ -322,7 +325,7 @@ Vector Vector::operator*(const Matrix& matrix) const {
     return result;
 }
 
-template<typename F>
+template <typename F>
 void Vector::apply(F unaryElementFunction) {
 #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(getDimension()); ++i) {
@@ -330,21 +333,21 @@ void Vector::apply(F unaryElementFunction) {
     }
 }
 
-template<typename L>
+template <typename L>
 inline void Vector::forElements(L handle) {
     for (uint64_t i = 0; i < getDimension(); ++i) {
         handle(values[i]);
     }
 }
 
-template<typename L>
+template <typename L>
 inline void Vector::forElements(L handle) const {
     for (uint64_t i = 0; i < getDimension(); ++i) {
         handle(values[i]);
     }
 }
 
-template<typename L>
+template <typename L>
 inline void Vector::parallelForElements(L handle) {
 #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(getDimension()); ++i) {
@@ -352,7 +355,7 @@ inline void Vector::parallelForElements(L handle) {
     }
 }
 
-template<typename L>
+template <typename L>
 inline void Vector::parallelForElements(L handle) const {
 #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(getDimension()); ++i) {

--- a/include/networkit/algebraic/Vector.hpp
+++ b/include/networkit/algebraic/Vector.hpp
@@ -1,5 +1,5 @@
 /*
- * Vector.h
+ * Vector.hpp
  *
  *  Created on: 12.03.2014
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
@@ -115,11 +115,11 @@ public:
     }
 
     /**
-     * Returns a constant reference to the element at index @a idx without checking the range of this vector.
+     * Returns the element at index @a idx without checking the range of this vector.
      * @a idx The index of the element.
      * @return Constant reference to the element at index @a idx.
      */
-    inline const double& operator[](index idx) const {
+    inline double operator[](index idx) const {
         assert(idx < values.size());
         return values[idx];
     }
@@ -258,7 +258,7 @@ public:
      * @param unaryElementFunction
      */
     template<typename F>
-    void apply(const F unaryElementFunction);
+    void apply(F unaryElementFunction);
 
     /**
      * Iterate over all elements of the vector and call handler (lambda closure).
@@ -287,7 +287,7 @@ public:
  * Multiplies the vector @a v with a scalar specified in @a scalar and returns the result.
  * @return The result of multiplying this vector with @a scalar.
  */
-inline Vector operator*(const double &scalar, const Vector &v) {
+inline Vector operator*(double scalar, const Vector &v) {
     return v.operator*(scalar);
 }
 
@@ -323,7 +323,7 @@ Vector Vector::operator*(const Matrix& matrix) const {
 }
 
 template<typename F>
-void Vector::apply(const F unaryElementFunction) {
+void Vector::apply(F unaryElementFunction) {
 #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(getDimension()); ++i) {
         values[i] = unaryElementFunction(values[i]);
@@ -332,14 +332,14 @@ void Vector::apply(const F unaryElementFunction) {
 
 template<typename L>
 inline void Vector::forElements(L handle) {
-    for (uint64_t i = 0; i < getDimension(); i++) {
+    for (uint64_t i = 0; i < getDimension(); ++i) {
         handle(values[i]);
     }
 }
 
 template<typename L>
 inline void Vector::forElements(L handle) const {
-    for (uint64_t i = 0; i < getDimension(); i++) {
+    for (uint64_t i = 0; i < getDimension(); ++i) {
         handle(values[i]);
     }
 }
@@ -347,7 +347,7 @@ inline void Vector::forElements(L handle) const {
 template<typename L>
 inline void Vector::parallelForElements(L handle) {
 #pragma omp parallel for
-    for (omp_index i = 0; i < static_cast<omp_index>(getDimension()); i++) {
+    for (omp_index i = 0; i < static_cast<omp_index>(getDimension()); ++i) {
         handle(i, values[i]);
     }
 }
@@ -355,13 +355,10 @@ inline void Vector::parallelForElements(L handle) {
 template<typename L>
 inline void Vector::parallelForElements(L handle) const {
 #pragma omp parallel for
-    for (omp_index i = 0; i < static_cast<omp_index>(getDimension()); i++) {
+    for (omp_index i = 0; i < static_cast<omp_index>(getDimension()); ++i) {
         handle(i, values[i]);
     }
 }
 
-
 } /* namespace NetworKit */
-
-
 #endif // NETWORKIT_ALGEBRAIC_VECTOR_HPP_

--- a/networkit/cpp/algebraic/CSRMatrix.cpp
+++ b/networkit/cpp/algebraic/CSRMatrix.cpp
@@ -318,11 +318,11 @@ CSRMatrix& CSRMatrix::operator-=(const CSRMatrix &other) {
     return *this;
 }
 
-CSRMatrix CSRMatrix::operator*(const double &scalar) const {
+CSRMatrix CSRMatrix::operator*(double scalar) const {
     return CSRMatrix(*this) *= scalar;
 }
 
-CSRMatrix& CSRMatrix::operator*=(const double &scalar) {
+CSRMatrix& CSRMatrix::operator*=(double scalar) {
 #pragma omp parallel for
     for (omp_index k = 0; k < static_cast<omp_index>(nonZeros.size()); ++k) {
         nonZeros[k] *= scalar;
@@ -421,11 +421,11 @@ CSRMatrix CSRMatrix::operator*(const CSRMatrix &other) const {
     return result;
 }
 
-CSRMatrix CSRMatrix::operator/(const double &divisor) const {
+CSRMatrix CSRMatrix::operator/(double divisor) const {
     return CSRMatrix(*this) /= divisor;
 }
 
-CSRMatrix& CSRMatrix::operator/=(const double &divisor) {
+CSRMatrix& CSRMatrix::operator/=(double divisor) {
     return *this *= 1.0 / divisor;
 }
 

--- a/networkit/cpp/algebraic/DenseMatrix.cpp
+++ b/networkit/cpp/algebraic/DenseMatrix.cpp
@@ -110,11 +110,11 @@ DenseMatrix& DenseMatrix::operator-=(const DenseMatrix &other) {
     return *this;
 }
 
-DenseMatrix DenseMatrix::operator*(const double &scalar) const {
+DenseMatrix DenseMatrix::operator*(double scalar) const {
     return DenseMatrix(*this) *= scalar;
 }
 
-DenseMatrix& DenseMatrix::operator*=(const double &scalar) {
+DenseMatrix& DenseMatrix::operator*=(double scalar) {
 #pragma omp parallel for
     for (omp_index k = 0; k < static_cast<omp_index>(entries.size()); ++k) {
         entries[k] *= scalar;
@@ -157,11 +157,11 @@ DenseMatrix DenseMatrix::operator*(const DenseMatrix &other) const {
     return DenseMatrix(numberOfRows(), other.numberOfColumns(), resultEntries);
 }
 
-DenseMatrix DenseMatrix::operator/(const double &divisor) const {
+DenseMatrix DenseMatrix::operator/(double divisor) const {
     return DenseMatrix(*this) /= divisor;
 }
 
-DenseMatrix& DenseMatrix::operator/=(const double &divisor) {
+DenseMatrix& DenseMatrix::operator/=(double divisor) {
     return *this *= 1.0 / divisor;
 }
 

--- a/networkit/cpp/algebraic/Vector.cpp
+++ b/networkit/cpp/algebraic/Vector.cpp
@@ -75,11 +75,11 @@ double Vector::operator*(const Vector &other) const {
     return innerProduct(*this, other);
 }
 
-Vector Vector::operator*(const double &scalar) const {
+Vector Vector::operator*(double scalar) const {
     return Vector(*this) *= scalar;
 }
 
-Vector& Vector::operator*=(const double &scalar) {
+Vector& Vector::operator*=(double scalar) {
 #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(getDimension()); i++) {
         values[i] *= scalar;
@@ -88,11 +88,11 @@ Vector& Vector::operator*=(const double &scalar) {
     return *this;
 }
 
-Vector Vector::operator/(const double &divisor) const {
+Vector Vector::operator/(double divisor) const {
     return Vector(*this) /= divisor;
 }
 
-Vector& Vector::operator/=(const double &divisor) {
+Vector& Vector::operator/=(double divisor) {
     return *this *= 1 / divisor;
 }
 

--- a/networkit/cpp/algebraic/Vector.cpp
+++ b/networkit/cpp/algebraic/Vector.cpp
@@ -100,7 +100,7 @@ Vector Vector::operator+(const Vector &other) const {
     return Vector(*this) += other;
 }
 
-Vector Vector::operator+(const double value) const {
+Vector Vector::operator+(double value) const {
     return Vector(*this) += value;
 }
 


### PR DESCRIPTION
This PR brings some improvements to the C++ code of the algebraic module. The changes include:
- All classes that are not inherited from are made final.
- The virtual keyword is removed from any non-base classes.
- Public functions passing `const value types` are changed to value types.