### PR TITLE
warning fix: clang-tidy/bugprone-use-after-move

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -61,6 +61,7 @@ WarningsAsErrors:  >
     bugprone-parent-virtual-call,
     bugprone-swapped-arguments,
     bugprone-unused-return-value,
+    bugprone-use-after-move,
     bugprone-virtual-near-miss,
     performance-implicit-conversion-in-loop,
     performance-inefficient-algorithm,

--- a/networkit/cpp/community/CutClustering.cpp
+++ b/networkit/cpp/community/CutClustering.cpp
@@ -234,8 +234,7 @@ void NetworKit::CutClustering::clusterHierarchyRecursion(const NetworKit::Graph 
         }
     }
 
-    if (result.count(upper) == 0) // FIXME actually this shouldn't happen, this has been copied from another implementation
-        result.insert(std::make_pair(upper, std::move(upperClusters))); // upperClusters won't be used anymore
+    assert(result.count(upper));
 }
 
 


### PR DESCRIPTION
Replace wrong behavior with an assertion, and fix `bugprone-use-after-move` warning.