### PR TITLE
Fix GlobalThresholdFilter

### DIFF
--- a/include/networkit/sparsification/GlobalThresholdFilter.hpp
+++ b/include/networkit/sparsification/GlobalThresholdFilter.hpp
@@ -1,9 +1,11 @@
 /*
- * GlobalThresholdFilter.h
+ * GlobalThresholdFilter.hpp
  *
  *  Created on: 23.07.2014
  *      Author: Gerd Lindner
  */
+
+// networkit-format
 
 #ifndef NETWORKIT_SPARSIFICATION_GLOBAL_THRESHOLD_FILTER_HPP_
 #define NETWORKIT_SPARSIFICATION_GLOBAL_THRESHOLD_FILTER_HPP_
@@ -18,32 +20,31 @@ namespace NetworKit {
 class GlobalThresholdFilter {
 
 public:
-
     /**
      * Creates a new instance of a global threshold filter.
-     * @param threshold		the threshold
-     * @param above			if set to true, edges with a score above or equal to the threshold remain in the filtered graph.
-     * 						If set to false, edges with a score below or equal to the threshold remain in the filtered graph.
+     * @param threshold the threshold
+     * @param above if set to true, edges with a score above or equal to the threshold remain in
+     * the filtered graph. If set to false, edges with a score below or equal to the threshold
+     * remain in the filtered graph.
      */
-    GlobalThresholdFilter(const Graph& graph, const std::vector<double>& attribute, double threshold, bool above);
+    GlobalThresholdFilter(const Graph &graph, const std::vector<double> &attribute,
+                          double threshold, bool above);
 
     Graph calculate();
 
 private:
-    const Graph& graph;
-    const std::vector<double>& attribute;
+    const Graph *graph;
+    const std::vector<double> &attribute;
     double threshold;
     bool above;
 
     /**
-    * Creates a new undirected graph that contains only the nodes of the given graph.
-    * @param graph 	the original graph to copy
-    * @param weighted	whether the new graph should be weighted
-    */
-    Graph cloneNodes(const Graph& graph, bool weighted);
-
+     * Creates a new undirected graph that contains only the nodes of the given graph.
+     * @param graph the original graph to copy
+     * @param weighted whether the new graph should be weighted
+     */
+    Graph cloneNodes(const Graph &graph, bool weighted);
 };
 
-}
-/* namespace NetworKit */
+} // namespace NetworKit
 #endif // NETWORKIT_SPARSIFICATION_GLOBAL_THRESHOLD_FILTER_HPP_

--- a/include/networkit/sparsification/GlobalThresholdFilter.hpp
+++ b/include/networkit/sparsification/GlobalThresholdFilter.hpp
@@ -18,6 +18,10 @@ namespace NetworKit {
  * Calculates a sparsified graph by applying a global threshold to an edge score.
  */
 class GlobalThresholdFilter {
+    const Graph *graph;
+    const std::vector<double> &attribute;
+    const double threshold;
+    const bool above;
 
 public:
     /**
@@ -31,19 +35,6 @@ public:
                           double threshold, bool above);
 
     Graph calculate();
-
-private:
-    const Graph *graph;
-    const std::vector<double> &attribute;
-    double threshold;
-    bool above;
-
-    /**
-     * Creates a new undirected graph that contains only the nodes of the given graph.
-     * @param graph the original graph to copy
-     * @param weighted whether the new graph should be weighted
-     */
-    Graph cloneNodes(const Graph &graph, bool weighted);
 };
 
 } // namespace NetworKit

