### PR TITLE
Revert travis to skip-cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -258,7 +258,7 @@ jobs:
         - rm -rf htmldocs/{.buildinfo,.doctrees}
       deploy:
         provider: pages
-        cleanup: false
+        skip-cleanup: true
         token: $SECRET_DEPLOY_GITHUB_PAGES
         local_dir: core_build/htmldocs
         repo: networkit/dev-docs


### PR DESCRIPTION
PR #487 fixed travis warnings, but may have introduced an error in the documentation builds.
This PR tries to fix that by explicitly stating which version of travis should be used i.e., the most recent release.

Some relevant links:
[https://blog.travis-ci.com/2019-10-24-build-config-validation](https://blog.travis-ci.com/2019-10-24-build-config-validation)
[https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release](https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release)