### PR TITLE
Reduce memory-footprint for BFS/Dijkstra

### DIFF
--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -167,8 +167,6 @@ protected:
     std::vector<edgeweight> distances;
     std::vector<std::vector<node>> previous; // predecessors on shortest path
     std::vector<bigfloat> npaths;
-    std::vector<uint8_t> visited;
-    uint8_t ts;
 
     std::vector<node> nodesSortedByDistance;
 

--- a/networkit/cpp/distance/BFS.cpp
+++ b/networkit/cpp/distance/BFS.cpp
@@ -23,15 +23,8 @@ void BFS::run() {
     const auto infDist = std::numeric_limits<edgeweight>::max();
     std::fill(distances.begin(), distances.end(), infDist);
 
-    if (distances.size() < z) {
+    if (distances.size() < z) 
         distances.resize(z, infDist);
-        visited.resize(z, ts);
-    }
-
-    if (ts++ == std::numeric_limits<uint8_t>::max()) {
-        ts = 1;
-        std::fill(visited.begin(), visited.end(), 0);
-    }
 
     if (storePaths) {
         previous.clear();
@@ -49,7 +42,6 @@ void BFS::run() {
     std::queue<node> q;
     q.push(source);
     distances[source] = 0.;
-    visited[source] = ts;
 
     bool breakWhenFound = (target != none);
     while (!q.empty()) {
@@ -65,9 +57,8 @@ void BFS::run() {
 
         // insert untouched neighbors into queue
         G->forNeighborsOf(u, [&](node v) {
-            if (ts != visited[v]) {
+            if (distances[v] == infDist) {
                 q.push(v);
-                visited[v] = ts;
                 distances[v] = distances[u] + 1.;
                 sumDist += distances[v];
                 ++reachedNodes;

--- a/networkit/cpp/distance/Dijkstra.cpp
+++ b/networkit/cpp/distance/Dijkstra.cpp
@@ -24,18 +24,11 @@ void Dijkstra::run() {
     auto infDist = std::numeric_limits<edgeweight>::max();
     std::fill(distances.begin(), distances.end(), infDist);
 
-    if (distances.size() < G->upperNodeIdBound()) {
+    if (distances.size() < G->upperNodeIdBound()) 
         distances.resize(G->upperNodeIdBound(), infDist);
-        visited.resize(G->upperNodeIdBound(), ts);
-    }
 
     sumDist = 0.;
     reachedNodes = 1;
-
-    if (ts++ == std::numeric_limits<uint8_t>::max()) {
-        ts = 1;
-        std::fill(visited.begin(), visited.end(), 0);
-    }
 
     if (storePaths) {
         previous.clear();
@@ -52,7 +45,6 @@ void Dijkstra::run() {
 
     // priority queue with distance-node pairs
     distances[source] = 0.;
-    visited[source] = ts;
     heap.push(source);
 
     auto initPath = [&](node u, node v) {
@@ -69,7 +61,7 @@ void Dijkstra::run() {
         sumDist += distances[u];
         TRACE("current node in Dijkstra: ", u);
         TRACE("pq size: ", heap.size());
-        if ((breakWhenFound && target == u) || visited[u] != ts)
+        if ((breakWhenFound && target == u) || distances[u] == infDist)
             break;
 
         if (storeNodesSortedByDistance)
@@ -77,8 +69,7 @@ void Dijkstra::run() {
 
         G->forNeighborsOf(u, [&](node v, edgeweight w) {
             double newDist = distances[u] + w;
-            if (ts != visited[v]) {
-                visited[v] = ts;
+            if (distances[v] == infDist) {
                 distances[v] = newDist;
                 heap.push(v);
                 ++reachedNodes;

--- a/networkit/cpp/distance/SSSP.cpp
+++ b/networkit/cpp/distance/SSSP.cpp
@@ -12,7 +12,7 @@ namespace NetworKit {
 
 SSSP::SSSP(const Graph &G, node source, bool storePaths,
            bool storeNodesSortedByDistance, node target)
-    : Algorithm(), G(&G), source(source), target(target), ts(0),
+    : Algorithm(), G(&G), source(source), target(target),
       storePaths(storePaths),
       storeNodesSortedByDistance(storeNodesSortedByDistance) {}
 


### PR DESCRIPTION
In the current state for `SSSP` (and inherited classes) there exists a `visited` vector, taking care of bookkeeping during runs. For `BFS` and `Dijkstra` this can be exchanged by comparing distances directly and removing the allocation of memory for `visited`. This saves roughly `#nodes * bytes * instances` amount of memory. 

The trade-off is comparing `double` instead of `uint_8`. Doing a quick-bench, this creates (depending on the compiler and flags) very low to none overhead in computational time. 
http://quick-bench.com/BKRXbz_iwoVyzk3W9Px_crliMLM

Thanks for @angriman to bring this up.