### PR TITLE
Importing networkit should not modify the global logging configuration

### DIFF
--- a/networkit/__init__.py
+++ b/networkit/__init__.py
@@ -161,8 +161,6 @@ def setup():
 	""" This function is run once on module import to configure initial settings """
 	setLogLevel("ERROR")  # set default loglevel for C++ code
 	setPrintLocation(True)
-	logging.basicConfig(
-		level=logging.INFO)  # set default loglevel for Python code
 
 
 setup()  # here the setup function is called once on import


### PR DESCRIPTION
Hey,
at the moment `import networkit` modifies the global logging setup. In particular, it reduces the default logging level from `WARNING` to `INFO`. I noticed this when I imported networkit and suddenly other packages started logging. Importing a package should have no side effects. If this log level is somehow essential to networkit, `setup` should set it only for a package specific root logger.

Best,
Marten