### PR TITLE
clang-tidy: readability-container-size-empty

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,12 +35,12 @@ Checks: >
     performance-unnecessary-copy-initialization,
     performance-unnecessary-value-param,
     readability-avoid-const-params-in-decls,
-    readability-const-return-type
+    readability-const-return-type,
+    readability-container-size-empty
 
 # Warnings whishlist
 #    modernize-avoid-c-arrays,
 #    modernize-use-emplace,
-#    readability-container-size-empty
 
 # Turn the warnings from the checks above into errors.
 # To turn all warnings into errors, simply write '*'
@@ -78,7 +78,8 @@ WarningsAsErrors:  >
     performance-type-promotion-in-math-fn,
     performance-unnecessary-copy-initialization,
     readability-avoid-const-params-in-decls,
-    readability-const-return-type
+    readability-const-return-type,
+    readability-container-size-empty
 
 FormatStyle: 'file'
 HeaderFilterRegex: '.*\/include\/networkit\/.*\.hpp'

--- a/include/networkit/auxiliary/PrioQueue.hpp
+++ b/include/networkit/auxiliary/PrioQueue.hpp
@@ -178,7 +178,7 @@ std::pair<Key, Value> Aux::PrioQueue<Key, Value>::peekMin(size_t n) {
 
 template<class Key, class Value>
 std::pair<Key, Value> Aux::PrioQueue<Key, Value>::extractMin() {
-    assert(pqset.size() > 0);
+    assert(!pqset.empty());
     ElemType elem = (* pqset.begin());
     remove(elem);
     return elem;

--- a/include/networkit/auxiliary/Random.hpp
+++ b/include/networkit/auxiliary/Random.hpp
@@ -105,7 +105,7 @@ typename Container::const_reference choice(const Container& container) {
  */
 template <typename Element>
 const Element& weightedChoice(const std::vector<std::pair<Element, double>>& weightedElements) {
-    if (weightedElements.size() == 0)
+    if (weightedElements.empty())
         throw std::runtime_error("Random::weightedChoice: input size equal to 0");
     double total = 0.0;
     for (const auto& entry : weightedElements) {

--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -126,7 +126,7 @@ GroupCloseness::scoreOfGroup(const std::vector<node> &group) const {
         });
     }
 
-    while (queue.size() > 0) {
+    while (!queue.empty()) {
         ++d;
         node u = queue.front();
         queue.erase(queue.begin());

--- a/include/networkit/generators/quadtree/QuadNode.hpp
+++ b/include/networkit/generators/quadtree/QuadNode.hpp
@@ -172,7 +172,7 @@ public:
             }
         }
         else {
-            assert(children.size() > 0);
+            assert(!children.empty());
             for (index i = 0; i < children.size(); i++) {
                 if (children[i].responsible(angle, R)) {
                     children[i].addContent(input, angle, R);
@@ -215,7 +215,7 @@ public:
         else {
             bool removed = false;
             bool allLeaves = true;
-            assert(children.size() > 0);
+            assert(!children.empty());
             for (index i = 0; i < children.size(); i++) {
                 if (!children[i].isLeaf) allLeaves = false;
                 if (children[i].removeContent(input, angle, R)) {
@@ -453,8 +453,8 @@ public:
             return content;
         } else {
             assert(content.size() == 0);
-            assert(angles.size() == 0);
-            assert(radii.size() == 0);
+            assert(angles.empty());
+            assert(radii.empty());
             vector<T> result;
             for (index i = 0; i < children.size(); i++) {
                 std::vector<T> subresult = children[i].getElements();
@@ -472,8 +472,8 @@ public:
         }
         else {
             assert(content.size() == 0);
-            assert(angles.size() == 0);
-            assert(radii.size() == 0);
+            assert(angles.empty());
+            assert(radii.empty());
             for (index i = 0; i < children.size(); i++) {
                 children[i].getCoordinates(anglesContainer, radiiContainer);
             }

--- a/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
+++ b/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
@@ -516,7 +516,7 @@ void MultiLevelSetup<Matrix>::aggregateLooseNodes(const Matrix& strongAdjMatrix,
         }
     }
 
-    if (looseNodes.size() > 0) {
+    if (!looseNodes.empty()) {
         status[looseNodes[0]] = looseNodes[0]; // mark first as seed
         for (index k = 1; k < looseNodes.size(); ++k) {
             status[looseNodes[k]] = looseNodes[0]; // first loose nodes becomes seed
@@ -572,7 +572,7 @@ void MultiLevelSetup<Matrix>::computeStrongAdjacencyMatrix(const Matrix& matrix,
 
 template<class Matrix>
 void MultiLevelSetup<Matrix>::computeAffinityMatrix(const Matrix& matrix, const std::vector<Vector>& tVs, Matrix& affinityMatrix) const {
-    assert(tVs.size() > 0);
+    assert(!tVs.empty());
 
     std::vector<index> rowIdx(matrix.numberOfRows()+1);
     std::vector<Triplet> triplets(matrix.nnz());

--- a/include/networkit/viz/GraphLayoutAlgorithm.hpp
+++ b/include/networkit/viz/GraphLayoutAlgorithm.hpp
@@ -69,7 +69,9 @@ public:
     }
 
     virtual bool writeGraphToGML(const std::string& filePath) {
-        if (vertexCoordinates.size() == 0 || vertexCoordinates[0].getDimensions() < 2 || vertexCoordinates[0].getDimensions() > 3) return false;
+        if (vertexCoordinates.empty() || vertexCoordinates[0].getDimensions() < 2
+            || vertexCoordinates[0].getDimensions() > 3)
+            return false;
         count dim = vertexCoordinates[0].getDimensions();
         std::ofstream file(filePath);
         Aux::enforceOpened(file);
@@ -106,7 +108,8 @@ public:
     }
 
     virtual bool writeKinemage(const std::string& filePath) {
-        if (vertexCoordinates.size() == 0 || vertexCoordinates[0].getDimensions() != 3) return false;
+        if (vertexCoordinates.empty() || vertexCoordinates[0].getDimensions() != 3)
+            return false;
         std::string fileName = filePath.substr(filePath.find_last_of("/"));
         std::ofstream file(filePath);
         Aux::enforceOpened(file);

--- a/include/networkit/viz/Octree.hpp
+++ b/include/networkit/viz/Octree.hpp
@@ -121,9 +121,7 @@ struct OctreeNode {
     /**
      * @return True if node is leaf, false otherwise.
      */
-    inline bool isLeaf() const {
-        return children.size() == 0;
-    }
+    inline bool isLeaf() const { return children.empty(); }
 
     /**
      * @return True if tree node has weight zero (== is empty), false otherwise.

--- a/networkit/cpp/algebraic/CSRMatrix.cpp
+++ b/networkit/cpp/algebraic/CSRMatrix.cpp
@@ -546,9 +546,10 @@ CSRMatrix CSRMatrix::extract(const std::vector<index>& rowIndices, const std::ve
     for (index i = 0; i < rowIndices.size(); ++i) {
         Triplet last = {i, 0, 0.0};
         (*this).forNonZeroElementsInRow(rowIndices[i], [&](index k, double value) {
-            if (columnMapping[k].size() > 0) {
+            if (!columnMapping[k].empty()) {
                 for (index j : columnMapping[k]) {
-                    if (last.row == i && last.column > j) sorted = false;
+                    if (last.row == i && last.column > j)
+                        sorted = false;
                     last = {i,j,value};
                     triplets.push_back(last);
                 }

--- a/networkit/cpp/algebraic/DynamicMatrix.cpp
+++ b/networkit/cpp/algebraic/DynamicMatrix.cpp
@@ -244,7 +244,7 @@ DynamicMatrix DynamicMatrix::extract(const std::vector<index>& rowIndices, const
     for (index i = 0; i < rowIndices.size(); ++i) {
         assert(rowIndices[i] < numberOfRows());
         (*this).forNonZeroElementsInRow(rowIndices[i], [&](index k, double value) {
-            if (columnMapping[k].size() > 0) {
+            if (!columnMapping[k].empty()) {
                 for (index j : columnMapping[k]) {
                     triplets.push_back({i, j, value});
                 }

--- a/networkit/cpp/centrality/DynApproxBetweenness.cpp
+++ b/networkit/cpp/centrality/DynApproxBetweenness.cpp
@@ -99,7 +99,7 @@ void DynApproxBetweenness::run() {
                 }
                 DEBUG("Node: ", t);
                 DEBUG("Source: ", u[i]);
-                assert (choices.size() > 0);
+                assert(!choices.empty());
                 node z = Aux::Random::weightedChoice(choices);
                 assert (z <= G.upperNodeIdBound());
                 if (z != u[i]) {
@@ -159,7 +159,7 @@ void DynApproxBetweenness::updateBatch(const std::vector<GraphEvent>& batch) {
                         }
                     });
                 }
-                assert (choices.size() > 0); // this should fail only if the graph is not connected
+                assert(!choices.empty()); // this should fail only if the graph is not connected
                 node z = Aux::Random::weightedChoice(choices);
                 assert (z <= G.upperNodeIdBound());
                 if (z != u[i]) {

--- a/networkit/cpp/centrality/DynBetweenness.cpp
+++ b/networkit/cpp/centrality/DynBetweenness.cpp
@@ -93,7 +93,7 @@ void DynBetweenness::run() {
 void DynBetweenness::increaseScore(std::vector<bool> & affected, node y, std::priority_queue<std::pair<double, node>, std::vector<std::pair<double,node>>, CompareDist> & Q) {
     std::vector<double> dep(G.upperNodeIdBound(), 0);
     std::vector<bool> visited(G.upperNodeIdBound(), false);
-    while(Q.size() > 0) {
+    while (!Q.empty()) {
         affectedDep ++;
     //	TRACE("(Before )Size: ", Q.size());
         node x = Q.top().second; // notice that the keys are diam - distance, so we actually extract in order of decreasing distance
@@ -128,7 +128,7 @@ void DynBetweenness::increaseScore(std::vector<bool> & affected, node y, std::pr
 void DynBetweenness::decreaseScore(std::vector<bool> & affected, node y, std::priority_queue<std::pair<double, node>, std::vector<std::pair<double,node>>, CompareDist> & Q) {
     std::vector<double> dep(G.upperNodeIdBound(), 0);
     std::vector<bool> visited(G.upperNodeIdBound(), false);
-    while(Q.size() > 0) {
+    while (!Q.empty()) {
         affectedDep ++;
     //	TRACE("(Before )Size: ", Q.size());
         node x = Q.top().second; // notice that the keys are diam - distance, so we actually extract in order of decreasing distance

--- a/networkit/cpp/centrality/KadabraBetweenness.cpp
+++ b/networkit/cpp/centrality/KadabraBetweenness.cpp
@@ -607,7 +607,7 @@ void SpSampler::randomPath(StateFrame *curFrame) {
 
     ++globalTS;
 
-    if (spEdges.size() == 0) {
+    if (spEdges.empty()) {
         resetSampler(endQ);
         if (globalTS == 128) {
             globalTS = 1;

--- a/networkit/cpp/community/CoverF1Similarity.cpp
+++ b/networkit/cpp/community/CoverF1Similarity.cpp
@@ -47,7 +47,7 @@ void CoverF1Similarity::run() {
     std::vector<index> overlappingReference;
 
     for (index i = 0; i < C->upperBound(); ++i) {
-        if (Csets[i].size() > 0) {
+        if (!Csets[i].empty()) {
             ++numClusters;
 
             for (node u : Csets[i]) {

--- a/networkit/cpp/distance/AlgebraicDistance.cpp
+++ b/networkit/cpp/distance/AlgebraicDistance.cpp
@@ -114,7 +114,7 @@ void AlgebraicDistance::preprocess() {
 }
 
 double AlgebraicDistance::distance(node u, node v) {
-    if (loads.size() == 0) {
+    if (loads.empty()) {
         throw std::runtime_error("Call preprocess() first.");
     }
     double result = 0.0;

--- a/networkit/cpp/distance/AllSimplePaths.cpp
+++ b/networkit/cpp/distance/AllSimplePaths.cpp
@@ -134,7 +134,7 @@ namespace NetworKit {
 
             std::vector<std::vector<node>> currPaths;
 
-            while (stack.size() > 0) {
+            while (!stack.empty()) {
 
                 node curr = stack.back().first.back();
 
@@ -157,7 +157,7 @@ namespace NetworKit {
                 currPair->second[curr] = true;
                 bool toEnqueue = false;
 
-                if (availableSources[curr].size() > 0) {
+                if (!availableSources[curr].empty()) {
                     node s = availableSources[curr][0];
                     if (!currPair->second[s]) {
                         currPair->first.push_back(s);

--- a/networkit/cpp/distance/BidirectionalBFS.cpp
+++ b/networkit/cpp/distance/BidirectionalBFS.cpp
@@ -94,7 +94,7 @@ void BidirectionalBFS::run() {
             expand(sQueue, sQueueNext, 0);
         else
             expand(tQueue, tQueueNext, ballMask);
-    } while (!stop && sQueue.size() && tQueue.size());
+    } while (!stop && !sQueue.empty() && !tQueue.empty());
 
     // Balls did not meet, source cannot reach target
     if (!stop)

--- a/networkit/cpp/generators/DynamicDGSParser.cpp
+++ b/networkit/cpp/generators/DynamicDGSParser.cpp
@@ -80,7 +80,7 @@ void DynamicDGSParser::generate() {
 
                 std::vector<std::string> currentNodeCategories(categories.begin(), categories.end());
                 nodeCategories.push_back(currentNodeCategories);
-                assert(nodeCategories.size() > 0);
+                assert(!nodeCategories.empty());
 
                 std::string dateFullString = split[3]; // Example: date="08-1997"
                 std::vector<std::string> dateFullStringSplit = Aux::StringTools::split(dateFullString, '"');

--- a/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
+++ b/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
@@ -143,8 +143,8 @@ std::vector<Point2D> DynamicHyperbolicGenerator::getCoordinates() const {
 
 std::vector<GraphEvent> DynamicHyperbolicGenerator::generate(count nSteps) {
     if (!initialized) {
-        assert(angles.size() == 0);
-        assert(radii.size() == 0);
+        assert(angles.empty());
+        assert(radii.empty());
         initializePoints();
         initializeMovement();
         if (T > 0) {

--- a/networkit/cpp/generators/MocnikGenerator.cpp
+++ b/networkit/cpp/generators/MocnikGenerator.cpp
@@ -298,7 +298,7 @@ Graph MocnikGenerator::generate() {
     assert(dim > 0);
     assert(std::all_of(ns.cbegin(), ns.cend(), [] (count n) { return n > 1; }));
     assert(std::all_of(ks.cbegin(), ks.cend(), [] (double k) {return k > 1.0; }));
-    assert(ns.size() > 0);
+    assert(!ns.empty());
     assert(ks.size() == ns.size());
     assert(relativeWeights.size() == ns.size());
 

--- a/networkit/cpp/graph/GraphBuilder.cpp
+++ b/networkit/cpp/graph/GraphBuilder.cpp
@@ -146,7 +146,7 @@ void GraphBuilder::increaseInWeight(node u, node v, edgeweight ew) {
 
 Graph GraphBuilder::toGraph(bool autoCompleteEdges, bool parallel) {
     Graph G(n, weighted, directed);
-    if (name != "") {
+    if (!name.empty()) {
         G.setName(name);
     }
 

--- a/networkit/cpp/linkprediction/AlgebraicDistanceIndex.cpp
+++ b/networkit/cpp/linkprediction/AlgebraicDistanceIndex.cpp
@@ -45,7 +45,7 @@ void AlgebraicDistanceIndex::preprocess() {
 }
 
 double AlgebraicDistanceIndex::runImpl(node u, node v) {
-    if (loads.size() == 0) {
+    if (loads.empty()) {
         throw std::logic_error("Call preprocess() first.");
     }
     double result = 0.0;

--- a/networkit/cpp/linkprediction/EvaluationMetric.cpp
+++ b/networkit/cpp/linkprediction/EvaluationMetric.cpp
@@ -26,10 +26,10 @@ void EvaluationMetric::setTestGraph(const Graph& newTestGraph) {
 std::pair<std::vector<double>, std::vector<double>> EvaluationMetric::getCurve(std::vector<LinkPredictor::prediction> predictions, count numThresholds) {
   if (testGraph == nullptr) {
     throw std::logic_error("Set testGraph first.");
-  } else if (predictions.size() == 0) {
-    throw std::logic_error("predictions.size() == 0");
+  } else if (predictions.empty()) {
+      throw std::logic_error("predictions.size() == 0");
   } else if (numThresholds < 2) {
-    throw std::invalid_argument("numThresholds < 2: At least 2 thresholds needed for curve.");
+      throw std::invalid_argument("numThresholds < 2: At least 2 thresholds needed for curve.");
   }
   // Don't overshoot with the number of thresholds being greater than the number of predictions + 1.
   if (predictions.size() + 1 < numThresholds || numThresholds == 0) {
@@ -69,9 +69,9 @@ double EvaluationMetric::getAreaUnderCurve(std::pair<std::vector<double>, std::v
 }
 
 double EvaluationMetric::getAreaUnderCurve() const {
-  if (generatedPoints.first.size() == 0) {
-    throw std::logic_error("Call getCurve first or use getAreaUnderCurve(curve).");
-  }
+    if (generatedPoints.first.empty()) {
+        throw std::logic_error("Call getCurve first or use getAreaUnderCurve(curve).");
+    }
   return getAreaUnderCurve(generatedPoints);
 }
 

--- a/networkit/cpp/randomization/CurveballImpl.cpp
+++ b/networkit/cpp/randomization/CurveballImpl.cpp
@@ -244,7 +244,7 @@ void TradeList::initialize(const trade_vector &trades) {
     offsets.resize(numNodes + 1);
 
     assert(numNodes > 0);
-    assert(trades.size() > 0);
+    assert(!trades.empty());
 
     std::vector<tradeid> trade_count(numNodes);
 
@@ -293,7 +293,7 @@ TradeList::TradeList(const trade_vector &trades, const node num_nodes)
     // Manuel: see above
 
     assert(num_nodes > 0);
-    assert(trades.size() > 0);
+    assert(!trades.empty());
 
     std::vector<tradeid> trade_count(num_nodes);
 

--- a/networkit/cpp/structures/Partition.cpp
+++ b/networkit/cpp/structures/Partition.cpp
@@ -143,7 +143,7 @@ std::set<std::set<index> > Partition::getSubsets() const {
 
     std::set<std::set<index> > subsets;
     for (const auto &set : table) {
-        if (set.size() > 0) {
+        if (!set.empty()) {
             subsets.insert(set);
         }
     }


### PR DESCRIPTION
Replace calls to `size()` with `empty()` where applicable.