### PR TITLE
Removed tlx as requirement for Python-builds with external core lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,20 +193,22 @@ else()
 endif()
 
 ################################################################################
-# Use TLX as a CMake submodule
-if(NOT NETWORKIT_EXT_TLX)
-	if(EXISTS "${PROJECT_SOURCE_DIR}/extlibs/tlx/CMakeLists.txt")
-		add_subdirectory(extlibs/tlx)
+# Use TLX as a CMake submodule if the core-library is build
+if(NOT NETWORKIT_PYTHON)
+	if(NOT NETWORKIT_EXT_TLX)
+		if(EXISTS "${PROJECT_SOURCE_DIR}/extlibs/tlx/CMakeLists.txt")
+			add_subdirectory(extlibs/tlx)
+		else()
+			message(FATAL_ERROR
+					"Missing TLX library in extlibs/tlx "
+					"Please run `git submodule update --init` to fetch the submodule.")
+		endif()
 	else()
-		message(FATAL_ERROR
-				"Missing TLX library in extlibs/tlx "
-				"Please run `git submodule update --init` to fetch the submodule.")
+		add_library(tlx STATIC IMPORTED)
+		set_target_properties(tlx PROPERTIES
+				IMPORTED_LOCATION "${NETWORKIT_EXT_TLX}/lib/libtlx.a"
+				INTERFACE_INCLUDE_DIRECTORIES "${NETWORKIT_EXT_TLX}/include/")
 	endif()
-else()
-	add_library(tlx STATIC IMPORTED)
-	set_target_properties(tlx PROPERTIES
-			IMPORTED_LOCATION "${NETWORKIT_EXT_TLX}/lib/libtlx.a"
-			INTERFACE_INCLUDE_DIRECTORIES "${NETWORKIT_EXT_TLX}/include/")
 endif()
 
 ################################################################################


### PR DESCRIPTION
Don't know if that is the best logic to solve this issue.

As of now if we use "--networkit_external_core" in setup.py, cmake still requires tlx (and compiles it) even though it not needs it. This breaks the build-process if we download a release from github and install via pip/setup.py with an external libnetworkit (like it is required for package managers like conda).