### PR TITLE
warning fix: clang-tidy/readability-avoid-const-params-in-decls

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,14 +33,13 @@ Checks: >
     performance-type-promotion-in-math-fn,
     performance-unnecessary-copy-initialization,
     performance-unnecessary-value-param,
+    readability-avoid-const-params-in-decls,
     readability-const-return-type
 
 # Warnings whishlist
 #    modernize-use-using,
 #    modernize-avoid-c-arrays,
 #    modernize-use-emplace,
-#    readability-avoid-const-params-in-decls,
-#    readability-const-return-type,
 #    readability-container-size-empty
 
 # Turn the warnings from the checks above into errors.
@@ -77,6 +76,7 @@ WarningsAsErrors:  >
     performance-trivially-destructible,
     performance-type-promotion-in-math-fn,
     performance-unnecessary-copy-initialization,
+    readability-avoid-const-params-in-decls,
     readability-const-return-type
 
 FormatStyle: 'file'

--- a/include/networkit/algebraic/CSRMatrix.hpp
+++ b/include/networkit/algebraic/CSRMatrix.hpp
@@ -362,8 +362,8 @@ public:
      * function applied to the zero element of this matrix returns the zero element.
      * @param unaryElementFunction
      */
-    template<typename F>
-    void apply(const F unaryElementFunction);
+    template <typename F>
+    void apply(F unaryElementFunction);
 
     /**
      * Compute the (weighted) adjacency matrix of the (weighted) Graph @a graph.

--- a/include/networkit/auxiliary/SortedList.hpp
+++ b/include/networkit/auxiliary/SortedList.hpp
@@ -39,12 +39,12 @@ public:
      * Creates a SortedList of size @a size accepting key values from 0 to
      * @a maxKey.
      */
-    SortedList(const uint64_t size, const uint64_t maxKey);
+    SortedList(uint64_t size, uint64_t maxKey);
 
     /**
      * Insert a key-value element.
      */
-    void insert(const uint64_t newElement, const double newValue);
+    void insert(uint64_t newElement, double newValue);
 
     /**
      * Returns the value at position @a i in the ranking.

--- a/include/networkit/centrality/ApproxBetweenness.hpp
+++ b/include/networkit/centrality/ApproxBetweenness.hpp
@@ -37,7 +37,8 @@ public:
      * computing the sample size. It is 1 by default. Some references suggest
      * using 0.5, but there is no guarantee in this case.
      */
-    ApproxBetweenness(const Graph& G, const double epsilon=0.01, const double delta=0.1, const double universalConstant=1.0);
+    ApproxBetweenness(const Graph &G, double epsilon = 0.01, double delta = 0.1,
+                      double universalConstant = 1.0);
 
     /**
      * Computes betweenness approximation on the graph passed in constructor.

--- a/include/networkit/centrality/ApproxGroupBetweenness.hpp
+++ b/include/networkit/centrality/ApproxGroupBetweenness.hpp
@@ -23,8 +23,7 @@ public:
      * @param groupSize Size of the set of nodes.
      * @aram epsilon Determines the accuracy of the approximation.
      */
-    ApproxGroupBetweenness(const Graph &G, const count groupSize,
-                           const double epsilon);
+    ApproxGroupBetweenness(const Graph &G, count groupSize, double epsilon);
 
     /**
      * Approximately computes a set of nodes with maximum groupbetweenness. Based
@@ -41,8 +40,7 @@ public:
     /**
      * Returns the score of the given set.
      */
-    double scoreOfGroup(const std::vector<node> &S,
-                        const bool normalized = false) const;
+    double scoreOfGroup(const std::vector<node> &S, bool normalized = false) const;
 
 protected:
     const Graph &G;

