### PR TITLE
Fix APSP

### DIFF
--- a/networkit/cpp/distance/BFS.cpp
+++ b/networkit/cpp/distance/BFS.cpp
@@ -20,12 +20,15 @@ void BFS::run() {
     reachedNodes = 1;
     sumDist = 0.;
 
+    const auto infDist = std::numeric_limits<edgeweight>::max();
+    std::fill(distances.begin(), distances.end(), infDist);
+
     if (distances.size() < z) {
-        distances.resize(z, std::numeric_limits<edgeweight>::max());
+        distances.resize(z, infDist);
         visited.resize(z, ts);
     }
 
-    if (ts++ == 255) {
+    if (ts++ == std::numeric_limits<uint8_t>::max()) {
         ts = 1;
         std::fill(visited.begin(), visited.end(), 0);
     }

--- a/networkit/cpp/distance/Dijkstra.cpp
+++ b/networkit/cpp/distance/Dijkstra.cpp
@@ -19,17 +19,20 @@ Dijkstra::Dijkstra(const Graph &G, node source, bool storePaths,
 void Dijkstra::run() {
 
     TRACE("initializing Dijkstra data structures");
+
     // init distances
+    auto infDist = std::numeric_limits<edgeweight>::max();
+    std::fill(distances.begin(), distances.end(), infDist);
+
     if (distances.size() < G->upperNodeIdBound()) {
-        distances.resize(G->upperNodeIdBound(),
-                         std::numeric_limits<double>::max());
+        distances.resize(G->upperNodeIdBound(), infDist);
         visited.resize(G->upperNodeIdBound(), ts);
     }
 
     sumDist = 0.;
     reachedNodes = 1;
 
-    if (ts++ == 255) {
+    if (ts++ == std::numeric_limits<uint8_t>::max()) {
         ts = 1;
         std::fill(visited.begin(), visited.end(), 0);
     }

--- a/networkit/cpp/distance/test/CMakeLists.txt
+++ b/networkit/cpp/distance/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 networkit_add_test(distance APSPGTest
-    auxiliary dyn_distance io)
+    auxiliary dyn_distance generators io)
 networkit_add_test(distance AllSimplePathsGTest
     auxiliary io)
 networkit_add_test(distance CommuteTimeDistanceGTest


### PR DESCRIPTION
In disconnected graphs `APSP` returns distances that are less than infinity for pairs of nodes that are not reachable. This happens because`APSP` calls multiple times `BFS/Dijkstra::run()`, but neither `BFS` nor `Dijkstra` reset `distance` before running.
This PR also includes new tests that failed with the previous implementation.