### PR TITLE
warning fix: clang-tidy/bugprone-fold-init-type

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,6 +52,7 @@ WarningsAsErrors:  >
     bugprone-dangling-handle,
     bugprone-dynamic-static-initializers,
     bugprone-exception-escape,
+    bugprone-fold-init-type,
     bugprone-forward-declaration-namespace,
     bugprone-forwarding-reference-overload,
     bugprone-inaccurate-erase,

--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -137,7 +137,7 @@ GroupCloseness::scoreOfGroup(const std::vector<node> &group) const {
         });
     }
 
-    double dSum = std::accumulate(distance.begin(), distance.end(), 0);
+    double dSum = std::accumulate(distance.begin(), distance.end(), 0.0);
     return dSum == 0
                ? 0.
                : ((double)G.upperNodeIdBound() - (double)group.size()) / dSum;

--- a/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
+++ b/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
@@ -87,7 +87,7 @@ void ParallelPartitionCoarsening::run() {
 
         // ensure consistency of data structure
         DEBUG("numEdges: ", numEdges);
-        count twiceM = std::accumulate(numEdges.begin(), numEdges.end(), 0);
+        count twiceM = std::accumulate(numEdges.begin(), numEdges.end(), count{0});
         assert(twiceM % 2 == 0);
         Gcombined.m = (twiceM / 2);
 

--- a/networkit/cpp/generators/ChungLuGenerator.cpp
+++ b/networkit/cpp/generators/ChungLuGenerator.cpp
@@ -17,7 +17,7 @@ namespace NetworKit {
 
 ChungLuGenerator::ChungLuGenerator(const std::vector<count> &degreeSequence) :
         StaticDegreeSequenceGenerator(degreeSequence) {
-    sum_deg = std::accumulate(seq.begin(), seq.end(), 0);
+    sum_deg = std::accumulate(seq.begin(), seq.end(), count{0});
     n = (count) seq.size();
 }
 

--- a/networkit/cpp/generators/LFRGenerator.cpp
+++ b/networkit/cpp/generators/LFRGenerator.cpp
@@ -129,7 +129,7 @@ void NetworKit::LFRGenerator::setPartition(NetworKit::Partition zeta) {
 
 NetworKit::Graph NetworKit::LFRGenerator::generateIntraClusterGraph(std::vector< NetworKit::count > intraDegreeSequence, const std::vector<NetworKit::node> &localToGlobalNode) {
     // check if sum of degrees is even and fix if necessary
-    count intraDegSum = std::accumulate(intraDegreeSequence.begin(), intraDegreeSequence.end(), 0);
+    count intraDegSum = std::accumulate(intraDegreeSequence.begin(), intraDegreeSequence.end(), count{0});
 
     DEBUG("Possibly correcting the degree sequence");
 


### PR DESCRIPTION
Fix possible loss of precision of `std::accumulate` due to truncation or overflow.