### PR TITLE
Refactor edgescores & sparsification modules

### DIFF
--- a/include/networkit/edgescores/ChibaNishizekiQuadrangleEdgeScore.hpp
+++ b/include/networkit/edgescores/ChibaNishizekiQuadrangleEdgeScore.hpp
@@ -1,5 +1,5 @@
 /*
- * ChibaNishizekiQuadrangleEdgeScore.h
+ * ChibaNishizekiQuadrangleEdgeScore.hpp
  *
  *  Created on: 18.11.2014
  *      Author: Michael Hamann, Gerd Lindner
@@ -12,13 +12,13 @@
 
 namespace NetworKit {
 
-class ChibaNishizekiQuadrangleEdgeScore : public EdgeScore<count> {
+class ChibaNishizekiQuadrangleEdgeScore final : public EdgeScore<count> {
 
 public:
     ChibaNishizekiQuadrangleEdgeScore(const Graph& G);
     virtual count score(edgeid eid) override;
     virtual count score(node u, node v) override;
-    virtual void run() override;
+    void run() override;
 };
 
 } // namespace NetworKit

--- a/include/networkit/edgescores/ChibaNishizekiQuadrangleEdgeScore.hpp
+++ b/include/networkit/edgescores/ChibaNishizekiQuadrangleEdgeScore.hpp
@@ -5,6 +5,8 @@
  *      Author: Michael Hamann, Gerd Lindner
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_EDGESCORES_CHIBA_NISHIZEKI_QUADRANGLE_EDGE_SCORE_HPP_
 #define NETWORKIT_EDGESCORES_CHIBA_NISHIZEKI_QUADRANGLE_EDGE_SCORE_HPP_
 
@@ -15,9 +17,9 @@ namespace NetworKit {
 class ChibaNishizekiQuadrangleEdgeScore final : public EdgeScore<count> {
 
 public:
-    ChibaNishizekiQuadrangleEdgeScore(const Graph& G);
-    virtual count score(edgeid eid) override;
-    virtual count score(node u, node v) override;
+    ChibaNishizekiQuadrangleEdgeScore(const Graph &G);
+    count score(edgeid eid) override;
+    count score(node u, node v) override;
     void run() override;
 };
 

--- a/include/networkit/edgescores/ChibaNishizekiTriangleEdgeScore.hpp
+++ b/include/networkit/edgescores/ChibaNishizekiTriangleEdgeScore.hpp
@@ -5,6 +5,8 @@
  *      Author: Gerd Lindner
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_EDGESCORES_CHIBA_NISHIZEKI_TRIANGLE_EDGE_SCORE_HPP_
 #define NETWORKIT_EDGESCORES_CHIBA_NISHIZEKI_TRIANGLE_EDGE_SCORE_HPP_
 
@@ -16,15 +18,15 @@ namespace NetworKit {
 /**
  * An implementation of the triangle counting algorithm by Chiba/Nishizeki.
  *
- * @deprecated Use TriangleEdgeScore instead which is parallelized and has a similar performance even in the sequential case.
+ * @deprecated Use TriangleEdgeScore instead which is parallelized and has a similar performance
+ * even in the sequential case.
  */
 class ChibaNishizekiTriangleEdgeScore final : public EdgeScore<count> {
 
 public:
-
-    ChibaNishizekiTriangleEdgeScore(const Graph& G);
-    virtual count score(edgeid eid) override;
-    virtual count score(node u, node v) override;
+    ChibaNishizekiTriangleEdgeScore(const Graph &G);
+    count score(edgeid eid) override;
+    count score(node u, node v) override;
     void run() override;
 };
 

--- a/include/networkit/edgescores/ChibaNishizekiTriangleEdgeScore.hpp
+++ b/include/networkit/edgescores/ChibaNishizekiTriangleEdgeScore.hpp
@@ -1,5 +1,5 @@
 /*
- * ChibaNishizekiTriangleEdgeScore.h
+ * ChibaNishizekiTriangleEdgeScore.hpp
  *
  *  Created on: 22.05.2014
  *      Author: Gerd Lindner
@@ -8,8 +8,8 @@
 #ifndef NETWORKIT_EDGESCORES_CHIBA_NISHIZEKI_TRIANGLE_EDGE_SCORE_HPP_
 #define NETWORKIT_EDGESCORES_CHIBA_NISHIZEKI_TRIANGLE_EDGE_SCORE_HPP_
 
-#include <networkit/graph/Graph.hpp>
 #include <networkit/edgescores/EdgeScore.hpp>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
@@ -18,14 +18,14 @@ namespace NetworKit {
  *
  * @deprecated Use TriangleEdgeScore instead which is parallelized and has a similar performance even in the sequential case.
  */
-class ChibaNishizekiTriangleEdgeScore : public EdgeScore<count> {
+class ChibaNishizekiTriangleEdgeScore final : public EdgeScore<count> {
 
 public:
 
     ChibaNishizekiTriangleEdgeScore(const Graph& G);
     virtual count score(edgeid eid) override;
     virtual count score(node u, node v) override;
-    virtual void run() override;
+    void run() override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/edgescores/EdgeScore.hpp
+++ b/include/networkit/edgescores/EdgeScore.hpp
@@ -1,5 +1,5 @@
 /*
- * EdgeScore.h
+ * EdgeScore.hpp
  *
  *  Created on: 18.08.2015
  *      Author: Gerd Lindner
@@ -8,8 +8,8 @@
 #ifndef NETWORKIT_EDGESCORES_EDGE_SCORE_HPP_
 #define NETWORKIT_EDGESCORES_EDGE_SCORE_HPP_
 
-#include <networkit/graph/Graph.hpp>
 #include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
 #include <vector>
 
 namespace NetworKit {
@@ -40,7 +40,7 @@ public:
     virtual T score(node u, node v);
 
 protected:
-    const Graph& G;
+    const Graph* G;
     std::vector<T> scoreData;
 
 };

--- a/include/networkit/edgescores/EdgeScore.hpp
+++ b/include/networkit/edgescores/EdgeScore.hpp
@@ -5,47 +5,48 @@
  *      Author: Gerd Lindner
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_EDGESCORES_EDGE_SCORE_HPP_
 #define NETWORKIT_EDGESCORES_EDGE_SCORE_HPP_
 
+#include <vector>
+
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
-#include <vector>
 
 namespace NetworKit {
 /**
  * Abstract base class for an edge score.
  */
-template<typename T>
+template <typename T>
 class EdgeScore : public Algorithm {
 
 public:
-
-    EdgeScore(const Graph& G);
+    EdgeScore(const Graph &G);
 
     /** Compute the edge score. */
     virtual void run();
 
     /** Get a vector containing the score for each edge in the graph.
-    @Return the edge scores calculated by @link run().
-    */
+     *
+     * @return the edge scores calculated by @link run().
+     */
     virtual std::vector<T> scores() const;
 
     /** Get the edge score of the edge with the given edge id.
-    */
+     */
     virtual T score(edgeid eid);
 
     /** Get the edge score of the given edge.
-    */
+     */
     virtual T score(node u, node v);
 
 protected:
-    const Graph* G;
+    const Graph *G;
     std::vector<T> scoreData;
-
 };
 
-}
-
+} // namespace NetworKit
 
 #endif // NETWORKIT_EDGESCORES_EDGE_SCORE_HPP_

