### PR TITLE
Update README.md and requirements for 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ package:
 
 - A modern C++ compiler, e.g.: [g++] (&gt;= 4.8) or [clang++] (&gt;= 3.7)
 - OpenMP for parallelism (usually ships with the compiler)
-- Python3 (3.4 or higher is recommended, 3.3 supported)
+- Python3 (3.5 or higher is supported)
 - [Pip]
 - [CMake] version 3.5 or higher (e.g., `pip3 install cmake`)
 - Build system: [Make] or [Ninja]
-- Cython version 0.21 or higher (e.g., `pip3 install cython`)
+- Cython version 0.29 or higher (e.g., `pip3 install cython`)
 
 ## Install
 

--- a/networkit/__init__.py
+++ b/networkit/__init__.py
@@ -26,10 +26,11 @@ Usage examples can be found on https://github.com/networkit/networkit/blob/Dev/n
 __author__ = "Christian Staudt"
 __copyright__ = "Copyright (c) 2014 Christan Staudt"
 __credits__ = ["Eugenio Angriman", "Lukas Barth", "Miriam Beddig", "Elisabetta Bergamini", "Stefan Bertsch", "Pratistha Bhattarai", "Andreas Bilke", "Simon Bischof", \
-	"Guido Brückner", "Mark Erb",  "Kolja Esders", "Patrick Flick", "Michael Hamann", "Lukas Hartmann", "Daniel Hoske", "Gerd Lindner", "Moritz v. Looz", "Yassine Marrakchi", "Henning Meyerhenke", \
-	"Manuel Penschuck", "Marcel Radermacher", "Klara Reichard", "Marvin Ritter", "Aleksejs Sazonovs", "Hung Tran", "Florian Weber", "Michael Wegner", "Jörg Weisbarth", "Kolja Esders"]
+	"Fabian Brandt-Tumescheit", "Guido Brückner", "Mark Erb",  "Kolja Esders", "Patrick Flick", "Michael Hamann", "Lukas Hartmann", "Daniel Hoske", "Gerd Lindner", \
+        "Moritz v. Looz", "Yassine Marrakchi", "Henning Meyerhenke", "Manuel Penschuck", "Marcel Radermacher", "Klara Reichard", "Marvin Ritter", \
+        "Aleksejs Sazonovs", "Hung Tran", "Alexander van der Grinten", "Florian Weber", "Michael Wegner", "Jörg Weisbarth"]
 __license__ = "MIT"
-__version__ = "6.0"
+__version__ = "7.0"
 
 # standard library modules
 import csv

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 name='networkit'
 
-version='6.0'
+version='7.0'
 
 url='https://networkit.github.io/'
 
@@ -41,10 +41,10 @@ classifiers = [
 'License :: OSI Approved :: MIT License',
 'Natural Language :: English',
 'Operating System :: OS Independent', 'Programming Language :: C++',
-'Programming Language :: Python :: 3.3',
-'Programming Language :: Python :: 3.4',
 'Programming Language :: Python :: 3.5',
 'Programming Language :: Python :: 3.6',
+'Programming Language :: Python :: 3.7',
+'Programming Language :: Python :: 3.8',
 'Topic :: Software Development :: Libraries :: Python Modules',
 'Topic :: Scientific/Engineering :: Bio-Informatics',
 'Topic :: Scientific/Engineering :: Chemistry',


### PR DESCRIPTION
This brings the README.md and requirements up-to-date.

- ~~Raised min. compiler version for GCC/G++ to 5.1~~
- ~~Aligned compiler versions for testing + documentation (+ removed older versions)~~
- Raised min. Python version to 3.5. 3.4 is EOL since nearly one year and we only test against 3.5
- Raised min. Cython version to 0.29 in order to support Python 3.8 (see #535) 

~~Note: Can't say how important it is, but I could not find a feasible way to choose g++-5.1 instead of g++5 (which should be 5.4) for travis.~~