### PR TITLE
Auxiliary and centrality modules: cpp-coreguideline-narrowing-conversion 

### DIFF
--- a/include/networkit/auxiliary/BucketPQ.hpp
+++ b/include/networkit/auxiliary/BucketPQ.hpp
@@ -107,7 +107,7 @@ public:
     /**
      * @return key to given value @val.
      */
-    virtual int getKey(const index& val);
+    virtual int64_t getKey(const index& val);
 
 };
 

--- a/include/networkit/centrality/ApproxGroupBetweenness.hpp
+++ b/include/networkit/centrality/ApproxGroupBetweenness.hpp
@@ -109,7 +109,7 @@ ApproxGroupBetweenness::scoreOfGroup(const std::vector<node> &S,
             result += curScore;
 
     if (normalized) {
-        double nPairs = (z - S.size()) * (z - S.size() - 1);
+        double nPairs = static_cast<double>((z - S.size()) * (z - S.size() - 1));
         if (nPairs <= 0)
             return 0;
         if (!G.isDirected())

--- a/include/networkit/centrality/Closeness.hpp
+++ b/include/networkit/centrality/Closeness.hpp
@@ -62,7 +62,7 @@ class Closeness : public Centrality {
        * Returns the maximum possible Closeness a node can have in a graph with
        * the same amount of nodes (=a star)
        */
-      double maximum() override { return normalized ? 1. : (1. / (G.upperNodeIdBound() - 1)); }
+      double maximum() override { return normalized ? 1. : (1. / (static_cast<double>(G.upperNodeIdBound() - 1))); }
 
   private:
     ClosenessVariant variant;
@@ -76,11 +76,15 @@ class Closeness : public Centrality {
     void dijkstra();
     void incTS();
     void updateScoreData(node u, count reached, double sum) {
-        scoreData[u] =
-            sum ? variant == ClosenessVariant::standard
-                      ? 1.0 / sum
-                      : (reached - 1) / sum / (G.numberOfNodes() - 1)
-                : 0.;
+        if (sum > 0) {
+            if (variant == ClosenessVariant::standard) {
+                scoreData[u] = 1.0/ sum;
+            } else {
+                scoreData[u] = static_cast<double>(reached - 1) / sum / static_cast<double>(G.numberOfNodes() - 1);
+            }
+        } else {
+            scoreData[u] = 0.;
+        }
         if (normalized)
             scoreData[u] *=
                 (variant == ClosenessVariant::standard ? G.numberOfNodes()

--- a/include/networkit/centrality/DynBetweenness.hpp
+++ b/include/networkit/centrality/DynBetweenness.hpp
@@ -81,7 +81,7 @@ private:
     void decreaseScore(std::vector<bool> & affected, node y, std::priority_queue<std::pair<double, node>, std::vector<std::pair<double,node>>, CompareDist> & Q);
     node u;
     node v;
-    count diameter = 0;
+    edgeweight diameter = 0.0;
     const edgeweight infDist = std::numeric_limits<edgeweight>::max();
     count visitedPairs = 0;
     std::vector<std::vector<edgeweight>> distances;

--- a/include/networkit/centrality/GedWalk.hpp
+++ b/include/networkit/centrality/GedWalk.hpp
@@ -36,8 +36,8 @@ private:
     const BoundStrategy boundStrategy;
     GreedyStrategy greedyStrategy;
     double spectralDelta;
-    count degOutMax;
-    count degInMax;
+    double degOutMax;
+    double degInMax;
     std::vector<double> alphas;
 
     // Size of pathsIn / pathsOut and related vectors.

--- a/networkit/cpp/auxiliary/BucketPQ.cpp
+++ b/networkit/cpp/auxiliary/BucketPQ.cpp
@@ -116,8 +116,8 @@ uint64_t BucketPQ::size() const {
     return numElems;
 }
 
-int BucketPQ::getKey(const index& val) {
-    int key =myBucket[val]-offset;
+int64_t BucketPQ::getKey(const index& val) {
+    int64_t key =myBucket[val]-offset;
     return key;
 }
 } // namespace

--- a/networkit/cpp/centrality/ApproxCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxCloseness.cpp
@@ -56,7 +56,7 @@ void ApproxCloseness::run() {
     } else {
         estimateClosenessForUndirectedGraph();
         G.parallelForNodes([&](node u) {
-            scoreData[u] = normalized? (G.numberOfNodes()-1) / scoreData[u] : 1 / scoreData[u];
+            scoreData[u] = normalized? (static_cast<double>(G.numberOfNodes()-1)) / scoreData[u] : 1 / scoreData[u];
         });
     }
 
@@ -187,9 +187,9 @@ void ApproxCloseness::computeClosenessForDirectedWeightedGraph(bool outbound) {
             scoreData[v] = distSum[v] / (double) count[v];
         }
         if (count[v] < nSamples) {
-            R[v] = count[v];
+            R[v] = static_cast<double>(count[v]);
         } else {
-            R[v] = 1 + ((nSamples - 1) * (G.numberOfNodes() - 2)) / (double) (T[v] - 1);
+            R[v] = 1 + static_cast<double>((nSamples - 1) * (G.numberOfNodes() - 2)) / static_cast<double>(T[v] - 1);
         }
     });
 }
@@ -259,7 +259,7 @@ void ApproxCloseness::computeClosenessForDirectedUnweightedGraph(bool outbound) 
         if (count[v] < nSamples) {
             R[v] = count[v];
         } else {
-            R[v] = 1 + ((nSamples - 1) * (G.numberOfNodes() - 2)) / (double) (T[v] - 1);
+            R[v] = 1 + static_cast<double>((nSamples - 1) * (G.numberOfNodes() - 2)) / static_cast<double>(T[v] - 1);
         }
     });
 }
