### PR TITLE
clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,87 @@
+Checks: >
+    -*,
+    bugprone-assert-side-effect,
+    bugprone-branch-clone,
+    bugprone-copy-constructor-init,
+    bugprone-dangling-handle,
+    bugprone-dynamic-static-initializers,
+    bugprone-exception-escape,
+    bugprone-fold-init-type,
+    bugprone-forward-declaration-namespace,
+    bugprone-forwarding-reference-overload,
+    bugprone-inaccurate-erase,
+    bugprone-incorrect-roundings,
+    bugprone-integer-division,
+    bugprone-misplaced-widening-cast,
+    bugprone-move-forwarding-reference,
+    bugprone-multiple-statement-macro,
+    bugprone-parent-virtual-call,
+    bugprone-swapped-arguments,
+    bugprone-unused-return-value,
+    bugprone-use-after-move,
+    bugprone-virtual-near-miss,
+    cppcoreguidelines-narrowing-conversions,
+    performance-for-range-copy,
+    performance-implicit-conversion-in-loop,
+    performance-inefficient-algorithm,
+    performance-inefficient-vector-operation,
+    performance-move-const-arg,
+    performance-noexcept-move-constructor,
+    performance-trivially-destructible,
+    performance-type-promotion-in-math-fn,
+    performance-unnecessary-copy-initialization,
+    performance-unnecessary-value-param,
+
+# Warnings whishlist
+#    modernize-deprecated-headers,
+#    modernize-use-using,
+#    modernize-avoid-c-arrays,
+#    modernize-use-emplace,
+#    modernize-use-override,
+#    readability-avoid-const-params-in-decls,
+#    readability-const-return-type,
+#    readability-container-size-empty
+
+# Turn the warnings from the checks above into errors.
+# To turn all warnings into errors, simply write '*'
+# in the first line after WarningsAsErrors
+WarningsAsErrors:  >
+    -*,
+    bugprone-assert-side-effect,
+    bugprone-copy-constructor-init,
+    bugprone-dangling-handle,
+    bugprone-dynamic-static-initializers,
+    bugprone-exception-escape,
+    bugprone-forward-declaration-namespace,
+    bugprone-forwarding-reference-overload,
+    bugprone-inaccurate-erase,
+    bugprone-misplaced-widening-cast,
+    bugprone-move-forwarding-reference,
+    bugprone-multiple-statement-macro,
+    bugprone-parent-virtual-call,
+    bugprone-swapped-arguments,
+    bugprone-unused-return-value,
+    bugprone-virtual-near-miss,
+    performance-implicit-conversion-in-loop,
+    performance-inefficient-algorithm,
+    performance-move-const-arg,
+    performance-trivially-destructible,
+    performance-unnecessary-copy-initialization
+
+FormatStyle: 'file'
+HeaderFilterRegex: '.*\/include\/networkit\/.*\.hpp'
+CheckOptions:
+  - key:   readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key:   readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key:   readability-identifier-naming.FunctionCase
+    value: camelBack
+  - key:   readability-identifier-naming.MemberCase
+    value: CamelCase
+  - key:   readability-identifier-naming.ParameterCase
+    value: CamelCase
+  - key:   readability-identifier-naming.UnionCase
+    value: CamelCase
+  - key:   readability-identifier-naming.VariableCase
+    value: CamelCase

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,36 @@ jobs:
             - libomp
           update: true
 
+    - name: Linux, Clang 9 with clang-tidy
+      env:
+        - CC=clang
+        - CXX=clang++
+      os: linux
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+            - sourceline: 'deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+            - libiomp-dev
+            - clang-9
+            - clang-tidy-9
+      script:
+        - sudo rm -rf /usr/local/clang-*
+        - sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 9999
+        - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 9999
+        - sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 9999
+        - $CXX --version
+        - clang-tidy --version
+        - mkdir debug_test && cd "$_"
+        - cmake -DNETWORKIT_BUILD_TESTS=ON -DNETWORKIT_CLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug ..
+        - make -j2
+        - ctest -V
+
     # Test with sanitizers.
     - name: "Linux, GCC 5: Core build, sanitizers, coverage"
       compiler: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(NETWORKIT_MONOLITH "Build single library (and tests is requested; require
 option(NETWORKIT_NATIVE "Optimize for native architecture (often better performance)" OFF)
 option(NETWORKIT_WARNINGS "Issue more warnings" OFF)
 option(NETWORKIT_WARNINGS_AS_ERRORS "Treat warnings as errors (except deprecated)" OFF)
+option(NETWORKIT_CLANG_TIDY "Check code with clang-tidy" OFF)
 option(NETWORKIT_FLATINSTALL "Install into a flat directory structure (useful when building a Python package)" OFF)
 option(NETWORKIT_COVERAGE "Build with support for coverage" OFF)
 set(NETWORKIT_PYTHON "" CACHE STRING "Directory containing Python.h. Implies MONOLITH=TRUE")
@@ -230,6 +231,16 @@ if(NETWORKIT_BUILD_CORE AND NETWORKIT_MONOLITH)
 	target_link_libraries(networkit PRIVATE OpenMP::OpenMP_CXX PUBLIC tlx)
 	target_include_directories(networkit BEFORE PUBLIC "${PROJECT_SOURCE_DIR}/include")
 	target_include_directories(networkit PUBLIC "${PROJECT_SOURCE_DIR}/extlibs/ttmath/")
+endif()
+
+################################################################################
+# ENABLE CLANG-TIDY
+if (NETWORKIT_CLANG_TIDY)
+	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+		set_target_properties(networkit PROPERTIES CXX_CLANG_TIDY clang-tidy)
+	else()
+		message(FATAL_ERROR "clang-tidy is only supported when compiling with clang")
+	endif()
 endif()
 
 if(NETWORKIT_PYTHON)


### PR DESCRIPTION
[clang-tidy](https://clang.llvm.org/extra/clang-tidy/index.html) is a very powerful tool to detect programming errors that are generally not detected by compilers, and it is easy to integrate with CMake.
I think that it would be a good idea to integrate it into our CI system: it would help us fixing existing programming errors (such as the ones fixed recently by @cndolo), and avoiding introducing new ones in future PRs.

If you agree with that, we might want to discuss about which [checks](https://clang.llvm.org/extra/clang-tidy/checks/list.html) should we use.