### PR TITLE
Use O(n logn) implemention in StaticDegreeSequenceGenerator

### DIFF
--- a/networkit/cpp/generators/StaticDegreeSequenceGenerator.cpp
+++ b/networkit/cpp/generators/StaticDegreeSequenceGenerator.cpp
@@ -1,3 +1,4 @@
+// networkit-format
 /*
  * StaticDegreeSequenceGenerator.cpp
  *
@@ -9,27 +10,25 @@
 #include <networkit/auxiliary/Parallel.hpp>
 #include <networkit/generators/StaticDegreeSequenceGenerator.hpp>
 
+#include <tlx/define.hpp>
+
 namespace NetworKit {
 
-StaticDegreeSequenceGenerator::StaticDegreeSequenceGenerator(const std::vector<count> &sequence):
-        seq(sequence), realizable(UNKNOWN)
-{
-
-}
+StaticDegreeSequenceGenerator::StaticDegreeSequenceGenerator(const std::vector<count> &sequence)
+    : seq(sequence), realizable(UNKNOWN) {}
 
 bool StaticDegreeSequenceGenerator::getRealizable() const {
     return realizable;
 }
 
-
 bool StaticDegreeSequenceGenerator::isRealizable() {
     DEBUG("check if sequence is realizable");
     count n = seq.size();
 
-    /* First inequality. */
+    // First inequality
     count deg_sum = 0;
     for (count i = 0; i < n; ++i) {
-        if (seq[i] >= n) {
+        if (TLX_UNLIKELY(seq[i] >= n)) {
             realizable = NO;
             DEBUG("not realizable: ", seq[i], ", n: ", n);
             return false;
@@ -43,22 +42,54 @@ bool StaticDegreeSequenceGenerator::isRealizable() {
         return false;
     }
 
-    /* Second inequality. */
-    // this inequality needs a sorted sequence
-    std::vector<count> sortedSeq = seq;
-    Aux::Parallel::sort(sortedSeq.begin(), sortedSeq.end(), std::greater<count>());
+    /**
+     * Second inequality
+     * We now check that for all 0 <= j < n the following inequality holds
+     *   sum(d[i] for 0 <= i <= j) <= sum( min(j+1, d[i]) for j < i < n),
+     * where d is the sorted degree sequence.
+     *
+     * To avoid the quadratic runtime of the naive implementation above, we search for each
+     * j the smallest index k with d[k] < j+1. Then the RHS becomes:
+     *     (j+1)*min(0, k-j-1)       // all cases where the min-term defaulted to (j+1)
+     *   + sum(d[i] for k <= i < n)  // "true" suffix sum.
+     *
+     * Observe that the suffix sum only depends on k and not j; so we can precompute it once
+     * to avoid recomputation.
+     *
+     * Together, both tricks reduce the runtime complexity from Theta(n^2) to O(n log n).
+     */
+    std::vector<count> partialSeqSum(n + 1);
+    std::copy(seq.cbegin(), seq.cend(), partialSeqSum.begin());
+    Aux::Parallel::sort(partialSeqSum.begin(), partialSeqSum.end(), std::greater<count>());
+    for (size_t i = n - 1;
+         i--;) { // not using std::partial_sum as unclear whether input/output may be identical
+        partialSeqSum[i] += partialSeqSum[i + 1];
+    }
+
+    auto degreeOf = [&](size_t i) {
+        assert(i < n);
+        return partialSeqSum[i] - partialSeqSum[i + 1];
+    };
 
     deg_sum = 0;
     for (count j = 0; j < n; ++j) {
-        deg_sum += sortedSeq[j];
-
-        /* sum of min(deg(i), j) for i from j + 1 to n - 1. */
+        deg_sum += degreeOf(j);
         count min_deg_sum = 0;
-        for (count i = j + 1; i < n; ++i) {
-            min_deg_sum += std::min(sortedSeq[i], j + 1);
+
+        size_t sumFrom = j + 1;
+        if (sumFrom < n && degreeOf(sumFrom) >= j + 1) {
+            // find the first element right of j that has a value less or equal to j
+            const auto it =
+                std::lower_bound(partialSeqSum.data() + sumFrom, partialSeqSum.data() + n, j,
+                                 [](const count &x, const count j) { return x - *(&x + 1) > j; });
+            sumFrom = std::distance(partialSeqSum.data(), it);
+            min_deg_sum += (j + 1) * (sumFrom - j - 1);
         }
 
-        if (deg_sum > (j + 1) * j + min_deg_sum) {
+        if (sumFrom != n)
+            min_deg_sum += partialSeqSum[sumFrom];
+
+        if (TLX_UNLIKELY(deg_sum > (j + 1) * j + min_deg_sum)) {
             DEBUG("not realizable");
             realizable = NO;
             return false;
@@ -68,6 +99,5 @@ bool StaticDegreeSequenceGenerator::isRealizable() {
     realizable = YES;
     return true;
 }
-
 
 } /* namespace NetworKit */

--- a/networkit/cpp/generators/test/GeneratorsGTest.cpp
+++ b/networkit/cpp/generators/test/GeneratorsGTest.cpp
@@ -570,16 +570,14 @@ TEST_F(GeneratorsGTest, testChungLuGeneratorVolumeConsistency) {
 
 TEST_F(GeneratorsGTest, testHavelHakimiGeneratorOnRandomSequence) {
     count n = 400;
-    count maxDegree = n / 10;
     std::vector<count> sequence(n);
-//	std::vector<count> sequence = {5, 4, 4, 3, 2, 2, 2, 2, 2, 2};
     bool realizable = false;
 
+    std::mt19937_64 prng(1);
+    std::uniform_int_distribution<count> deg_distr(0, n / 10 - 1);
     do {
         // fill sequence with random values (this is not power-law, of course!)
-        for (index i = 0; i < n; ++i) {
-            sequence[i] = rand() % maxDegree;
-        }
+        std::generate(sequence.begin(), sequence.end(), [&] {return deg_distr(prng);});
 
         // check if sequence is realizable
         HavelHakimiGenerator hhgen(sequence);


### PR DESCRIPTION
`StaticDegreeSequenceGenerator::isRealizable()` uses the Erdős–Gallai theorem to test whether a degree sequence is graphical. The old implementation was a direct translation of the theorem, which involved a sum over all degree which needs to be calculated for each node --- this gave an Theta(n^2) algorithm, and prevented us from using it with n >~ 1e6.

This PR uses the same theorem but carries out straight-forward transformations to reduce the complexity to O(n log n). The main idea is to avoid calculating the same sums again and again. Hence, rather than storing a sorted sequence of degree, we store a their suffix-sums. 

The PR also adds unit tests for this function specifically. The PR has some overlap with the unit tests for HavelHakimi, but checks more cases that are relevant for `StaticDegreeSequenceGenerator::isRealizable()`.

As a "drive-by" fix, I replaced an "rand() % max" construct with an proper "std::uniform_int_distrubtion" in a unit test of HavelHakimi.