### PR TITLE
Fix: Commute Time Distance

### DIFF
--- a/include/networkit/distance/CommuteTimeDistance.hpp
+++ b/include/networkit/distance/CommuteTimeDistance.hpp
@@ -57,11 +57,6 @@ public:
      */
     uint64_t getSetupTime() const;
 
-    /**
-     * Returns the commute time distance between node @a u and node @a v.
-     * @return commute time distance between the two nodes. Needs to call run() or runApproximation() first.
-     */
-    double distance(node u, node v);
 
     /**
      * Returns the commute time distance between node @a u and node @a v.
@@ -72,10 +67,11 @@ public:
     double runSinglePair(node u, node v);
 
     /**
-     * Returns the sum of the distances from node @a u.
-     * This method does not need the initial preprocessing.
-     * @return commute sum of the distances from the node.
+     * Returns the commute time distance between node @a u and node @a v.
+     * @return commute time distance between the two nodes. Needs to call run() or runApproximation() first.
      */
+    double distance(node u, node v);
+
     double runSingleSource(node u);
 
 protected:

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -129,6 +129,14 @@ std::pair<node, node> size(const Graph &G) noexcept;
 double density(const Graph &G) noexcept;
 
 /**
+ * Returns the volume (sum of the out-degree of all nodes) of the graph.
+ *
+ * @param G The input graph.
+ * @return Volume of the graph.
+ */
+double volume(const Graph &G);
+
+/**
  * Copies all nodes of the input graph to a new graph (edges are not copied).
  *
  * @param G The input graph.

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -5236,6 +5236,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	vector[pair[node, node]] randomEdges(_Graph G, count numEdges) nogil except +
 	pair[count, count] size(_Graph G) nogil except +
 	double density(_Graph G) nogil except +
+	double volume(_Graph G) nogil except +
 	_Graph copyNodes(_Graph G) nogil except +
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
@@ -5528,6 +5529,23 @@ cdef class GraphTools:
 			The density of the input graph.
 		"""
 		return density(graph._this)
+
+	@staticmethod
+	def volume(Graph graph):
+		"""
+		Get the volume of the input graph.
+
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph.
+
+		Returns
+		-------
+		double
+			The volume of the input graph.
+		"""
+		return volume(graph._this)
 
 	@staticmethod
 	def copyNodes(Graph graph):

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -200,6 +200,17 @@ double density(const Graph &G) noexcept {
     return m / (n * (n - 1));
 }
 
+double volume(const Graph &G) {
+    if (G.isDirected())
+        throw std::runtime_error("Volume computation is only supported for undirected graphs.");
+
+    if (!G.isWeighted()) {
+        return 2.0 * G.numberOfEdges();
+    } else {
+        return 2.0 * G.totalEdgeWeight();
+    }
+}
+
 Graph copyNodes(const Graph &G) {
     Graph C(G.upperNodeIdBound(), G.isWeighted(), G.isDirected());
     for (node u = 0; u < G.upperNodeIdBound(); ++u) {


### PR DESCRIPTION
Fixes #447 

The volume of the graph for `distance(u,v)` was computed differently then `runSinglePair(u,v)`, leading to a difference of factor `sqrt(2)` in the results. The update also includes a warning, when the algorithm is called on directed graph. 