### PR TITLE
Fix node sizes being passed as tuple-of-list

### DIFF
--- a/networkit/viztasks.py
+++ b/networkit/viztasks.py
@@ -37,7 +37,7 @@ def drawGraph(G, **kwargs):
 		raise MissingDependencyError("networkx")
 	nxG = nxadapter.nk2nx(G)
 	if not "node_size" in kwargs:
-		kwargs["node_size"] =[30+270*s for s in centrality.DegreeCentrality(G,True).run().scores()],
+		kwargs["node_size"] = [30+270*s for s in centrality.DegreeCentrality(G,True).run().scores()]
 	networkx.draw(nxG, **kwargs)
 
 def drawCommunityGraph(G, zeta, **kwargs):


### PR DESCRIPTION
The stray comma on that line causes computed node sizes to be passed as a one-tuple containing the desired list instead of the list itself. This makes networkx choke when it tries to access the list of node sizes. 