### PR TITLE
clang-tidy auto fix: modernize-deprecated-headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,7 @@ Checks: >
     bugprone-virtual-near-miss,
     cppcoreguidelines-narrowing-conversions,
     modernize-use-override,
+    modernize-deprecated-headers,
     performance-for-range-copy,
     performance-implicit-conversion-in-loop,
     performance-inefficient-algorithm,
@@ -34,7 +35,6 @@ Checks: >
     performance-unnecessary-value-param,
 
 # Warnings whishlist
-#    modernize-deprecated-headers,
 #    modernize-use-using,
 #    modernize-avoid-c-arrays,
 #    modernize-use-emplace,
@@ -66,6 +66,7 @@ WarningsAsErrors:  >
     bugprone-unused-return-value,
     bugprone-use-after-move,
     bugprone-virtual-near-miss,
+    modernize-deprecated-headers,
     modernize-use-override,
     performance-for-range-copy,
     performance-implicit-conversion-in-loop,

--- a/include/networkit/centrality/DynApproxBetweenness.hpp
+++ b/include/networkit/centrality/DynApproxBetweenness.hpp
@@ -13,8 +13,8 @@
 #include <networkit/dynamics/GraphEvent.hpp>
 #include <networkit/distance/DynSSSP.hpp>
 
-#include <math.h>
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <omp.h>
 

--- a/networkit/cpp/auxiliary/SignalHandling.cpp
+++ b/networkit/cpp/auxiliary/SignalHandling.cpp
@@ -1,7 +1,7 @@
-#include <networkit/auxiliary/SignalHandling.hpp>
-#include <exception>
 #include <atomic>