--- a/include/networkit/centrality/Closeness.hpp
+++ b/include/networkit/centrality/Closeness.hpp
@@ -36,36 +36,33 @@ class Closeness : public Centrality {
      * for unweighted graphs.
      *
      */
-    Closeness(const Graph &G, bool normalized,
-              const ClosenessVariant variant = ClosenessVariant::standard);
+      Closeness(const Graph &G, bool normalized,
+                ClosenessVariant variant = ClosenessVariant::standard);
 
-    /**
-     * Old constructor, we keep it for backward compatibility. It computes the
-     * standard variant of the closenes.
-     *
-     * @param G The graph.
-     * @param normalized Set this parameter to <code>false</code> if scores
-     * should not be normalized into an interval of [0, 1]. Normalization only
-     * for unweighted graphs.
-     * @param checkConnectedness turn this off if you know the graph is
-     * connected.
-     *
-     */
-    Closeness(const Graph &G, bool normalized = true,
-              bool checkConnectedness = true);
+      /**
+       * Old constructor, we keep it for backward compatibility. It computes the
+       * standard variant of the closenes.
+       *
+       * @param G The graph.
+       * @param normalized Set this parameter to <code>false</code> if scores
+       * should not be normalized into an interval of [0, 1]. Normalization only
+       * for unweighted graphs.
+       * @param checkConnectedness turn this off if you know the graph is
+       * connected.
+       *
+       */
+      Closeness(const Graph &G, bool normalized = true, bool checkConnectedness = true);
 
-    /**
-     * Computes closeness cetrality on the graph passed in constructor.
-     */
-    void run() override;
+      /**
+       * Computes closeness cetrality on the graph passed in constructor.
+       */
+      void run() override;
 
-    /*
-     * Returns the maximum possible Closeness a node can have in a graph with
-     * the same amount of nodes (=a star)
-     */
-    double maximum() override {
-        return normalized ? 1. : (1. / (G.upperNodeIdBound() - 1));
-    }
+      /*
+       * Returns the maximum possible Closeness a node can have in a graph with
+       * the same amount of nodes (=a star)
+       */
+      double maximum() override { return normalized ? 1. : (1. / (G.upperNodeIdBound() - 1)); }
 
   private:
     ClosenessVariant variant;

--- a/include/networkit/centrality/DynApproxBetweenness.hpp
+++ b/include/networkit/centrality/DynApproxBetweenness.hpp
@@ -40,7 +40,8 @@ public:
       * computing the sample size. It is 1 by default. Some references suggest
       * using 0.5, but there is no guarantee in this case.
      */
-    DynApproxBetweenness(const Graph& G, const double epsilon=0.01, const double delta=0.1, const bool storePredecessors = true, const double universalConstant = 1.0);
+    DynApproxBetweenness(const Graph &G, double epsilon = 0.01, double delta = 0.1,
+                         bool storePredecessors = true, double universalConstant = 1.0);
 
     /**
      * Runs the static approximated betweenness centrality algorithm on the initial graph.

--- a/include/networkit/centrality/KadabraBetweenness.hpp
+++ b/include/networkit/centrality/KadabraBetweenness.hpp
@@ -37,14 +37,14 @@ class StateFrame {
 
 class Status {
   public:
-    Status(const count k);
-    const count k;
-    std::vector<node> top;
-    std::vector<double> approxTop;
-    std::vector<bool> finished;
-    std::vector<double> bet;
-    std::vector<double> errL;
-    std::vector<double> errU;
+      Status(count k);
+      const count k;
+      std::vector<node> top;
+      std::vector<double> approxTop;
+      std::vector<bool> finished;
+      std::vector<double> bet;
+      std::vector<double> errL;
+      std::vector<double> errU;
 };
 
 class SpSampler {
@@ -70,8 +70,8 @@ class SpSampler {
     std::vector<std::pair<node, node>> spEdges;
 
     inline node randomNode() const;
-    void backtrackPath(const node source, const node target, const node start);
-    void resetSampler(const count endQ);
+    void backtrackPath(node source, node target, node start);
+    void resetSampler(count endQ);
     count getDegree(const Graph &graph, node y, bool useDegreeIn);
 };
 
@@ -113,10 +113,9 @@ class KadabraBetweenness : public Algorithm {
      * @param unionSample, startFactor algorithm parameters that are
      * automatically chosen.
      */
-    KadabraBetweenness(const Graph &G, const double err = 0.01,
-                       const double delta = 0.1,
-                       const bool deterministic = false, const count k = 0,
-                       count unionSample = 0, const count startFactor = 100);
+    KadabraBetweenness(const Graph &G, double err = 0.01, double delta = 0.1,
+                       bool deterministic = false, count k = 0, count unionSample = 0,
+                       count startFactor = 100);
 
     /**
      * Executes the Kadabra algorithm.
@@ -214,12 +213,10 @@ class KadabraBetweenness : public Algorithm {
                        std::vector<double> &errL,
                        std::vector<double> &errU) const;
     bool computeFinished(Status *status) const;
-    void getStatus(Status *status, const bool parallel = false) const;
+    void getStatus(Status *status, bool parallel = false) const;
     void computeApproxParallel(const std::vector<StateFrame> &firstFrames);
-    double computeF(const double btilde, const count iterNum,
-                    const double deltaL) const;
-    double computeG(const double btilde, const count iterNum,
-                    const double deltaU) const;
+    double computeF(double btilde, count iterNum, double deltaL) const;
+    double computeG(double btilde, count iterNum, double deltaU) const;
     void fillResult();
     void checkConvergence(Status &status);
 

--- a/include/networkit/community/CommunityDetectionAlgorithm.hpp
+++ b/include/networkit/community/CommunityDetectionAlgorithm.hpp
@@ -33,7 +33,7 @@ public:
      * @param[in] G input graph
      * @param[in] baseClustering optional; the algorithm will start from the given clustering.
      */
-    CommunityDetectionAlgorithm(const Graph& G, const Partition baseClustering);
+    CommunityDetectionAlgorithm(const Graph &G, Partition baseClustering);
 
     /** Default destructor */
     ~CommunityDetectionAlgorithm() override = default;

--- a/include/networkit/community/PLP.hpp
+++ b/include/networkit/community/PLP.hpp
@@ -49,7 +49,7 @@ public:
      * @param[in] baseClustering optional; the algorithm will start from the given clustering.
      * @param[in] theta updateThreshold: number of nodes that have to be changed in each iteration so that a new iteration starts.
      */
-    PLP(const Graph& G, const Partition baseClustering, count theta = none);
+    PLP(const Graph &G, Partition baseClustering, count theta = none);
 
     /**
      * Run the label propagation clustering algorithm.

--- a/include/networkit/distance/DynSSSP.hpp
+++ b/include/networkit/distance/DynSSSP.hpp
@@ -52,7 +52,7 @@ public:
     *
     * @param t Node to be `observed`.
     */
-    void setTargetNode(const node t = 0);
+    void setTargetNode(node t = 0);
 
     /**
      * Returns the predecessor nodes of @a t on all shortest paths from source to @a t.

--- a/include/networkit/distance/EffectiveDiameterApproximation.hpp
+++ b/include/networkit/distance/EffectiveDiameterApproximation.hpp
@@ -31,7 +31,7 @@ public:
     * @param k the number of parallel approximations to get a more robust result; default = 64
     * @param r the amount of bits that are added to the length of the bitmask to improve the accuracy; default = 7
     */
-    EffectiveDiameterApproximation(const Graph& G, const double ratio=0.9, const count k=64, const count r=7);
+    EffectiveDiameterApproximation(const Graph &G, double ratio = 0.9, count k = 64, count r = 7);
 
     void run() override;
 

--- a/include/networkit/distance/Volume.hpp
+++ b/include/networkit/distance/Volume.hpp
@@ -41,7 +41,7 @@ public:
     * @param samples	the number of samples
     *
     **/
-    static double volume(const Graph &G, const double r, const count samples);
+    static double volume(const Graph &G, double r, count samples);
 
     /**
     * Number of nodes within different given radii; average for many nodes
@@ -58,7 +58,7 @@ public:
     * @param samples	the number of samples
     *
     **/
-    static std::vector<double> volume(const Graph &G, const std::vector<double> rs, const count samples);
+    static std::vector<double> volume(const Graph &G, std::vector<double> rs, count samples);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/generators/DynamicDGSParser.hpp
+++ b/include/networkit/generators/DynamicDGSParser.hpp
@@ -36,8 +36,7 @@ public:
      */
     void generate() override;
 
-    void evaluateClusterings(const std::string path, const Partition& clustering);
-
+    void evaluateClusterings(std::string path, const Partition &clustering);
 
 private:
     bool graphInitialized;  //!< true if initializeGraph has been called and graph has been properly initialized

--- a/include/networkit/io/EdgeListReader.hpp
+++ b/include/networkit/io/EdgeListReader.hpp
@@ -35,9 +35,8 @@ public:
      * @param[in]  continuous  boolean to specify, if node ids are continuous
      * @param[in]  directed  treat graph as directed
      */
-    EdgeListReader(const char separator, const node firstNode,
-                   const std::string commentPrefix = "#", const bool continuous = true,
-                   const bool directed = false);
+    EdgeListReader(char separator, node firstNode, std::string commentPrefix = "#",
+                   bool continuous = true, bool directed = false);
 
     /**
      * Given the path of an input file, read the graph contained.

--- a/include/networkit/numerics/GaussSeidelRelaxation.hpp
+++ b/include/networkit/numerics/GaussSeidelRelaxation.hpp
@@ -40,7 +40,7 @@ public:
      * @return The (approximate) solution to the system.
      */
     Vector relax(const Matrix &A, const Vector &b, const Vector &initialGuess,
-                 const count maxIterations = std::numeric_limits<count>::max()) const override;
+                 count maxIterations = std::numeric_limits<count>::max()) const override;
 
     /**
      * Utilizes Gauss-Seidel relaxations until the given number of @a maxIterations is reached or the relative residual
@@ -51,7 +51,7 @@ public:
      * @return The (approximate) solution to the system.
      */
     Vector relax(const Matrix &A, const Vector &b,
-                 const count maxIterations = std::numeric_limits<count>::max()) const override;
+                 count maxIterations = std::numeric_limits<count>::max()) const override;
 };
 
 template<class Matrix>

