### PR TITLE
warning fix: clang-tidy/performance-type-promotion-in-math-fn

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,6 +66,7 @@ WarningsAsErrors:  >
     performance-inefficient-algorithm,
     performance-move-const-arg,
     performance-trivially-destructible,
+    performance-type-promotion-in-math-fn,
     performance-unnecessary-copy-initialization
 
 FormatStyle: 'file'

--- a/networkit/cpp/community/GraphClusteringTools.cpp
+++ b/networkit/cpp/community/GraphClusteringTools.cpp
@@ -1,13 +1,15 @@
-#include <networkit/community/GraphClusteringTools.hpp>
+#include <cmath>
 #include <networkit/auxiliary/Log.hpp>
+#include <networkit/community/GraphClusteringTools.hpp>
 
 namespace NetworKit {
 
 namespace GraphClusteringTools {
 
 float getImbalance(const Partition &zeta) {
-    float avg = ceil(
-            (float) zeta.numberOfElements() / (float) zeta.numberOfSubsets()); //TODO number of nodes and not number of elements
+    float avg = std::ceil(
+        (float)zeta.numberOfElements()
+        / (float)zeta.numberOfSubsets()); // TODO number of nodes and not number of elements
     std::vector<count> clusterSizes = zeta.subsetSizes();
     float maxClusterSize = (float) *std::max_element(clusterSizes.begin(),
             clusterSizes.end());


### PR DESCRIPTION
Avoid implicit promotion from `float` to `double` due to calls to C math library functions.