### PR TITLE
clang-tidy: modernize-use-emplace

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@ Checks: >
     bugprone-use-after-move,
     bugprone-virtual-near-miss,
     cppcoreguidelines-narrowing-conversions,
+    modernize-use-emplace,
     modernize-use-override,
     modernize-deprecated-headers,
     modernize-use-using,
@@ -37,10 +38,6 @@ Checks: >
     readability-avoid-const-params-in-decls,
     readability-const-return-type,
     readability-container-size-empty
-
-# Warnings whishlist
-#    modernize-avoid-c-arrays,
-#    modernize-use-emplace,
 
 # Turn the warnings from the checks above into errors.
 # To turn all warnings into errors, simply write '*'
@@ -67,6 +64,7 @@ WarningsAsErrors:  >
     bugprone-use-after-move,
     bugprone-virtual-near-miss,
     modernize-deprecated-headers,
+    modernize-use-emplace,
     modernize-use-override,
     modernize-use-using,
     performance-for-range-copy,

--- a/networkit/cpp/centrality/Centrality.cpp
+++ b/networkit/cpp/centrality/Centrality.cpp
@@ -29,7 +29,7 @@ double Centrality::score(node v) {
 std::vector<std::pair<node, double>> Centrality::ranking() {
   assureFinished();
   std::vector<std::pair<node, double>> ranking;
-  G.forNodes([&](node v) { ranking.push_back({v, scoreData[v]}); });
+  G.forNodes([&](node v) { ranking.emplace_back(v, scoreData[v]); });
   Aux::Parallel::sort(ranking.begin(), ranking.end(),
                       [](std::pair<node, double> x, std::pair<node, double> y) {
                         if (x.second == y.second) {

--- a/networkit/cpp/centrality/KadabraBetweenness.cpp
+++ b/networkit/cpp/centrality/KadabraBetweenness.cpp
@@ -564,7 +564,7 @@ void SpSampler::randomPath(StateFrame *curFrame) {
             dist[y] = dist[x] + 1;
         } else if ((timestamp[x] & ballMask) != (timestamp[y] & ballMask)) {
             hasToStop = true;
-            spEdges.push_back(std::make_pair(x, y));
+            spEdges.emplace_back(x, y);
         } else if (dist[y] == dist[x] + 1) {
             nPaths[y] += nPaths[x];
         }

--- a/networkit/cpp/components/BiconnectedComponents.cpp
+++ b/networkit/cpp/components/BiconnectedComponents.cpp
@@ -66,11 +66,11 @@ void BiconnectedComponents::run() {
           visitNode(neighbor);
           parent[neighbor] = u;
           stack.push(std::make_pair(neighbor, G->neighborRange(neighbor).begin()));
-          edgeStack.push_back(std::make_pair(u, neighbor));
+          edgeStack.emplace_back(u, neighbor);
           break;
         } else if (neighbor != parent[u] && level[neighbor] < level[u]) {
-          edgeStack.push_back(std::make_pair(u, neighbor));
-          lowpt[u] = std::min(lowpt[u], level[neighbor]);
+            edgeStack.emplace_back(u, neighbor);
+            lowpt[u] = std::min(lowpt[u], level[neighbor]);
         }
       }
 

--- a/networkit/cpp/distance/AllSimplePaths.cpp
+++ b/networkit/cpp/distance/AllSimplePaths.cpp
@@ -130,7 +130,7 @@ namespace NetworKit {
             *v = {source, availableSources[source][i]};
             std::vector<bool> visited(G->upperNodeIdBound(), false);
             visited[source] = true;
-            stack.push_back(std::make_pair(*v, visited));
+            stack.emplace_back(*v, visited);
 
             std::vector<std::vector<node>> currPaths;
 
@@ -181,7 +181,7 @@ namespace NetworKit {
                             toEnqueue = false;
                         }
                         else {
-                            stack.push_back(std::pair<std::vector<node>, std::vector<bool>> (*currPair));
+                            stack.emplace_back(*currPair);
                             std::pair<std::vector<node>, std::vector<bool>>* newPair = &stack.back();
                             newPair->first[newPair->first.size() - 1] = s;
                             ++step;

--- a/networkit/cpp/dynamics/DGSStreamParser.cpp
+++ b/networkit/cpp/dynamics/DGSStreamParser.cpp
@@ -59,7 +59,7 @@ std::vector<GraphEvent> DGSStreamParser::getStream() {
 
             // parse commands
             if (tag.compare("st") == 0) { // clock
-                stream.push_back(GraphEvent(GraphEvent::TIME_STEP));
+                stream.emplace_back(GraphEvent::TIME_STEP);
             } else if (tag.compare("an") == 0) { // add node
                 node u = map(split[1]);
                 auto ev = GraphEvent(GraphEvent::NODE_ADDITION, u);
@@ -121,40 +121,40 @@ std::vector<GraphEvent> DGSStreamParser::getStream() {
 
             // parse commands
             if (tag.compare("st") == 0) { // clock
-                stream.push_back(GraphEvent(GraphEvent::TIME_STEP));
+                stream.emplace_back(GraphEvent::TIME_STEP);
             } else if (tag.compare("an") == 0) { // add node
                 node u = offset(std::stoul(split[1]));
-                stream.push_back(GraphEvent(GraphEvent::NODE_ADDITION, u));
+                stream.emplace_back(GraphEvent::NODE_ADDITION, u);
             } else if (tag.compare("ae") == 0) { // add edge
                 node u = offset(std::stoul(split[2]));
                 node v = offset(std::stoul(split[3]));
                 edgeweight w = std::stod(Aux::StringTools::split(split[4], '=')[1]); // weight=<w>
-                stream.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, u, v, w));
+                stream.emplace_back(GraphEvent::EDGE_ADDITION, u, v, w);
             } else if (tag.compare("ce") == 0) {
                 // update edge. Only the "weight" attribute is supported so far
                 std::vector<std::string> uvs = Aux::StringTools::split(split[1], '-');
                 node u = offset(std::stoul(uvs[0]));
                 node v = offset(std::stoul(uvs[1]));
                 edgeweight w = std::stod(Aux::StringTools::split(split[2], '=')[1]); // weight=<w>
-                stream.push_back(GraphEvent(GraphEvent::EDGE_WEIGHT_UPDATE, u, v, w));
+                stream.emplace_back(GraphEvent::EDGE_WEIGHT_UPDATE, u, v, w);
             } else if (tag.compare("ie") == 0) {
                 // update edge. Only the "weight" attribute is supported so far
                 std::vector<std::string> uvs = Aux::StringTools::split(split[1], '-');
                 node u = offset(std::stoul(uvs[0]));
                 node v = offset(std::stoul(uvs[1]));
                 edgeweight w = std::stod(Aux::StringTools::split(split[2], '=')[1]); // weight=<w>
-                stream.push_back(GraphEvent(GraphEvent::EDGE_WEIGHT_INCREMENT, u, v, w));
+                stream.emplace_back(GraphEvent::EDGE_WEIGHT_INCREMENT, u, v, w);
             } else if (tag.compare("de") == 0) {
                 std::vector<std::string> uvs = Aux::StringTools::split(split[1], '-');
                 node u = offset(std::stoul(uvs[0]));
                 node v = offset(std::stoul(uvs[1]));
-                stream.push_back(GraphEvent(GraphEvent::EDGE_REMOVAL, u, v));
+                stream.emplace_back(GraphEvent::EDGE_REMOVAL, u, v);
             } else if (tag.compare("dn") == 0) {
                 node u = offset(std::stoul(split[1]));
-                stream.push_back(GraphEvent(GraphEvent::NODE_REMOVAL, u));
+                stream.emplace_back(GraphEvent::NODE_REMOVAL, u);
             } else if (tag.compare("rn") == 0) {
                 node u = offset(std::stoul(split[1]));
-                stream.push_back(GraphEvent(GraphEvent::NODE_RESTORATION, u));
+                stream.emplace_back(GraphEvent::NODE_RESTORATION, u);
             } else {
                 ERROR("malformed line (" , lineCount , ") : " , line);
                 throw std::runtime_error("malformed line in .DGS file");

--- a/networkit/cpp/dynamics/GraphUpdater.cpp
+++ b/networkit/cpp/dynamics/GraphUpdater.cpp
@@ -54,7 +54,7 @@ void GraphUpdater::update(const std::vector<GraphEvent>& stream) {
         }
     }
     // record graph size
-    size.push_back(std::make_pair(G->numberOfNodes(), G->numberOfEdges()));
+    size.emplace_back(G->numberOfNodes(), G->numberOfEdges());
 }
 
 std::vector<std::pair<count, count>> GraphUpdater::getSizeTimeline() {

--- a/networkit/cpp/generators/DynamicDorogovtsevMendesGenerator.cpp
+++ b/networkit/cpp/generators/DynamicDorogovtsevMendesGenerator.cpp
@@ -17,36 +17,36 @@ std::vector<GraphEvent> DynamicDorogovtsevMendesGenerator::generate(count nSteps
 
     if (initial) {
         node s1 = u++;
-        stream.push_back(GraphEvent(GraphEvent::NODE_ADDITION, s1));
+        stream.emplace_back(GraphEvent::NODE_ADDITION, s1);
         node s2 = u++;
-        stream.push_back(GraphEvent(GraphEvent::NODE_ADDITION, s2));
+        stream.emplace_back(GraphEvent::NODE_ADDITION, s2);
         node s3 = u;
-        stream.push_back(GraphEvent(GraphEvent::NODE_ADDITION, s3));
-        edges.push_back({s1, s2});
-        stream.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, s1, s2));
-        edges.push_back({s2, s3});
-        stream.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, s2, s3));
-        edges.push_back({s3, s1});
-        stream.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, s3, s1));
+        stream.emplace_back(GraphEvent::NODE_ADDITION, s3);
+        edges.emplace_back(s1, s2);
+        stream.emplace_back(GraphEvent::EDGE_ADDITION, s1, s2);
+        edges.emplace_back(s2, s3);
+        stream.emplace_back(GraphEvent::EDGE_ADDITION, s2, s3);
+        edges.emplace_back(s3, s1);
+        stream.emplace_back(GraphEvent::EDGE_ADDITION, s3, s1);
 
-        stream.push_back(GraphEvent(GraphEvent::TIME_STEP));
+        stream.emplace_back(GraphEvent::TIME_STEP);
         initial = false;
     }
 
     for (index i = 0; i < nSteps; ++i) {
         ++u; // new node
-        stream.push_back(GraphEvent(GraphEvent::NODE_ADDITION, u));
+        stream.emplace_back(GraphEvent::NODE_ADDITION, u);
         // select random edge
         index e = Aux::Random::integer(edges.size() - 1);
         node s = edges[e].first;
         node t = edges[e].second;
-        edges.push_back({s,u});
-        edges.push_back({t,u});
+        edges.emplace_back(s, u);
+        edges.emplace_back(t, u);
         // connect node
-        stream.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, u, s));
-        stream.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, u, t));
+        stream.emplace_back(GraphEvent::EDGE_ADDITION, u, s);
+        stream.emplace_back(GraphEvent::EDGE_ADDITION, u, t);
 
