### PR TITLE
Fix inconsistency in scaling z-coordinate for writeGraphToGML

### DIFF
--- a/include/networkit/viz/GraphLayoutAlgorithm.hpp
+++ b/include/networkit/viz/GraphLayoutAlgorithm.hpp
@@ -86,7 +86,7 @@ public:
             file << "    [ x " << 50*vertexCoordinates[u][0] << "\n";
             file << "      y " << 50*vertexCoordinates[u][1] << "\n";
             if (dim == 3) {
-                file << "      z " << vertexCoordinates[u][2] << "\n";
+                file << "      z " << 50*vertexCoordinates[u][2] << "\n";
             }
             file << "    ]\n";
             file << "  ]\n";


### PR DESCRIPTION
There are appears to be a mistake in how GML is written in 3D. See https://github.com/networkit/networkit/issues/500