--- a/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
+++ b/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
@@ -81,7 +81,7 @@ private:
      * @param numVectors Number of test vectors to create.
      * @return The created test vectors.
      */
-    std::vector<Vector> generateTVs(const Matrix& matrix, Vector& tv, const count numVectors) const;
+    std::vector<Vector> generateTVs(const Matrix &matrix, Vector &tv, count numVectors) const;
 
     /**
      * Adds high degree nodes as seeds to @a status.
@@ -143,8 +143,10 @@ private:
      * @param s[out] The best seed for node @a u.
      * @return @code{True} if a seed has been found for @a u, @code{false} otherwise.
      */
-    bool findBestSeedEnergyCorrected(const Matrix& strongAdjMatrix, const Matrix& affinityMatrix, const std::vector<double>& diag, const std::vector<Vector>& tVs, const std::vector<index>& status, const index u, index& s) const;
-
+    bool findBestSeedEnergyCorrected(const Matrix &strongAdjMatrix, const Matrix &affinityMatrix,
+                                     const std::vector<double> &diag,
+                                     const std::vector<Vector> &tVs,
+                                     const std::vector<index> &status, index u, index &s) const;
 
     /**
      * Determines if the Laplacian matrix @a A can be coarsened further.

--- a/include/networkit/numerics/Smoother.hpp
+++ b/include/networkit/numerics/Smoother.hpp
@@ -26,8 +26,10 @@ public:
     Smoother() {}
     virtual ~Smoother(){}
 
-    virtual Vector relax(const Matrix& A, const Vector& b, const Vector& initialGuess, const count maxIterations = std::numeric_limits<count>::max()) const = 0;
-    virtual Vector relax(const Matrix& A, const Vector& b, const count maxIterations = std::numeric_limits<count>::max()) const = 0;
+    virtual Vector relax(const Matrix &A, const Vector &b, const Vector &initialGuess,
+                         count maxIterations = std::numeric_limits<count>::max()) const = 0;
+    virtual Vector relax(const Matrix &A, const Vector &b,
+                         count maxIterations = std::numeric_limits<count>::max()) const = 0;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/viz/MaxentStress.hpp
+++ b/include/networkit/viz/MaxentStress.hpp
@@ -55,10 +55,13 @@ class MaxentStress final : public GraphLayoutAlgorithm<double> {
             double solveTime = 0.0;
         };
 
-        MaxentStress(const Graph& G, const count dim, const count k, double tolerance, LinearSolverType linearSolverType = LAMG, bool fastComputation=false, GraphDistance graphDistance = EDGE_WEIGHT);
+        MaxentStress(const Graph &G, count dim, count k, double tolerance,
+                     LinearSolverType linearSolverType = LAMG, bool fastComputation = false,
+                     GraphDistance graphDistance = EDGE_WEIGHT);
 
-        MaxentStress(const Graph& G, const count dim, const std::vector<Point<double>>& coordinates, const count k, double tolerance, LinearSolverType linearSolverType = LAMG, bool fastComputation=false, GraphDistance graphDistance = EDGE_WEIGHT);
-
+        MaxentStress(const Graph &G, count dim, const std::vector<Point<double>> &coordinates,
+                     count k, double tolerance, LinearSolverType linearSolverType = LAMG,
+                     bool fastComputation = false, GraphDistance graphDistance = EDGE_WEIGHT);
 
         /** Default destructor. */
         ~MaxentStress() override = default;