-        stream.push_back(GraphEvent(GraphEvent::TIME_STEP));
+        stream.emplace_back(GraphEvent::TIME_STEP);
     }
 
     return stream;

--- a/networkit/cpp/generators/DynamicForestFireGenerator.cpp
+++ b/networkit/cpp/generators/DynamicForestFireGenerator.cpp
@@ -91,7 +91,7 @@ std::vector<GraphEvent> DynamicForestFireGenerator::generate(count nSteps) {
         DEBUG("selected ambassador: ", a);
 
         node v = G.addNode();
-        stream.push_back(GraphEvent(GraphEvent::NODE_ADDITION, v));
+        stream.emplace_back(GraphEvent::NODE_ADDITION, v);
         DEBUG("created node ", v);
 
         visited[a] = true;
@@ -116,22 +116,22 @@ std::vector<GraphEvent> DynamicForestFireGenerator::generate(count nSteps) {
 
         for (node w : burnedNodes) {
             G.addEdge(v, w);
-            stream.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, v, w));
+            stream.emplace_back(GraphEvent::EDGE_ADDITION, v, w);
         }
     };
 
     // initial graph
     if (firstCall && nSteps > 0) {
         node s = G.addNode();
-        stream.push_back(GraphEvent(GraphEvent::NODE_ADDITION, s));
-        stream.push_back(GraphEvent(GraphEvent::TIME_STEP));
+        stream.emplace_back(GraphEvent::NODE_ADDITION, s);
+        stream.emplace_back(GraphEvent::TIME_STEP);
         firstCall = false;
         --nSteps;
     }
 
     for (index step = 0; step < nSteps; ++step) {
         connectNewNode();
-        stream.push_back(GraphEvent(GraphEvent::TIME_STEP));
+        stream.emplace_back(GraphEvent::TIME_STEP);
     }
 
     return stream;

