### PR TITLE
warning fix: clang-tidy/performance-inefficient-vector-operation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,6 +68,7 @@ WarningsAsErrors:  >
     performance-for-range-copy,
     performance-implicit-conversion-in-loop,
     performance-inefficient-algorithm,
+    performance-inefficient-vector-operation,
     performance-move-const-arg,
     performance-trivially-destructible,
     performance-type-promotion-in-math-fn,

--- a/networkit/cpp/distance/Volume.cpp
+++ b/networkit/cpp/distance/Volume.cpp
@@ -61,6 +61,7 @@ std::vector<double> Volume::volume(const Graph &G, std::vector<double> rs, count
         }
     }
     std::vector<double> ys;
+    ys.reserve(xs.size());
     for (const auto &x : xs) {
         ys.push_back(x / samples);
     }

--- a/networkit/cpp/generators/DynamicDGSParser.cpp
+++ b/networkit/cpp/generators/DynamicDGSParser.cpp
@@ -78,10 +78,7 @@ void DynamicDGSParser::generate() {
                 std::string categoriesCommaSeparated = categoriesFullStringSplit[1]; // Example: cond-mat.stat-mech, q-fin.ST
                 std::vector<std::string> categories = Aux::StringTools::split(categoriesCommaSeparated, ',');
 
-                std::vector<std::string> currentNodeCategories;
-                for (const std::string &category : categories) {
-                    currentNodeCategories.push_back(category);
-                }
+                std::vector<std::string> currentNodeCategories(categories.begin(), categories.end());
                 nodeCategories.push_back(currentNodeCategories);
                 assert(nodeCategories.size() > 0);
 

--- a/networkit/cpp/generators/MocnikGenerator.cpp
+++ b/networkit/cpp/generators/MocnikGenerator.cpp
@@ -175,6 +175,7 @@ std::vector<int> MocnikGenerator::boxSurface(MocnikGenerator::LayerState &s, int
     }
     // convert the list of grid cells from a multi to a one-dimensional index
     std::vector<int> seResult;
+    seResult.reserve(se.size());
     for (std::vector<int> &v : se) {
         seResult.push_back(toIndex(s, v));
     }
@@ -204,6 +205,7 @@ std::vector<int> MocnikGenerator::boxVolume(MocnikGenerator::LayerState &s, int 
     }
     // convert the list of grid cells from a multi to a one-dimensional index
     std::vector<int> seResult;
+    seResult.reserve(se.size());
     for (std::vector<int> &v : se) {
         seResult.push_back(toIndex(s, v));
     }

--- a/networkit/cpp/io/DGSReader.cpp
+++ b/networkit/cpp/io/DGSReader.cpp
@@ -68,10 +68,7 @@ void DGSReader::read(std::string path, GraphEventProxy& Gproxy) {
                     std::string categoriesCommaSeparated = categoriesFullStringSplit[1]; // Example: cond-mat.stat-mech, q-fin.ST
                     std::vector<std::string> categories = Aux::StringTools::split(categoriesCommaSeparated, ',');
 
-                    std::vector<std::string> currentNodeCategories;
-                    for (const std::string &category : categories) {
-                        currentNodeCategories.push_back(category);
-                    }
+                    std::vector<std::string> currentNodeCategories(categories.begin(), categories.end());
                     nodeCategories.push_back(currentNodeCategories);
 
                     std::string dateFullString = split[3]; // Example: date="08-1997"

--- a/networkit/cpp/structures/Partition.cpp
+++ b/networkit/cpp/structures/Partition.cpp
@@ -99,6 +99,7 @@ void Partition::compact(bool useTurbo) {
 std::vector<count> Partition::subsetSizes() const {
     std::vector<count> sizes;
     std::map<index, count> map = this->subsetSizeMap();
+    sizes.reserve(map.size());
     for (auto kv : map) {
         sizes.push_back(kv.second);
     }


### PR DESCRIPTION
Avoid inefficient `push_back` operations.