### PR TITLE
Support user specified source nodes for APSP algorithm.

### DIFF
--- a/include/networkit/distance/APSP.hpp
+++ b/include/networkit/distance/APSP.hpp
@@ -30,6 +30,14 @@ class APSP : public Algorithm {
      */
     APSP(const Graph &G);
 
+    /**
+     * Creates the APSP class for @a G with specified source nodes.
+     *
+     * @param G The graph.
+     * @param srcs The source nodes.
+     */
+    APSP(const Graph &G, std::vector<count>& srcs);
+
     virtual ~APSP() = default;
 
     /** Computes the shortest paths from each node to all other nodes. */
@@ -70,6 +78,7 @@ class APSP : public Algorithm {
     const Graph &G;
     std::vector<std::vector<edgeweight>> distances;
     std::vector<std::unique_ptr<SSSP>> sssps;
+    std::vector<count> srcs;
 };
 
 } /* namespace NetworKit */

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -2191,6 +2191,7 @@ cdef extern from "<networkit/distance/APSP.hpp>":
 
 	cdef cppclass _APSP "NetworKit::APSP"(_Algorithm):
 		_APSP(_Graph G) except +
+		_APSP(_Graph G, vector[count] srcs) except +
 		vector[vector[edgeweight]] getDistances() except +
 		edgeweight getDistance(node u, node v) except +
 
@@ -2208,9 +2209,12 @@ cdef class APSP(Algorithm):
     """
 	cdef Graph _G
 
-	def __cinit__(self, Graph G):
+	def __cinit__(self, Graph G, vector[count] srcs = vector[count]()):
 		self._G = G
-		self._this = new _APSP(G._this)
+		if srcs.empty():
+			self._this = new _APSP(G._this)
+		else:
+			self._this = new _APSP(G._this, srcs)
 
 	def __dealloc__(self):
 		self._G = None

--- a/networkit/cpp/distance/APSP.cpp
+++ b/networkit/cpp/distance/APSP.cpp
@@ -15,10 +15,14 @@ namespace NetworKit {
 
 APSP::APSP(const Graph &G) : Algorithm(), G(G) {}
 
+APSP::APSP(const Graph &G, std::vector<count> &srcs) : Algorithm(), G(G), srcs(srcs) {}
+
 void APSP::run() {
-    count n = G.upperNodeIdBound();
+    const count n = G.upperNodeIdBound();
+    const bool src_all = srcs.size() == 0;
+    const count num_srcs = src_all ? n : srcs.size();
     std::vector<edgeweight> distanceVector(n, 0.0);
-    distances.resize(n, distanceVector);
+    distances.resize(num_srcs, distanceVector);
 
     count nThreads = omp_get_max_threads();
     sssps.resize(nThreads);
@@ -32,11 +36,12 @@ void APSP::run() {
     }
 
 #pragma omp parallel for schedule(dynamic)
-    for (omp_index source = 0; source < n; ++source) {
+    for (omp_index source_idx = 0; source_idx < num_srcs; ++source_idx) {
         auto sssp = sssps[omp_get_thread_num()].get();
+        count source = src_all ? source_idx : srcs[source_idx];
         sssp->setSource(source);
         sssp->run();
-        distances[source] = sssp->getDistances();
+        distances[source_idx] = sssp->getDistances();
     }
 
     hasRun = true;


### PR DESCRIPTION
Signed-off-by: YanzheL <lee.yanzhe@yanzhe.org>

### Purpose

Currently, if user want to calculate multi-source (instead of all-pairs) shortest paths for a graph, he/she can only run SSSP for multiple times sequentially, because the API of APSP and SSSP do not support multiple custom sources.

### What does this PR do

This PR enables users to specify source nodes for APSP algorithm. Since the APSP algorithm is executed in parallel with OpenMP, users can benefit from it with minimal API change.

### API Changes

Full backwards Compatible, no breaking changes.

New C++ constructor for APSP:
```c++
APSP(const Graph &G, std::vector<count>& srcs);
```

New Cython constructor for APSP:
```cython
def __cinit__(self, Graph G, vector[count] srcs = vector[count]()):
```

### Backwards Compatibility



### Example

Python usage:
```python
import networkit as nk
srcs = [0,2,3]
apsp = nk.distance.APSP(graph, srcs)
apsp.run()
dists = apsp.getDistances()
```