--- a/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
+++ b/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
@@ -160,7 +160,7 @@ std::vector<GraphEvent> DynamicHyperbolicGenerator::generate(count nSteps) {
         if (moveEachStep > 0 && moveDistance > 0) {
             getEventsFromNodeMovement(result);
         }
-        result.push_back(GraphEvent(GraphEvent::TIME_STEP));
+        result.emplace_back(GraphEvent::TIME_STEP);
     }
     return result;
 }

--- a/networkit/cpp/generators/DynamicPathGenerator.cpp
+++ b/networkit/cpp/generators/DynamicPathGenerator.cpp
@@ -13,16 +13,16 @@ std::vector<GraphEvent> DynamicPathGenerator::generate(count nSteps) {
 
     std::vector<GraphEvent> stream;
     node u = G.addNode();
-    stream.push_back(GraphEvent(GraphEvent::NODE_ADDITION, u));
+    stream.emplace_back(GraphEvent::NODE_ADDITION, u);
 
     count step = 0;
     while (step < nSteps) {
         node v = G.addNode();
-        stream.push_back(GraphEvent(GraphEvent::NODE_ADDITION, v));
+        stream.emplace_back(GraphEvent::NODE_ADDITION, v);
         G.addEdge(u, v);
-        stream.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, u, v, 1.0));
+        stream.emplace_back(GraphEvent::EDGE_ADDITION, u, v, 1.0);
         u = v;
