### PR TITLE
warning fix: clang-tidy/readability-const-return-type

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,6 +32,7 @@ Checks: >
     performance-type-promotion-in-math-fn,
     performance-unnecessary-copy-initialization,
     performance-unnecessary-value-param,
+    readability-const-return-type
 
 # Warnings whishlist
 #    modernize-deprecated-headers,
@@ -74,7 +75,8 @@ WarningsAsErrors:  >
     performance-move-const-arg,
     performance-trivially-destructible,
     performance-type-promotion-in-math-fn,
-    performance-unnecessary-copy-initialization
+    performance-unnecessary-copy-initialization,
+    readability-const-return-type
 
 FormatStyle: 'file'
 HeaderFilterRegex: '.*\/include\/networkit\/.*\.hpp'

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -907,9 +907,7 @@ public:
 
         bool operator!=(const NeighborWeightIterator &rhs) const { return !(*this == rhs); }
 
-        const std::pair<node, edgeweight> operator*() const {
-            return std::make_pair(*nIter, *wIter);
-        }
+        std::pair<node, edgeweight> operator*() const { return std::make_pair(*nIter, *wIter); }
     };
 
     /**
@@ -1578,7 +1576,7 @@ public:
      * @return a pair (n, m) where n is the number of nodes and m is the
      * number of edges
      */
-    std::pair<count, count> const TLX_DEPRECATED(size() const noexcept);
+    std::pair<count, count> TLX_DEPRECATED(size() const noexcept);
 
     /**
      * @return the density of the graph

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -770,7 +770,7 @@ void Graph::removeEdge(node u, node v) {
     }
 }
 
-std::pair<count, count> const Graph::size() const noexcept {
+std::pair<count, count> Graph::size() const noexcept {
     return GraphTools::size(*this);
 }
 


### PR DESCRIPTION
Remove `const` from return types of value-returning functions.