@@ -410,7 +410,7 @@ void ApproxCloseness::orderNodesByIncreasingDistance(node c, std::vector<node> &
 }
 
 double ApproxCloseness::maximum() {
-    return (double) 1 / (G.numberOfNodes() - 1);
+    return 1. / static_cast<double>(G.numberOfNodes() - 1);
 }
 
 std::vector<double> ApproxCloseness::getSquareErrorEstimates() {

--- a/networkit/cpp/centrality/Betweenness.cpp
+++ b/networkit/cpp/centrality/Betweenness.cpp
@@ -131,7 +131,7 @@ double Betweenness::maximum(){
         return 1;
     }
 
-    count n = G.numberOfNodes();
+    const double n = G.numberOfNodes();
     double score = (n-1)*(n-2);
     if (!G.isDirected())
         score /= 2.;

--- a/networkit/cpp/centrality/CoreDecomposition.cpp
+++ b/networkit/cpp/centrality/CoreDecomposition.cpp
@@ -335,7 +335,7 @@ index CoreDecomposition::maxCoreNumber() const {
 }
 
 double CoreDecomposition::maximum() {
-    return G.numberOfNodes() - 1;
+    return static_cast<double>(G.numberOfNodes() - 1);
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/centrality/DegreeCentrality.cpp
+++ b/networkit/cpp/centrality/DegreeCentrality.cpp
@@ -26,7 +26,7 @@ void DegreeCentrality::run() {
     }
 
     if (normalized) {
-        count maxDeg = maximum();
+        const double maxDeg = maximum();
         G.parallelForNodes([&](node u) {
             scoreData[u] = scoreData[u] / maxDeg;
         });
@@ -36,7 +36,13 @@ void DegreeCentrality::run() {
 
 
 double DegreeCentrality::maximum() {
-    return G.numberOfNodes() - ignoreSelfLoops;
+    if (G.isEmpty())
+        return 0.;
+    if (ignoreSelfLoops) {
+        return static_cast<double>(G.numberOfNodes() - 1);
+    } else {
+        return static_cast<double>(G.numberOfNodes());
+    }
 }
 
 

--- a/networkit/cpp/centrality/DynBetweenness.cpp
+++ b/networkit/cpp/centrality/DynBetweenness.cpp
@@ -116,7 +116,7 @@ void DynBetweenness::increaseScore(std::vector<bool> & affected, node y, std::pr
                 }
                 if (! visited[w] && !affected[w] && w != y) {
                     TRACE("Inserting node ", w, " with new priority ", distances[w][y]);
-                    Q.push(std::make_pair(diameter + 1 - distances[w][y], w));
+                    Q.push(std::make_pair(diameter + 1.0 - distances[w][y], w));
                     visited[w] = true;
                 }
             }
@@ -153,7 +153,7 @@ void DynBetweenness::decreaseScore(std::vector<bool> & affected, node y, std::pr
                 }
                 if (! visited[w] && !affected[w] && w != y) {
                     TRACE("Inserting node ", w, " with old priority ", distancesOld[w][y]);
-                    Q.push(std::make_pair(diameter + 1 - distancesOld[w][y], w));
+                    Q.push(std::make_pair(diameter + 1.0 - distancesOld[w][y], w));
                     visited[w] = true;
                 }
             }
@@ -239,8 +239,8 @@ void DynBetweenness::update(GraphEvent event) {
                 // since u is not in source, we insert it now
                 // Qnew.insert(diameter + 1 - distances[u][y], u);
                 // Qold.insert(diameter + 1 - distancesOld[u][y], u);
-                Qnew.push(std::make_pair(diameter + 1 - distances[u][y], u));
-                Qold.push(std::make_pair(diameter + 1 - distancesOld[u][y], u));
+                Qnew.push(std::make_pair(diameter + 1.0 - distances[u][y], u));
+                Qold.push(std::make_pair(diameter + 1.0 - distancesOld[u][y], u));
                 for (count c = 0; c < n_sources[y]; c++) {
                     node s = source_nodes[c];
                     if (s != u) {
@@ -272,8 +272,8 @@ void DynBetweenness::update(GraphEvent event) {
                             TRACE("Node ", y,", Inserting node ", s, " with old priority ", diameter + 1 - distancesOld[s][y]);
                             // Qnew.insert(diameter + 1 - distances[s][y], s);
                             // Qold.insert(diameter + 1 - distancesOld[s][y], s);
-                            Qnew.push(std::make_pair(diameter + 1 - distances[s][y], s));
-                            Qold.push(std::make_pair(diameter + 1 - distancesOld[s][y], s));
+                            Qnew.push(std::make_pair(diameter + 1.0 - distances[s][y], s));
+                            Qold.push(std::make_pair(diameter + 1.0 - distancesOld[s][y], s));
                     }
                     else if (distances[s][y] < distances[s][u] + weightuv + distances[v][y]) {
                         std::swap(source_nodes[c], source_nodes[n_sources[y] - 1]);

--- a/networkit/cpp/centrality/DynKatzCentrality.cpp
+++ b/networkit/cpp/centrality/DynKatzCentrality.cpp
@@ -26,7 +26,7 @@ DynKatzCentrality::DynKatzCentrality(const Graph& G, count k, bool groupOnly, do
     });
     assert(maxdeg && "Alpha is chosen based on the max. degree; therefore, that degree must not be zero");
 
-    alpha = double(1)/(maxdeg + 1);
+    alpha = 1.0 / (maxdeg + 1.0);
     DEBUG("alpha: ", alpha);
     DEBUG("1/(1-alpha): ", 1/(1-alpha));
 }

--- a/networkit/cpp/centrality/DynTopHarmonicCloseness.cpp
+++ b/networkit/cpp/centrality/DynTopHarmonicCloseness.cpp
@@ -42,7 +42,7 @@ DynTopHarmonicCloseness::BFScut(node v, edgeweight x, count n, count r,
                                 std::vector<count> &distances,
                                 std::vector<node> &pred, count &visitedEdges) {
 
-    count d = 0;
+    double d = 0;
     int64_t gamma = 0, nd = 0;
 
     distances[v] = 0;
@@ -76,9 +76,9 @@ DynTopHarmonicCloseness::BFScut(node v, edgeweight x, count n, count r,
         if (distances[u] > d) {
             d = d + 1;
 
-            int64_t d2 = int64_t(r) - nd;
-            ctilde = c + (edgeweight(gamma) / ((d + 2) * (d + 1))) +
-                     (edgeweight(d2) / (d + 2));
+            double d2 = static_cast<double>(int64_t(r) - nd);
+            ctilde = c + (static_cast<edgeweight>(gamma) / ((d + 2.0) * (d + 1.0))) +
+                     (d2 / (d + 2.0));
 
             if (ctilde < x) {
                 exactCutOff[v] = true;
@@ -111,7 +111,7 @@ DynTopHarmonicCloseness::BFScut(node v, edgeweight x, count n, count r,
                     ++nd;
                     pred[w] = u;
                 } else if (distances[w] > 1 && (pred[u] != w)) {
-                    ctilde = ctilde - 1.0 / (d + 1) + 1.0 / (d + 2);
+                    ctilde = ctilde - 1.0 / (d + 1.0) + 1.0 / (d + 2.0);
 
                     if (ctilde < x) {
                         cont = false;

--- a/networkit/cpp/centrality/EstimateBetweenness.cpp
+++ b/networkit/cpp/centrality/EstimateBetweenness.cpp
@@ -104,7 +104,7 @@ void EstimateBetweenness::run() {
 
     // extrapolate
     G.parallelForNodes([&](node u) {
-        scoreData[u] = scoreData[u] * (2 * n / double(nSamples));
+        scoreData[u] = scoreData[u] * (2 * static_cast<double>(n) / static_cast<double>(nSamples));
 
         if (normalized) {
             // divide by the number of possible pairs

--- a/networkit/cpp/centrality/GedWalk.cpp
+++ b/networkit/cpp/centrality/GedWalk.cpp
@@ -87,8 +87,8 @@ void GedWalk::init() {
     groupScore = 0.0;
     groupW = 0.0;
     groupBound = 0.0;
-    degOutMax = GraphTools::maxDegree(*G);
-    degInMax = GraphTools::maxInDegree(*G);
+    degOutMax = static_cast<double>(GraphTools::maxDegree(*G));
+    degInMax = static_cast<double>(GraphTools::maxInDegree(*G));
 
     inGroup.resize(n, 0);
     isExact.resize(n, 0);
@@ -123,7 +123,7 @@ void GedWalk::init() {
             alpha = 1.0 / (1.0 + degInMax);
         } else {
             assert(boundStrategy == BoundStrategy::adaptiveGeometric);
-            alpha = 1.0 / (1.0 + (degOutMax + degInMax));
+            alpha = 1.0 / (1.0 + degOutMax + degInMax);
         }
     }
 
@@ -534,12 +534,12 @@ void GedWalk::fillPQs() {
 
 void GedWalk::run() {
     if (boundStrategy == BoundStrategy::spectral) {
-        assert(alpha < 1 / static_cast<double>(sigmaMax));
+        assert(alpha < 1.0 / static_cast<double>(sigmaMax));
     } else if (boundStrategy == BoundStrategy::geometric) {
-        assert(alpha < 1 / static_cast<double>(degInMax));
+        assert(alpha < 1.0 / degInMax);
     } else {
         assert(boundStrategy == BoundStrategy::adaptiveGeometric);
-        assert(alpha < 1 / static_cast<double>(degOutMax + degInMax));
+        assert(alpha < 1.0 / (degOutMax + degInMax));
     }
 
     // Should we reset nLevels to zero?

--- a/networkit/cpp/centrality/HarmonicCloseness.cpp
+++ b/networkit/cpp/centrality/HarmonicCloseness.cpp
@@ -43,13 +43,13 @@ void HarmonicCloseness::run() {
     scoreData[v] = sum;
   });
   if (normalized) {
-    G.forNodes([&](node w) { scoreData[w] /= (G.numberOfNodes() - 1); });
+    G.forNodes([&](node w) { scoreData[w] /= static_cast<double>(G.numberOfNodes() - 1); });
   }
 
   hasRun = true;
 }
 
 double HarmonicCloseness::maximum() {
-  return normalized ? (G.numberOfNodes() - 1) : 1.f;
+  return normalized ? static_cast<double>(G.numberOfNodes() - 1) : 1.f;
 }
 } // namespace NetworKit

--- a/networkit/cpp/centrality/KPathCentrality.cpp
+++ b/networkit/cpp/centrality/KPathCentrality.cpp
@@ -22,7 +22,7 @@ KPathCentrality::KPathCentrality(const Graph& G, double alpha, count k) : Centra
         throw std::runtime_error("alpha must lie in interval [-0.5, 0.5]");
     }
     if (k == 0) {
-        this->k = log(G.numberOfNodes() + G.numberOfEdges());
+        this->k = log(static_cast<double>(G.numberOfNodes() + G.numberOfEdges()));
     } else if (k >0) {
         this->k = k;
     } else {
@@ -32,7 +32,7 @@ KPathCentrality::KPathCentrality(const Graph& G, double alpha, count k) : Centra
 
 void KPathCentrality::run() {
     count z = G.upperNodeIdBound();
-    count n = G.numberOfNodes();
+    double n = G.numberOfNodes();
     scoreData.clear();
     scoreData.resize(z);
 
@@ -42,7 +42,7 @@ void KPathCentrality::run() {
     counter.assign(z, 0);
     explored.assign(z, false);
 
-    count t = 2 * k * k * pow(n, 1 - 2 * alpha) * log(n);
+    count t = 2.0 * k * k * pow(n, 1 - 2 * alpha) * log(n);
     std::stack<node> stack;
     node v;
 
@@ -95,7 +95,7 @@ void KPathCentrality::run() {
     }
 
     G.forNodes([&](node v) {
-        scoreData[v] = k * n * ((double) counter[v] / t);
+        scoreData[v] = k * n * (static_cast<double>(counter[v]) / t);
     });
 
     hasRun = true;

--- a/networkit/cpp/centrality/KadabraBetweenness.cpp
+++ b/networkit/cpp/centrality/KadabraBetweenness.cpp
@@ -187,7 +187,7 @@ void KadabraBetweenness::computeBetErr(Status *status, std::vector<double> &bet,
 }
 
 void KadabraBetweenness::computeDeltaGuess() {
-    const count n = G.upperNodeIdBound();
+    const double n = G.upperNodeIdBound();
     const double balancingFactor = 0.001;
     double a = 0,
            b = 1. / err / err * std::log(n * 4 * (1 - balancingFactor) / delta),
@@ -232,18 +232,18 @@ void KadabraBetweenness::computeDeltaGuess() {
 
     deltaLMinGuess = std::exp(-b * errL[unionSample - 1] *
                               errL[unionSample - 1] / bet[unionSample - 1]) +
-                     delta * balancingFactor / 4. / (double)n;
+                     delta * balancingFactor / 4. / n;
     deltaUMinGuess = std::exp(-b * errU[unionSample - 1] *
                               errU[unionSample - 1] / bet[unionSample - 1]) +
-                     delta * balancingFactor / 4. / (double)n;
+                     delta * balancingFactor / 4. / n;
 
 #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(unionSample); ++i) {
         node v = status.top[i];
         deltaLGuess[v] = std::exp(-b * errL[i] * errL[i] / bet[i]) +
-                         delta * balancingFactor / 4. / (double)n;
+                         delta * balancingFactor / 4. / n;
         deltaUGuess[v] = std::exp(-b * errU[i] * errU[i] / bet[i]) +
-                         delta * balancingFactor / 4. / (double)n;
+                         delta * balancingFactor / 4. / n;
     }
 }
 

--- a/networkit/cpp/centrality/LaplacianCentrality.cpp
+++ b/networkit/cpp/centrality/LaplacianCentrality.cpp
@@ -18,9 +18,9 @@ void LaplacianCentrality::run() {
 
     G.parallelForNodes([&](node u) {
         count degreeU = G.weightedDegree(u);
-        double energyLossOnNodeDrop = degreeU * degreeU;
+        double energyLossOnNodeDrop = static_cast<double>(degreeU * degreeU);
 #pragma omp atomic
-        totalLaplacianEnergy += degreeU * degreeU;
+        totalLaplacianEnergy += static_cast<double>(degreeU * degreeU);
 
         G.forNeighborsOf(u, [&](node v, edgeweight ew) {
             energyLossOnNodeDrop += ew * (ew + 2 * G.weightedDegree(v));

--- a/networkit/cpp/centrality/PermanenceCentrality.cpp
+++ b/networkit/cpp/centrality/PermanenceCentrality.cpp
@@ -136,7 +136,7 @@ double NetworKit::PermanenceCentrality::getIntraClustering(NetworKit::node u) {
 
     if (numNeighbors < 2) return 0;
 
-    return numTriangles * 1.0 / (0.5 * numNeighbors * (numNeighbors - 1)); // triangles are counted only once, so divide by 2 here!
+    return numTriangles * 1.0 / (0.5 * static_cast<double>(numNeighbors * (numNeighbors - 1))); // triangles are counted only once, so divide by 2 here!
 }
 
 double NetworKit::PermanenceCentrality::getPermanence(NetworKit::node u) {

--- a/networkit/cpp/centrality/Sfigality.cpp
+++ b/networkit/cpp/centrality/Sfigality.cpp
@@ -32,7 +32,7 @@ void Sfigality::run() {
 
 double Sfigality::maximum() {
     throw std::runtime_error("Not Implemented");
-    return G.numberOfNodes() - 1;
+    return G.isEmpty() ? 0. : static_cast<double>(G.numberOfNodes() - 1);
 }
 
 

--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -211,14 +211,16 @@ void TopCloseness::computelBound1(std::vector<double> &S) {
 
                 count n_old = N[u];
                 N[u] += neighbors_new[u];
-                sumDist[u] += level * neighbors_new[u];
+                sumDist[u] += static_cast<double>(level * neighbors_new[u]);
 
                 if (N[u] >= reachL[u]) {
                     if (n_old < reachL[u]) {
                         // We have to consider the case in which the number of reachable
                         // vertices is reachL.
-                        S[u] = (sumDist[u] - level * (N[u] - reachL[u])) * (n - 1) / (reachL[u] - 1)
-                               / (reachL[u] - 1);
+                        double s1 = sumDist[u] - static_cast<double>(level * (N[u] - reachL[u]));
+                        double s2 = static_cast<double>(n - 1) / static_cast<double>(reachL[u] - 1)
+                                    / static_cast<double>(reachL[u] - 1);
+                        S[u] = s1 * s2;
                     }
                     if (neighbors_new[u] == 0) {
                         reachU[u] = N[u];
@@ -226,8 +228,11 @@ void TopCloseness::computelBound1(std::vector<double> &S) {
                     if (N[u] >= reachU[u]) {
                         // We have to consider the case in which the number of reachable
                         // vertices is reachU.
-                        S[u] = std::min(S[u], (sumDist[u] - level * (N[u] - reachU[u])) * (n - 1)
-                                                  / (reachU[u] - 1) / (reachU[u] - 1));
+                        S[u] = std::min(
+                            S[u], (sumDist[u] - static_cast<double>(level * (N[u] - reachU[u])))
+                                      * static_cast<double>(n - 1)
+                                      / static_cast<double>(reachU[u] - 1)
+                                      / static_cast<double>(reachU[u] - 1));
                         finished[u] = true;
                         n_finished++;
 
@@ -235,7 +240,9 @@ void TopCloseness::computelBound1(std::vector<double> &S) {
                     } else { // reachL < N < reachU
                         // We have to consider the case in which the number of reachable is
                         // N[u].
-                        S[u] = std::min(S[u], sumDist[u] * (n - 1) / (N[u] - 1) / (N[u] - 1));
+                        S[u] = std::min(S[u], sumDist[u] * static_cast<double>(n - 1)
+                                                  / static_cast<double>(N[u] - 1)
+                                                  / static_cast<double>(N[u] - 1));
                     }
                 }
             }
@@ -310,7 +317,7 @@ void TopCloseness::BFSbound(node x, std::vector<double> &S2, count &visEdges,
             level_bound += sumLevs[i - 3];
         }
         if (i < nLevs) {
-            level_bound -= (sumLevs[nLevs] - sumLevs[i + 1]);
+            level_bound -= static_cast<edgeweight>(sumLevs[nLevs] - sumLevs[i + 1]);
         }
         for (count j = 0; j < levels[i].size(); j++) {
             node w = levels[i][j];
@@ -351,8 +358,12 @@ double TopCloseness::BFScut(node v, double x, std::vector<bool> &visited,
         sum_dist += distances[u];
         if (distances[u] > d) { // Need to update bounds!
             d++;
-            ftildeL = (f + (d + 2) * (rL - nd) - gamma) * (n - 1) / (rL - 1.0) / (rL - 1.0);
-            ftildeU = (f + (d + 2) * (rU - nd) - gamma) * (n - 1) / (rU - 1.0) / (rU - 1.0);
+            double f1 = f + static_cast<double>(d + 2) * static_cast<double>(rL - nd) - gamma;
+            double f2 = static_cast<double>(n - 1) / (rL - 1.0) / (rL - 1.0);
+            ftildeL = f1 * f2;
+            f1 = f + static_cast<double>(d + 2) * static_cast<double>(rU - nd) - gamma;
+            f2 = static_cast<double>(n - 1) / (rU - 1.0) / (rU - 1.0);
+            ftildeU = f1 * f2;
             if (std::min(ftildeL, ftildeU) >= x) {
                 farnessV = std::min(ftildeL, ftildeU);
                 break;
@@ -370,15 +381,16 @@ double TopCloseness::BFScut(node v, double x, std::vector<bool> &visited,
                     visited[w] = true;
                     f += distances[w];
                     if (!G.isDirected())
-                        gamma += (G.degree(w) - 1); // notice: only because it's undirected
+                        gamma += static_cast<double>(G.degree(w)
+                                                     - 1); // notice: only because it's undirected
                     else
                         gamma += G.degreeOut(w);
                     nd++;
                     pred[w] = u;
                 } else {
                     if (G.isDirected() || pred[u] != w) {
-                        ftildeL += (n - 1) / (rL - 1.0) / (rL - 1.0);
-                        ftildeU += (n - 1) / (rU - 1.0) / (rU - 1.0);
+                        ftildeL += static_cast<double>(n - 1) / (rL - 1.0) / (rL - 1.0);
+                        ftildeU += static_cast<double>(n - 1) / (rU - 1.0) / (rU - 1.0);
                         if (std::min(ftildeL, ftildeU) > x) {
                             cont = false;
                         }
@@ -401,7 +413,8 @@ double TopCloseness::BFScut(node v, double x, std::vector<bool> &visited,
         visited[u] = false;
     } while (!to_reset.empty());
     if (farnessV < x) {
-        farnessV = sum_dist * (n - 1) / (nd - 1.0) / (nd - 1.0);
+        farnessV = static_cast<double>(sum_dist * (n - 1)) / static_cast<double>(nd - 1.0)
+                   / static_cast<double>(nd - 1.0);
     }
     return farnessV;
 }

--- a/networkit/cpp/centrality/TopHarmonicCloseness.cpp
+++ b/networkit/cpp/centrality/TopHarmonicCloseness.cpp
@@ -31,7 +31,7 @@ TopHarmonicCloseness::BFScut(node v, edgeweight x, count n, count r,
                              std::vector<count> &distances,
                              std::vector<node> &pred, count &visitedEdges) {
 
-  count d = 0;
+  double d = 0;
   int64_t gamma = 0, nd = 0;
   distances[v] = 0;
   std::queue<node> Q;
@@ -64,9 +64,9 @@ TopHarmonicCloseness::BFScut(node v, edgeweight x, count n, count r,
     if (distances[u] > d) {
       d = d + 1;
 
-      int64_t d2 = int64_t(r) - nd;
-      ctilde = c + (edgeweight(gamma) / ((d + 2) * (d + 1))) +
-               (edgeweight(d2) / (d + 2));
+      double d2 = static_cast<double>(int64_t(r) - nd);
+      ctilde = c + (static_cast<edgeweight>(gamma) / ((d + 2.0) * (d + 1.0))) +
+               (d2 / (d + 2.0));
 
       if (ctilde < x) {
         exactCutOff[v] = true;


### PR DESCRIPTION
I changed the signature of the `BucketPQ::getKey` to `int64_t` because the function now returns an `int64_t`. Other than that none of the changes affect the interface.