### PR TITLE
warning fix: clang-tidy/modernize-use-override

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@ Checks: >
     bugprone-use-after-move,
     bugprone-virtual-near-miss,
     cppcoreguidelines-narrowing-conversions,
+    modernize-use-override,
     performance-for-range-copy,
     performance-implicit-conversion-in-loop,
     performance-inefficient-algorithm,
@@ -37,7 +38,6 @@ Checks: >
 #    modernize-use-using,
 #    modernize-avoid-c-arrays,
 #    modernize-use-emplace,
-#    modernize-use-override,
 #    readability-avoid-const-params-in-decls,
 #    readability-const-return-type,
 #    readability-container-size-empty
@@ -65,6 +65,7 @@ WarningsAsErrors:  >
     bugprone-unused-return-value,
     bugprone-use-after-move,
     bugprone-virtual-near-miss,
+    modernize-use-override,
     performance-for-range-copy,
     performance-implicit-conversion-in-loop,
     performance-inefficient-algorithm,

--- a/include/networkit/auxiliary/BucketPQ.hpp
+++ b/include/networkit/auxiliary/BucketPQ.hpp
@@ -75,34 +75,34 @@ public:
     /**
      * Default destructor
      */
-    virtual ~BucketPQ() = default;
+    ~BucketPQ() override = default;
 
     /**
      * Inserts key-value pair (@key, @value).
      */
-    virtual void insert(int64_t key, index value) override;
+    void insert(int64_t key, index value) override;
 
     /**
      * Removes the element with minimum key and returns the key-value pair.
      */
-    virtual std::pair<int64_t, index> extractMin() override;
+    std::pair<int64_t, index> extractMin() override;
 
     /**
      * Modifies entry with value @a value.
      * The entry is then set to @a newKey with the same value.
      * If the corresponding key is not present, the element will be inserted.
      */
-    virtual void changeKey(int64_t newKey, index value) override;
+    void changeKey(int64_t newKey, index value) override;
 
     /**
      * @return Number of elements in PQ.
      */
-    virtual uint64_t size() const override;
+    uint64_t size() const override;
 
     /**
      * Removes key-value pair given by value @a val.
      */
-    virtual void remove(const index& val) override;
+    void remove(const index &val) override;
 
     /**
      * @return key to given value @val.

--- a/include/networkit/auxiliary/SignalHandling.hpp
+++ b/include/networkit/auxiliary/SignalHandling.hpp
@@ -24,10 +24,7 @@ namespace SignalHandling {
         class InterruptException : public std::exception {
         public:
             InterruptException() : std::exception() {}
-            virtual const char* what() const noexcept
-            {
-                return "Received CTRL+C/SIGINT";
-            }
+            const char *what() const noexcept override { return "Received CTRL+C/SIGINT"; }
         };
 
         /**

--- a/include/networkit/centrality/ApproxSpanningEdge.hpp
+++ b/include/networkit/centrality/ApproxSpanningEdge.hpp
@@ -41,7 +41,7 @@ public:
      */
     ApproxSpanningEdge(const Graph &G, double eps = 0.1);
 
-    ~ApproxSpanningEdge() = default;
+    ~ApproxSpanningEdge() override = default;
 
     /**
      * Executes the algorithm.

--- a/include/networkit/centrality/Centrality.hpp
+++ b/include/networkit/centrality/Centrality.hpp
@@ -32,12 +32,12 @@ public:
     Centrality(const Graph& G, bool normalized=false, bool computeEdgeCentrality=false);
 
     /** Default destructor */
-    virtual ~Centrality() = default;
+    ~Centrality() override = default;
 
     /**
      * Computes centrality scores on the graph passed in constructor.
      */
-    virtual void run() = 0;
+    void run() override = 0;
 
     /**
      * Get a vector containing the centrality score for each node in the graph.

--- a/include/networkit/centrality/CoreDecomposition.hpp
+++ b/include/networkit/centrality/CoreDecomposition.hpp
@@ -44,7 +44,7 @@ public:
     /**
      * Perform k-core decomposition of graph passed in constructor.
      */
