### PR TITLE
warning fix: clang-tidy/bugprone-incorrect-roundings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -55,6 +55,7 @@ WarningsAsErrors:  >
     bugprone-forward-declaration-namespace,
     bugprone-forwarding-reference-overload,
     bugprone-inaccurate-erase,
+    bugprone-incorrect-roundings,
     bugprone-misplaced-widening-cast,
     bugprone-move-forwarding-reference,
     bugprone-multiple-statement-macro,

--- a/networkit/cpp/distance/EffectiveDiameter.cpp
+++ b/networkit/cpp/distance/EffectiveDiameter.cpp
@@ -32,7 +32,7 @@ void EffectiveDiameter::run() {
     // the current distance of the neighborhoods
     count h = 1;
     // number of nodes that need to be connected with all other nodes
-    auto threshold = static_cast<count>(std::ceil(ratio * G->numberOfNodes()) + 0.5);
+    auto threshold = static_cast<count>(std::ceil(ratio * G->numberOfNodes()));
     // nodes that are not connected to enough nodes yet
     std::vector<node> activeNodes;
 


### PR DESCRIPTION
Fix rounding by using [std::round](https://en.cppreference.com/w/cpp/numeric/math/round), which provides the same behavior but it is safer (as reported [here](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-incorrect-roundings.html)).