### PR TITLE
Fix inNeighbors

### DIFF
--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1058,7 +1058,7 @@ cdef class Graph:
 			warn("The graph is not directed, returning the neighbors!")
 			return self.neighbors(u)
 		neighborList = []
-		self.forInEdgesOf(u, lambda v : neighborList.append(v))
+		self.forInEdgesOf(u, lambda u, v, w, eid : neighborList.append(v))
 		return neighborList
 
 	def forNodes(self, object callback):

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -71,10 +71,15 @@ class TestGraph(unittest.TestCase):
 		G.addEdge(3, 2)
 		G.addEdge(1, 2)
 
-		self.assertEqual(sorted(G.neighbors(0)), [1, 2])
-		self.assertEqual(sorted(G.neighbors(1)), [2])
-		self.assertEqual(sorted(G.neighbors(2)), [])
-		self.assertEqual(sorted(G.neighbors(3)), [1, 2])
+		self.assertListEqual(sorted(G.neighbors(0)), [1, 2])
+		self.assertListEqual(sorted(G.neighbors(1)), [2])
+		self.assertListEqual(sorted(G.neighbors(2)), [])
+		self.assertListEqual(sorted(G.neighbors(3)), [1, 2])
+
+		self.assertListEqual(sorted(G.inNeighbors(0)), [])
+		self.assertListEqual(sorted(G.inNeighbors(1)), [0, 3])
+		self.assertListEqual(sorted(G.inNeighbors(2)), [0, 1, 3])
+		self.assertListEqual(sorted(G.inNeighbors(3)), [])
 
 		# Undirected
 		G = nk.Graph(4, False, False)


### PR DESCRIPTION
This PR fixes the bug in the Python code of `Graph.inNeighbors` described in #469. It also includes new Python tests for `inNeighbors`.