### PR TITLE
Derive exception in CppClangFormat.py from a BaseException.

### DIFF
--- a/extrafiles/tooling/CppClangFormat.py
+++ b/extrafiles/tooling/CppClangFormat.py
@@ -17,7 +17,7 @@ import os
 
 def findClangFormat():
 	"""Tries to find clang-format-XXX variants within the path"""
-	allowed = ["clang-format" + x for x in ["-8"]]
+	allowed = ["clang-format" + x for x in ["-8", ""]]
 	for candidate in allowed:
 		if not shutil.which(candidate) is None:
 			if nkt.isVerbose():
@@ -26,7 +26,7 @@ def findClangFormat():
 
 			return candidate
 
-	raise "clang-format binary not found. We searched for:\n " + "\n ".join(allowed)
+	raise FileNotFoundError("clang-format binary not found. We searched for:\n " + "\n ".join(allowed))
 
 def subscribedToFormat(filename, pattern = "networkit-format"):
 	"""If pattern is present within the file, this file subscribed to auto formatting."""


### PR DESCRIPTION
With Python 3.8 `CppClangFormat.py` throws an error stating the exception that is raised must be derived from a `BaseException`, so that this PR adds that. I also added a blank space to the allowed variants of `clang-format` so that versions such as `/usr/bin/clang-format` can be found.