### PR TITLE
Fix extract largest cc

### DIFF
--- a/include/networkit/components/ConnectedComponents.hpp
+++ b/include/networkit/components/ConnectedComponents.hpp
@@ -5,6 +5,8 @@
  *      Author: cls
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_COMPONENTS_CONNECTED_COMPONENTS_HPP_
 #define NETWORKIT_COMPONENTS_CONNECTED_COMPONENTS_HPP_
 
@@ -12,9 +14,9 @@
 #include <map>
 #include <vector>
 
+#include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
 #include <networkit/structures/Partition.hpp>
-#include <networkit/base/Algorithm.hpp>
 
 namespace NetworKit {
 
@@ -29,7 +31,7 @@ public:
      *
      * @param G The graph.
      */
-    ConnectedComponents(const Graph& G);
+    ConnectedComponents(const Graph &G);
 
     /**
      * This method determines the connected components for the graph given in the constructor.
@@ -50,7 +52,6 @@ public:
      */
     count componentOfNode(node u) const;
 
-
     /**
      * Get a Partition that represents the components.
      *
@@ -66,7 +67,7 @@ public:
     /**
      * @return Vector of components, each stored as (unordered) set of nodes.
      */
-    std::vector<std::vector<node> > getComponents() const;
+    std::vector<std::vector<node>> getComponents() const;
 
     /**
      * Constructs a new graph that contains only the nodes inside the largest
@@ -78,13 +79,13 @@ public:
     static Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph = false);
 
 private:
-    const Graph* G;
+    const Graph *G;
     Partition component;
     count numComponents;
 };
 
 inline count ConnectedComponents::componentOfNode(node u) const {
-    assert (component[u] != none);
+    assert(component[u] != none);
     assureFinished();
     return component[u];
 }
@@ -94,7 +95,6 @@ inline count ConnectedComponents::numberOfComponents() const {
     return this->numComponents;
 }
 
-}
-
+} // namespace NetworKit
 
 #endif // NETWORKIT_COMPONENTS_CONNECTED_COMPONENTS_HPP_

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -84,44 +84,49 @@ std::map<index, count> ConnectedComponents::getComponentSizes() const {
 }
 
 Graph ConnectedComponents::extractLargestConnectedComponent(const Graph &G, bool compactGraph) {
-    if (!G.numberOfNodes())
+    if (!G.numberOfNodes()) {
         return G;
+    }
 
     ConnectedComponents cc(G);
     cc.run();
 
-    auto compSizes = cc.getComponentSizes();
-    if (compSizes.size() == 1)
+    const auto compSizes = cc.getComponentSizes();
+    if (compSizes.size() == 1) {
         return G;
+    }
 
-    auto largestCC = std::max_element(
+    const auto largestCC = std::max_element(
         compSizes.begin(), compSizes.end(),
         [](const std::pair<index, count> &x, const std::pair<index, count> &y) {
             return x.second < y.second;
         });
 
-    std::unordered_map<node, node> continuousNodeIds;
-    index nextId = 0;
-    G.forNodes([&](node u) {
-        if (cc.componentOfNode(u) == largestCC->first)
-            continuousNodeIds[u] = nextId++;
-    });
-
     if (compactGraph) {
+        std::unordered_map<node, node> continuousNodeIds;
+        index nextId = 0;
+        G.forNodes([&](const node u) {
+            if (cc.componentOfNode(u) == largestCC->first) {
+                continuousNodeIds[u] = nextId++;
+            }
+        });
+
         return GraphTools::getRemappedGraph(
             G, largestCC->second,
-            [&](node u) { return continuousNodeIds[u]; },
-            [&](node u) { return cc.componentOfNode(u) != largestCC->first; });
+            [&](const node u) { return continuousNodeIds[u]; },
+            [&](const node u) { return cc.componentOfNode(u) != largestCC->first; });
 
     } else {
         Graph S(G);
-        auto components = cc.getComponents();
-        for (count i = 0; i < components.size(); ++i) {
+        const auto components = cc.getComponents();
+        for (size_t i = 0; i < components.size(); ++i) {
             if (i != largestCC->first) {
-                for (node u : components[i])
+                for (auto u : components[i]) {
                     S.removeNode(u);
+                }
             }
         }
+
         return S;
     }
 }

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -5,6 +5,8 @@
  *      Author: cls
  */
 
+// networkit-format
+
 #include <set>
 #include <unordered_map>
 
@@ -15,9 +17,10 @@
 
 namespace NetworKit {
 
-ConnectedComponents::ConnectedComponents(const Graph& G) : G(&G) {
+ConnectedComponents::ConnectedComponents(const Graph &G) : G(&G) {
     if (G.isDirected()) {
-        throw std::runtime_error("Error, connected components of directed graphs cannot be computed, use StronglyConnectedComponents for them.");
+        throw std::runtime_error("Error, connected components of directed graphs cannot be "
+                                 "computed, use StronglyConnectedComponents for them.");
     }
 }
 
@@ -31,7 +34,7 @@ void ConnectedComponents::run() {
     // perform breadth-first searches
     G->forNodes([&](node u) {
         if (component[u] == none) {
-            component.setUpperBound(numComponents+1);
+            component.setUpperBound(numComponents + 1);
             index c = numComponents;
 
             q.push(u);
@@ -56,27 +59,21 @@ void ConnectedComponents::run() {
     hasRun = true;
 }
 
-
 Partition ConnectedComponents::getPartition() const {
     assureFinished();
     return this->component;
 }
 
-
-std::vector<std::vector<node> > ConnectedComponents::getComponents() const {
+std::vector<std::vector<node>> ConnectedComponents::getComponents() const {
     assureFinished();
 
     // transform partition into vector of unordered_set
-    std::vector<std::vector<node> > result(numComponents);
+    std::vector<std::vector<node>> result(numComponents);
 
-    G->forNodes([&](node u) {
-        result[component[u]].push_back(u);
-    });
+    G->forNodes([&](node u) { result[component[u]].push_back(u); });
 
     return result;
 }
-
-
 
 std::map<index, count> ConnectedComponents::getComponentSizes() const {
     assureFinished();
@@ -99,11 +96,11 @@ Graph ConnectedComponents::extractLargestConnectedComponent(const Graph &G, bool
         return G;
     }
 
-    const auto largestCC = std::max_element(
-        compSizes.begin(), compSizes.end(),
-        [](const std::pair<index, count> &x, const std::pair<index, count> &y) {
-            return x.second < y.second;
-        });
+    const auto largestCC =
+        std::max_element(compSizes.begin(), compSizes.end(),
+                         [](const std::pair<index, count> &x, const std::pair<index, count> &y) {
+                             return x.second < y.second;
+                         });
 
     if (compactGraph) {
         std::unordered_map<node, node> continuousNodeIds;
@@ -115,8 +112,7 @@ Graph ConnectedComponents::extractLargestConnectedComponent(const Graph &G, bool
         });
 
         return GraphTools::getRemappedGraph(
-            G, largestCC->second,
-            [&](const node u) { return continuousNodeIds[u]; },
+            G, largestCC->second, [&](const node u) { return continuousNodeIds[u]; },
             [&](const node u) { return cc.componentOfNode(u) != largestCC->first; });
 
     } else {
@@ -134,4 +130,4 @@ Graph ConnectedComponents::extractLargestConnectedComponent(const Graph &G, bool
     }
 }
 
-}
+} // namespace NetworKit

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -93,6 +93,9 @@ Graph ConnectedComponents::extractLargestConnectedComponent(const Graph &G, bool
 
     const auto compSizes = cc.getComponentSizes();
     if (compSizes.size() == 1) {
+        if (compactGraph) {
+            return GraphTools::getCompactedGraph(G, GraphTools::getContinuousNodeIds(G));
+        }
         return G;
     }
 
@@ -121,7 +124,7 @@ Graph ConnectedComponents::extractLargestConnectedComponent(const Graph &G, bool
         const auto components = cc.getComponents();
         for (size_t i = 0; i < components.size(); ++i) {
             if (i != largestCC->first) {
-                for (auto u : components[i]) {
+                for (const auto u : components[i]) {
                     S.removeNode(u);
                 }
             }

--- a/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
@@ -526,10 +526,19 @@ TEST_F(ConnectedComponentsGTest, testExtractLargestConnectedComponent) {
     G.addEdge(5, 6);
     Graph G1(G);
 
-    G = ConnectedComponents::extractLargestConnectedComponent(G, true);
-    EXPECT_EQ(G.numberOfNodes(), 5);
-    EXPECT_EQ(G.upperNodeIdBound(), 5);
-    EXPECT_EQ(G.numberOfEdges(), 4);
+    auto lcc = ConnectedComponents::extractLargestConnectedComponent(G, true);
+    EXPECT_EQ(lcc.numberOfNodes(), 5);
+    EXPECT_EQ(lcc.upperNodeIdBound(), 5);
+    EXPECT_EQ(lcc.numberOfEdges(), 4);
+
+    G.removeNode(0);
+    lcc = ConnectedComponents::extractLargestConnectedComponent(G, false);
+    lcc = ConnectedComponents::extractLargestConnectedComponent(lcc, true);
+    EXPECT_EQ(lcc.numberOfNodes(), 4);
+    EXPECT_EQ(lcc.upperNodeIdBound(), 4);
+    EXPECT_EQ(lcc.numberOfEdges(), 3);
+    node u = 0;
+    lcc.forNodes([&u](const node v) { EXPECT_EQ(u++, v); });
 
     G1 = ConnectedComponents::extractLargestConnectedComponent(G1, false);
     EXPECT_EQ(G1.numberOfNodes(), 5);


### PR DESCRIPTION
This PR fixes a bug in `extractLargestConnectedComponents`: connected graphs are never compacted, even if `compactGraph` is set to true. Additional tests for this scenario are also included.