### PR TITLE
Ignore lib64 in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ build/
 /build*
 /.build*
 lib/
+lib64/
 include/tlx
 
 ### IDE


### PR DESCRIPTION
When building networkit a `lib64` directory is created, I think we should ignore it as well as `lib`.