--- a/networkit/cpp/edgescores/EdgeScore.cpp
+++ b/networkit/cpp/edgescores/EdgeScore.cpp
@@ -13,7 +13,7 @@ namespace NetworKit {
     template<typename T>
     EdgeScore<T>::EdgeScore(const Graph& G) : Algorithm(), G(&G), scoreData() {
         if (G.isDirected()) {
-            WARN("Application to directed graphs is not well tested");
+            WARN("EdgeScore is not well tested on directed graphs");
         }
     }
 

--- a/networkit/cpp/sparsification/GlobalThresholdFilter.cpp
+++ b/networkit/cpp/sparsification/GlobalThresholdFilter.cpp
@@ -5,24 +5,28 @@
  *      Author: Gerd Lindner
  */
 
-#include <networkit/sparsification/GlobalThresholdFilter.hpp>
+// networkit-format
+
 #include <networkit/graph/GraphBuilder.hpp>
+#include <networkit/sparsification/GlobalThresholdFilter.hpp>
 
 namespace NetworKit {
 
-GlobalThresholdFilter::GlobalThresholdFilter(const Graph& graph, const std::vector<double>& attribute, const double threshold, bool above) :
-        graph(graph), attribute(attribute), threshold(threshold), above(above) {}
+GlobalThresholdFilter::GlobalThresholdFilter(const Graph &graph,
+                                             const std::vector<double> &attribute, double threshold,
+                                             bool above)
+    : graph(&graph), attribute(attribute), threshold(threshold), above(above) {}
 
 Graph GlobalThresholdFilter::calculate() {
-    if (!graph.hasEdgeIds()) {
+    if (!graph->hasEdgeIds()) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
     // Create an edge-less graph.
     GraphBuilder builder(graph->upperNodeIdBound(), graph->isWeighted(), graph->isDirected());
 
-    //Re-add the edges of the sparsified graph.
-    graph.balancedParallelForNodes([&](node u) {
+    // Re-add the edges of the sparsified graph.
+    graph->balancedParallelForNodes([&](const node u) {
         // add each edge in both directions
         graph->forEdgesOf(u, [&](const node u, const node v, const edgeweight ew,
                                  const edgeid eid) {
@@ -32,10 +36,11 @@ Graph GlobalThresholdFilter::calculate() {
         });
     });
 
-    Graph sGraph = builder.toGraph(graph.isDirected());
-    // WARNING: removeNode() must not be called in parallel (writes on vector<bool> and does non-atomic decrement of number of nodes)!
-    sGraph.forNodes([&](node u) {
-        if (!graph.hasNode(u)) {
+    auto sGraph = builder.toGraph(graph->isDirected());
+    // WARNING: removeNode() must not be called in parallel (writes on vector<bool> and does
+    // non-atomic decrement of number of nodes)!
+    sGraph.forNodes([&](const node u) {
+        if (!graph->hasNode(u)) {
             sGraph.removeNode(u);
         }
     });
@@ -43,8 +48,8 @@ Graph GlobalThresholdFilter::calculate() {
     return sGraph;
 }
 
-Graph GlobalThresholdFilter::cloneNodes(const Graph& graph, bool weighted) {
-    Graph sparsifiedGraph (graph.upperNodeIdBound(), weighted, false);
+Graph GlobalThresholdFilter::cloneNodes(const Graph &graph, bool weighted) {
+    Graph sparsifiedGraph(graph.upperNodeIdBound(), weighted, false);
 
     for (node i = 0; i < graph.upperNodeIdBound(); i++) {
         if (!graph.hasNode(i))

--- a/networkit/cpp/sparsification/GlobalThresholdFilter.cpp
+++ b/networkit/cpp/sparsification/GlobalThresholdFilter.cpp
@@ -18,21 +18,21 @@ Graph GlobalThresholdFilter::calculate() {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
     }
 
-    //Create an edge-less graph.
-    GraphBuilder builder(graph.upperNodeIdBound(), false);
+    // Create an edge-less graph.
+    GraphBuilder builder(graph->upperNodeIdBound(), graph->isWeighted(), graph->isDirected());
 
     //Re-add the edges of the sparsified graph.
     graph.balancedParallelForNodes([&](node u) {
         // add each edge in both directions
-        graph.forEdgesOf(u, [&](node u, node v, edgeid eid) {
-            if ((above && attribute[eid] >= threshold)
-            || (!above && attribute[eid] <= threshold)) {
-                builder.addHalfEdge(u, v);
+        graph->forEdgesOf(u, [&](const node u, const node v, const edgeweight ew,
+                                 const edgeid eid) {
+            if ((above && attribute[eid] >= threshold) || (!above && attribute[eid] <= threshold)) {
+                builder.addHalfEdge(u, v, ew);
             }
         });
     });
 
-    Graph sGraph = builder.toGraph(false);
+    Graph sGraph = builder.toGraph(graph.isDirected());
     // WARNING: removeNode() must not be called in parallel (writes on vector<bool> and does non-atomic decrement of number of nodes)!
     sGraph.forNodes([&](node u) {
         if (!graph.hasNode(u)) {

--- a/networkit/cpp/sparsification/GlobalThresholdFilter.cpp
+++ b/networkit/cpp/sparsification/GlobalThresholdFilter.cpp
@@ -48,14 +48,4 @@ Graph GlobalThresholdFilter::calculate() {
     return sGraph;
 }
 
-Graph GlobalThresholdFilter::cloneNodes(const Graph &graph, bool weighted) {
-    Graph sparsifiedGraph(graph.upperNodeIdBound(), weighted, false);
-
-    for (node i = 0; i < graph.upperNodeIdBound(); i++) {
-        if (!graph.hasNode(i))
-            sparsifiedGraph.removeNode(i);
-    }
-    return sparsifiedGraph;
-}
-
 } /* namespace NetworKit */

--- a/networkit/cpp/sparsification/test/CMakeLists.txt
+++ b/networkit/cpp/sparsification/test/CMakeLists.txt
@@ -1,4 +1,6 @@
 networkit_add_test(sparsification LocalDegreeGTest)
+networkit_add_test(sparsification GlobalThresholdFilterGTest
+    generators)
 networkit_add_test(sparsification LocalSimilarityGTest
     edgescores)
 networkit_add_test(sparsification MultiscaleBackboneGTest)

--- a/networkit/cpp/sparsification/test/GlobalThresholdFilterGTest.cpp
+++ b/networkit/cpp/sparsification/test/GlobalThresholdFilterGTest.cpp
@@ -1,0 +1,61 @@
+// networkit-format
+
+#include <gtest/gtest.h>
+
+#include <networkit/auxiliary/Random.hpp>
+#include <networkit/generators/ErdosRenyiGenerator.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/sparsification/GlobalThresholdFilter.hpp>
+#include <networkit/sparsification/LocalDegreeScore.hpp>
+
+namespace NetworKit {
+
+class GlobalThresholdFilterGTest : public testing::TestWithParam<std::pair<bool, bool>> {
+protected:
+    bool isWeighted() const noexcept { return GetParam().first; }
+    bool isDirected() const noexcept { return GetParam().second; }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    InstantiationName, GlobalThresholdFilterGTest,
+    testing::Values(std::make_pair(false, false), std::make_pair(true, false),
+                    std::make_pair(false, true),
+                    std::make_pair(true, true)), ); // comma required for variadic macro
+
+TEST_P(GlobalThresholdFilterGTest, testGlobalThresholdFilter) {
+    static constexpr count n = 100;
+    static constexpr double p = 0.15;
+
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, false);
+        auto G = ErdosRenyiGenerator(n, p, isDirected()).generate();
+        if (isWeighted()) {
+            G = GraphTools::toWeighted(G);
+            G.forEdges([&G](const node u, const node v) {
+                G.setWeight(u, v, Aux::Random::probability());
+            });
+        }
+
+        G.indexEdges();
+
+        LocalDegreeScore lds(G);
+        lds.run();
+        const auto scores = lds.scores();
+
+        GlobalThresholdFilter gtf(G, scores, 0.5, false);
+        auto G1 = gtf.calculate();
+
+        EXPECT_EQ(G.isDirected(), G1.isDirected());
+        EXPECT_EQ(G.isWeighted(), G1.isWeighted());
+        EXPECT_EQ(G.numberOfNodes(), G1.numberOfNodes());
+        EXPECT_EQ(G.upperNodeIdBound(), G1.upperNodeIdBound());
+
+        G1.forEdges([&G](const node u, const node v, const edgeweight ew, edgeid) {
+            EXPECT_TRUE(G.hasEdge(u, v));
+            EXPECT_DOUBLE_EQ(G.weight(u, v), ew);
+        });
+    }
+}
+
+} // namespace NetworKit


### PR DESCRIPTION
This PR fixes two main issues:
- Templated methods of `EdgeScore` were implemented in the `.cpp` file. They have been moved to the header file.
- `GlobalThresholdFilter` now also support directed and weighted graphs. In the previous implementation the graph was transformed to an undirected graph with default edgeweights without throwing any warnings or errors. If the input graph is directed, this yields a discrepancy in the number of edges in the resulting graph (as reported in #499).