### PR TITLE
clang-tidy: modernize-use-using

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ Checks: >
     cppcoreguidelines-narrowing-conversions,
     modernize-use-override,
     modernize-deprecated-headers,
+    modernize-use-using,
     performance-for-range-copy,
     performance-implicit-conversion-in-loop,
     performance-inefficient-algorithm,
@@ -36,7 +37,6 @@ Checks: >
     readability-const-return-type
 
 # Warnings whishlist
-#    modernize-use-using,
 #    modernize-avoid-c-arrays,
 #    modernize-use-emplace,
 #    readability-avoid-const-params-in-decls,
@@ -69,6 +69,7 @@ WarningsAsErrors:  >
     bugprone-virtual-near-miss,
     modernize-deprecated-headers,
     modernize-use-override,
+    modernize-use-using,
     performance-for-range-copy,
     performance-implicit-conversion-in-loop,
     performance-inefficient-algorithm,

--- a/include/networkit/auxiliary/BloomFilter.hpp
+++ b/include/networkit/auxiliary/BloomFilter.hpp
@@ -15,8 +15,8 @@
 
 namespace Aux {
 
-typedef NetworKit::index index;
-typedef NetworKit::count count;
+using index = NetworKit::index;
+using count = NetworKit::count;
 
 /**
  * Bloom filter for fast set membership queries for type index with one-sided error (false positives).

--- a/include/networkit/auxiliary/BucketPQ.hpp
+++ b/include/networkit/auxiliary/BucketPQ.hpp
@@ -16,9 +16,9 @@
 
 namespace Aux {
 
-typedef NetworKit::index index;
-typedef NetworKit::count count;
-typedef std::list<index> Bucket;
+using index = NetworKit::index;
+using count = NetworKit::count;
+using Bucket = std::list<index>;
 constexpr int64_t none = std::numeric_limits<int64_t>::max();
 
 /**

--- a/include/networkit/auxiliary/PrioQueue.hpp
+++ b/include/networkit/auxiliary/PrioQueue.hpp
@@ -23,7 +23,7 @@ namespace Aux {
 template<class Key, class Value>
 class PrioQueue {
 private:
-    typedef std::pair<Key, Value> ElemType;
+    using ElemType = std::pair<Key, Value>;
 
     std::set<ElemType> pqset; // TODO: would std::map work and simplify things?
     std::vector<Key> mapValToKey;

--- a/include/networkit/community/DynamicNMIDistance.hpp
+++ b/include/networkit/community/DynamicNMIDistance.hpp
@@ -13,7 +13,7 @@
 
 namespace NetworKit {
 
-typedef std::vector<std::vector<count> > Matrix;
+using Matrix = std::vector<std::vector<count>>;
 
 /**
  * @ingroup community

--- a/include/networkit/community/LPDegreeOrdered.hpp
+++ b/include/networkit/community/LPDegreeOrdered.hpp
@@ -12,7 +12,7 @@
 
 namespace NetworKit {
 
-typedef index label; // a label is the same as a cluster id
+using label = index; // a label is the same as a cluster id
 
 /**
  * @ingroup community

--- a/include/networkit/generators/MocnikGenerator.hpp
+++ b/include/networkit/generators/MocnikGenerator.hpp
@@ -29,13 +29,13 @@ class MocnikGenerator final: public StaticGraphGenerator {
     /**
      * Collection of nodes.
      */
-    typedef std::vector<node> NodeCollection;
+    using NodeCollection = std::vector<node>;
 
     /**
      * The cell array reflects how nodes are assigned to a grid. Each element of
      * the vector corresponds to one grid cell.
      */
-    typedef std::vector<NodeCollection> CellArray;
+    using CellArray = std::vector<NodeCollection>;
 
     /**
      * State of a layer

--- a/include/networkit/linkprediction/LinkPredictor.hpp
+++ b/include/networkit/linkprediction/LinkPredictor.hpp
@@ -22,7 +22,7 @@ namespace NetworKit {
 class LinkPredictor {
 public:
   // Declare typedef in advance for use in the protected section
-  typedef std::pair<std::pair<node, node>, double> prediction; //!< Type of predictions
+  using prediction = std::pair<std::pair<node, node>, double>; //!< Type of predictions
 
 private:
   /**

--- a/include/networkit/sparsification/SimmelianScore.hpp
+++ b/include/networkit/sparsification/SimmelianScore.hpp
@@ -48,7 +48,7 @@ struct RankedEdge {
     }
 };
 
-typedef std::vector<RankedEdge> RankedNeighbors;
+using RankedNeighbors = std::vector<RankedEdge>;
 
 /**
  * Represents the result of the comparison of two ranked neighborhood lists, namely

--- a/include/networkit/viz/MaxentStress.hpp
+++ b/include/networkit/viz/MaxentStress.hpp
@@ -20,7 +20,7 @@
 
 namespace NetworKit {
 
-    typedef std::vector<Vector> CoordinateVector; // more meaningful and shorter name for coordinates stored by dimension
+    using CoordinateVector = std::vector<Vector>; // more meaningful and shorter name for coordinates stored by dimension
 
     struct ForwardEdge {
         node head;

--- a/networkit/cpp/auxiliary/test/AuxGTest.cpp
+++ b/networkit/cpp/auxiliary/test/AuxGTest.cpp
@@ -180,7 +180,7 @@ TEST_F(AuxGTest, benchmarkBinomial) {
 }
 
 TEST_F(AuxGTest, testPriorityQueue) {
-    typedef std::pair<double, uint64_t> ElemType;
+    using ElemType = std::pair<double, uint64_t>;
 
     // fill vector with keys
     std::vector<double> vec = {0.5, 3.5, 4.5, 2.5, 0.75, 1.5, 8.5, 3.25, 4.75, 5.0, 11.5, 0.25};

--- a/networkit/cpp/centrality/ApproxCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxCloseness.cpp
@@ -14,10 +14,10 @@
 
 namespace NetworKit {
 
-typedef struct ListEntry_struct {
+struct ListEntry {
     node node_val;
     edgeweight dist_val;
-} ListEntry;
+};
 
 ApproxCloseness::ApproxCloseness(const Graph& G, count nSamples, double epsilon, bool normalized, CLOSENESS_TYPE type) : Centrality(G, normalized), nSamples(nSamples), epsilon(epsilon), type(type) {
     assert(nSamples > 0 && nSamples <= G.numberOfNodes() && epsilon >= 0);

--- a/networkit/cpp/community/PLP.cpp
+++ b/networkit/cpp/community/PLP.cpp
@@ -31,7 +31,7 @@ void PLP::run() {
         result.allToSingletons();
     }
 
-    typedef index label; // a label is the same as a cluster id
+    using label = index; // a label is the same as a cluster id
 
     count n = G->numberOfNodes();
     // update threshold heuristic

--- a/networkit/cpp/edgescores/EdgeScoreLinearizer.cpp
+++ b/networkit/cpp/edgescores/EdgeScoreLinearizer.cpp
@@ -30,7 +30,7 @@ void EdgeScoreLinearizer::run() {
             scoreData[eid] = 0.5;
         });
     } else {
-        typedef std::tuple<edgeweight, index, edgeid> edgeTuple;
+        using edgeTuple = std::tuple<edgeweight, index, edgeid>;
         std::vector<edgeTuple> sorted(G->upperEdgeIdBound(), std::make_tuple(std::numeric_limits<edgeweight>::max(), std::numeric_limits<index>::max(), none));
 
         G->parallelForEdges([&](node, node, edgeid eid) {

--- a/networkit/cpp/generators/DynamicForestFireGenerator.cpp
+++ b/networkit/cpp/generators/DynamicForestFireGenerator.cpp
@@ -15,7 +15,7 @@
 
 namespace NetworKit {
 
-typedef std::function<std::vector<node>(node)> neighborFunction;
+using neighborFunction = std::function<std::vector<node>(node)>;
 
 DynamicForestFireGenerator::DynamicForestFireGenerator(double p, bool directed, double r) :p(p), directed(directed), r(r), firstCall(true) {
     G = Graph(0, false, directed);

--- a/networkit/cpp/generators/HavelHakimiGenerator.cpp
+++ b/networkit/cpp/generators/HavelHakimiGenerator.cpp
@@ -31,8 +31,8 @@ Graph HavelHakimiGenerator::generate() {
     // this vertex is connected to the following elements
     // when done, the other connected vertices are moved to the next list in reverse order
 
-    typedef std::pair<count, node> DeficitAndNode;
-    typedef std::vector<std::list<DeficitAndNode> > Buckets;
+    using DeficitAndNode = std::pair<count, node>;
+    using Buckets = std::vector<std::list<DeficitAndNode>>;
 
     // put nodes in appropriate lists
     Buckets nodesByDeficit(numDegVals);

--- a/networkit/cpp/simulation/EpidemicSimulationSEIR.cpp
+++ b/networkit/cpp/simulation/EpidemicSimulationSEIR.cpp
@@ -16,7 +16,7 @@ EpidemicSimulationSEIR::EpidemicSimulationSEIR(const Graph& G, count tMax, doubl
 
 void EpidemicSimulationSEIR::run() {
 
-    typedef EpidemicSimulationSEIR::State State;
+    using State = EpidemicSimulationSEIR::State;
 
     index t = 0;
 


### PR DESCRIPTION
Replace `typedef` with `using`.