### PR TITLE
Address issue #489: Deprecate enabling nested parallelism

### DIFF
--- a/include/networkit/auxiliary/Parallelism.hpp
+++ b/include/networkit/auxiliary/Parallelism.hpp
@@ -10,6 +10,7 @@
 #ifndef NETWORKIT_AUXILIARY_PARALLELISM_HPP_
 #define NETWORKIT_AUXILIARY_PARALLELISM_HPP_
 
+#include <tlx/define/deprecated.hpp>
 
 
 namespace Aux {
@@ -35,7 +36,7 @@ int getMaxNumberOfThreads();
 
 
 /** Enable OpenMP nested parallelism */
-void enableNestedParallelism();
+void TLX_DEPRECATED(enableNestedParallelism());
 
 }
 

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -228,9 +228,6 @@ void Lamg<Matrix>::parallelSolve(const std::vector<Vector>& rhs, std::vector<Vec
             }
         }
 
-        bool nested = omp_get_nested();
-        if (nested) omp_set_nested(false);
-
 #pragma omp parallel for
         for (omp_index i = 0; i < static_cast<omp_index>(rhs.size()); ++i) {
             index threadId = omp_get_thread_num();
@@ -241,7 +238,6 @@ void Lamg<Matrix>::parallelSolve(const std::vector<Vector>& rhs, std::vector<Vec
             compSolvers[threadId].solve(results[i], rhs[i], stat);
         }
 
-        if (nested) omp_set_nested(true);
     }
 }
 

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -243,7 +243,6 @@ def enableNestedParallelism():
 	""" Enable nested parallelism for OpenMP"""
 	from warnings import warn
 	warn("Nested parallelism has been deprecated.")
-	_enableNestedParallelism()
 
 cdef extern from "<networkit/auxiliary/Random.hpp>" namespace "Aux::Random":
 

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -241,6 +241,8 @@ def getMaxNumberOfThreads():
 
 def enableNestedParallelism():
 	""" Enable nested parallelism for OpenMP"""
+	from warnings import warn
+	warn("Nested parallelism has been deprecated.")
 	_enableNestedParallelism()
 
 cdef extern from "<networkit/auxiliary/Random.hpp>" namespace "Aux::Random":

--- a/networkit/__init__.py
+++ b/networkit/__init__.py
@@ -161,7 +161,6 @@ def setup():
 	""" This function is run once on module import to configure initial settings """
 	setLogLevel("ERROR")  # set default loglevel for C++ code
 	setPrintLocation(True)
-	enableNestedParallelism()  # enable nested parallelism
 	logging.basicConfig(
 		level=logging.INFO)  # set default loglevel for Python code
 

--- a/networkit/cpp/Unittests-X.cpp
+++ b/networkit/cpp/Unittests-X.cpp
@@ -74,8 +74,6 @@ int main(int argc, char *argv[]) {
 
     // Configure parallelism
     {
-        omp_set_nested(1); // enable nested parallelism
-
         if (options.numThreads) {
             Aux::setNumberOfThreads(options.numThreads);
         }

--- a/networkit/cpp/auxiliary/Parallelism.cpp
+++ b/networkit/cpp/auxiliary/Parallelism.cpp
@@ -35,9 +35,5 @@ int Aux::getMaxNumberOfThreads() {
 }
 
 void Aux::enableNestedParallelism() {
-    #ifdef _OPENMP
-    omp_set_nested(1); // enable nested parallelism
-    #else
-    ERROR("OpenMP is not available");
-    #endif
+    WARN("Nested parallelism has been deprecated.");
 }

--- a/networkit/cpp/distance/NeighborhoodFunctionApproximation.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionApproximation.cpp
@@ -48,7 +48,6 @@ void NeighborhoodFunctionApproximation::run() {
     std::vector<std::vector<unsigned int>> localHighest(omp_get_max_threads(), std::vector<unsigned int>(k, 0));
 
     std::vector<unsigned int> bitmasks(k, 0);
-    omp_set_nested(1);
     Aux::Random::setSeed(Aux::Random::getSeed(), true);
     G->parallelForNodes([&](node v) {
         mCurr[v] = bitmasks;


### PR DESCRIPTION
In this PR the `enableNestedParallelism` function is deprecated.