### PR TITLE
warning fix: clang-tidy/performance-for-range-copy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -62,6 +62,7 @@ WarningsAsErrors:  >
     bugprone-swapped-arguments,
     bugprone-unused-return-value,
     bugprone-virtual-near-miss,
+    performance-for-range-copy,
     performance-implicit-conversion-in-loop,
     performance-inefficient-algorithm,
     performance-move-const-arg,

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -134,7 +134,7 @@ void Lamg<Matrix>::setup(const Matrix& laplacianMatrix) {
 
         // create solver for every component
         index compIdx = 0;
-        for (auto component : con.getPartition().getSubsets()) {
+        for (const auto &component : con.getPartition().getSubsets()) {
             components[compIdx] = std::vector<index>(component.begin(), component.end());
 
             std::vector<Triplet> triplets;

--- a/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
@@ -79,7 +79,7 @@ void ApproxGroupBetweenness::run() {
     // Transfer edges from hyperEdgesPerSample to hyperEdges and prepare building
     // nodeDegrees.
     std::vector<count> tempDegrees(n);
-    for (auto edge : hyperEdgesPerSample) {
+    for (const auto &edge : hyperEdgesPerSample) {
         node hyperEdgeStart = hyperEdges.size();
         hyperEdges.push_back(edge.size());
         for (auto const &n : edge) {

--- a/networkit/cpp/generators/DynamicDGSParser.cpp
+++ b/networkit/cpp/generators/DynamicDGSParser.cpp
@@ -79,7 +79,7 @@ void DynamicDGSParser::generate() {
                 std::vector<std::string> categories = Aux::StringTools::split(categoriesCommaSeparated, ',');
 
                 std::vector<std::string> currentNodeCategories;
-                for (std::string category : categories) {
+                for (const std::string &category : categories) {
                     currentNodeCategories.push_back(category);
                 }
                 nodeCategories.push_back(currentNodeCategories);
@@ -183,7 +183,7 @@ void DynamicDGSParser::evaluateClusterings(const std::string path, const Partiti
         std::vector<std::string> currentNodeCategories = nodeCategories[v];
         clusterMappings[normalizedID].reserve(100000);
 
-        for (std::string category : currentNodeCategories) {
+        for (const std::string &category : currentNodeCategories) {
             clusterMappings[normalizedID].find (category);
 
             std::unordered_map<std::string, index>::const_iterator got = clusterMappings[normalizedID].find (category);

--- a/networkit/cpp/io/DGSReader.cpp
+++ b/networkit/cpp/io/DGSReader.cpp
@@ -69,7 +69,7 @@ void DGSReader::read(std::string path, GraphEventProxy& Gproxy) {
                     std::vector<std::string> categories = Aux::StringTools::split(categoriesCommaSeparated, ',');
 
                     std::vector<std::string> currentNodeCategories;
-                    for (std::string category : categories) {
+                    for (const std::string &category : categories) {
                         currentNodeCategories.push_back(category);
                     }
                     nodeCategories.push_back(currentNodeCategories);

--- a/networkit/cpp/structures/Partition.cpp
+++ b/networkit/cpp/structures/Partition.cpp
@@ -141,7 +141,7 @@ std::set<std::set<index> > Partition::getSubsets() const {
     });
 
     std::set<std::set<index> > subsets;
-    for (auto set : table) {
+    for (const auto &set : table) {
         if (set.size() > 0) {
             subsets.insert(set);
         }


### PR DESCRIPTION
Avoid useless copies in range-based for loops.