### PR TITLE
Fix for Apple Clang 11.03

### DIFF
--- a/networkit/cpp/randomization/DegreePreservingShuffle.cpp
+++ b/networkit/cpp/randomization/DegreePreservingShuffle.cpp
@@ -174,8 +174,11 @@ void DegreePreservingShuffle::run() {
 Graph DegreePreservingShuffle::getGraph() const {
     const auto n = G->numberOfNodes();
     assert(permutation.size() == n);
+    // localPerm introduced due to a bug in AppleClang 11.03. Direct access to permutation
+    // vector creates a seqfault in the compiler.
+    const std::vector<node> &localPerm = permutation;
 
-    return GraphTools::getRemappedGraph(*G, n, [this](node u) { return permutation[u]; });
+    return GraphTools::getRemappedGraph(*G, n, [&localPerm](node u) { return localPerm[u]; });
 }
 
 } // namespace NetworKit


### PR DESCRIPTION
Currently installing networkit with macOS Catalina 15.04 is not possible due to a bug in Apple Clang 11.03 (clang-1103.0.32.29), leading to a seq-fault in the compiler. While I already filled a bug report, there are related problems in Apple Dev from the past, where these kind of errors may also point to potential problems in the code.

After narrowing down the problem, the seq-fault occurs during `getRemappedGraph` in `DegreePreservingShuffle`. It is fixed by doing a local copy of permutation before accessing it. Should we merge this fix?

[Error on stackoverflow](https://stackoverflow.com/questions/60874746/problems-installing-networkit-with-pip3)
[Error on github](https://github.com/Homebrew/homebrew-core/pull/52078)