### PR TITLE
SSSP/STSP: Changing getPredecessors() to return by-reference

### DIFF
--- a/include/networkit/distance/DynSSSP.hpp
+++ b/include/networkit/distance/DynSSSP.hpp
@@ -59,7 +59,7 @@ public:
      * @param t Target node.
      * @return The predecessors of @a t on all shortest paths from source to @a t.
      */
-    std::vector<node> getPredecessors(node t) const;
+    const std::vector<node>& getPredecessors(node t) const;
 
 protected:
     bool storePreds = true;
@@ -75,7 +75,7 @@ inline void DynSSSP::setTargetNode(const node t) {
     target = t;
 }
 
-inline std::vector<node> DynSSSP::getPredecessors(node t) const {
+inline const std::vector<node>& DynSSSP::getPredecessors(node t) const {
     if (! storePreds) {
         throw std::runtime_error("predecessors have not been stored");
     }

--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -84,7 +84,7 @@ public:
      * @return The predecessors of @a t on all shortest paths from source to @a
      * t.
      */
-    std::vector<node> getPredecessors(node t) const;
+    const std::vector<node>& getPredecessors(node t) const;
 
     /**
      * Returns a shortest path from source to @a t and an empty path if source
@@ -201,7 +201,7 @@ inline double SSSP::_numberOfPaths(node t) const {
     return res;
 }
 
-inline std::vector<node> SSSP::getPredecessors(node t) const {
+inline const std::vector<node>& SSSP::getPredecessors(node t) const {
     if (!storePaths) {
         throw std::runtime_error("predecessors have not been stored");
     }

--- a/include/networkit/distance/STSP.hpp
+++ b/include/networkit/distance/STSP.hpp
@@ -62,7 +62,7 @@ public:
      *
      * @return The list of predecessors from @a target to @a source.
      */
-    std::vector<node> getPredecessors() const {
+    const std::vector<node>& getPredecessors() const {
         checkStorePredecessors();
         assureFinished();
         return pred;


### PR DESCRIPTION
Based on #533.

Changing `DynSSSP`, `SSSP` and `STSP` to return predecessors by reference instead of by value. NetworKit-code using this function is not influenced by this change, since all occurrences involve deep-copies (if I understand the standard correctly).