--- a/include/networkit/edgescores/EdgeScoreAsWeight.hpp
+++ b/include/networkit/edgescores/EdgeScoreAsWeight.hpp
@@ -1,5 +1,5 @@
 /*
- * EdgeScoreAsWeight.h
+ * EdgeScoreAsWeight.hpp
  *
  *  Created on: 18.11.2014
  *      Author: Michael Hamann
@@ -12,15 +12,15 @@
 
 namespace NetworKit {
 
-class EdgeScoreAsWeight {
+class EdgeScoreAsWeight final {
 
 public:
     EdgeScoreAsWeight(const Graph& G, const std::vector<double>& score, bool squared = false, edgeweight offset = 1, edgeweight factor = 1);
     Graph calculate();
 
 private:
-    const Graph& G;
-    const std::vector<double>& score;
+    const Graph* G;
+    const std::vector<double>* score;
     bool squared;
     edgeweight offset;
     edgeweight factor;

--- a/include/networkit/edgescores/EdgeScoreBlender.hpp
+++ b/include/networkit/edgescores/EdgeScoreBlender.hpp
@@ -1,5 +1,5 @@
 /*
- * EdgeScoreBlender.h
+ * EdgeScoreBlender.hpp
  *
  *  Created on: 18.11.2014
  *      Author: Michael Hamann
@@ -8,12 +8,12 @@
 #ifndef NETWORKIT_EDGESCORES_EDGE_SCORE_BLENDER_HPP_
 #define NETWORKIT_EDGESCORES_EDGE_SCORE_BLENDER_HPP_
 
-#include <networkit/graph/Graph.hpp>
 #include <networkit/edgescores/EdgeScore.hpp>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
-class EdgeScoreBlender : public EdgeScore<double> {
+class EdgeScoreBlender final : public EdgeScore<double> {
 
 public:
 
@@ -21,11 +21,11 @@ public:
 
     virtual double score(edgeid eid) override;
     virtual double score(node u, node v) override;
-    virtual void run() override;
+    void run() override;
 
 private:
-    const std::vector<double> &attribute0, &attribute1;
-    const std::vector<bool> &selection;
+    const std::vector<double> *attribute0, *attribute1;
+    const std::vector<bool> *selection;
 };
 
 } // namespace NetworKit

--- a/include/networkit/edgescores/EdgeScoreBlender.hpp
+++ b/include/networkit/edgescores/EdgeScoreBlender.hpp
@@ -19,8 +19,8 @@ public:
 
     EdgeScoreBlender(const Graph &G, const std::vector<double> &attribute0, const std::vector<double> &attribute1, const std::vector<bool> &selection);
 
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
     void run() override;
 
 private:

--- a/include/networkit/edgescores/EdgeScoreLinearizer.hpp
+++ b/include/networkit/edgescores/EdgeScoreLinearizer.hpp
@@ -1,5 +1,5 @@
 /*
- * EdgeScoreLinearizer.h
+ * EdgeScoreLinearizer.hpp
  *
  *  Created on: 18.11.2014
  *      Author: Michael Hamann
@@ -12,18 +12,18 @@
 
 namespace NetworKit {
 
-class EdgeScoreLinearizer : public EdgeScore<double> {
+class EdgeScoreLinearizer final : public EdgeScore<double> {
 
 private:
-    const std::vector<double>& attribute;
+    const std::vector<double>* attribute;
     bool inverse;
 
 public:
     EdgeScoreLinearizer(const Graph& graph, const std::vector<double>& attribute, bool inverse = false);
 
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
-    virtual void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
+    void run() override;
 
 };
 

--- a/include/networkit/edgescores/EdgeScoreNormalizer.hpp
+++ b/include/networkit/edgescores/EdgeScoreNormalizer.hpp
@@ -1,5 +1,5 @@
 /*
- * EdgeScoreNormalizer.h
+ * EdgeScoreNormalizer.hpp
  *
  *  Created on: 18.11.2014
  *      Author: Michael Hamann
@@ -8,23 +8,23 @@
 #ifndef NETWORKIT_EDGESCORES_EDGE_SCORE_NORMALIZER_HPP_
 #define NETWORKIT_EDGESCORES_EDGE_SCORE_NORMALIZER_HPP_
 
-#include <networkit/graph/Graph.hpp>
 #include <networkit/edgescores/EdgeScore.hpp>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
 template <typename A>
-class EdgeScoreNormalizer : public EdgeScore<double> {
+class EdgeScoreNormalizer final : public EdgeScore<double> {
 
 public:
     EdgeScoreNormalizer(const Graph &G, const std::vector<A> &score, bool invert = false, double lower = 0, double upper = 1.0);
 
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
-    virtual void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
+    void run() override;
 
 private:
-    const std::vector<A> &input;
+    const std::vector<A> *input;
     bool invert;
     double lower, upper;
 };

--- a/include/networkit/edgescores/GeometricMeanScore.hpp
+++ b/include/networkit/edgescores/GeometricMeanScore.hpp
@@ -1,5 +1,5 @@
 /*
- * GeometricMeanScore.h
+ * GeometricMeanScore.hpp
  *
  *  Created on: 18.11.2014
  *      Author: Michael Hamann
@@ -12,16 +12,16 @@
 
 namespace NetworKit {
 
-class GeometricMeanScore : public EdgeScore<double> {
+class GeometricMeanScore final : public EdgeScore<double> {
 
 private:
-    const std::vector<double>& attribute;
+    const std::vector<double>* attribute;
 
 public:
     GeometricMeanScore(const Graph& G, const std::vector<double>& attribute);
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
-    virtual void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
+    void run() override;
 };
 
 } // namespace NetworKit

--- a/include/networkit/edgescores/PrefixJaccardScore.hpp
+++ b/include/networkit/edgescores/PrefixJaccardScore.hpp
@@ -6,17 +6,17 @@
 namespace NetworKit {
 
 template <typename AttributeT>
-class PrefixJaccardScore : public EdgeScore<double> {
+class PrefixJaccardScore final : public EdgeScore<double> {
 
 public:
     PrefixJaccardScore(const Graph& G, const std::vector<AttributeT>& attribute);
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
-    virtual void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
+    void run() override;
 
 
 private:
-    const std::vector<AttributeT>& inAttribute;
+    const std::vector<AttributeT>* inAttribute;
 
 };
 

--- a/include/networkit/edgescores/TriangleEdgeScore.hpp
+++ b/include/networkit/edgescores/TriangleEdgeScore.hpp
@@ -5,6 +5,8 @@
  *      Author: Gerd Lindner, Michael Hamann
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_EDGESCORES_TRIANGLE_EDGE_SCORE_HPP_
 #define NETWORKIT_EDGESCORES_TRIANGLE_EDGE_SCORE_HPP_
 
@@ -22,18 +24,16 @@ namespace NetworKit {
  * ChibaNishizekiTriangleEdgeScore in NetworKit.
  *
  * [0] Triangle Listing Algorithms: Back from the Diversion
- * Mark Ortmann and Ulrik Brandes                                                                          *
- * 2014 Proceedings of the Sixteenth Workshop on Algorithm Engineering and Experiments (ALENEX). 2014, 1-8
+ * Mark Ortmann and Ulrik Brandes * 2014 Proceedings of the Sixteenth Workshop on Algorithm
+ * Engineering and Experiments (ALENEX). 2014, 1-8
  */
 class TriangleEdgeScore final : public EdgeScore<count> {
 
 public:
-
-    TriangleEdgeScore(const Graph& G);
+    TriangleEdgeScore(const Graph &G);
     count score(edgeid eid) override;
     count score(node u, node v) override;
     void run() override;
-
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/edgescores/TriangleEdgeScore.hpp
+++ b/include/networkit/edgescores/TriangleEdgeScore.hpp
@@ -1,5 +1,5 @@
 /*
- * TriangleEdgeScore.h
+ * TriangleEdgeScore.hpp
  *
  *  Created on: 22.05.2014
  *      Author: Gerd Lindner, Michael Hamann
@@ -25,14 +25,14 @@ namespace NetworKit {
  * Mark Ortmann and Ulrik Brandes                                                                          *
  * 2014 Proceedings of the Sixteenth Workshop on Algorithm Engineering and Experiments (ALENEX). 2014, 1-8
  */
-class TriangleEdgeScore : public EdgeScore<count> {
+class TriangleEdgeScore final : public EdgeScore<count> {
 
 public:
 
     TriangleEdgeScore(const Graph& G);
-    virtual count score(edgeid eid) override;
-    virtual count score(node u, node v) override;
-    virtual void run() override;
+    count score(edgeid eid) override;
+    count score(node u, node v) override;
+    void run() override;
 
 };
 

--- a/include/networkit/sparsification/ChanceCorrectedTriangleScore.hpp
+++ b/include/networkit/sparsification/ChanceCorrectedTriangleScore.hpp
@@ -1,5 +1,5 @@
 /*
- * ChangeCorrectedTriangleScore.h
+ * ChangeCorrectedTriangleScore.hpp
  *
  *  Created on: 20.11.2014
  *      Author: Michael Hamann
@@ -12,16 +12,16 @@
 
 namespace NetworKit {
 
-class ChanceCorrectedTriangleScore : public EdgeScore<double> {
+class ChanceCorrectedTriangleScore final : public EdgeScore<double> {
 
 public:
     ChanceCorrectedTriangleScore(const Graph& graph, const std::vector<count>& triangles);
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
-    virtual void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
+    void run() override;
 
 private:
-    const std::vector<count>& triangles;
+    const std::vector<count>* triangles;
 
 };
 

--- a/include/networkit/sparsification/ChanceCorrectedTriangleScore.hpp
+++ b/include/networkit/sparsification/ChanceCorrectedTriangleScore.hpp
@@ -5,6 +5,8 @@
  *      Author: Michael Hamann
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_SPARSIFICATION_CHANCE_CORRECTED_TRIANGLE_SCORE_HPP_
 #define NETWORKIT_SPARSIFICATION_CHANCE_CORRECTED_TRIANGLE_SCORE_HPP_
 
@@ -15,15 +17,14 @@ namespace NetworKit {
 class ChanceCorrectedTriangleScore final : public EdgeScore<double> {
 
 public:
-    ChanceCorrectedTriangleScore(const Graph& graph, const std::vector<count>& triangles);
+    ChanceCorrectedTriangleScore(const Graph &graph, const std::vector<count> &triangles);
     double score(edgeid eid) override;
     double score(node u, node v) override;
     void run() override;
 
 private:
-    const std::vector<count>* triangles;
-
+    const std::vector<count> *triangles;
 };
 
-}
+} // namespace NetworKit
 #endif // NETWORKIT_SPARSIFICATION_CHANCE_CORRECTED_TRIANGLE_SCORE_HPP_

--- a/include/networkit/sparsification/ForestFireScore.hpp
+++ b/include/networkit/sparsification/ForestFireScore.hpp
@@ -1,5 +1,5 @@
 /*
- * ForestFireScore.h
+ * ForestFireScore.hpp
  *
  *  Created on: 26.08.2014
  *      Author: Gerd Lindner
@@ -16,14 +16,14 @@ namespace NetworKit {
  * Based on the Forest Fire algorithm introduced by Leskovec et al.
  * The burn frequency of the edges is used as edge score.
  */
-class ForestFireScore : public EdgeScore<double> {
+class ForestFireScore final : public EdgeScore<double> {
 
 public:
 
     ForestFireScore(const Graph& graph, double pf, double targetBurntRatio);
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
-    virtual void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
+    void run() override;
 
 private:
     double pf;

--- a/include/networkit/sparsification/LocalDegreeScore.hpp
+++ b/include/networkit/sparsification/LocalDegreeScore.hpp
@@ -1,5 +1,5 @@
 /*
- * LocalDegreeScore.h
+ * LocalDegreeScore.hpp
  *
  *  Created on: 28.08.2014
  *      Author: Gerd Lindner
@@ -16,14 +16,14 @@ namespace NetworKit {
  * Local Degree sparsification method.
  * See 'Structure-Preserving Sparsification of Social Networks' by Lindner, Staudt, Hamann.
  */
-class LocalDegreeScore : public EdgeScore<double> {
+class LocalDegreeScore final : public EdgeScore<double> {
 
 public:
 
     LocalDegreeScore(const Graph& G);
-    virtual void run() override;
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
+    void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
 
 };
 

--- a/include/networkit/sparsification/LocalFilterScore.hpp
+++ b/include/networkit/sparsification/LocalFilterScore.hpp
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <memory>
+
 #include <networkit/auxiliary/Parallel.hpp>
 #include <networkit/edgescores/EdgeScore.hpp>
 
@@ -29,7 +30,7 @@ public:
      * Initialize the local edge filtering score.
      *
      * @param G The graph for which the score shall be.
-     * @param attribute The input attribute according to which the edges shall be fitlered locally.
+     * @param attribute The input attribute according to which the edges shall be filtered locally.
      * @param logarithmic If the score shall be logarithmic in the rank (then d^e edges are kept). Linear otherwise.
      */
     LocalFilterScore(const Graph& G, const std::vector< InType > &attribute, bool logarithmic = true) :

--- a/include/networkit/sparsification/LocalSimilarityScore.hpp
+++ b/include/networkit/sparsification/LocalSimilarityScore.hpp
@@ -1,5 +1,5 @@
 /*
- * LocalSimilarityScore.h
+ * LocalSimilarityScore.hpp
  *
  *  Created on: 26.07.2014
  *      Author: Gerd Lindner
@@ -47,17 +47,17 @@ struct greater {
 /**
  * Implementation of the Local Sparsification Algorithm by Sataluri et al.
  */
-class LocalSimilarityScore : public EdgeScore<double> {
+class LocalSimilarityScore final : public EdgeScore<double> {
 
 public:
 
     LocalSimilarityScore(const Graph& G, const std::vector<count>& triangles);
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
-    virtual void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
+    void run() override;
 
 private:
-    const std::vector<count>& triangles;
+    const std::vector<count>* triangles;
 };
 
 }

--- a/include/networkit/sparsification/MultiscaleScore.hpp
+++ b/include/networkit/sparsification/MultiscaleScore.hpp
@@ -1,5 +1,5 @@
 /*
- * MultiscaleScore.h
+ * MultiscaleScore.hpp
  *
  *  Created on: 20.06.2014
  *      Author: Gerd Lindner
@@ -19,18 +19,18 @@ namespace NetworKit {
  *
  * See "Extracting the multiscale backbone of complex weighted networks" by Serrano et al.
  */
-class MultiscaleScore : public EdgeScore<double> {
+class MultiscaleScore final : public EdgeScore<double> {
 
 public:
 
     MultiscaleScore(const Graph& graph, const std::vector<double>& attribute);
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
-    virtual void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
+    void run() override;
     double getProbability(count degree, edgeweight normalizedWeight);
 
 private:
-    const std::vector<double>& attribute;
+    const std::vector<double>* attribute;
 };
 
 }

--- a/include/networkit/sparsification/RandomEdgeScore.hpp
+++ b/include/networkit/sparsification/RandomEdgeScore.hpp
@@ -1,5 +1,5 @@
 /*
- * RandomEdgeScore.h
+ * RandomEdgeScore.hpp
  *
  *  Created on: 11.08.2014
  *      Author: Gerd Lindner
@@ -15,7 +15,7 @@ namespace NetworKit {
 /**
  * Generates a random edge attribute. Each edge is assigned a random value in [0,1].
  */
-class RandomEdgeScore : public EdgeScore<double> {
+class RandomEdgeScore final : public EdgeScore<double> {
 
 public:
 
@@ -24,9 +24,9 @@ public:
      */
     RandomEdgeScore(const Graph& G);
 
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
-    virtual void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
+    void run() override;
 };
 
 }

--- a/include/networkit/sparsification/RandomNodeEdgeScore.hpp
+++ b/include/networkit/sparsification/RandomNodeEdgeScore.hpp
@@ -1,5 +1,5 @@
 /*
- * RandomNodeEdgeScore.h
+ * RandomNodeEdgeScore.hpp
  *
  *  Created on: 20.11.2014
  *      Author: Michael Hamann
@@ -12,13 +12,13 @@
 
 namespace NetworKit {
 
-class RandomNodeEdgeScore : public EdgeScore<double> {
+class RandomNodeEdgeScore final : public EdgeScore<double> {
 
 public:
     RandomNodeEdgeScore(const Graph& graph, double rneRatio = 0.8);
-    virtual void run() override;
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
+    void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
 
 private:
     double rneRatio;

--- a/include/networkit/sparsification/SCANStructuralSimilarityScore.hpp
+++ b/include/networkit/sparsification/SCANStructuralSimilarityScore.hpp
@@ -6,18 +6,18 @@
 
 namespace NetworKit {
 
-    class SCANStructuralSimilarityScore : public EdgeScore<double> {
+class SCANStructuralSimilarityScore final : public EdgeScore<double> {
 
-    public:
-        SCANStructuralSimilarityScore(const Graph& G, const std::vector<count>& triangles);
-        virtual void run() override;
-        virtual double score(edgeid eid) override;
-        virtual double score(node u, node v) override;
+public:
+    SCANStructuralSimilarityScore(const Graph& G, const std::vector<count>& triangles);
+    void run() override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
 
-    private:
-        const std::vector<count>& triangles;
+private:
+    const std::vector<count>* triangles;
 
-    };
+};
 
 } // namespace NetworKit
 

--- a/include/networkit/sparsification/SimmelianOverlapScore.hpp
+++ b/include/networkit/sparsification/SimmelianOverlapScore.hpp
@@ -1,5 +1,5 @@
 /*
- * SimmelianOverlapScore.h
+ * SimmelianOverlapScore.hpp
  *
  *  Created on: 22.07.2014
  *      Author: Gerd Lindner
@@ -16,16 +16,16 @@ namespace NetworKit {
 /**
  * Calculates the Simmelian backbone (paramaetric variant) for a given input graph.
  */
-class SimmelianOverlapScore : public SimmelianScore {
+class SimmelianOverlapScore final : public SimmelianScore {
 
 public:
 
     /**
      * Creates a new instance of the parametric variant of the Simmelian Backbone calculator.
-     * @param maxRank 		the maximum rank that is considered for overlap calculation
+     * @param maxRank     the maximum rank that is considered for overlap calculation
      */
     SimmelianOverlapScore(const Graph& graph, const std::vector<count>& triangles, count maxRank);
-    virtual void run() override;
+    void run() override;
 
 private:
     count maxRank;

--- a/include/networkit/sparsification/SimmelianScore.hpp
+++ b/include/networkit/sparsification/SimmelianScore.hpp
@@ -92,7 +92,7 @@ public:
             count& overlap);
 
 protected:
-    const std::vector<count>& triangles;
+    const std::vector<count>* triangles;
 
 };
 

--- a/networkit/cpp/edgescores/ChibaNishizekiQuadrangleEdgeScore.cpp
+++ b/networkit/cpp/edgescores/ChibaNishizekiQuadrangleEdgeScore.cpp
@@ -13,34 +13,34 @@ ChibaNishizekiQuadrangleEdgeScore::ChibaNishizekiQuadrangleEdgeScore(const Graph
 }
 
 void ChibaNishizekiQuadrangleEdgeScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    std::vector<std::vector<std::pair<node, edgeid> > > edges(G.upperNodeIdBound());
+    std::vector<std::vector<std::pair<node, edgeid> > > edges(G->upperNodeIdBound());
 
     // copy edges with edge ids
-    G.parallelForNodes([&](node u) {
-        edges[u].reserve(G.degree(u));
-        G.forEdgesOf(u, [&](node, node v, edgeid eid) {
+    G->parallelForNodes([&](node u) {
+        edges[u].reserve(G->degree(u));
+        G->forEdgesOf(u, [&](node, node v, edgeid eid) {
             edges[u].emplace_back(v, eid);
         });
     });
 
     //Node attribute: marker
-    std::vector<count> nodeMarker(G.upperNodeIdBound(), 0);
+    std::vector<count> nodeMarker(G->upperNodeIdBound(), 0);
 
     //Edge attribute: triangle count
-    scoreData.resize(G.upperEdgeIdBound(), 0);
+    scoreData.resize(G->upperEdgeIdBound(), 0);
 
     // bucket sort
-    count n = G.numberOfNodes();
+    count n = G->numberOfNodes();
     std::vector<node> sortedNodes(n);
     {
         std::vector<index> nodePos(n + 1, 0);
 
-        G.forNodes([&](node u) {
-            ++nodePos[n - G.degree(u)];
+        G->forNodes([&](node u) {
+            ++nodePos[n - G->degree(u)];
         });
 
         // exclusive prefix sum
@@ -54,8 +54,8 @@ void ChibaNishizekiQuadrangleEdgeScore::run() {
             sum += tmp;
         }
 
-        G.forNodes([&](node u) {
-            sortedNodes[nodePos[n - G.degree(u)]++] = u;
+        G->forNodes([&](node u) {
+            sortedNodes[nodePos[n - G->degree(u)]++] = u;
         });
     }
 

--- a/networkit/cpp/edgescores/ChibaNishizekiQuadrangleEdgeScore.cpp
+++ b/networkit/cpp/edgescores/ChibaNishizekiQuadrangleEdgeScore.cpp
@@ -9,8 +9,7 @@
 
 namespace NetworKit {
 
-ChibaNishizekiQuadrangleEdgeScore::ChibaNishizekiQuadrangleEdgeScore(const Graph& G) : EdgeScore<count>(G) {
-}
+ChibaNishizekiQuadrangleEdgeScore::ChibaNishizekiQuadrangleEdgeScore(const Graph& G) : EdgeScore<count>(G) {}
 
 void ChibaNishizekiQuadrangleEdgeScore::run() {
     if (!G->hasEdgeIds()) {

--- a/networkit/cpp/edgescores/ChibaNishizekiTriangleEdgeScore.cpp
+++ b/networkit/cpp/edgescores/ChibaNishizekiTriangleEdgeScore.cpp
@@ -11,15 +11,14 @@
 
 namespace NetworKit {
 
-ChibaNishizekiTriangleEdgeScore::ChibaNishizekiTriangleEdgeScore(const Graph& G) : EdgeScore<count>(G) {
-}
+ChibaNishizekiTriangleEdgeScore::ChibaNishizekiTriangleEdgeScore(const Graph& G) : EdgeScore<count>(G) {}
 
 void ChibaNishizekiTriangleEdgeScore::run() {
     if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    std::vector<std::vector<std::pair<node, edgeid> > > edges(G->upperNodeIdBound());
+    std::vector<std::vector<std::pair<node, edgeid>>> edges(G->upperNodeIdBound());
 
     // copy edges with edge ids
     G->parallelForNodes([&](node u) {

--- a/networkit/cpp/edgescores/ChibaNishizekiTriangleEdgeScore.cpp
+++ b/networkit/cpp/edgescores/ChibaNishizekiTriangleEdgeScore.cpp
@@ -5,9 +5,9 @@
  *      Author: Gerd Lindner
  */
 
-#include <networkit/edgescores/ChibaNishizekiTriangleEdgeScore.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Timer.hpp>
+#include <networkit/edgescores/ChibaNishizekiTriangleEdgeScore.hpp>
 
 namespace NetworKit {
 
@@ -15,34 +15,34 @@ ChibaNishizekiTriangleEdgeScore::ChibaNishizekiTriangleEdgeScore(const Graph& G)
 }
 
 void ChibaNishizekiTriangleEdgeScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    std::vector<std::vector<std::pair<node, edgeid> > > edges(G.upperNodeIdBound());
+    std::vector<std::vector<std::pair<node, edgeid> > > edges(G->upperNodeIdBound());
 
     // copy edges with edge ids
-    G.parallelForNodes([&](node u) {
-        edges[u].reserve(G.degree(u));
-        G.forEdgesOf(u, [&](node, node v, edgeid eid) {
+    G->parallelForNodes([&](node u) {
+        edges[u].reserve(G->degree(u));
+        G->forEdgesOf(u, [&](node, node v, edgeid eid) {
             edges[u].emplace_back(v, eid);
         });
     });
 
     //Node attribute: marker
-    std::vector<edgeid> nodeMarker(G.upperNodeIdBound(), none);
+    std::vector<edgeid> nodeMarker(G->upperNodeIdBound(), none);
 
     //Edge attribute: triangle count
-    scoreData.resize(G.upperEdgeIdBound(), 0);
+    scoreData.resize(G->upperEdgeIdBound(), 0);
 
     // bucket sort
-    count n = G.numberOfNodes();
+    count n = G->numberOfNodes();
     std::vector<node> sortedNodes(n);
     {
         std::vector<index> nodePos(n + 1, 0);
 
-        G.forNodes([&](node u) {
-            ++nodePos[n - G.degree(u)];
+        G->forNodes([&](node u) {
+            ++nodePos[n - G->degree(u)];
         });
 
         // exclusive prefix sum
@@ -56,8 +56,8 @@ void ChibaNishizekiTriangleEdgeScore::run() {
             sum += tmp;
         }
 
-        G.forNodes([&](node u) {
-            sortedNodes[nodePos[n - G.degree(u)]++] = u;
+        G->forNodes([&](node u) {
+            sortedNodes[nodePos[n - G->degree(u)]++] = u;
         });
     }
 

--- a/networkit/cpp/edgescores/EdgeScore.cpp
+++ b/networkit/cpp/edgescores/EdgeScore.cpp
@@ -25,7 +25,8 @@ namespace NetworKit {
     }
 
     /** Get a vector containing the score for each edge in the graph.
-    @Return the edge scores calculated by @link run().
+     *
+     * @return the edge scores calculated by @link run().
     */
     template<typename T>
     std::vector<T> EdgeScore<T>::scores() const {

--- a/networkit/cpp/edgescores/EdgeScore.cpp
+++ b/networkit/cpp/edgescores/EdgeScore.cpp
@@ -11,7 +11,7 @@
 namespace NetworKit {
 
     template<typename T>
-    EdgeScore<T>::EdgeScore(const Graph& G) : Algorithm(), G(G), scoreData() {
+    EdgeScore<T>::EdgeScore(const Graph& G) : Algorithm(), G(&G), scoreData() {
         if (G.isDirected()) {
             WARN("Application to directed graphs is not well tested");
         }
@@ -45,7 +45,7 @@ namespace NetworKit {
     */
     template<typename T>
     T EdgeScore<T>::score(node u, node v) {
-        return score(G.edgeId(u,v));
+        return score(G->edgeId(u,v));
     }
 
     template class EdgeScore<double>;

--- a/networkit/cpp/edgescores/EdgeScoreAsWeight.cpp
+++ b/networkit/cpp/edgescores/EdgeScoreAsWeight.cpp
@@ -10,23 +10,23 @@
 namespace NetworKit {
 
 EdgeScoreAsWeight::EdgeScoreAsWeight(const Graph& G, const std::vector<double>& score, bool squared, edgeweight offset, edgeweight factor) :
-        G(G), score(score), squared(squared), offset(offset), factor(factor) {
+        G(&G), score(&score), squared(squared), offset(offset), factor(factor) {
 }
 
 Graph EdgeScoreAsWeight::calculate() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    Graph result(G, true, false);
+    Graph result(*G, true, false);
 
     if (squared) {
-        G.parallelForEdges([&](node u, node v, edgeid eid) {
-            result.setWeight(u, v, offset + factor * score[eid] * score[eid]);
+        G->parallelForEdges([&](node u, node v, edgeid eid) {
+            result.setWeight(u, v, offset + factor * (*score)[eid] * (*score)[eid]);
         });
     } else {
-        G.parallelForEdges([&](node u, node v, edgeid eid) {
-            result.setWeight(u, v, offset + factor * score[eid]);
+        G->parallelForEdges([&](node u, node v, edgeid eid) {
+            result.setWeight(u, v, offset + factor * (*score)[eid]);
         });
     }
 

--- a/networkit/cpp/edgescores/EdgeScoreBlender.cpp
+++ b/networkit/cpp/edgescores/EdgeScoreBlender.cpp
@@ -10,17 +10,17 @@
 namespace NetworKit {
 
 EdgeScoreBlender::EdgeScoreBlender(const Graph &G, const std::vector< double > &attribute0, const std::vector< double > &attribute1, const std::vector< bool > &selection) :
-EdgeScore(G), attribute0(attribute0), attribute1(attribute1), selection(selection) {}
+EdgeScore(G), attribute0(&attribute0), attribute1(&attribute1), selection(&selection) {}
 
 void EdgeScoreBlender::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    scoreData.resize(G.upperEdgeIdBound());
+    scoreData.resize(G->upperEdgeIdBound());
 
-    G.parallelForEdges([&](node, node, edgeid eid) {
-        scoreData[eid] = (selection[eid] ? attribute1[eid] : attribute0[eid]);
+    G->parallelForEdges([&](node, node, edgeid eid) {
+        scoreData[eid] = ((*selection)[eid] ? (*attribute1)[eid] : (*attribute0)[eid]);
     });
 
     hasRun = true;

--- a/networkit/cpp/edgescores/EdgeScoreLinearizer.cpp
+++ b/networkit/cpp/edgescores/EdgeScoreLinearizer.cpp
@@ -1,40 +1,40 @@
 /*
- * EdgeScoreLinearizer.h
+ * EdgeScoreLinearizer.cpp
  *
  *  Created on: 18.11.2014
  *      Author: Michael Hamann
  */
 
-#include <networkit/edgescores/EdgeScoreLinearizer.hpp>
 #include <numeric>
 #include <tuple>
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
+#include <networkit/edgescores/EdgeScoreLinearizer.hpp>
 
 namespace NetworKit {
 
-EdgeScoreLinearizer::EdgeScoreLinearizer(const Graph& G, const std::vector<double>& attribute, bool inverse) : EdgeScore<double>(G), attribute(attribute), inverse(inverse) {
+EdgeScoreLinearizer::EdgeScoreLinearizer(const Graph& G, const std::vector<double>& attribute, bool inverse) : EdgeScore<double>(G), attribute(&attribute), inverse(inverse) {
 }
 
 
 void EdgeScoreLinearizer::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    scoreData.resize(G.upperEdgeIdBound());
+    scoreData.resize(G->upperEdgeIdBound());
 
     // Special case for m = 1
-    if (G.numberOfEdges() == 1) {
-        G.forEdges([&](node, node, edgeid eid) {
+    if (G->numberOfEdges() == 1) {
+        G->forEdges([&](node, node, edgeid eid) {
             scoreData[eid] = 0.5;
         });
     } else {
         typedef std::tuple<edgeweight, index, edgeid> edgeTuple;
-        std::vector<edgeTuple> sorted(G.upperEdgeIdBound(), std::make_tuple(std::numeric_limits<edgeweight>::max(), std::numeric_limits<index>::max(), none));
+        std::vector<edgeTuple> sorted(G->upperEdgeIdBound(), std::make_tuple(std::numeric_limits<edgeweight>::max(), std::numeric_limits<index>::max(), none));
 
-        G.parallelForEdges([&](node, node, edgeid eid) {
-            sorted[eid] = std::make_tuple(attribute[eid], Aux::Random::integer(), eid);
+        G->parallelForEdges([&](node, node, edgeid eid) {
+            sorted[eid] = std::make_tuple((*attribute)[eid], Aux::Random::integer(), eid);
         });
 
         if (inverse) {
@@ -44,10 +44,10 @@ void EdgeScoreLinearizer::run() {
         }
 
         #pragma omp parallel for
-        for (omp_index pos = 0; pos < static_cast<omp_index>(G.upperEdgeIdBound()); ++pos) {
+        for (omp_index pos = 0; pos < static_cast<omp_index>(G->upperEdgeIdBound()); ++pos) {
             edgeid eid = std::get<2>(sorted[pos]);
             if (eid != none) {
-                scoreData[eid] = pos * 1.0 / (G.numberOfEdges()-1); // TODO maybe writing back to sorted and then sorting again by eid could be faster (cache efficiency)?
+                scoreData[eid] = pos * 1.0 / (G->numberOfEdges()-1); // TODO maybe writing back to sorted and then sorting again by eid could be faster (cache efficiency)?
             }
         }
     }

--- a/networkit/cpp/edgescores/EdgeScoreLinearizer.cpp
+++ b/networkit/cpp/edgescores/EdgeScoreLinearizer.cpp
@@ -7,15 +7,15 @@
 
 #include <numeric>
 #include <tuple>
-#include <networkit/auxiliary/Random.hpp>
+
 #include <networkit/auxiliary/Parallel.hpp>
+#include <networkit/auxiliary/Random.hpp>
 #include <networkit/edgescores/EdgeScoreLinearizer.hpp>
 
 namespace NetworKit {
 
 EdgeScoreLinearizer::EdgeScoreLinearizer(const Graph& G, const std::vector<double>& attribute, bool inverse) : EdgeScore<double>(G), attribute(&attribute), inverse(inverse) {
 }
-
 
 void EdgeScoreLinearizer::run() {
     if (!G->hasEdgeIds()) {

--- a/networkit/cpp/edgescores/EdgeScoreNormalizer.cpp
+++ b/networkit/cpp/edgescores/EdgeScoreNormalizer.cpp
@@ -4,20 +4,20 @@ namespace NetworKit {
 
     template<typename A>
     EdgeScoreNormalizer<A>::EdgeScoreNormalizer(const Graph &G, const std::vector<A> &score, bool invert, double lower, double upper) :
-        EdgeScore<double>(G), input(score), invert(invert), lower(lower), upper(upper) {}
+        EdgeScore<double>(G), input(&score), invert(invert), lower(lower), upper(upper) {}
 
     template<typename A>
     void EdgeScoreNormalizer<A>::run() {
         A minValue = std::numeric_limits< A >::max();
         A maxValue = std::numeric_limits< A >::lowest();
 
-        G.forEdges([&](node, node, edgeid eid) {
-            if (input[eid] < minValue) {
-                minValue = input[eid];
+        G->forEdges([&](node, node, edgeid eid) {
+            if ((*input)[eid] < minValue) {
+                minValue = (*input)[eid];
             }
 
-            if (input[eid] > maxValue) {
-                maxValue = input[eid];
+            if ((*input)[eid] > maxValue) {
+                maxValue = (*input)[eid];
             }
         });
 
@@ -28,10 +28,10 @@ namespace NetworKit {
             offset = upper - minValue * factor;
         }
 
-        scoreData.resize(G.upperEdgeIdBound(), std::numeric_limits<double>::quiet_NaN());
+        scoreData.resize(G->upperEdgeIdBound(), std::numeric_limits<double>::quiet_NaN());
 
-        G.parallelForEdges([&](node, node, edgeid eid) {
-            scoreData[eid] = factor * input[eid] + offset;
+        G->parallelForEdges([&](node, node, edgeid eid) {
+            scoreData[eid] = factor * (*input)[eid] + offset;
         });
 
         hasRun = true;

--- a/networkit/cpp/edgescores/GeometricMeanScore.cpp
+++ b/networkit/cpp/edgescores/GeometricMeanScore.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cmath>
+
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/edgescores/GeometricMeanScore.hpp>
 
@@ -20,15 +21,15 @@ void GeometricMeanScore::run() {
     }
 
     scoreData.resize(G->upperEdgeIdBound());
-    
+
     std::vector<double> nodeSum(G->upperNodeIdBound());
-    
+
     G->parallelForNodes([&](node u) {
         G->forEdgesOf(u, [&](node, node, edgeid eid) {
             nodeSum[u] += (*attribute)[eid];
         });
     });
-    
+
     G->parallelForEdges([&](node u, node v, edgeid eid) {
         if ((*attribute)[eid] > 0) {
             scoreData[eid] = (*attribute)[eid] * 1.0 / std::sqrt(nodeSum[u] * nodeSum[v]);
@@ -37,7 +38,7 @@ void GeometricMeanScore::run() {
             }
         }
     });
-    
+
     hasRun = true;
 }
 

--- a/networkit/cpp/edgescores/GeometricMeanScore.cpp
+++ b/networkit/cpp/edgescores/GeometricMeanScore.cpp
@@ -1,39 +1,39 @@
 /*
- * GeometricMeanScore.h
+ * GeometricMeanScore.cpp
  *
  *  Created on: 20.11.2014
  *      Author: Michael Hamann
  */
 
 #include <cmath>
-#include <networkit/edgescores/GeometricMeanScore.hpp>
 #include <networkit/auxiliary/Log.hpp>
+#include <networkit/edgescores/GeometricMeanScore.hpp>
 
 namespace NetworKit {
 
-GeometricMeanScore::GeometricMeanScore(const Graph& G, const std::vector<double>& attribute): EdgeScore<double>(G), attribute(attribute) {
+GeometricMeanScore::GeometricMeanScore(const Graph& G, const std::vector<double>& attribute): EdgeScore<double>(G), attribute(&attribute) {
 }
 
 void GeometricMeanScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    scoreData.resize(G.upperEdgeIdBound());
+    scoreData.resize(G->upperEdgeIdBound());
     
-    std::vector<double> nodeSum(G.upperNodeIdBound());
+    std::vector<double> nodeSum(G->upperNodeIdBound());
     
-    G.parallelForNodes([&](node u) {
-        G.forEdgesOf(u, [&](node, node, edgeid eid) {
-            nodeSum[u] += attribute[eid];
+    G->parallelForNodes([&](node u) {
+        G->forEdgesOf(u, [&](node, node, edgeid eid) {
+            nodeSum[u] += (*attribute)[eid];
         });
     });
     
-    G.parallelForEdges([&](node u, node v, edgeid eid) {
-        if (attribute[eid] > 0) {
-            scoreData[eid] = attribute[eid] * 1.0 / std::sqrt(nodeSum[u] * nodeSum[v]);
+    G->parallelForEdges([&](node u, node v, edgeid eid) {
+        if ((*attribute)[eid] > 0) {
+            scoreData[eid] = (*attribute)[eid] * 1.0 / std::sqrt(nodeSum[u] * nodeSum[v]);
             if (std::isnan(scoreData[eid])) {
-                ERROR("Attribute ", attribute[eid], " couldn't be normalized with sum ", nodeSum[u], " and sum ", nodeSum[v]);
+                ERROR("Attribute ", (*attribute)[eid], " couldn't be normalized with sum ", nodeSum[u], " and sum ", nodeSum[v]);
             }
         }
     });

--- a/networkit/cpp/edgescores/PrefixJaccardScore.cpp
+++ b/networkit/cpp/edgescores/PrefixJaccardScore.cpp
@@ -5,8 +5,9 @@
  *      Author: Michael Hamann
  */
 
-#include <networkit/edgescores/PrefixJaccardScore.hpp>
 #include <omp.h>
+
+#include <networkit/edgescores/PrefixJaccardScore.hpp>
 
 namespace NetworKit {
 

--- a/networkit/cpp/edgescores/PrefixJaccardScore.cpp
+++ b/networkit/cpp/edgescores/PrefixJaccardScore.cpp
@@ -1,5 +1,5 @@
 /*
- * PrefixJaccardScore.h
+ * PrefixJaccardScore.cpp
  *
  *  Created on: 26.09.2014
  *      Author: Michael Hamann
@@ -12,16 +12,16 @@ namespace NetworKit {
 
 template <typename AttributeT>
 PrefixJaccardScore<AttributeT>::PrefixJaccardScore(const Graph &G, const std::vector< AttributeT > &attribute) :
-    EdgeScore<double>(G), inAttribute(attribute) {
+    EdgeScore<double>(G), inAttribute(&attribute) {
 }
 
 template <typename AttributeT>
 void PrefixJaccardScore<AttributeT>::run() {
     //this-> required to access members of base class, since this is a template class.
-    if (!this->G.hasEdgeIds()) throw std::runtime_error("Error, edges need to be indexed first");
+    if (!this->G->hasEdgeIds()) throw std::runtime_error("Error, edges need to be indexed first");
 
     this->scoreData.clear();
-    this->scoreData.resize(this->G.upperEdgeIdBound());
+    this->scoreData.resize(this->G->upperEdgeIdBound());
 
     struct RankedEdge {
         node u;
@@ -39,22 +39,22 @@ void PrefixJaccardScore<AttributeT>::run() {
         };
     };
 
-    std::vector<size_t> rankedEdgeBegin(G.upperNodeIdBound() + 1);
+    std::vector<size_t> rankedEdgeBegin(G->upperNodeIdBound() + 1);
     std::vector<RankedEdge> rankedEdges;
-    rankedEdges.reserve(2*G.numberOfEdges());
+    rankedEdges.reserve(2*G->numberOfEdges());
 
-    for (node u = 0; u < G.upperNodeIdBound(); ++u) {
+    for (node u = 0; u < G->upperNodeIdBound(); ++u) {
         rankedEdgeBegin[u] = rankedEdges.size();
-        if (G.hasNode(u)) {
-            G.forEdgesOf(u, [&](node, node v, edgeid eid) {
-                rankedEdges.emplace_back(v, inAttribute[eid], 0);
+        if (G->hasNode(u)) {
+            G->forEdgesOf(u, [&](node, node v, edgeid eid) {
+                rankedEdges.emplace_back(v, ((*inAttribute)[eid]), 0);
             });
         }
     }
-    rankedEdgeBegin[G.upperNodeIdBound()] = rankedEdges.size();
+    rankedEdgeBegin[G->upperNodeIdBound()] = rankedEdges.size();
 
-    this->G.balancedParallelForNodes([&](node u) {
-        if (this->G.degree(u) == 0) return;
+    this->G->balancedParallelForNodes([&](node u) {
+        if (this->G->degree(u) == 0) return;
 
         const auto beginIt = rankedEdges.begin() + rankedEdgeBegin[u];
         const auto endIt = rankedEdges.begin() + rankedEdgeBegin[u+1];
@@ -77,10 +77,10 @@ void PrefixJaccardScore<AttributeT>::run() {
         }
     });
 
-    std::vector<std::vector<bool>> uMarker(omp_get_max_threads(), std::vector<bool>(G.upperNodeIdBound(), false));
+    std::vector<std::vector<bool>> uMarker(omp_get_max_threads(), std::vector<bool>(G->upperNodeIdBound(), false));
     auto vMarker = uMarker;
 
-    this->G.parallelForEdges([&](node u, node v, edgeid eid) {
+    this->G->parallelForEdges([&](node u, node v, edgeid eid) {
         count curRank = 0;
         double bestJaccard = 0;
         auto tid = omp_get_thread_num();
@@ -136,11 +136,11 @@ void PrefixJaccardScore<AttributeT>::run() {
             ++curRank;
         }
 
-        G.forNeighborsOf(u, [&](node w) {
+        G->forNeighborsOf(u, [&](node w) {
             uMarker[tid][w] = false;
         });
 
-        G.forNeighborsOf(v, [&](node w) {
+        G->forNeighborsOf(v, [&](node w) {
             vMarker[tid][w] = false;
         });
 

--- a/networkit/cpp/edgescores/TriangleEdgeScore.cpp
+++ b/networkit/cpp/edgescores/TriangleEdgeScore.cpp
@@ -5,9 +5,9 @@
  *      Author: Michael Hamann, Gerd Lindner
  */
 
-#include <networkit/edgescores/TriangleEdgeScore.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Timer.hpp>
+#include <networkit/edgescores/TriangleEdgeScore.hpp>
 #include <omp.h>
 
 namespace NetworKit {
@@ -16,59 +16,59 @@ TriangleEdgeScore::TriangleEdgeScore(const Graph& G) : EdgeScore<count>(G) {
 }
 
 void TriangleEdgeScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
     // direct edge from high to low-degree nodes
     auto isOutEdge = [&](node u, node v) {
-        return G.degree(u) > G.degree(v) || (G.degree(u) == G.degree(v) && u < v);
+        return G->degree(u) > G->degree(v) || (G->degree(u) == G->degree(v) && u < v);
     };
 
     Aux::Timer filterEdgesTimer;
     filterEdgesTimer.start();
     // Store in-edges explicitly. Idea: all nodes have (relatively) low in-degree
-    std::vector<index> inBegin(G.upperNodeIdBound() + 1);
-    std::vector<node> inEdges(G.numberOfEdges());
+    std::vector<index> inBegin(G->upperNodeIdBound() + 1);
+    std::vector<node> inEdges(G->numberOfEdges());
 
     {
         index pos = 0;
-        for (index u = 0; u < G.upperNodeIdBound(); ++u) {
+        for (index u = 0; u < G->upperNodeIdBound(); ++u) {
             inBegin[u] = pos;
-            if (G.hasNode(u)) {
-                G.forEdgesOf(u, [&](node, node v, edgeid) {
+            if (G->hasNode(u)) {
+                G->forEdgesOf(u, [&](node, node v, edgeid) {
                     if (isOutEdge(v, u)) {
                         inEdges[pos++] = v;
                     }
                 });
             }
         }
-        inBegin[G.upperNodeIdBound()] = pos;
+        inBegin[G->upperNodeIdBound()] = pos;
     }
 
     filterEdgesTimer.stop();
     INFO("Needed ", filterEdgesTimer.elapsedMilliseconds(), "ms for filtering edges");
 
     //Edge attribute: triangle count
-    std::vector<count> triangleCount(G.upperEdgeIdBound(), 0);
+    std::vector<count> triangleCount(G->upperEdgeIdBound(), 0);
     // Store triangle counts of edges incident to the current node indexed by the adjacent node
     // none indicates that the edge to that node does not exist
-    std::vector<std::vector<count> > incidentTriangleCount(omp_get_max_threads(), std::vector<count>(G.upperNodeIdBound(), none));
+    std::vector<std::vector<count> > incidentTriangleCount(omp_get_max_threads(), std::vector<count>(G->upperNodeIdBound(), none));
 
     Aux::Timer triangleTimer;
     triangleTimer.start();
 
-    G.balancedParallelForNodes([&](node u) {
+    G->balancedParallelForNodes([&](node u) {
         auto tid = omp_get_thread_num();
 
         // mark nodes as neighbors
-        G.forEdgesOf(u, [&](node, node v) {
+        G->forEdgesOf(u, [&](node, node v) {
             incidentTriangleCount[tid][v] = 0;
         });
 
         // Find all triangles of the form u-v-w-u where (v, w) is an in-edge.
         // Note that we find each triangle u is part of once.
-        G.forEdgesOf(u, [&](node, node v) {
+        G->forEdgesOf(u, [&](node, node v) {
             // for all in-edges (v, w).
             for (index i = inBegin[v]; i < inBegin[v + 1]; ++i) {
                 auto w = inEdges[i];
@@ -94,7 +94,7 @@ void TriangleEdgeScore::run() {
         });
 
         // Write local triangle counts into global array, unset local counters
-        G.forEdgesOf(u, [&](node, node v, edgeid eid) {
+        G->forEdgesOf(u, [&](node, node v, edgeid eid) {
             if (incidentTriangleCount[tid][v] > 0) {
                 triangleCount[eid] += incidentTriangleCount[tid][v];
             }

--- a/networkit/cpp/edgescores/TriangleEdgeScore.cpp
+++ b/networkit/cpp/edgescores/TriangleEdgeScore.cpp
@@ -5,10 +5,11 @@
  *      Author: Michael Hamann, Gerd Lindner
  */
 
+#include <omp.h>
+
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Timer.hpp>
 #include <networkit/edgescores/TriangleEdgeScore.hpp>
-#include <omp.h>
 
 namespace NetworKit {
 

--- a/networkit/cpp/sparsification/ChanceCorrectedTriangleScore.cpp
+++ b/networkit/cpp/sparsification/ChanceCorrectedTriangleScore.cpp
@@ -9,20 +9,20 @@
 
 namespace NetworKit {
 
-ChanceCorrectedTriangleScore::ChanceCorrectedTriangleScore(const Graph& G, const std::vector<count>& triangles) : EdgeScore<double>(G), triangles(triangles) {
+ChanceCorrectedTriangleScore::ChanceCorrectedTriangleScore(const Graph& G, const std::vector<count>& triangles) : EdgeScore<double>(G), triangles(&triangles) {
 }
 
 void ChanceCorrectedTriangleScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    scoreData.resize(G.upperEdgeIdBound(), 0.0);
+    scoreData.resize(G->upperEdgeIdBound(), 0.0);
     
-    G.parallelForEdges([&](node u, node v, edgeid eid) {
-        if (triangles[eid] > 0) {
-            scoreData[eid] = triangles[eid] * (G.numberOfNodes() - 2) * 1.0 / ((G.degree(u) - 1) * (G.degree(v) - 1));
-        } else if (G.degree(u) == 1 || G.degree(v) == 1) {
+    G->parallelForEdges([&](node u, node v, edgeid eid) {
+        if ((*triangles)[eid] > 0) {
+            scoreData[eid] = (*triangles)[eid] * (G->numberOfNodes() - 2) * 1.0 / ((G->degree(u) - 1) * (G->degree(v) - 1));
+        } else if (G->degree(u) == 1 || G->degree(v) == 1) {
             scoreData[eid] = 1;
         }
     });

--- a/networkit/cpp/sparsification/ChanceCorrectedTriangleScore.cpp
+++ b/networkit/cpp/sparsification/ChanceCorrectedTriangleScore.cpp
@@ -18,7 +18,7 @@ void ChanceCorrectedTriangleScore::run() {
     }
 
     scoreData.resize(G->upperEdgeIdBound(), 0.0);
-    
+
     G->parallelForEdges([&](node u, node v, edgeid eid) {
         if ((*triangles)[eid] > 0) {
             scoreData[eid] = (*triangles)[eid] * (G->numberOfNodes() - 2) * 1.0 / ((G->degree(u) - 1) * (G->degree(v) - 1));
@@ -26,7 +26,7 @@ void ChanceCorrectedTriangleScore::run() {
             scoreData[eid] = 1;
         }
     });
-    
+
     hasRun = true;
 }
 

--- a/networkit/cpp/sparsification/ForestFireScore.cpp
+++ b/networkit/cpp/sparsification/ForestFireScore.cpp
@@ -19,23 +19,23 @@ namespace NetworKit {
 ForestFireScore::ForestFireScore(const Graph& G, double pf, double targetBurntRatio): EdgeScore<double>(G), pf(pf), targetBurntRatio(targetBurntRatio) {}
 
 void ForestFireScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    std::vector<count> burnt (G.upperEdgeIdBound(), 0);
+    std::vector<count> burnt (G->upperEdgeIdBound(), 0);
     count edgesBurnt = 0;
 
     #pragma omp parallel
-    while (edgesBurnt < targetBurntRatio * G.numberOfEdges()) {
+    while (edgesBurnt < targetBurntRatio * G->numberOfEdges()) {
         //Start a new fire
         std::queue<node> activeNodes;
-        std::vector<bool> visited (G.upperNodeIdBound(), false);
-        activeNodes.push(GraphTools::randomNode(G));
+        std::vector<bool> visited (G->upperNodeIdBound(), false);
+        activeNodes.push(GraphTools::randomNode(*G));
 
         auto forwardNeighbors = [&](node u) {
             std::vector<std::pair<node, edgeid>> validEdges;
-            G.forNeighborsOf(u, [&](node, node x, edgeid eid){
+            G->forNeighborsOf(u, [&](node, node x, edgeid eid){
                 if (! visited[x]) {
                     validEdges.emplace_back(x, eid);
                 }
@@ -77,7 +77,7 @@ void ForestFireScore::run() {
         edgesBurnt += localEdgesBurnt;
     }
 
-    std::vector<double> burntNormalized (G.upperEdgeIdBound(), 0.0);
+    std::vector<double> burntNormalized (G->upperEdgeIdBound(), 0.0);
     double maxv = (double) *Aux::Parallel::max_element(std::begin(burnt), std::end(burnt));
 
     if (maxv > 0) {

--- a/networkit/cpp/sparsification/LocalSimilarityScore.cpp
+++ b/networkit/cpp/sparsification/LocalSimilarityScore.cpp
@@ -12,10 +12,10 @@
 namespace NetworKit {
 
 LocalSimilarityScore::LocalSimilarityScore(const Graph& G, const std::vector<count>& triangles) :
-    EdgeScore<double>(G), triangles(triangles) {}
+    EdgeScore<double>(G), triangles(&triangles) {}
 
 void LocalSimilarityScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
@@ -24,18 +24,18 @@ void LocalSimilarityScore::run() {
      * such that the edge is contained in the sparse graph.
      */
 
-    std::vector<double> sparsificationExp(G.upperEdgeIdBound(), 0.0);
+    std::vector<double> sparsificationExp(G->upperEdgeIdBound(), 0.0);
 
-    G.balancedParallelForNodes([&](node i) {
-        count d = G.degree(i);
+    G->balancedParallelForNodes([&](node i) {
+        count d = G->degree(i);
 
         /* The top d^e edges (sorted by similarity)
          * are to be kept in the graph. */
 
         std::vector<AttributizedEdge<double>> neighbors;
-        neighbors.reserve(G.degree(i));
-        G.forNeighborsOf(i, [&](node, node j, edgeid eid) {
-            double sim = triangles[eid] * 1.0 / (G.degree(i) + G.degree(j) - triangles[eid]);
+        neighbors.reserve(G->degree(i));
+        G->forNeighborsOf(i, [&](node, node j, edgeid eid) {
+            double sim = (*triangles)[eid] * 1.0 / (G->degree(i) + G->degree(j) - (*triangles)[eid]);
             neighbors.emplace_back(i, j, eid, sim);
         });
         std::sort(neighbors.begin(), neighbors.end());

--- a/networkit/cpp/sparsification/MultiscaleScore.cpp
+++ b/networkit/cpp/sparsification/MultiscaleScore.cpp
@@ -9,33 +9,33 @@
 
 namespace NetworKit {
 
-MultiscaleScore::MultiscaleScore(const Graph& G, const std::vector<double>& attribute) : EdgeScore<double>(G), attribute(attribute) {}
+MultiscaleScore::MultiscaleScore(const Graph& G, const std::vector<double>& attribute) : EdgeScore<double>(G), attribute(&attribute) {}
 
 void MultiscaleScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
     //The following vector is used for the _local_ normalization of edgeweights.
     //We use a global vector for performance reasons.
-    std::vector<edgeweight> normalizedWeights(G.upperNodeIdBound());
+    std::vector<edgeweight> normalizedWeights(G->upperNodeIdBound());
 
-    std::vector<double> multiscaleAttribute(G.upperEdgeIdBound(), 0.0);
+    std::vector<double> multiscaleAttribute(G->upperEdgeIdBound(), 0.0);
 
-    G.forNodes([&](node u) {
-        count k = G.degree(u);
+    G->forNodes([&](node u) {
+        count k = G->degree(u);
 
         //Normalize edgeweights of N(u)
         edgeweight sum = 0.0;
-        G.forNeighborsOf(u, [&](node, node, edgeid eid) {
-            sum += attribute[eid];
+        G->forNeighborsOf(u, [&](node, node, edgeid eid) {
+            sum += (*attribute)[eid];
         });
-        G.forNeighborsOf(u, [&](node, node v, edgeid eid) {
-            normalizedWeights[v] = attribute[eid] / sum;
+        G->forNeighborsOf(u, [&](node, node v, edgeid eid) {
+            normalizedWeights[v] = (*attribute)[eid] / sum;
         });
 
         //Filter edges by probability
-        G.forNeighborsOf(u, [&](node, node v, edgeid eid) {
+        G->forNeighborsOf(u, [&](node, node v, edgeid eid) {
             //In case d(u) == 1 and d(v) > 1: ignore u
             //if (k > 1 || G.degree(v) == 1) {
                 edgeweight p = normalizedWeights[v];

--- a/networkit/cpp/sparsification/RandomEdgeScore.cpp
+++ b/networkit/cpp/sparsification/RandomEdgeScore.cpp
@@ -9,8 +9,7 @@
 
 namespace NetworKit {
 
-RandomEdgeScore::RandomEdgeScore(const Graph& G) : EdgeScore<double>(G) {
-}
+RandomEdgeScore::RandomEdgeScore(const Graph& G) : EdgeScore<double>(G) {}
 
 void RandomEdgeScore::run() {
     if (!G->hasEdgeIds()) {
@@ -19,8 +18,6 @@ void RandomEdgeScore::run() {
     scoreData.resize(G->upperEdgeIdBound(), 0.0);
 
     G->parallelForEdges([&](node, node, edgeid eid) {
-        //double r = Aux::Random::probability();
-        //scoreData[eid] = randomness * r + (1 - randomness) * attribute[eid];
         scoreData[eid] = Aux::Random::probability();
     });
     hasRun = true;

--- a/networkit/cpp/sparsification/RandomEdgeScore.cpp
+++ b/networkit/cpp/sparsification/RandomEdgeScore.cpp
@@ -13,12 +13,12 @@ RandomEdgeScore::RandomEdgeScore(const Graph& G) : EdgeScore<double>(G) {
 }
 
 void RandomEdgeScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
-    scoreData.resize(G.upperEdgeIdBound(), 0.0);
+    scoreData.resize(G->upperEdgeIdBound(), 0.0);
 
-    G.parallelForEdges([&](node, node, edgeid eid) {
+    G->parallelForEdges([&](node, node, edgeid eid) {
         //double r = Aux::Random::probability();
         //scoreData[eid] = randomness * r + (1 - randomness) * attribute[eid];
         scoreData[eid] = Aux::Random::probability();

--- a/networkit/cpp/sparsification/RandomNodeEdgeScore.cpp
+++ b/networkit/cpp/sparsification/RandomNodeEdgeScore.cpp
@@ -15,12 +15,12 @@ RandomNodeEdgeScore::RandomNodeEdgeScore(const Graph& G, double rneRatio) : Edge
 }
 
 void RandomNodeEdgeScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    Graph sparseGraph = G;
-    std::vector<double> workScores(G.upperEdgeIdBound(), 0);
+    Graph sparseGraph = *G;
+    std::vector<double> workScores(G->upperEdgeIdBound(), 0);
     count numRemoved = 0;
     std::vector< std::pair<node, node> > uniformlyRandomEdges;
 
@@ -39,7 +39,7 @@ void RandomNodeEdgeScore::run() {
                 if (sparseGraph.hasEdge(edge.first, edge.second)) {
                     edgeid id = sparseGraph.edgeId(edge.first, edge.second);
 
-                    workScores[id] = numRemoved * 1.0 / G.numberOfEdges();
+                    workScores[id] = numRemoved * 1.0 / G->numberOfEdges();
 
                     sparseGraph.removeEdge(edge.first, edge.second);
 
@@ -52,7 +52,7 @@ void RandomNodeEdgeScore::run() {
 
             edgeid id = sparseGraph.edgeId(edge.first, edge.second);
 
-            workScores[id] = numRemoved * 1.0 / G.numberOfEdges();
+            workScores[id] = numRemoved * 1.0 / G->numberOfEdges();
 
             sparseGraph.removeEdge(edge.first, edge.second);
 

--- a/networkit/cpp/sparsification/SCANStructuralSimilarityScore.cpp
+++ b/networkit/cpp/sparsification/SCANStructuralSimilarityScore.cpp
@@ -1,14 +1,14 @@
 #include <networkit/sparsification/SCANStructuralSimilarityScore.hpp>
 
-NetworKit::SCANStructuralSimilarityScore::SCANStructuralSimilarityScore(const NetworKit::Graph &G, const std::vector< NetworKit::count > &triangles) : EdgeScore<double>(G), triangles(triangles) { }
+NetworKit::SCANStructuralSimilarityScore::SCANStructuralSimilarityScore(const NetworKit::Graph &G, const std::vector< NetworKit::count > &triangles) : EdgeScore<double>(G), triangles(&triangles) { }
 
 void NetworKit::SCANStructuralSimilarityScore::run() {
-    std::vector<double> workScores(G.upperEdgeIdBound());
+    std::vector<double> workScores(G->upperEdgeIdBound());
 
-    if (!G.hasEdgeIds()) throw std::runtime_error("Error, edges must be indexed");
+    if (!G->hasEdgeIds()) throw std::runtime_error("Error, edges must be indexed");
 
-    G.parallelForEdges([&](node u, node v, edgeid eid) {
-        workScores[eid] = (triangles[eid] + 1) * 1.0 / std::sqrt((G.degree(u) + 1)*(G.degree(v) + 1));
+    G->parallelForEdges([&](node u, node v, edgeid eid) {
+        workScores[eid] = ((*triangles)[eid] + 1) * 1.0 / std::sqrt((G->degree(u) + 1)*(G->degree(v) + 1));
     });
 
     scoreData = std::move(workScores);

--- a/networkit/cpp/sparsification/SimmelianOverlapScore.cpp
+++ b/networkit/cpp/sparsification/SimmelianOverlapScore.cpp
@@ -14,14 +14,14 @@ SimmelianOverlapScore::SimmelianOverlapScore(const Graph& G, const std::vector<c
         SimmelianScore(G, triangles), maxRank(maxRank) {}
 
 void SimmelianOverlapScore::run() {
-    if (!G.hasEdgeIds()) {
+    if (!G->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    std::vector<RankedNeighbors> neighbors = getRankedNeighborhood(G, triangles);
-    scoreData.resize(G.upperEdgeIdBound(), 0.0);
+    std::vector<RankedNeighbors> neighbors = getRankedNeighborhood(*G, *triangles);
+    scoreData.resize(G->upperEdgeIdBound(), 0.0);
 
-    G.parallelForEdges([&](node u, node v, edgeid eid) {
+    G->parallelForEdges([&](node u, node v, edgeid eid) {
         Redundancy redundancy = getOverlap(u, v, neighbors, maxRank);
 
         scoreData[eid] = (double) redundancy.overlap;

--- a/networkit/cpp/sparsification/SimmelianScore.cpp
+++ b/networkit/cpp/sparsification/SimmelianScore.cpp
@@ -10,7 +10,7 @@
 
 namespace NetworKit {
 
-SimmelianScore::SimmelianScore(const Graph& G, const std::vector<count>& triangles) : EdgeScore<double>(G), triangles(triangles) {
+SimmelianScore::SimmelianScore(const Graph& G, const std::vector<count>& triangles) : EdgeScore<double>(G), triangles(&triangles) {
 }
 
 std::vector<RankedNeighbors> SimmelianScore::getRankedNeighborhood(const Graph& g, const std::vector<count>& triangles) {


### PR DESCRIPTION
This PR brings some improvements to the C++ code of the edgescores and sparsification modules. The major changes include:
- Member variables are changed from references to pointers
- All classes that are not inherited from are made final.
- The virtual keyword is removed from any non-base classes.
- The documentation in the header files is changed from *.h to *.hpp.