@@ -221,7 +224,9 @@ class MaxentStress final : public GraphLayoutAlgorithm<double> {
          * @param theta Parameter for Barnes-Hut cell-opening criterion
          * @param b Repulsive force vector to compute
          */
-        void approxRepulsiveForces(const CoordinateVector& coordinates, const Octree<double>& octree, const double theta, CoordinateVector& b) const;
+        void approxRepulsiveForces(const CoordinateVector &coordinates,
+                                   const Octree<double> &octree, double theta,
+                                   CoordinateVector &b) const;
 
         /**
          * Initializes the @a coordinates corresponding to vertices in the Graph to a random point in d-dimensional space 2000^d pixel.
@@ -241,8 +246,7 @@ class MaxentStress final : public GraphLayoutAlgorithm<double> {
          * @param i
          * @param j
          */
-        double squaredDistance(const CoordinateVector& coordinates, const index i, const index j) const;
-
+        double squaredDistance(const CoordinateVector &coordinates, index i, index j) const;
 
         /**
          * Computes the distance ||c_i - c_j|| between @a coordinates @a i and @a j.
@@ -261,7 +265,8 @@ class MaxentStress final : public GraphLayoutAlgorithm<double> {
          * @param i
          * @param j
          */
-        double squaredDistance(const CoordinateVector& coordinates1, const CoordinateVector& coordinates2, const index i, const index j) const;
+        double squaredDistance(const CoordinateVector &coordinates1,
+                               const CoordinateVector &coordinates2, index i, index j) const;
 
         /**
          * Computes the squared distance ||c1_i - c2_j|| between coordinate @a i from @a coordinates1 and coordinate @a j from @a coordinates 2.
@@ -279,7 +284,7 @@ class MaxentStress final : public GraphLayoutAlgorithm<double> {
          * @param coordinates
          * @param i
          */
-        double squaredLength(const CoordinateVector& coordinates, const index i) const;
+        double squaredLength(const CoordinateVector &coordinates, index i) const;
 
         /**
          * Computes the length ||c_i|| of coordinate @a i in @a coordinates.
@@ -330,20 +335,20 @@ class MaxentStress final : public GraphLayoutAlgorithm<double> {
          * @param k
          * @param graphDistance
          */
-        void computeKnownDistances(const count k, const GraphDistance graphDistance);
+        void computeKnownDistances(count k, GraphDistance graphDistance);
 
         /**
          * Add the k-neighborhood (except for the 1-neighbors) of vertex @a u to the knownDistances of @a u
          * @param u
          */
-        void addKNeighborhoodOfVertex(const node u, const count k);
+        void addKNeighborhoodOfVertex(node u, count k);
 
         /**
          * Computes the algebraic distances from each vertex to its k-hop neighborhood.
          * @param graph
          * @param k
          */
-        void computeAlgebraicDistances(const Graph& graph, const count k);
+        void computeAlgebraicDistances(const Graph &graph, count k);
     };
 
 } /* namespace NetworKit */


### PR DESCRIPTION
Remove `const` from top level parameters in function declarations.