### PR TITLE
warning fix: clang-tidy/bugprone-integer-division

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -57,6 +57,7 @@ WarningsAsErrors:  >
     bugprone-forwarding-reference-overload,
     bugprone-inaccurate-erase,
     bugprone-incorrect-roundings,
+    bugprone-integer-division,
     bugprone-misplaced-widening-cast,
     bugprone-move-forwarding-reference,
     bugprone-multiple-statement-macro,

--- a/networkit/cpp/centrality/Betweenness.cpp
+++ b/networkit/cpp/centrality/Betweenness.cpp
@@ -130,13 +130,11 @@ double Betweenness::maximum(){
     if (normalized) {
         return 1;
     }
-    double score;
+
     count n = G.numberOfNodes();
-    if (G.isDirected()) {
-        score = (n-1)*(n-2);
-    } else {
-        score = (n-1)*(n-2)/2;
-    }
+    double score = (n-1)*(n-2);
+    if (!G.isDirected())
+        score /= 2.;
     return score;
 }
 

--- a/networkit/cpp/community/AdjustedRandMeasure.cpp
+++ b/networkit/cpp/community/AdjustedRandMeasure.cpp
@@ -38,11 +38,11 @@ double NetworKit::AdjustedRandMeasure::getDissimilarity(const NetworKit::Graph &
         sumEta += s * (s - 1) / 2;
     }
 
-    count n = G.numberOfNodes();
+    const count denominator = (G.numberOfNodes() * (G.numberOfNodes() - 1)) / 2;
 
     double maxIndex = 0.5 * (sumZeta + sumEta);
 
-    double expectedIndex = sumZeta * sumEta / (n * (n-1) / 2);
+    double expectedIndex = static_cast<double>(sumZeta * sumEta) / static_cast<double>(denominator);
 
     if (maxIndex == 0) { // both clusterings are singleton clusterings
         return 0.0;

--- a/networkit/cpp/distance/HopPlotApproximation.cpp
+++ b/networkit/cpp/distance/HopPlotApproximation.cpp
@@ -66,7 +66,7 @@ void HopPlotApproximation::run() {
         }
     });
     // at zero distance, all nodes can only reach themselves
-    hopPlot[0] = 1/G->numberOfNodes();
+    hopPlot[0] = 1.0 / static_cast<double>(G->numberOfNodes());
     // as long as we need to connect more nodes
     while (!activeNodes.empty() && (maxDistance <= 0 || h < maxDistance)) {
         totalConnectedNodes = 0;


### PR DESCRIPTION
Fix integer divisions meant to be floating-point divisions.