### PR TITLE
Fix wrong parameter in user guide

### DIFF
--- a/notebooks/User-Guide.ipynb
+++ b/notebooks/User-Guide.ipynb
@@ -818,7 +818,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nk.viztasks.drawGraph(K, nodeSizes=[(k**2)*20 for k in coreDec.scores()])\n",
+    "nk.viztasks.drawGraph(K, node_size=[(k**2)*20 for k in coreDec.scores()])\n",
     "plt.show()"
    ]
   },


### PR DESCRIPTION
The parameter controlling node sizes in the `drawGraph` method is named `node_size`, not `nodeSizes`.