-        stream.push_back(GraphEvent(GraphEvent::TIME_STEP));
+        stream.emplace_back(GraphEvent::TIME_STEP);
         step += 1;
     }
     return stream;

--- a/networkit/cpp/generators/DynamicPubWebGenerator.cpp
+++ b/networkit/cpp/generators/DynamicPubWebGenerator.cpp
@@ -30,14 +30,13 @@ std::vector<GraphEvent> DynamicPubWebGenerator::generate(count nSteps) {
 
     if (writeInitialGraphToStream) {
         // write initial graph to stream
-        G.forNodes(
-            [&](node v) { eventStream.push_back(GraphEvent(GraphEvent::NODE_ADDITION, v)); });
+        G.forNodes([&](node v) { eventStream.emplace_back(GraphEvent::NODE_ADDITION, v); });
 
         G.forEdges([&](node u, node v, edgeweight ew) {
-            eventStream.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, u, v, ew));
+            eventStream.emplace_back(GraphEvent::EDGE_ADDITION, u, v, ew);
         });
 
-        eventStream.push_back(GraphEvent(GraphEvent::TIME_STEP));
+        eventStream.emplace_back(GraphEvent::TIME_STEP);
 
         writeInitialGraphToStream = false;
     }
@@ -54,9 +53,8 @@ std::vector<GraphEvent> DynamicPubWebGenerator::generate(count nSteps) {
             } while (!G.hasNode(nodeToDel));
 
             // mark incident edges first for deletion, delete them outside of neighborhood iterator
