### PR TITLE
Refactor: clique, coarsening, correlation

### DIFF
--- a/include/networkit/algebraic/algorithms/AlgebraicMatchingCoarsening.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicMatchingCoarsening.hpp
@@ -1,5 +1,5 @@
 /*
- * AlgebraicMatchingCoarsening.h
+ * AlgebraicMatchingCoarsening.hpp
  *
  *  Created on: Jul 12, 2016
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
@@ -20,7 +20,7 @@ namespace NetworKit {
  * coarse.
  */
 template<class Matrix>
-class AlgebraicMatchingCoarsening : public GraphCoarsening {
+class AlgebraicMatchingCoarsening final : public GraphCoarsening {
 public:
     /**
      * Constructs an instance of AlgebraicMatchingCoarsening for the given Graph @a graph and the corresponding
@@ -45,7 +45,7 @@ private:
 
 template<class Matrix>
 AlgebraicMatchingCoarsening<Matrix>::AlgebraicMatchingCoarsening(const Graph& graph, const Matching& matching, bool noSelfLoops) : GraphCoarsening(graph), A(Matrix::adjacencyMatrix(graph)), noSelfLoops(noSelfLoops) {
-    if (G.isDirected()) throw std::runtime_error("Only defined for undirected graphs.");
+    if (G->isDirected()) throw std::runtime_error("Only defined for undirected graphs.");
     nodeMapping.resize(graph.numberOfNodes());
     std::vector<Triplet> triplets(graph.numberOfNodes());
 

--- a/include/networkit/algebraic/algorithms/AlgebraicMatchingCoarsening.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicMatchingCoarsening.hpp
@@ -74,7 +74,7 @@ void AlgebraicMatchingCoarsening<Matrix>::run() {
     Matrix coarseAdj = P.transpose() * A * P; // Matrix::mTmMultiply performs worse due to high sparsity of P (nnz = n)
 
     Gcoarsened = Graph(coarseAdj.numberOfRows(), true);
-    coarseAdj.forNonZeroElementsInRowOrder([&](node u, node v, double weight) {
+    coarseAdj.forNonZeroElementsInRowOrder([&](node u, node v, edgeweight weight) {
         if (u == v && !noSelfLoops) {
             Gcoarsened.addEdge(u, v, weight / 2.0);
         } else if (u < v) {

--- a/include/networkit/clique/MaximalCliques.hpp
+++ b/include/networkit/clique/MaximalCliques.hpp
@@ -1,9 +1,10 @@
 #ifndef NETWORKIT_CLIQUE_MAXIMAL_CLIQUES_HPP_
 #define NETWORKIT_CLIQUE_MAXIMAL_CLIQUES_HPP_
 
-#include <networkit/graph/Graph.hpp>
-#include <networkit/base/Algorithm.hpp>
 #include <functional>
+
+#include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
@@ -15,12 +16,12 @@ namespace NetworKit {
  * Eppstein, D., & Strash, D. (2011).
  * Listing All Maximal Cliques in Large Sparse Real-World Graphs.
  * In P. M. Pardalos & S. Rebennack (Eds.),
- * Experimental Algorithms (pp. 364375). Springer Berlin Heidelberg.
+ * Experimental Algorithms (pp. 364 - 375). Springer Berlin Heidelberg.
  * Retrieved from http://link.springer.com/chapter/10.1007/978-3-642-20662-7_31
  *
  * The running time of this algorithm should be in @f$O(d^2 \cdot n \cdot 3^{d/3})@f$
  * where @f$d@f$ is the degeneracy of the graph, i.e., the maximum core number.
- * The running time in practive depends on the structure of the graph. In
+ * The running time in practice depends on the structure of the graph. In
  * particular for complex networks it is usually quite fast, even graphs with
  * millions of edges can usually be processed in less than a minute.
  */

--- a/include/networkit/clique/MaximalCliques.hpp
+++ b/include/networkit/clique/MaximalCliques.hpp
@@ -24,7 +24,7 @@ namespace NetworKit {
  * particular for complex networks it is usually quite fast, even graphs with
  * millions of edges can usually be processed in less than a minute.
  */
-class MaximalCliques : public Algorithm {
+class MaximalCliques final : public Algorithm {
 
 public:
     /**
@@ -68,8 +68,8 @@ public:
      */
     const std::vector<std::vector<node>>& getCliques() const;
 
-protected:
-    const Graph& G;
+private:
+    const Graph* G;
 
     std::vector<std::vector<node>> result;
 

--- a/include/networkit/coarsening/ClusteringProjector.hpp
+++ b/include/networkit/coarsening/ClusteringProjector.hpp
@@ -2,7 +2,7 @@
  * ClusteringProjector.hpp
  *
  *  Created on: 07.01.2013
- *      Author: Christian Staudt (christian.staudt@kit.edu)
+ *      Author: Christian Staudt
  */
 
 #ifndef NETWORKIT_COARSENING_CLUSTERING_PROJECTOR_HPP_
@@ -19,22 +19,6 @@ namespace NetworKit {
 class ClusteringProjector {
 
 public:
-
-
-    /**
-     * DEPRECATED
-     *
-     * Given
-     * 		@param[in]	Gcoarse
-     * 		@param[in] 	Gfine
-     * 		@param[in]	fineToCoarse
-     * 		@param[in]	zetaCoarse	a clustering of the coarse graph
-     *
-     * 	, project the clustering back to the fine graph to create a clustering of the fine graph.
-     * 		@param[out] 			a clustering of the fine graph
-     **/
-    //virtual Partition projectBack(Graph& Gcoarse, Graph& Gfine, std::vector<node>& fineToCoarse,	Partition& zetaCoarse);
-
 
     /**
      * Given

--- a/include/networkit/coarsening/ClusteringProjector.hpp
+++ b/include/networkit/coarsening/ClusteringProjector.hpp
@@ -1,5 +1,5 @@
 /*
- * ClusteringProjector.h
+ * ClusteringProjector.hpp
  *
  *  Created on: 07.01.2013
  *      Author: Christian Staudt (christian.staudt@kit.edu)

--- a/include/networkit/coarsening/GraphCoarsening.hpp
+++ b/include/networkit/coarsening/GraphCoarsening.hpp
@@ -43,7 +43,7 @@ public:
     std::map<node, std::vector<node> > getCoarseToFineNodeMapping() const;
 
 protected:
-    const Graph& G;
+    const Graph* G;
     Graph Gcoarsened;
     std::vector<node> nodeMapping;
 

--- a/include/networkit/coarsening/MatchingCoarsening.hpp
+++ b/include/networkit/coarsening/MatchingCoarsening.hpp
@@ -1,5 +1,5 @@
 /*
- * MatchingCoarsening.h
+ * MatchingCoarsening.hpp
  *
  *  Created on: 30.10.2012
  *      Author: Christian Staudt (christian.staudt@kit.edu)
@@ -18,7 +18,7 @@ namespace NetworKit {
  * @ingroup coarsening
  * Coarsens graph according to a matching.
  */
-class MatchingCoarsening: public GraphCoarsening {
+class MatchingCoarsening final : public GraphCoarsening {
 
 public:
     MatchingCoarsening(const Graph& G, const Matching& M, bool noSelfLoops = false);
@@ -32,7 +32,7 @@ public:
      *
      * @return		coarse graph
      */
-    virtual void run();
+    void run() override;
 
 private:
     const Matching& M;

--- a/include/networkit/coarsening/MatchingCoarsening.hpp
+++ b/include/networkit/coarsening/MatchingCoarsening.hpp
@@ -2,14 +2,13 @@
  * MatchingCoarsening.hpp
  *
  *  Created on: 30.10.2012
- *      Author: Christian Staudt (christian.staudt@kit.edu)
+ *      Author: Christian Staudt
  */
 
 #ifndef NETWORKIT_COARSENING_MATCHING_COARSENING_HPP_
 #define NETWORKIT_COARSENING_MATCHING_COARSENING_HPP_
 
 #include <networkit/coarsening/GraphCoarsening.hpp>
-
 #include <networkit/matching/Matching.hpp>
 
 namespace NetworKit {

--- a/include/networkit/coarsening/ParallelPartitionCoarsening.hpp
+++ b/include/networkit/coarsening/ParallelPartitionCoarsening.hpp
@@ -1,5 +1,5 @@
 /*
- * ParallelPartitionCoarsening.h
+ * ParallelPartitionCoarsening.hpp
  *
  *  Created on: 03.07.2014
  *      Author: cls
@@ -17,11 +17,11 @@ namespace NetworKit {
 /**
  * @ingroup coarsening
  */
-class ParallelPartitionCoarsening: public GraphCoarsening {
+class ParallelPartitionCoarsening final : public GraphCoarsening {
 public:
     ParallelPartitionCoarsening(const Graph& G, const Partition& zeta, bool useGraphBuilder = true);
 
-    virtual void run();
+    void run() override;
 
 private:
     const Partition& zeta;

--- a/include/networkit/correlation/Assortativity.hpp
+++ b/include/networkit/correlation/Assortativity.hpp
@@ -1,5 +1,5 @@
 /*
- * Assortativity.h
+ * Assortativity.hpp
  *
  *  Created on: Jun 13, 2015
  *      Author: Christian Staudt
@@ -21,7 +21,7 @@ namespace NetworKit {
  * Assortativity computes a coefficient that expresses the correlation of a
  * node attribute among connected pairs of nodes.
  */
-class Assortativity : public Algorithm {
+class Assortativity final : public Algorithm {
 
 public:
 
@@ -64,11 +64,11 @@ public:
 
 
 private:
-    const Graph& G;
+    const Graph* G;
     const std::vector<double> emptyVector;
     const Partition emptyPartition;
-    const std::vector<double>& attribute;
-    const Partition& partition;
+    const std::vector<double>* attribute;
+    const Partition* partition;
     bool nominal; // whether we calculate assortativity for a nominal or ordinal attribute
     double coefficient;
 };

--- a/networkit/cpp/clique/MaximalCliques.cpp
+++ b/networkit/cpp/clique/MaximalCliques.cpp
@@ -1,9 +1,9 @@
-#include <networkit/clique/MaximalCliques.hpp>
-#include <networkit/centrality/CoreDecomposition.hpp>
-#include <networkit/auxiliary/SignalHandling.hpp>
-
-#include <cassert>
 #include <algorithm>
+#include <cassert>
+
+#include <networkit/auxiliary/SignalHandling.hpp>
+#include <networkit/centrality/CoreDecomposition.hpp>
+#include <networkit/clique/MaximalCliques.hpp>
 
 namespace {
     // Private implementation namespace
@@ -31,7 +31,7 @@ namespace {
             G(&G), result(&result), callback(callback), maximumOnly(maximumOnly), maxFound(0),
             pxvector(G.numberOfNodes()), pxlookup(G.upperNodeIdBound()),
             firstOut(G.upperNodeIdBound() + 1), head(G.numberOfEdges()) {}
-    
+
     private:
         void buildOutGraph() {
             index currentOut = 0;

--- a/networkit/cpp/clique/MaximalCliques.cpp
+++ b/networkit/cpp/clique/MaximalCliques.cpp
@@ -13,8 +13,8 @@ namespace {
 
     class MaximalCliquesImpl {
     private:
-        const NetworKit::Graph& G;
-        std::vector<std::vector<node>>& result;
+        const NetworKit::Graph* G;
+        std::vector<std::vector<node>>* result;
         std::function<void(const std::vector<node>&)>& callback;
         bool maximumOnly;
         count maxFound;
@@ -28,25 +28,25 @@ namespace {
     public:
         MaximalCliquesImpl(const NetworKit::Graph& G, std::vector<std::vector<node>>& result,
                 std::function<void(const std::vector<node>&)>& callback, bool maximumOnly) :
-            G(G), result(result), callback(callback), maximumOnly(maximumOnly), maxFound(0),
+            G(&G), result(&result), callback(callback), maximumOnly(maximumOnly), maxFound(0),
             pxvector(G.numberOfNodes()), pxlookup(G.upperNodeIdBound()),
             firstOut(G.upperNodeIdBound() + 1), head(G.numberOfEdges()) {}
     
     private:
         void buildOutGraph() {
             index currentOut = 0;
-            for (node u = 0; u < G.upperNodeIdBound(); ++u) {
+            for (node u = 0; u < G->upperNodeIdBound(); ++u) {
                 firstOut[u] = currentOut;
-                if (G.hasNode(u)) {
+                if (G->hasNode(u)) {
                     index xpboundU = pxlookup[u];
-                    G.forEdgesOf(u, [&](node v) {
+                    G->forEdgesOf(u, [&](node v) {
                         if (xpboundU < pxlookup[v]) {
                             head[currentOut++] = v;
                         }
                     });
                 }
             }
-            firstOut[G.upperNodeIdBound()] = currentOut;
+            firstOut[G->upperNodeIdBound()] = currentOut;
         }
 
         template <typename F>
@@ -78,7 +78,7 @@ namespace {
 
     public:
         void run() {
-            NetworKit::CoreDecomposition cores(G, false, false, true);
+            NetworKit::CoreDecomposition cores(*G, false, false, true);
             cores.run();
 
             Aux::SignalHandler handler;
@@ -132,7 +132,7 @@ namespace {
 
                 count xcount = 0;
                 count pcount = 0;
-                G.forNeighborsOf(u, [&] (node v) {
+                G->forNeighborsOf(u, [&] (node v) {
 
 #ifndef NDEBUG
                     assert(pxlookup[v] < pxvector.size());
@@ -153,10 +153,10 @@ namespace {
 #ifndef NDEBUG
                 { // assert all neighbors of u were stored in one range around xpbound
 
-                    assert(xcount + pcount == G.degree(u));
+                    assert(xcount + pcount == G->degree(u));
 
                     std::vector<index> neighborPositions;
-                    G.forNeighborsOf(u, [&](node v) {
+                    G->forNeighborsOf(u, [&](node v) {
                         neighborPositions.push_back(pxlookup[v]);
                         assert(pxvector[pxlookup[v]] == v);
                     });
@@ -182,10 +182,10 @@ namespace {
                 if (callback) {
                     callback(r);
                 } else if (!maximumOnly) {
-                    result.push_back(r);
+                    result->push_back(r);
                 } else if (r.size() > maxFound) {
-                    result.clear();
-                    result.push_back(r);
+                    result->clear();
+                    result->push_back(r);
                     maxFound = r.size();
                 }
                 return;
@@ -358,7 +358,7 @@ namespace {
             }
 
 #ifndef NDEBUG
-            assert(maxnode < G.upperNodeIdBound() + 1);
+            assert(maxnode < G->upperNodeIdBound() + 1);
 #endif
 
             return maxnode;
@@ -370,10 +370,10 @@ namespace {
 
 namespace NetworKit {
 
-MaximalCliques::MaximalCliques(const Graph& G, bool maximumOnly) : G(G), maximumOnly(maximumOnly) {
+MaximalCliques::MaximalCliques(const Graph& G, bool maximumOnly) : G(&G), maximumOnly(maximumOnly) {
 }
 
-MaximalCliques::MaximalCliques(const Graph& G, std::function<void(const std::vector<node>&)> callback) : G(G), callback(callback), maximumOnly(false) {
+MaximalCliques::MaximalCliques(const Graph& G, std::function<void(const std::vector<node>&)> callback) : G(&G), callback(callback), maximumOnly(false) {
 }
 
 const std::vector<std::vector<node>>& MaximalCliques::getCliques() const {
@@ -387,7 +387,7 @@ void MaximalCliques::run() {
 
     result.clear();
 
-    MaximalCliquesImpl(G, result, callback, maximumOnly).run();
+    MaximalCliquesImpl(*G, result, callback, maximumOnly).run();
 
     hasRun = true;
 }

--- a/networkit/cpp/coarsening/ClusteringProjector.cpp
+++ b/networkit/cpp/coarsening/ClusteringProjector.cpp
@@ -2,11 +2,11 @@
  * ClusteringProjector.cpp
  *
  *  Created on: 07.01.2013
- *      Author: Christian Staudt (christian.staudt@kit.edu)
+ *      Author: Christian Staudt
  */
 
-#include <networkit/coarsening/ClusteringProjector.hpp>
 #include <networkit/auxiliary/Log.hpp>
+#include <networkit/coarsening/ClusteringProjector.hpp>
 
 namespace NetworKit {
 
@@ -14,7 +14,7 @@ namespace NetworKit {
 Partition ClusteringProjector::projectBack(const Graph&, const Graph& Gfine, const std::vector<node>& fineToCoarse,
         const Partition& zetaCoarse) {
 
-    Partition zetaFine(Gfine.upperNodeIdBound()); //Gfine.numberOfNodes()
+    Partition zetaFine(Gfine.upperNodeIdBound());
     zetaFine.setUpperBound(zetaCoarse.upperBound());
     Gfine.forNodes([&](node v) {
         node sv = fineToCoarse[v];
@@ -31,11 +31,11 @@ Partition ClusteringProjector::projectBackToFinest(const Partition& zetaCoarse,
         return zetaCoarse;
     }
 
-    Partition zetaFine(Gfinest.upperNodeIdBound()); //Gfinest.numberOfNodes()
+    Partition zetaFine(Gfinest.upperNodeIdBound());
     zetaFine.setUpperBound(zetaCoarse.upperBound()); // upper bound for ids in zetaFine must be set to upper bound of zetaCoarse, or modularity assertions fail
 
     // store temporarily coarsest supernode here
-    std::vector<node> tempMap(Gfinest.upperNodeIdBound()); //Gfinest.numberOfNodes()
+    std::vector<node> tempMap(Gfinest.upperNodeIdBound());
 
     // initialize to identity
     Gfinest.parallelForNodes([&](node v){
@@ -53,7 +53,7 @@ Partition ClusteringProjector::projectBackToFinest(const Partition& zetaCoarse,
     // set clusters for fine nodes
     Gfinest.parallelForNodes([&](node v) {
         index sc = zetaCoarse[tempMap[v]];
-        zetaFine.addToSubset(sc,v);//zetaFine[v] = sc;
+        zetaFine.addToSubset(sc,v);
     });
 
     return zetaFine;
@@ -81,7 +81,6 @@ Partition ClusteringProjector::projectCoarseGraphToFinestClustering(const Graph&
 
     // assign super node id as cluster id
     Gfinest.parallelForNodes([&](node v) {
-        //zeta.addToSubset(super[v],v);
         zeta[v] = super[v];
     });
 
@@ -92,18 +91,5 @@ Partition ClusteringProjector::projectCoarseGraphToFinestClustering(const Graph&
     return zeta;
 
 }
-/* FIXME: to be deleted?
-Partition ClusteringProjector::projectBack(Graph& Gcoarse, Graph& Gfine, std::vector<node>& fineToCoarse, Partition& zetaCoarse) {
-
-    Partition zetaFine(Gfine.numberOfNodes());
-
-    Gfine.forNodes([&](node v) {
-        node sv = fineToCoarse[v];
-        index cv = zetaCoarse[sv];//zetaCoarse.clusterOf(sv);
-        zetaFine.addToSubset(cv,v); //zetaFine[v] = cv;
-    });
-
-    return zetaFine;
-}*/
 
 } /* namespace NetworKit */

--- a/networkit/cpp/coarsening/GraphCoarsening.cpp
+++ b/networkit/cpp/coarsening/GraphCoarsening.cpp
@@ -9,7 +9,7 @@
 
 namespace NetworKit {
 
-GraphCoarsening::GraphCoarsening(const Graph& G) : Algorithm(), G(G) {
+GraphCoarsening::GraphCoarsening(const Graph& G) : Algorithm(), G(&G) {
 
 }
 
@@ -38,7 +38,7 @@ std::map<node, std::vector<node> > GraphCoarsening::getCoarseToFineNodeMapping()
     });
 
 
-    G.forNodes([&](node v) {
+    G->forNodes([&](node v) {
         node v_ = nodeMapping[v];
         reverseMap[v_].push_back(v);
     });

--- a/networkit/cpp/coarsening/MatchingCoarsening.cpp
+++ b/networkit/cpp/coarsening/MatchingCoarsening.cpp
@@ -2,7 +2,7 @@
  * MatchingCoarsening.cpp
  *
  *  Created on: 30.10.2012
- *      Author: Christian Staudt (christian.staudt@kit.edu)
+ *      Author: Christian Staudt
  */
 
 #include <networkit/coarsening/MatchingCoarsening.hpp>

--- a/networkit/cpp/coarsening/MatchingCoarsening.cpp
+++ b/networkit/cpp/coarsening/MatchingCoarsening.cpp
@@ -14,15 +14,15 @@ MatchingCoarsening::MatchingCoarsening(const Graph& G, const Matching& M, bool n
 }
 
 void MatchingCoarsening::run() {
-    count n = G.numberOfNodes();
-    index z = G.upperNodeIdBound();
-    count cn = n - M.size(G);
+    count n = G->numberOfNodes();
+    index z = G->upperNodeIdBound();
+    count cn = n - M.size(*G);
     Graph cG(cn, true);
 
     // compute map: old ID -> new coarse ID
     index idx = 0;
     std::vector<node> mapFineToCoarse(z, none);
-    G.forNodes([&](node v) { // TODO: difficult in parallel
+    G->forNodes([&](node v) { // TODO: difficult in parallel
         index mate = M.mate(v);
         if (mate == v) DEBUG("Node ", v, " is its own matching!");
         assert(mate != v);
@@ -39,8 +39,8 @@ void MatchingCoarsening::run() {
         assert(mapFineToCoarse[v] < cn);
     });
 
-    G.forNodes([&](node v) { // TODO: difficult in parallel
-        G.forNeighborsOf(v, [&](node u, edgeweight ew) {
+    G->forNodes([&](node v) { // TODO: difficult in parallel
+        G->forNeighborsOf(v, [&](node u, edgeweight ew) {
             node cv = mapFineToCoarse[v];
             node cu = mapFineToCoarse[u];
             if ((v <= u) && (! noSelfLoops || (cv != cu))) {

--- a/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
+++ b/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
@@ -27,7 +27,7 @@ void ParallelPartitionCoarsening::run() {
     Partition nodeToSuperNode = zeta;
     nodeToSuperNode.compact(
         (zeta.upperBound() <=
-         G.upperNodeIdBound())); // use turbo if the upper id bound is <= number
+         G->upperNodeIdBound())); // use turbo if the upper id bound is <= number
                                  // of nodes
     count nextNodeId = nodeToSuperNode.upperBound();
 
@@ -42,7 +42,7 @@ void ParallelPartitionCoarsening::run() {
         // iterate over edges of G and create edges in coarse graph or update edge
         // and node weights in Gcon
         DEBUG("create edges in coarse graphs");
-        G.parallelForEdges([&](node u, node v, edgeweight ew) {
+        G->parallelForEdges([&](node u, node v, edgeweight ew) {
             index t = omp_get_thread_num();
 
             node su = nodeToSuperNode[u];
@@ -98,7 +98,7 @@ void ParallelPartitionCoarsening::run() {
         INFO("combining coarse graphs took ", timer2.elapsedTag());
     } else {
         std::vector<std::vector<node>> nodesPerSuperNode(nextNodeId);
-        G.forNodes([&](node v) {
+        G->forNodes([&](node v) {
             node sv = nodeToSuperNode[v];
             nodesPerSuperNode[sv].push_back(v);
         });
@@ -111,7 +111,7 @@ void ParallelPartitionCoarsening::run() {
         for (omp_index su = 0; su < static_cast<omp_index>(nextNodeId); su++) {
             std::map<index, edgeweight> outEdges;
             for (node u : nodesPerSuperNode[su]) {
-                G.forNeighborsOf(u, [&](node v, edgeweight ew) {
+                G->forNeighborsOf(u, [&](node v, edgeweight ew) {
                     node sv = nodeToSuperNode[v];
                     if (su != sv || u >= v) { // count edges inside uv only once (we
                                                 // iterate over them twice)

--- a/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
+++ b/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
@@ -10,8 +10,8 @@
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Timer.hpp>
-#include <networkit/graph/GraphBuilder.hpp>
 #include <networkit/coarsening/ParallelPartitionCoarsening.hpp>
+#include <networkit/graph/GraphBuilder.hpp>
 
 namespace NetworKit {
 


### PR DESCRIPTION
This PR includes:
- All classes that are not inherited from are made final.
- The `virtual` keyword is removed from any non-base classes.
- All __member__ variables are changed from references to pointers.
- The `override` keyword is added to functions accordingly.
- The access modifiers of member variables is changed from protected to private.
- The documentation in the header files is changed from `*.h` to `*.hpp`.
