### PR TITLE
Add main to Python sparsification and community unit tests

### DIFF
--- a/networkit/test/test_community.py
+++ b/networkit/test/test_community.py
@@ -28,3 +28,5 @@ class Test_CommunityDetection(unittest.TestCase):
 		hierarchy = community.CutClustering.getClusterHierarchy(jazz)
 		self.assertEqual(3, len(hierarchy))
 
+if __name__ == "__main__":
+	unittest.main()

--- a/networkit/test/test_sparsification.py
+++ b/networkit/test/test_sparsification.py
@@ -40,3 +40,6 @@ class Test_Sparsification(unittest.TestCase):
 			ratio = S.numberOfEdges() / self.G.numberOfEdges()
 			self.assertGreaterEqual(ratio, minExpectedRatio)
 			self.assertLessEqual(ratio, maxExpectedRatio)
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
The `test_sparsification` and `test_community` unit tests lack a `main` method.
This PR just adds a `main` method so that the tests are executed.