-#include <signal.h>
+#include <csignal>
+#include <exception>
+#include <networkit/auxiliary/SignalHandling.hpp>
 
 namespace Aux {
 

--- a/networkit/cpp/centrality/ApproxBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxBetweenness.cpp
@@ -15,8 +15,8 @@
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/SignalHandling.hpp>
 
-#include <math.h>
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <omp.h>
 

--- a/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
@@ -5,7 +5,7 @@
  *      Author: Marvin Pogoda
  */
 
-#include <math.h>
+#include <cmath>
 #include <omp.h>
 
 #include <networkit/auxiliary/BucketPQ.hpp>

--- a/networkit/cpp/centrality/DynBetweenness.cpp
+++ b/networkit/cpp/centrality/DynBetweenness.cpp
@@ -5,11 +5,11 @@
  *      Author: Arie Slobbe, Elisabetta Bergamini
  */
 
-#include <queue>
+#include <algorithm>
+#include <ctime>
 #include <memory>
-#include<unordered_set>
-#include<algorithm>
-#include <time.h>
+#include <queue>
+#include <unordered_set>
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/NumericTools.hpp>

--- a/networkit/cpp/centrality/DynKatzCentrality.cpp
+++ b/networkit/cpp/centrality/DynKatzCentrality.cpp
@@ -6,12 +6,12 @@
  *      based on code by Elisabetta Bergamini
  */
 
-#include <networkit/centrality/DynKatzCentrality.hpp>
-#include <networkit/auxiliary/Timer.hpp>
-#include <networkit/auxiliary/NumericTools.hpp>
-#include <float.h>
-#include <math.h>
+#include <cfloat>
+#include <cmath>
 #include <omp.h>
+#include <networkit/auxiliary/NumericTools.hpp>
+#include <networkit/auxiliary/Timer.hpp>
+#include <networkit/centrality/DynKatzCentrality.hpp>
 
 namespace NetworKit {
 

--- a/networkit/cpp/distance/CommuteTimeDistance.cpp
+++ b/networkit/cpp/distance/CommuteTimeDistance.cpp
@@ -5,7 +5,7 @@
  *      Author: henning
  */
 
-#include <math.h>
+#include <cmath>
 #include <omp.h>
 
 #include <networkit/auxiliary/Log.hpp>

--- a/networkit/cpp/distance/EffectiveDiameter.cpp
+++ b/networkit/cpp/distance/EffectiveDiameter.cpp
@@ -5,7 +5,7 @@
 *      Author: Marc Nemes
 */
 
-#include <math.h>
+#include <cmath>
 #include <omp.h>
 
 #include <networkit/auxiliary/Random.hpp>

--- a/networkit/cpp/distance/HopPlotApproximation.cpp
+++ b/networkit/cpp/distance/HopPlotApproximation.cpp
@@ -5,7 +5,7 @@
 *      Author: Marc Nemes
 */
 
-#include <math.h>
+#include <cmath>
 #include <omp.h>
 
 #include <networkit/auxiliary/Random.hpp>

--- a/networkit/cpp/distance/NeighborhoodFunction.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunction.cpp
@@ -4,8 +4,8 @@
 *  Created on: 30.03.2016
 *      Author: Maximilian Vogel
 */
+#include <cmath>
 #include <map>
-#include <math.h>
 #include <omp.h>
 
 #include <networkit/auxiliary/Random.hpp>

--- a/networkit/cpp/distance/NeighborhoodFunctionApproximation.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionApproximation.cpp
@@ -5,8 +5,8 @@
 *      Author: Maximilian Vogel
 */
 
+#include <cmath>
 #include <map>
-#include <math.h>
 #include <omp.h>
 #include <vector>
 

--- a/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
@@ -4,8 +4,8 @@
 *      Author: Maximilian Vogel
 */
 
+#include <cmath>
 #include <map>
-#include <math.h>
 #include <omp.h>
 
 #include <networkit/auxiliary/Parallel.hpp>

--- a/networkit/cpp/io/NetworkitBinaryReader.cpp
+++ b/networkit/cpp/io/NetworkitBinaryReader.cpp
@@ -6,8 +6,8 @@
  */
 
 #include <atomic>
+#include <cstring>
 #include <fstream>
-#include <string.h>
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/io/NetworkitBinaryReader.hpp>

--- a/networkit/cpp/io/test/MemoryMappedFileGTest.cpp
+++ b/networkit/cpp/io/test/MemoryMappedFileGTest.cpp
@@ -9,7 +9,7 @@
 #define NOMINMAX // windows.h by default defines the maros min/max, which prevent the usage of numeric_limits
 #include <windows.h>
 #else
-#include <stdlib.h>
+#include <cstdlib>
 #endif
 
 #include <algorithm>

--- a/networkit/cpp/sparsification/LocalSimilarityScore.cpp
+++ b/networkit/cpp/sparsification/LocalSimilarityScore.cpp
@@ -5,9 +5,9 @@
  *      Author: Gerd Lindner
  */
 
-#include <networkit/sparsification/LocalSimilarityScore.hpp>
-#include <math.h> //log
+#include <cmath> //log
 #include <set>
+#include <networkit/sparsification/LocalSimilarityScore.hpp>
 
 namespace NetworKit {
 

--- a/networkit/cpp/sparsification/test/LocalDegreeGTest.cpp
+++ b/networkit/cpp/sparsification/test/LocalDegreeGTest.cpp
@@ -5,11 +5,11 @@
  *      Author: Gerd Lindner
  */
 
+#include <cmath>
 #include <gtest/gtest.h>
 #include <networkit/Globals.hpp>
 #include <networkit/graph/Graph.hpp>
 #include <networkit/sparsification/LocalDegreeScore.hpp>
-#include <math.h>
 
 namespace NetworKit {
 

--- a/networkit/cpp/viz/test/MaxentStressGTest.cpp
+++ b/networkit/cpp/viz/test/MaxentStressGTest.cpp
@@ -38,7 +38,7 @@
 
 #include <networkit/viz/PivotMDS.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace NetworKit {
 


### PR DESCRIPTION
Replace deprecated C standard library headers with their C++ alternatives.