-    void run();
+    void run() override;
 
     /**
      * Get the k-cores as a graph cover object.
@@ -72,7 +72,7 @@ public:
     *
     * @return The theoretical maximum centrality score.
     */
-    double maximum();
+    double maximum() override;
 
     /**
      * Get the node order.
@@ -87,9 +87,7 @@ public:
      * The algorithm ParK can run in parallel under certain conditions,
      * the bucket PQ based one cannot.
      */
-    virtual bool isParallel() const {
-        return canRunInParallel;
-    }
+    bool isParallel() const override { return canRunInParallel; }
 
 private:
 

--- a/include/networkit/centrality/DynTopHarmonicCloseness.hpp
+++ b/include/networkit/centrality/DynTopHarmonicCloseness.hpp
@@ -39,7 +39,7 @@ public:
   DynTopHarmonicCloseness(const Graph &G, count k = 1,
                           bool useBFSbound = false);
 
-  ~DynTopHarmonicCloseness();
+  ~DynTopHarmonicCloseness() override;
 
   /**
    * Computes the k most central nodes on the initial graph.

--- a/include/networkit/centrality/EigenvectorCentrality.hpp
+++ b/include/networkit/centrality/EigenvectorCentrality.hpp
@@ -34,7 +34,7 @@ public:
     /**
      * Computes eigenvector centrality on the graph passed in constructor.
      */
-    virtual void run();
+    void run() override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -41,7 +41,7 @@ public:
      * Computes the group with maximum closeness on the graph passed in the
      * constructor.
      */
-    void run();
+    void run() override;
 
     /**
      * Returns group with maximum closeness.

--- a/include/networkit/centrality/KatzCentrality.hpp
+++ b/include/networkit/centrality/KatzCentrality.hpp
@@ -40,7 +40,7 @@ public:
     /**
      * Computes katz centrality on the graph passed in constructor.
      */
-    virtual void run();
+    void run() override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/centrality/LocalClusteringCoefficient.hpp
+++ b/include/networkit/centrality/LocalClusteringCoefficient.hpp
@@ -50,7 +50,8 @@ public:
     *
     * @return The maximum centrality score.
     */
-    virtual double maximum() override;
+    double maximum() override;
+
 protected:
     bool turbo;
 

--- a/include/networkit/centrality/LocalPartitionCoverage.hpp
+++ b/include/networkit/centrality/LocalPartitionCoverage.hpp
@@ -23,26 +23,27 @@ public:
     /**
      * Computes local partition coverage on the graph passed in constructor.
      */
-    virtual void run() override;
+    void run() override;
 
     /**
      * Get the maximum value (1.0)
      *
      * @return 1.0
      */
-    virtual double maximum() override;
+    double maximum() override;
 
     /**
      * This algorithm is parallel.
      * @return true
      */
-    virtual bool isParallel() const override;
+    bool isParallel() const override;
 
     /**
      * The name of this algorithm.
      * @return "Local partition coverage"
      */
-    virtual std::string toString() const override;
+    std::string toString() const override;
+
 protected:
     const Partition& P;
 };