-            G.forNeighborsOf(nodeToDel, [&](node neigh) {
-                edgesToDelete.push_back(std::make_pair(nodeToDel, neigh));
-            });
+            G.forNeighborsOf(nodeToDel,
+                             [&](node neigh) { edgesToDelete.emplace_back(nodeToDel, neigh); });
             for (auto elem : edgesToDelete) {
                 node neigh = elem.second;
                 G.removeEdge(nodeToDel, neigh);
@@ -135,7 +133,7 @@ std::vector<GraphEvent> DynamicPubWebGenerator::generate(count nSteps) {
         G.forEdges([&](node u, node v) {
             edge e = std::make_pair(std::min(u, v), std::max(u, v));
             if (eligibleEdges[e] < 2) {
-                edgesToDelete.push_back(std::make_pair(u, v));
+                edgesToDelete.emplace_back(u, v);
             } else {
                 assert(G.hasEdge(u, v));
                 edgeweight ew =
@@ -175,7 +173,7 @@ std::vector<GraphEvent> DynamicPubWebGenerator::generate(count nSteps) {
             }
         }
 
-        eventStream.push_back(GraphEvent(GraphEvent::TIME_STEP));
+        eventStream.emplace_back(GraphEvent::TIME_STEP);
     }
 
     return eventStream;

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -972,7 +972,7 @@ std::vector<std::pair<node, node>> Graph::edges() const {
     WARN("Graph::edges is deprecated and will not be supported in future releases.");
     std::vector<std::pair<node, node>> edges;
     edges.reserve(numberOfEdges());
-    this->forEdges([&](node u, node v) { edges.push_back(std::pair<node, node>(u, v)); });
+    this->forEdges([&](node u, node v) { edges.emplace_back(u, v); });
     return edges;
 }
 

--- a/networkit/cpp/graph/GraphBuilder.cpp
+++ b/networkit/cpp/graph/GraphBuilder.cpp
@@ -50,14 +50,14 @@ index GraphBuilder::indexInInEdgeArray(node u, node v) const {
 }
 
 node GraphBuilder::addNode() {
-    outEdges.push_back(std::vector<node>{});
+    outEdges.emplace_back();
     if (weighted) {
-        outEdgeWeights.push_back(std::vector<edgeweight>{});
+        outEdgeWeights.emplace_back();
     }
     if (directed) {
-        inEdges.push_back(std::vector<node>{});
+        inEdges.emplace_back();
         if (weighted) {
-            inEdgeWeights.push_back(std::vector<edgeweight>{});
+            inEdgeWeights.emplace_back();
         }
     }
     return n++;

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -174,7 +174,7 @@ std::vector<std::pair<node, node>> randomEdges(const Graph &G, count nr) {
                 v = randomNeighbor(G, u);
             } while (u > v);
         }
-        edges.push_back({u, v});
+        edges.emplace_back(u, v);
     }
 
     return edges;

--- a/networkit/cpp/io/METISParser.cpp
+++ b/networkit/cpp/io/METISParser.cpp
@@ -71,7 +71,7 @@ static std::vector<std::pair<node,double>> parseWeightedLine(std::string line, c
         try {
             std::tie(v, it) = Aux::Parsing::strTo<node>(it,end);
             std::tie(weight, it) = Aux::Parsing::strTo<double,decltype(it),Aux::Checkers::Enforcer>(it,end);
-            adjacencies.push_back(std::make_pair(v,weight));
+            adjacencies.emplace_back(v, weight);
             content << v << " " << weight << "\t";
         } catch (const std::exception &e) {
             ERROR("malformed line; not all edges have been read correctly");

--- a/networkit/cpp/linkprediction/LinkPredictor.cpp
+++ b/networkit/cpp/linkprediction/LinkPredictor.cpp
@@ -54,7 +54,7 @@ std::vector<LinkPredictor::prediction> LinkPredictor::runAll() {
   G->forNodes([&](node i) {
     G->forNodes([&](node j) {
       if (!G->hasEdge(i, j))
-        nodePairs.push_back(std::make_pair(i, j));
+          nodePairs.emplace_back(i, j);
     });
   });
   return runOn(nodePairs);

--- a/networkit/cpp/linkprediction/MissingLinksFinder.cpp
+++ b/networkit/cpp/linkprediction/MissingLinksFinder.cpp
@@ -61,8 +61,8 @@ std::vector<std::pair<node, node>> MissingLinksFinder::findFromNode(node u, coun
     q = newFound;
   }
   while (!q.empty()) {
-    missingLinks.push_back(std::make_pair(u, q.front()));
-    q.pop();
+      missingLinks.emplace_back(u, q.front());
+      q.pop();
   }
   return missingLinks;
 }

--- a/networkit/cpp/scd/ApproximatePageRank.cpp
+++ b/networkit/cpp/scd/ApproximatePageRank.cpp
@@ -50,7 +50,7 @@ std::vector<std::pair<node, double>> ApproximatePageRank::run(node seed) {
     pr.reserve(pr_res.size());
 
     for (auto it = pr_res.begin(); it != pr_res.end(); it++) {
-        pr.push_back(std::make_pair(it->first, it->second.first));
+        pr.emplace_back(it->first, it->second.first);
     }
 
     return pr;


### PR DESCRIPTION
Replace `push_back` with `emplace` where applicable. 