--- a/include/networkit/centrality/PermanenceCentrality.hpp
+++ b/include/networkit/centrality/PermanenceCentrality.hpp
@@ -10,7 +10,7 @@ namespace NetworKit {
 class PermanenceCentrality : public Algorithm {
 public:
     PermanenceCentrality(const Graph &G, const Partition &P);
-    void run();
+    void run() override;
     double getPermanence(node u);
     double getIntraClustering(node u);
 private:

--- a/include/networkit/centrality/SpanningEdgeCentrality.hpp
+++ b/include/networkit/centrality/SpanningEdgeCentrality.hpp
@@ -38,8 +38,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~SpanningEdgeCentrality() = default;
-
+    ~SpanningEdgeCentrality() override = default;
 
     /**
     * Compute spanning edge centrality scores exactly for all edges. This solves a linear system for each edge, so the empirical running time is O(m^2),

--- a/include/networkit/centrality/TopHarmonicCloseness.hpp
+++ b/include/networkit/centrality/TopHarmonicCloseness.hpp
@@ -43,7 +43,7 @@ public:
   /**
    * Computes top-k harmonic closeness on the graph passed in the constructor.
    */
-  void run();
+  void run() override;
 
   /**
    * Returns a list with the k nodes with highest harmonic closeness.

--- a/include/networkit/coarsening/GraphCoarsening.hpp
+++ b/include/networkit/coarsening/GraphCoarsening.hpp
@@ -26,9 +26,9 @@ public:
 
     GraphCoarsening(const Graph& G);
 
-    virtual ~GraphCoarsening() = default;
+    ~GraphCoarsening() override = default;
 
-    virtual void run() = 0;
+    void run() override = 0;
 
     Graph getCoarseGraph() const;
 

--- a/include/networkit/community/CommunityDetectionAlgorithm.hpp
+++ b/include/networkit/community/CommunityDetectionAlgorithm.hpp
@@ -36,12 +36,12 @@ public:
     CommunityDetectionAlgorithm(const Graph& G, const Partition baseClustering);
 
     /** Default destructor */
-    virtual ~CommunityDetectionAlgorithm() = default;
+    ~CommunityDetectionAlgorithm() override = default;
 
     /**
      * Apply algorithm to graph
      */
-    virtual void run() = 0;
+    void run() override = 0;
 
     /**
      * Returns the result of the run method or throws an error, if the algorithm hasn't run yet.
@@ -52,7 +52,7 @@ public:
     /**
      * @return string representation of algorithm and parameters.
      */
-    virtual std::string toString() const;
+    std::string toString() const override;
 
 protected:
     const Graph* G;

--- a/include/networkit/community/LocalCommunityEvaluation.hpp
+++ b/include/networkit/community/LocalCommunityEvaluation.hpp
@@ -17,7 +17,7 @@ public:
     /**
      * Default destructor for the virtual base class
      */
-    virtual ~LocalCommunityEvaluation() = default;
+    ~LocalCommunityEvaluation() override = default;
 
     /**
      * Get the average value weighted by cluster size.

--- a/include/networkit/components/RandomSpanningForest.hpp
+++ b/include/networkit/components/RandomSpanningForest.hpp
@@ -22,7 +22,7 @@ class RandomSpanningForest final : public SpanningForest {
 public:
     RandomSpanningForest(const Graph& G);
 
-    ~RandomSpanningForest() = default;
+    ~RandomSpanningForest() override = default;
 
     /**
      * Computes for each component a random spanning tree.

--- a/include/networkit/distance/APSP.hpp
+++ b/include/networkit/distance/APSP.hpp
@@ -30,7 +30,7 @@ class APSP : public Algorithm {
      */
     APSP(const Graph &G);
 
-    virtual ~APSP() = default;
+    ~APSP() override = default;
 
     /** Computes the shortest paths from each node to all other nodes. */
     void run() override;
@@ -38,7 +38,7 @@ class APSP : public Algorithm {
     /**
      * @return string representation of algorithm and parameters.
      */
-    virtual std::string toString() const override;
+    std::string toString() const override;
 
     /**
      * Returns a vector of weighted distances between node pairs.
@@ -64,9 +64,9 @@ class APSP : public Algorithm {
     /**
      * @return True if algorithm can run multi-threaded.
      */
-    virtual bool isParallel() const override { return true; }
+    bool isParallel() const override { return true; }
 
-  protected:
+protected:
     const Graph &G;
     std::vector<std::vector<edgeweight>> distances;
     std::vector<std::unique_ptr<SSSP>> sssps;

--- a/include/networkit/distance/AllSimplePaths.hpp
+++ b/include/networkit/distance/AllSimplePaths.hpp
@@ -32,7 +32,7 @@ namespace NetworKit {
         */
         AllSimplePaths(const Graph& G, node source, node target, count cutoff = none);
 
-        ~AllSimplePaths() = default;
+        ~AllSimplePaths() override = default;
 
         /**
         * This method computes all possible paths from a given source node to a target node.

--- a/include/networkit/distance/CommuteTimeDistance.hpp
+++ b/include/networkit/distance/CommuteTimeDistance.hpp
@@ -34,8 +34,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~CommuteTimeDistance() = default;
-
+    ~CommuteTimeDistance() override = default;
 
     /**
      * Computes ECTD exactly.

--- a/include/networkit/distance/DynSSSP.hpp
+++ b/include/networkit/distance/DynSSSP.hpp
@@ -36,7 +36,7 @@ public:
      */
     DynSSSP(const Graph& G, node source, bool storePredecessors = true, node target = none);
 
-    virtual ~DynSSSP() = default;
+    ~DynSSSP() override = default;
 
     /**
     * Returns true or false depending on whether the node previoulsy specified

--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -40,10 +40,10 @@ public:
     SSSP(const Graph &G, node source, bool storePaths = true,
          bool storeNodesSortedByDistance = false, node target = none);
 
-    virtual ~SSSP() = default;
+    ~SSSP() override = default;
 
     /** Computes the shortest paths from the source to all other nodes. */
-    virtual void run() = 0;
+    void run() override = 0;
 
     /**
      * Returns a vector of weighted distances from the source node, i.e. the

--- a/include/networkit/edgescores/EdgeScore.hpp
+++ b/include/networkit/edgescores/EdgeScore.hpp
@@ -26,7 +26,7 @@ public:
     EdgeScore(const Graph &G);
 
     /** Compute the edge score. */
-    virtual void run();
+    void run() override;
 
     /** Get a vector containing the score for each edge in the graph.
      *

--- a/include/networkit/generators/ErdosRenyiGenerator.hpp
+++ b/include/networkit/generators/ErdosRenyiGenerator.hpp
@@ -43,7 +43,7 @@ public:
      */
     ErdosRenyiGenerator(count nNodes, double prob, bool directed = false, bool self_loops = false);
 
-    Graph generate();
+    Graph generate() override;
 
 private:
     node nNodes;

--- a/include/networkit/generators/PubWebGenerator.hpp
+++ b/include/networkit/generators/PubWebGenerator.hpp
@@ -46,7 +46,7 @@ class PubWebGenerator final : public StaticGraphGenerator {
 public:
     PubWebGenerator() {
     } // nullary constructor needed for Python Shell - do not use this to construct instance
-    ~PubWebGenerator() = default;
+    ~PubWebGenerator() override = default;
 
     PubWebGenerator(count numNodes, count numberOfDenseAreas, coordinate neighborhoodRadius,
                     count maxNumberOfNeighbors);

--- a/include/networkit/generators/StaticDegreeSequenceGenerator.hpp
+++ b/include/networkit/generators/StaticDegreeSequenceGenerator.hpp
@@ -36,8 +36,7 @@ public:
 
     virtual bool getRealizable() const;
 
-
-    virtual Graph generate() = 0;
+    Graph generate() override = 0;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/graph/KruskalMSF.hpp
+++ b/include/networkit/graph/KruskalMSF.hpp
@@ -21,7 +21,7 @@ namespace NetworKit {
 class KruskalMSF final: public SpanningForest {
 public:
     KruskalMSF(const Graph& G);
-    virtual ~KruskalMSF() = default;
+    ~KruskalMSF() override = default;
 
     /**
      * Computes for each component a minimum weight spanning tree

--- a/include/networkit/graph/RandomMaximumSpanningForest.hpp
+++ b/include/networkit/graph/RandomMaximumSpanningForest.hpp
@@ -36,7 +36,7 @@ public:
     /**
      * Execute the algorithm.
      */
-    virtual void run() override;
+    void run() override;
 
     /**
      * Get a boolean attribute that indicates for each edge if it is part of the calculated maximum-weight spanning forest.
@@ -76,12 +76,12 @@ public:
     /**
      * @return false - this algorithm is not parallelized
      */
-    virtual bool isParallel() const override;
+    bool isParallel() const override;
 
     /**
      * @return The name of this algorithm.
      */
-    virtual std::string toString() const override;
+    std::string toString() const override;
 
 private:
     struct weightedEdge {

--- a/include/networkit/io/DGSReader.hpp
+++ b/include/networkit/io/DGSReader.hpp
@@ -34,7 +34,7 @@ public:
      * @param[in]  path  Path to file in DGS format.
      * @param[in]  Gproxy  Graph event proxy receives the events from the file.
      */
-    void read(std::string path, GraphEventProxy &Gproxy);
+    void read(std::string path, GraphEventProxy &Gproxy) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/EdgeListReader.hpp
+++ b/include/networkit/io/EdgeListReader.hpp
@@ -44,7 +44,7 @@ public:
      *
      * @param[in]  path  input file path
      */
-    Graph read(const std::string &path);
+    Graph read(const std::string &path) override;
 
     /**
      * Return the node map, in case node ids are not continuous

--- a/include/networkit/matching/Matcher.hpp
+++ b/include/networkit/matching/Matcher.hpp
@@ -39,14 +39,13 @@ public:
     Matcher(const Graph& G, const std::vector<double>& edgeScores);
 
     /** Default destructor */
-    virtual ~Matcher() = default;
+    ~Matcher() override = default;
 
     /**
      * Run the matching algorithm on the stored graph and return a matching.
      * @return A matching of the stored graph.
      */
-    virtual void run() = 0;
-
+    void run() override = 0;
 
     Matching getMatching() const;
 };

--- a/include/networkit/numerics/ConjugateGradient.hpp
+++ b/include/networkit/numerics/ConjugateGradient.hpp
@@ -26,12 +26,12 @@ class ConjugateGradient : public LinearSolver<Matrix> {
 public:
     ConjugateGradient(double tolerance = 1e-5) : LinearSolver<Matrix>(tolerance), matrix(Matrix()) {}
 
-    void setup(const Matrix& matrix) {
+    void setup(const Matrix &matrix) override {
         this->matrix = matrix;
         precond = Preconditioner(matrix);
     }
 
-    void setupConnected(const Matrix& matrix) {
+    void setupConnected(const Matrix &matrix) override {
         this->matrix = matrix;
         precond = Preconditioner(matrix);
     }
@@ -47,7 +47,8 @@ public:
      * @a status.residual must be nonnegative. You may also request that the algorithm
      * does not run for more than @a status.max_iters iterations.
      */
-    SolverStatus solve(const Vector& rhs, Vector& result, count maxConvergenceTime = 5 * 60 * 1000, count maxIterations = std::numeric_limits<count>::max());
+    SolverStatus solve(const Vector &rhs, Vector &result, count maxConvergenceTime = 5 * 60 * 1000,
+                       count maxIterations = std::numeric_limits<count>::max()) override;
 
     /**
      * Solves the linear systems in parallel.
@@ -56,7 +57,9 @@ public:
      * @param maxConvergenceTime
      * @param maxIterations
      */
-    void parallelSolve(const std::vector<Vector>& rhs, std::vector<Vector>& results, count maxConvergenceTime = 5 * 60 * 1000, count maxIterations = std::numeric_limits<count>::max());
+    void parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
+                       count maxConvergenceTime = 5 * 60 * 1000,
+                       count maxIterations = std::numeric_limits<count>::max()) override;
 
 private:
     Matrix matrix;

--- a/include/networkit/numerics/GaussSeidelRelaxation.hpp
+++ b/include/networkit/numerics/GaussSeidelRelaxation.hpp
@@ -39,7 +39,8 @@ public:
      * @param maxIterations
      * @return The (approximate) solution to the system.
      */
-    Vector relax(const Matrix& A, const Vector& b, const Vector& initialGuess, const count maxIterations = std::numeric_limits<count>::max()) const;
+    Vector relax(const Matrix &A, const Vector &b, const Vector &initialGuess,
+                 const count maxIterations = std::numeric_limits<count>::max()) const override;
 
     /**
      * Utilizes Gauss-Seidel relaxations until the given number of @a maxIterations is reached or the relative residual
@@ -49,8 +50,8 @@ public:
      * @param maxIterations
      * @return The (approximate) solution to the system.
      */
-    Vector relax(const Matrix& A, const Vector& b, const count maxIterations = std::numeric_limits<count>::max()) const;
-
+    Vector relax(const Matrix &A, const Vector &b,
+                 const count maxIterations = std::numeric_limits<count>::max()) const override;
 };
 
 template<class Matrix>

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -54,7 +54,7 @@ public:
      */
     Lamg(const double tolerance = 1e-6) : LinearSolver<Matrix>(tolerance), validSetup(false), lamgSetup(smoother), numComponents(0) {}
     /** Default destructor */
-    ~Lamg() = default;
+    ~Lamg() override = default;
 
     /**
      * Compute the multigrid hierarchy for the given Laplacian matrix @a laplacianMatrix.
@@ -62,14 +62,14 @@ public:
      * @note This method also works for disconnected graphs. If you know that the graph is connected,
      * if is faster to use @ref setupConnected instead.
      */
-    void setup(const Matrix& laplacianMatrix);
+    void setup(const Matrix &laplacianMatrix) override;
 
     /**
      * Compute the multigrid hierarchy for te given Laplacian matrix @a laplacianMatrix.
      * @param laplacianMatrix
      * @note The graph has to be connected for this method to work. Otherwise the output is undefined.
      */
-    void setupConnected(const Matrix& laplacianMatrix);
+    void setupConnected(const Matrix &laplacianMatrix) override;
 
     /**
      * Computes the @a result for the matrix currently setup and the right-hand side @a rhs.
@@ -81,7 +81,8 @@ public:
      * @param maxIterations
      * @return A @ref SolverStatus object which provides some statistics like the final absolute residual.
      */
-    SolverStatus solve(const Vector& rhs, Vector& result, count maxConvergenceTime = 5 * 60 * 1000, count maxIterations = std::numeric_limits<count>::max());
+    SolverStatus solve(const Vector &rhs, Vector &result, count maxConvergenceTime = 5 * 60 * 1000,
+                       count maxIterations = std::numeric_limits<count>::max()) override;
 
     /**
      * Compute the @a results for the matrix currently setup and the right-hand sides @a rhs.
@@ -92,8 +93,9 @@ public:
      * @param maxConvergenceTime
      * @param maxIterations
      */
-    void parallelSolve(const std::vector<Vector>& rhs, std::vector<Vector>& results, count maxConvergenceTime = 5 * 60 * 1000, count maxIterations = std::numeric_limits<count>::max());
-
+    void parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
+                       count maxConvergenceTime = 5 * 60 * 1000,
+                       count maxIterations = std::numeric_limits<count>::max()) override;
 };
 
 template<class Matrix>

--- a/include/networkit/numerics/LAMG/Level/LevelAggregation.hpp
+++ b/include/networkit/numerics/LAMG/Level/LevelAggregation.hpp
@@ -24,11 +24,11 @@ private:
 public:
     LevelAggregation(const Matrix& A, const Matrix& P, const Matrix& R) : Level<Matrix>(LevelType::AGGREGATION, A), P(P), R(R) {}
 
-    void coarseType(const Vector& xf, Vector& xc) const;
+    void coarseType(const Vector &xf, Vector &xc) const override;
 
-    void restrict(const Vector& bf, Vector& bc) const;
+    void restrict(const Vector &bf, Vector &bc) const override;
 
-    void interpolate(const Vector& xc, Vector& xf) const;
+    void interpolate(const Vector &xc, Vector &xf) const override;
 };
 
 template<class Matrix>

--- a/include/networkit/numerics/LAMG/Level/LevelElimination.hpp
+++ b/include/networkit/numerics/LAMG/Level/LevelElimination.hpp
@@ -27,9 +27,10 @@ private:
 public:
     LevelElimination(const Matrix& A, const std::vector<EliminationStage<Matrix>>& coarseningStages);
 
-    void coarseType(const Vector& xf, Vector& xc) const;
-    void restrict(const Vector& bf, Vector& bc, std::vector<Vector>& bStages) const;
-    void interpolate(const Vector& xc, Vector& xf, const std::vector<Vector>& bStages) const;
+    void coarseType(const Vector &xf, Vector &xc) const override;
+    void restrict(const Vector &bf, Vector &bc, std::vector<Vector> &bStages) const override;
+    void interpolate(const Vector &xc, Vector &xf,
+                     const std::vector<Vector> &bStages) const override;
 };
 
 template<class Matrix>

--- a/include/networkit/randomization/Curveball.hpp
+++ b/include/networkit/randomization/Curveball.hpp
@@ -27,9 +27,9 @@ class Curveball final : public Algorithm {
 public:
     explicit Curveball(const Graph &G);
 
-    ~Curveball();
+    ~Curveball() override;
 
-    void run() override final {
+    void run() final {
         throw std::runtime_error("run() is not supported by this algorithm; use run(trades)");
     };
 
@@ -37,9 +37,9 @@ public:
 
     Graph getGraph(bool parallel = false);
 
-    std::string toString() const override final;
+    std::string toString() const final;
 
-    bool isParallel() const override final { return false; }
+    bool isParallel() const final { return false; }
 
     count getNumberOfAffectedEdges() const;
 

--- a/include/networkit/randomization/DegreePreservingShuffle.hpp
+++ b/include/networkit/randomization/DegreePreservingShuffle.hpp
@@ -44,13 +44,13 @@ public:
      */
     explicit DegreePreservingShuffle(const Graph &G);
 
-    virtual ~DegreePreservingShuffle();
+    ~DegreePreservingShuffle() override;
 
     /**
      * Execute trades as configured in the constructor.
      * @warning This function has to be called exactly once before invoking getGraph()
      */
-    void run() override final;
+    void run() final;
 
     /**
      * Returns a shuffled copy of the input graph.
@@ -66,9 +66,9 @@ public:
      */
     const std::vector<node> &getPermutation() const noexcept { return permutation; }
 
-    std::string toString() const override final;
+    std::string toString() const final;
 
-    bool isParallel() const override final { return true; }
+    bool isParallel() const final { return true; }
 
 private:
     const Graph *G;

--- a/include/networkit/randomization/GlobalCurveball.hpp
+++ b/include/networkit/randomization/GlobalCurveball.hpp
@@ -45,13 +45,13 @@ public:
                              bool allowSelfLoops = false,
                              bool degreePreservingShufflePreprocessing = true);
 
-    ~GlobalCurveball();
+    ~GlobalCurveball() override;
 
     /**
      * Execute trades as configured in the constructor.
      * @warning This function has to be called exactly one before invoking getGraph()
      */
-    void run() override final;
+    void run() final;
 
     /**
      * Returns a new graph instance with the same degree sequence as the input
@@ -59,9 +59,9 @@ public:
      */
     Graph getGraph();
 
-    std::string toString() const override final;
+    std::string toString() const final;
 
-    bool isParallel() const override final { return false; }
+    bool isParallel() const final { return false; }
 
 private:
     std::unique_ptr<CurveballDetails::GlobalCurveballImpl> impl;

--- a/include/networkit/scd/PageRankNibble.hpp
+++ b/include/networkit/scd/PageRankNibble.hpp
@@ -38,7 +38,7 @@ public:
      */
     PageRankNibble(const Graph& g, double alpha, double epsilon);
 
-    ~PageRankNibble() = default;
+    ~PageRankNibble() override = default;
 
     std::map<node, std::set<node>> run(const std::set<node>& seeds) override;
 

--- a/include/networkit/scoring/ModularityScoring.hpp
+++ b/include/networkit/scoring/ModularityScoring.hpp
@@ -33,7 +33,7 @@ public:
     ModularityScoring(Graph& G, double gTotalEdgeWeight = 0.0);
 
     /** Default destructor */
-    ~ModularityScoring() = default;
+    ~ModularityScoring() override = default;
 
     void scoreEdges(int attrId) override;
 

--- a/include/networkit/sparsification/SimmelianScore.hpp
+++ b/include/networkit/sparsification/SimmelianScore.hpp
@@ -69,8 +69,8 @@ class SimmelianScore : public EdgeScore<double> {
 public:
 
     SimmelianScore(const Graph& graph, const std::vector<count>& attribute);
-    virtual double score(edgeid eid) override;
-    virtual double score(node u, node v) override;
+    double score(edgeid eid) override;
+    double score(node u, node v) override;
 
     std::vector<RankedNeighbors> getRankedNeighborhood(const Graph& g, const std::vector<count>& triangles);
 

--- a/include/networkit/sparsification/Sparsifiers.hpp
+++ b/include/networkit/sparsification/Sparsifiers.hpp
@@ -57,7 +57,7 @@ public:
      */
     SimmelianSparsifierNonParametric(const Graph& graph, double threshold);
 
-    virtual void run() override;
+    void run() override;
 
 private:
     double threshold;
@@ -80,7 +80,7 @@ public:
      */
     SimmelianSparsifierParametric(const Graph& graph, int maxRank, int minOverlap);
 
-    virtual void run() override;
+    void run() override;
 
 private:
     int maxRank;
@@ -101,7 +101,7 @@ public:
      */
     MultiscaleSparsifier(const Graph& graph, double alpha);
 
-    virtual void run() override;
+    void run() override;
 
 private:
     double alpha;
@@ -121,7 +121,7 @@ public:
      */
     LocalSimilaritySparsifier(const Graph& graph, double e);
 
-    virtual void run() override;
+    void run() override;
 
 private:
     double e;
@@ -141,7 +141,7 @@ public:
      */
     SimmelianMultiscaleSparsifier(const Graph& graph, double alpha);
 
-    virtual void run() override;
+    void run() override;
 
 private:
     double alpha;
@@ -162,7 +162,7 @@ public:
     */
     RandomSparsifier(const Graph& graph, double ratio);
 
-    virtual void run() override;
+    void run() override;
 
 private:
     double ratio;

--- a/include/networkit/viz/MaxentStress.hpp
+++ b/include/networkit/viz/MaxentStress.hpp
@@ -61,7 +61,7 @@ class MaxentStress final : public GraphLayoutAlgorithm<double> {
 
 
         /** Default destructor. */
-         ~MaxentStress() = default;
+        ~MaxentStress() override = default;
 
         /** Computes a graph drawing according to the Maxent-Stress model. */
          void run() override;

--- a/include/networkit/viz/PivotMDS.hpp
+++ b/include/networkit/viz/PivotMDS.hpp
@@ -34,7 +34,7 @@ class PivotMDS final : public GraphLayoutAlgorithm<double> {
     /*
      * Default destructor
      */
-    ~PivotMDS() = default;
+    ~PivotMDS() override = default;
 
     /**
      * Runs the PivotMDS algorithm.


### PR DESCRIPTION
This PR adds `override` to virtual overridden virtual functions, and removes `virtual` where not required.