### PR TITLE
Refactor WeaklyConnectedComponents

### DIFF
--- a/include/networkit/components/ComponentDecomposition.hpp
+++ b/include/networkit/components/ComponentDecomposition.hpp
@@ -1,0 +1,74 @@
+/*
+ * ComponentDecomposition.hpp
+ *
+ *  Created on: 17.12.2020
+ *      Author: cls,
+ *              Eugenio Angriman <angrimae@hu-berlin.de>
+ */
+
+// networkit-format
+
+#ifndef NETWORKIT_COMPONENTS_COMPONENT_DECOMPOSITION_HPP_
+#define NETWORKIT_COMPONENTS_COMPONENT_DECOMPOSITION_HPP_
+
+#include <map>
+#include <vector>
+
+#include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/structures/Partition.hpp>
+
+namespace NetworKit {
+
+/**
+ * @ingroup components
+ * Abstract class for algorithms that compute the components of a graph.
+ */
+class ComponentDecomposition : public Algorithm {
+public:
+    /**
+     * Constructs the ComponentDecomposition class for the given Graph @a G.
+     *
+     * @param G The graph.
+     */
+    ComponentDecomposition(const Graph &G);
+
+    /**
+     * Get the number of connected components.
+     *
+     * @return The number of connected components.
+     */
+    count numberOfComponents() const;
+
+    /**
+     * Get the component in which node @a u is situated.
+     *
+     * @param[in] u The node whose component is asked for.
+     */
+    count componentOfNode(node u) const;
+
+    /**
+     * Get a Partition that represents the components.
+     *
+     * @return A partition representing the found components.
+     */
+    const Partition &getPartition() const;
+
+    /**
+     * Return the map from component to size
+     */
+    std::map<index, count> getComponentSizes() const;
+
+    /**
+     * @return Vector of components, each stored as (unordered) set of nodes.
+     */
+    std::vector<std::vector<node>> getComponents() const;
+
+protected:
+    const Graph *G;
+    Partition component;
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_COMPONENTS_COMPONENT_DECOMPOSITION_HPP_

--- a/include/networkit/components/ConnectedComponents.hpp
+++ b/include/networkit/components/ConnectedComponents.hpp
@@ -1,5 +1,5 @@
 /*
- * ConnectedComponents.cpp
+ * ConnectedComponents.hpp
  *
  *  Created on: Dec 16, 2013
  *      Author: cls
@@ -10,64 +10,32 @@
 #ifndef NETWORKIT_COMPONENTS_CONNECTED_COMPONENTS_HPP_
 #define NETWORKIT_COMPONENTS_CONNECTED_COMPONENTS_HPP_
 
-#include <cassert>
-#include <map>
-#include <vector>
+#include <memory>
 
-#include <networkit/base/Algorithm.hpp>
-#include <networkit/graph/Graph.hpp>
-#include <networkit/structures/Partition.hpp>
+#include <networkit/components/ComponentDecomposition.hpp>
 
 namespace NetworKit {
 
-/**
- * @ingroup components
- * Determines the connected components of an undirected graph.
- */
-class ConnectedComponents final : public Algorithm {
+// pImpl
+namespace ConnectedComponentsDetails {
+template <bool>
+class ConnectedComponentsImpl;
+} // namespace ConnectedComponentsDetails
+
+class ConnectedComponents final : public ComponentDecomposition {
 public:
-    /**
-     * Create ConnectedComponents class for Graph @a G.
+    /* Creates the ConnectedComponents class for graph @G.
      *
      * @param G The graph.
      */
     ConnectedComponents(const Graph &G);
 
-    /**
-     * This method determines the connected components for the graph given in the constructor.
+    ~ConnectedComponents() override;
+
+    /*
+     * Computes the connected components of the input graph.
      */
     void run() override;
-
-    /**
-     * Get the number of connected components.
-     *
-     * @return The number of connected components.
-     */
-    count numberOfComponents() const;
-
-    /**
-     * Get the the component in which node @a u is situated.
-     *
-     * @param[in]	u	The node whose component is asked for.
-     */
-    count componentOfNode(node u) const;
-
-    /**
-     * Get a Partition that represents the components.
-     *
-     * @return A partition representing the found components.
-     */
-    Partition getPartition() const;
-
-    /**
-     *Return the map from component to size
-     */
-    std::map<index, count> getComponentSizes() const;
-
-    /**
-     * @return Vector of components, each stored as (unordered) set of nodes.
-     */
-    std::vector<std::vector<node>> getComponents() const;
 
     /**
      * Constructs a new graph that contains only the nodes inside the largest
@@ -75,25 +43,13 @@ public:
      * @param G            The input graph.
      * @param compactGraph If true, the node ids of the output graph will be compacted
      * (i.e. re-numbered from 0 to n-1). If false, the node ids will not be changed.
+     * @return The largest connected component of the input graph @a G.
      */
     static Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph = false);
 
 private:
-    const Graph *G;
-    Partition component;
-    count numComponents;
+    std::unique_ptr<ConnectedComponentsDetails::ConnectedComponentsImpl<false>> impl;
 };
-
-inline count ConnectedComponents::componentOfNode(node u) const {
-    assert(component[u] != none);
-    assureFinished();
-    return component[u];
-}
-
-inline count ConnectedComponents::numberOfComponents() const {
-    assureFinished();
-    return this->numComponents;
-}
 
 } // namespace NetworKit
 

--- a/include/networkit/components/DynConnectedComponents.hpp
+++ b/include/networkit/components/DynConnectedComponents.hpp
@@ -1,5 +1,5 @@
 /*
-* DynConnectedComponents.cpp
+* DynConnectedComponents.hpp
 *
 *  Created on: June 2017
 *      Author: Eugenio Angriman

--- a/include/networkit/components/StronglyConnectedComponents.hpp
+++ b/include/networkit/components/StronglyConnectedComponents.hpp
@@ -13,20 +13,14 @@
 #ifndef NETWORKIT_COMPONENTS_STRONGLY_CONNECTED_COMPONENTS_HPP_
 #define NETWORKIT_COMPONENTS_STRONGLY_CONNECTED_COMPONENTS_HPP_
 
-#include <map>
-#include <vector>
-
-#include <networkit/base/Algorithm.hpp>
-#include <networkit/graph/Graph.hpp>
-#include <networkit/structures/Partition.hpp>
+#include <networkit/components/ComponentDecomposition.hpp>
 
 namespace NetworKit {
 
 /**
  * @ingroup components
- *
  */
-class StronglyConnectedComponents final : public Algorithm {
+class StronglyConnectedComponents final : public ComponentDecomposition {
 
 public:
     /**

--- a/include/networkit/components/StronglyConnectedComponents.hpp
+++ b/include/networkit/components/StronglyConnectedComponents.hpp
@@ -36,73 +36,14 @@ public:
     void run() override;
 
     /**
-     * Return the number of connected components.
-     *
-     * @return count The number of components of the graph.
+     * Constructs a new graph that contains only the nodes inside the largest
+     * strongly connected component.
+     * @param G            The input graph.
+     * @param compactGraph If true, the node ids of the output graph will be compacted
+     * (i.e. re-numbered from 0 to n-1). If false, the node ids will not be changed.
      */
-    count numberOfComponents() const {
-        assureFinished();
-        return componentIndex;
-    }
-
-    /**
-     * Returns the component of the input node.
-     *
-     * @param[in] u The input node.
-     * @return count The index of the component of the input node.
-     */
-    index componentOfNode(node u) const {
-        assureFinished();
-        assert(G->hasNode(u));
-        return component[u];
-    }
-
-    /**
-     * Return a Partition object that represents the components.
-     *
-     * @return Partition Partitioning of the strongly connected components.
-     */
-    Partition getPartition() const {
-        assureFinished();
-        return Partition(component);
-    }
-
-    /**
-     * Return a map with the component indexes as keys, and their size as values.
-     *
-     * @return std::map<index, count> Map with components indexes as keys, and their size as values.
-     */
-    std::map<node, count> getComponentSizes() const {
-        assureFinished();
-
-        std::vector<count> componentSizes(componentIndex, 0);
-        G->forNodes([&](const node u) { ++componentSizes[component[u]]; });
-
-        std::map<node, count> result;
-        for (index i = 0; i < componentIndex; ++i)
-            result[i] = componentSizes[i];
-
-        return result;
-    }
-
-    /**
-     * Return a list of components.
-     *
-     * @return std::vector<std::vector<node>> List of components.
-     */
-    std::vector<std::vector<node>> getComponents() const {
-        assureFinished();
-        std::vector<std::vector<node>> result(componentIndex);
-
-        G->forNodes([&](const node u) { result[component[u]].push_back(u); });
-
-        return result;
-    }
-
-private:
-    const Graph *G;
-    std::vector<index> component;
-    index componentIndex;
+    static Graph extractLargestStronglyConnectedComponent(const Graph &G,
+                                                          bool compactGraph = false);
 };
 
 } // namespace NetworKit

--- a/include/networkit/components/WeaklyConnectedComponents.hpp
+++ b/include/networkit/components/WeaklyConnectedComponents.hpp
@@ -1,100 +1,60 @@
 /*
-* WeaklyConnectedComponents.h
-*
-*  Created on: June 20, 2017
-*      Author: Eugenio Angriman
-*/
+ * WeaklyConnectedComponents.hpp
+ *
+ *  Created on: June 20, 2017
+ *      Author: Eugenio Angriman
+ */
+
+// networkit-format
 
 #ifndef NETWORKIT_COMPONENTS_WEAKLY_CONNECTED_COMPONENTS_HPP_
 #define NETWORKIT_COMPONENTS_WEAKLY_CONNECTED_COMPONENTS_HPP_
 
-#include <networkit/graph/Graph.hpp>
-#include <networkit/structures/Partition.hpp>
-#include <networkit/base/Algorithm.hpp>
+#include <memory>
+
+#include <networkit/components/ComponentDecomposition.hpp>
 
 namespace NetworKit {
 
+// pImpl
+namespace ConnectedComponentsDetails {
+template <bool>
+class ConnectedComponentsImpl;
+} // namespace ConnectedComponentsDetails
+
+/**
+ * @ingroup components
+ * Determines the weakly connected components of a directed graph.
+ */
+class WeaklyConnectedComponents final : public ComponentDecomposition {
+public:
     /**
-    * @ingroup components
-    * Determines the weakly connected components of a directed graph.
-    */
-    class WeaklyConnectedComponents : public Algorithm {
-    public:
-        /**
-        * Create WeaklyConnectedComponents class for Graph @a G.
-        *
-        * @param G The graph.
-        */
-        WeaklyConnectedComponents(const Graph& G);
+     * Create WeaklyConnectedComponents class for Graph @a G.
+     *
+     * @param G The graph.
+     */
+    WeaklyConnectedComponents(const Graph &G);
 
-        /**
-        * This method determines the weakly connected components for the graph
-        * given in the constructor.
-        */
-        void run() override;
+    ~WeaklyConnectedComponents() override;
 
-        /**
-        * Get the number of weakly connected components.
-        *
-        * @return The number of weakly connected components.
-        */
-        count numberOfComponents();
+    /*
+     * Computes the weakly connected components of the input graph.
+     */
+    void run() override;
 
-        /**
-        * Get the the component in which node @a u is.
-        *
-        * @param[in]	u	The index of the component where @a is located.
-        */
-        count componentOfNode(node u);
+    /**
+     * Constructs a new graph that contains only the nodes inside the largest
+     * weakly connected component.
+     * @param G            The input graph.
+     * @param compactGraph If true, the node ids of the output graph will be compacted
+     * (i.e. re-numbered from 0 to n-1). If false, the node ids will not be changed.
+     * @return The largest weakly connected component of the input graph @a G.
+     */
+    static Graph extractLargestWeaklyConnectedComponent(const Graph &G, bool compactGraph = false);
 
-        /**
-        * Get the map from component to size.
-        *
-        * @return A map that maps each component to its size.
-        */
-        std::map<index, count> getComponentSizes();
-
-        /**
-        * @return Vector of components, each stored as (unordered) set of nodes.
-        */
-        std::vector<std::vector<node>> getComponents();
-
-
-    private:
-        void updateComponent(
-            index c, node w, std::queue<node>& q, bool inNeighbor
-        );
-
-        void init();
-
-        // Pointer to the graph
-        const Graph& G;
-
-        // This vector associates each node to a component
-        std::vector<index> components;
-
-        // This map stores all components
-        // <Key: component ID, Value: component size>
-        std::map<index, count> compSize;
-    };
-
-    inline count WeaklyConnectedComponents::componentOfNode(node u) {
-        assert (components[u] != none);
-        assureFinished();
-        return components[u];
-    }
-
-    inline count WeaklyConnectedComponents::numberOfComponents() {
-        assureFinished();
-        return compSize.size();
-    }
-
-    inline std::map<index, count> WeaklyConnectedComponents::getComponentSizes() {
-        assureFinished(); 
-        return compSize;
-    }
-
-}
-
+private:
+    std::unique_ptr<ConnectedComponentsDetails::ConnectedComponentsImpl<true>> impl;
+};
+} // namespace NetworKit
 
 #endif // NETWORKIT_COMPONENTS_WEAKLY_CONNECTED_COMPONENTS_HPP_

--- a/include/networkit/structures/Partition.hpp
+++ b/include/networkit/structures/Partition.hpp
@@ -50,6 +50,13 @@ public:
 
     Partition(const std::vector<index>& data);
 
+    void reset(index newSize, index defaultValue) {
+        data.clear();
+        data.resize(newSize, defaultValue);
+        z = newSize;
+        omega = 0;
+    }
+
     /**
      *  Index operator.
      *

--- a/include/networkit/structures/Partition.hpp
+++ b/include/networkit/structures/Partition.hpp
@@ -50,10 +50,16 @@ public:
 
     Partition(const std::vector<index>& data);
 
-    void reset(index newSize, index defaultValue) {
+    /* Updates the maximum index of the partition to @a newZ and sets all its
+     * values to @a defaultValue.
+     *
+     * @param[in] newZ New maximum index of the partition. @param[in]
+     * defaultValue Default value of all the elements in the partition.
+     */
+    void reset(index newZ, index defaultValue) {
         data.clear();
-        data.resize(newSize, defaultValue);
-        z = newSize;
+        data.resize(newZ, defaultValue);
+        z = newZ;
         omega = 0;
     }
 

--- a/networkit/cpp/community/CutClustering.cpp
+++ b/networkit/cpp/community/CutClustering.cpp
@@ -94,7 +94,7 @@ std::map< NetworKit::edgeweight, NetworKit::Partition > NetworKit::CutClustering
     }
 
     // for unconnected networks the lower bound for the computation are the connected components
-    ConnectedComponents connComp = ConnectedComponents(G);
+    ConnectedComponents connComp(G);
     connComp.run();
 
     // construct a partition that uses a node of each cluster as representative

--- a/networkit/cpp/components/CMakeLists.txt
+++ b/networkit/cpp/components/CMakeLists.txt
@@ -1,6 +1,8 @@
 networkit_add_module(components
     BiconnectedComponents.cpp
     ConnectedComponents.cpp
+    ConnectedComponentsImpl.cpp
+    ComponentDecomposition.cpp
     DynConnectedComponents.cpp
     DynWeaklyConnectedComponents.cpp
     ParallelConnectedComponents.cpp

--- a/networkit/cpp/components/ComponentDecomposition.cpp
+++ b/networkit/cpp/components/ComponentDecomposition.cpp
@@ -1,0 +1,40 @@
+// networkit-format
+
+#include <networkit/components/ComponentDecomposition.hpp>
+
+namespace NetworKit {
+
+ComponentDecomposition::ComponentDecomposition(const Graph &G)
+    : G(&G), component(G.upperNodeIdBound()) {
+    hasRun = false;
+}
+
+count ComponentDecomposition::numberOfComponents() const {
+    assureFinished();
+    return component.upperBound();
+}
+
+count ComponentDecomposition::componentOfNode(node u) const {
+    assureFinished();
+    assert(component[u] != none);
+    return component[u];
+}
+
+const Partition &ComponentDecomposition::getPartition() const {
+    assureFinished();
+    return component;
+}
+
+std::vector<std::vector<node>> ComponentDecomposition::getComponents() const {
+    assureFinished();
+    std::vector<std::vector<node>> result(numberOfComponents());
+    G->forNodes([&](node u) { result[component[u]].push_back(u); });
+    return result;
+}
+
+std::map<index, count> ComponentDecomposition::getComponentSizes() const {
+    assureFinished();
+    return component.subsetSizeMap();
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -7,126 +7,26 @@
 
 // networkit-format
 
-#include <set>
-#include <unordered_map>
+#include "ConnectedComponentsImpl.hpp"
 
-#include <networkit/auxiliary/Log.hpp>
 #include <networkit/components/ConnectedComponents.hpp>
-#include <networkit/graph/GraphTools.hpp>
-#include <networkit/structures/Partition.hpp>
 
 namespace NetworKit {
 
-ConnectedComponents::ConnectedComponents(const Graph &G) : G(&G) {
-    if (G.isDirected()) {
-        throw std::runtime_error("Error, connected components of directed graphs cannot be "
-                                 "computed, use StronglyConnectedComponents for them.");
-    }
-}
+ConnectedComponents::ConnectedComponents(const Graph &G)
+    : ComponentDecomposition(G),
+      impl(new ConnectedComponentsDetails::ConnectedComponentsImpl<false>{G, component}) {}
+
+ConnectedComponents::~ConnectedComponents() = default;
 
 void ConnectedComponents::run() {
-    DEBUG("initializing labels");
-    component = Partition(G->upperNodeIdBound(), none);
-    numComponents = 0;
-
-    std::queue<node> q;
-
-    // perform breadth-first searches
-    G->forNodes([&](node u) {
-        if (component[u] == none) {
-            component.setUpperBound(numComponents + 1);
-            index c = numComponents;
-
-            q.push(u);
-            component[u] = c;
-
-            do {
-                node u = q.front();
-                q.pop();
-                // enqueue neighbors, set component
-                G->forNeighborsOf(u, [&](node v) {
-                    if (component[v] == none) {
-                        q.push(v);
-                        component[v] = c;
-                    }
-                });
-            } while (!q.empty());
-
-            ++numComponents;
-        }
-    });
-
+    impl->run();
     hasRun = true;
 }
 
-Partition ConnectedComponents::getPartition() const {
-    assureFinished();
-    return this->component;
-}
-
-std::vector<std::vector<node>> ConnectedComponents::getComponents() const {
-    assureFinished();
-
-    std::vector<std::vector<node>> result(numComponents);
-
-    G->forNodes([&](node u) { result[component[u]].push_back(u); });
-
-    return result;
-}
-
-std::map<index, count> ConnectedComponents::getComponentSizes() const {
-    assureFinished();
-    return this->component.subsetSizeMap();
-}
-
 Graph ConnectedComponents::extractLargestConnectedComponent(const Graph &G, bool compactGraph) {
-    if (!G.numberOfNodes()) {
-        return G;
-    }
-
-    ConnectedComponents cc(G);
-    cc.run();
-
-    const auto compSizes = cc.getComponentSizes();
-    if (compSizes.size() == 1) {
-        if (compactGraph) {
-            return GraphTools::getCompactedGraph(G, GraphTools::getContinuousNodeIds(G));
-        }
-        return G;
-    }
-
-    const auto largestCC =
-        std::max_element(compSizes.begin(), compSizes.end(),
-                         [](const std::pair<index, count> &x, const std::pair<index, count> &y) {
-                             return x.second < y.second;
-                         });
-
-    if (compactGraph) {
-        std::unordered_map<node, node> continuousNodeIds;
-        index nextId = 0;
-        G.forNodes([&](const node u) {
-            if (cc.componentOfNode(u) == largestCC->first) {
-                continuousNodeIds[u] = nextId++;
-            }
-        });
-
-        return GraphTools::getRemappedGraph(
-            G, largestCC->second, [&](const node u) { return continuousNodeIds[u]; },
-            [&](const node u) { return cc.componentOfNode(u) != largestCC->first; });
-
-    } else {
-        Graph S(G);
-        const auto components = cc.getComponents();
-        for (size_t i = 0; i < components.size(); ++i) {
-            if (i != largestCC->first) {
-                for (const auto u : components[i]) {
-                    S.removeNode(u);
-                }
-            }
-        }
-
-        return S;
-    }
+    return ConnectedComponentsDetails::ConnectedComponentsImpl<
+        false>::extractLargestConnectedComponent(G, compactGraph);
 }
 
 } // namespace NetworKit

--- a/networkit/cpp/components/ConnectedComponentsImpl.cpp
+++ b/networkit/cpp/components/ConnectedComponentsImpl.cpp
@@ -1,0 +1,107 @@
+// networkit-format
+
+#include "ConnectedComponentsImpl.hpp"
+
+#include <networkit/graph/GraphTools.hpp>
+
+namespace NetworKit {
+namespace ConnectedComponentsDetails {
+
+template <bool WeaklyCC>
+ConnectedComponentsImpl<WeaklyCC>::ConnectedComponentsImpl(const Graph &G, Partition &components)
+    : G(&G), componentPtr(&components) {
+
+    if (!WeaklyCC && G.isDirected())
+        throw std::runtime_error(
+            "Error, connected components of directed graphs cannot be "
+            "computed, use StronglyConnectedComponents or WeaklyConnectedComponents instead.");
+
+    if (WeaklyCC && !G.isDirected())
+        throw std::runtime_error("Error, weakly connected components of an undirected graph cannot "
+                                 "be computed, use ConnectedComponents instead.");
+}
+
+template <bool WeaklyCC>
+void ConnectedComponentsImpl<WeaklyCC>::run() {
+    index nComponents = 0;
+    count visitedNodes = 0;
+
+    std::queue<node> q;
+    auto &component = *componentPtr;
+    component.reset(G->upperNodeIdBound(), none);
+
+    // perform breadth-first searches
+    for (const node u : G->nodeRange()) {
+        if (component[u] != none)
+            continue;
+
+        component.setUpperBound(nComponents + 1);
+        const index c = nComponents;
+
+        q.push(u);
+        component[u] = c;
+
+        do {
+            const node v = q.front();
+            q.pop();
+            ++visitedNodes;
+
+            const auto visitNeighbor = [&](node w) -> void {
+                if (component[w] == none) {
+                    q.push(w);
+                    component[w] = c;
+                }
+            };
+
+            // enqueue neighbors, set component
+            G->forNeighborsOf(v, visitNeighbor);
+            if (WeaklyCC)
+                G->forInNeighborsOf(v, visitNeighbor);
+
+        } while (!q.empty());
+
+        ++nComponents;
+
+        if (visitedNodes == G->numberOfNodes())
+            break;
+    }
+
+    hasRun = true;
+}
+
+template <bool WeaklyCC>
+Graph ConnectedComponentsImpl<WeaklyCC>::extractLargestConnectedComponent(const Graph &G,
+                                                                          bool compactGraph) {
+    if (G.isEmpty())
+        return G;
+
+    Partition component;
+    ConnectedComponentsImpl<WeaklyCC> cc(G, component);
+    cc.run();
+    const auto compSizes = component.subsetSizeMap();
+    if (compSizes.size() == 1) {
+        if (compactGraph)
+            return GraphTools::getCompactedGraph(G, GraphTools::getContinuousNodeIds(G));
+        return G;
+    }
+
+    const auto largestCCIndex =
+        std::max_element(compSizes.begin(), compSizes.end(),
+                         [](const std::pair<index, count> &x, const std::pair<index, count> &y) {
+                             return x.second < y.second;
+                         })
+            ->first;
+
+    const auto nodesInLCC = component.getMembers(largestCCIndex);
+    const auto largestCC = GraphTools::subgraphFromNodes(G, {nodesInLCC.begin(), nodesInLCC.end()});
+    if (compactGraph)
+        return GraphTools::getCompactedGraph(largestCC,
+                                             GraphTools::getContinuousNodeIds(largestCC));
+    return largestCC;
+}
+
+template class ConnectedComponentsImpl<false>;
+template class ConnectedComponentsImpl<true>;
+
+} // namespace ConnectedComponentsDetails
+} // namespace NetworKit

--- a/networkit/cpp/components/ConnectedComponentsImpl.hpp
+++ b/networkit/cpp/components/ConnectedComponentsImpl.hpp
@@ -1,0 +1,49 @@
+// networkit-format
+
+#ifndef NETWORKIT_COMPONENTS_CONNECTED_COMPONENTS_GENERAL_HPP_
+#define NETWORKIT_COMPONENTS_CONNECTED_COMPONENTS_GENERAL_HPP_
+
+#include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/structures/Partition.hpp>
+
+namespace NetworKit {
+namespace ConnectedComponentsDetails {
+
+/**
+ * @ingroup components
+ * Determines the (weakly) connected components of a graph.
+ */
+template <bool WeaklyCC = false>
+class ConnectedComponentsImpl final : public Algorithm {
+public:
+    /* Create the ConnectedComponentsImpl class for graph @G.
+     *
+     * @param G The graph.
+     */
+    ConnectedComponentsImpl(const Graph &G, Partition &components);
+
+    /*
+     * Compute the (weakly) connected components of the input graph.
+     */
+    void run() override;
+
+    /**
+     * Constructs a new graph that contains only the nodes inside the largest
+     * (weakly) connected component.
+     * @param G            The input graph.
+     * @param compactGraph If true, the node ids of the output graph will be compacted
+     * (i.e. re-numbered from 0 to n-1). If false, the node ids will not be changed.
+     * @return The largest (weakly) connected component of the input graph @a G.
+     */
+    static Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph);
+
+private:
+    const Graph *G;
+    Partition *componentPtr;
+};
+
+} // namespace ConnectedComponentsDetails
+} // namespace NetworKit
+
+#endif /* ifndef NETWORKIT_COMPONENTS_CONNECTED_COMPONENTS_GENERAL_HPP_ */

--- a/networkit/cpp/components/StronglyConnectedComponents.cpp
+++ b/networkit/cpp/components/StronglyConnectedComponents.cpp
@@ -18,7 +18,9 @@
 
 namespace NetworKit {
 
-StronglyConnectedComponents::StronglyConnectedComponents(const Graph &G) : G(&G) {
+StronglyConnectedComponents::StronglyConnectedComponents(const Graph &G)
+    : ComponentDecomposition(G) {
+
     if (!G.isDirected())
         WARN("The input graph is undirected, use ConnectedComponents for more efficiency.");
 }
@@ -43,7 +45,7 @@ void StronglyConnectedComponents::run() {
     std::vector<node> lastVisited(n, none);
 
     count curDepth = 0, visitedNodes = 0;
-    componentIndex = 0;
+    index nComponents = 0;
 
     std::stack<std::pair<node, Graph::NeighborIterator>> dfsStack;
 

--- a/networkit/cpp/components/WeaklyConnectedComponents.cpp
+++ b/networkit/cpp/components/WeaklyConnectedComponents.cpp
@@ -3,108 +3,31 @@
  *
  *  Created on: June 20, 2017
  *      Author: Eugenio Angriman
-*/
+ */
+
+// networkit-format
+
+#include "ConnectedComponentsImpl.hpp"
 
 #include <networkit/components/WeaklyConnectedComponents.hpp>
 
 namespace NetworKit {
 
-    WeaklyConnectedComponents::WeaklyConnectedComponents(const Graph& G) :
-    G(G) {
-        if (!G.isDirected()) {
-            throw std::runtime_error("Weakly Connected Components can be computeed for directed graphs. Use ConnectedComponents for undirected graphs.");
-        }
-    }
+WeaklyConnectedComponents::WeaklyConnectedComponents(const Graph &G)
+    : ComponentDecomposition(G),
+      impl(new ConnectedComponentsDetails::ConnectedComponentsImpl<true>{G, component}) {}
 
-    void WeaklyConnectedComponents::init() {
+WeaklyConnectedComponents::~WeaklyConnectedComponents() = default;
 
-        if (hasRun) {
-            compSize.clear();
-            std::fill(components.begin(), components.end(), none);
-        }
-        else {
-            components.assign(G.upperNodeIdBound(), none);
-        }
-
-        hasRun = false;
-    }
-
-    void WeaklyConnectedComponents::run() {
-
-        // Initialization of data structures
-        init();
-
-        // Queue for BFS.
-        std::queue<node> q;
-
-        // Perform BFSs to assign a component ID to each node.
-        G.forNodes([&](node u) {
-
-            // Node u has not been visited.
-            if (components[u] == none) {
-
-                // New component ID.
-                index c = compSize.size();
-                components[u] = c;
-                compSize.insert(std::make_pair(c, 1));
-
-
-                // Start a new BFS from u.
-                q.push(u);
-
-                do {
-                    node v = q.front();
-                    q.pop();
-
-                    // Enqueue neighbors (both from in and out edges) and set
-                    // new component.
-                    G.forNeighborsOf(v, [&](node w) {
-                        updateComponent(c, w, q, false);
-                    });
-
-                    G.forInNeighborsOf(v, [&](node w) {
-                        updateComponent(c, w, q, true);
-
-                    });
-                } while (!q.empty());
-            }
-        });
-
-        hasRun = true;
-    }
-
-    void WeaklyConnectedComponents::updateComponent(
-        index c, node w, std::queue<node>& q, bool
-    ) {
-
-        if (components[w] == none) {
-            q.push(w);
-            components[w] = c;
-            compSize.find(c)->second += 1;
-        }
-    }
-
-
-    std::vector<std::vector<node> > WeaklyConnectedComponents::getComponents() {
-        assureFinished();
-
-        // transform partition into vector of unordered_set
-        std::vector<std::vector<node> > result(compSize.size());
-        std::map<index, count> compIndex;
-
-        int i = 0;
-        for (auto it=compSize.begin(); it!=compSize.end(); ++it) {
-            auto indexIterator = compIndex.find(it->first);
-            if (indexIterator == compIndex.end()) {
-                compIndex.insert(std::pair<index, count>(it->first, i));
-                ++i;
-            }
-        }
-
-        G.forNodes([&](node u) {
-            result[compIndex.find(components[u])->second].push_back(u);
-        });
-
-        return result;
-    }
+void WeaklyConnectedComponents::run() {
+    impl->run();
+    hasRun = true;
 }
+
+Graph WeaklyConnectedComponents::extractLargestWeaklyConnectedComponent(const Graph &G,
+                                                                        bool compactGraph) {
+    return ConnectedComponentsDetails::ConnectedComponentsImpl<
+        true>::extractLargestConnectedComponent(G, compactGraph);
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
@@ -11,6 +11,7 @@
 #include <networkit/components/StronglyConnectedComponents.hpp>
 #include <networkit/components/DynConnectedComponents.hpp>
 #include <networkit/components/DynWeaklyConnectedComponents.hpp>
+#include <networkit/components/WeaklyConnectedComponents.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/graph/GraphTools.hpp>
 #include <networkit/graph/BFS.hpp>
@@ -604,5 +605,28 @@ TEST_F(ConnectedComponentsGTest, testExtractLargestConnectedComponent) {
     EXPECT_EQ(G1.numberOfEdges(), 4);
 }
 
+TEST_F(ConnectedComponentsGTest, testExtractLargestStronglyConnectedComponent) {
+    Aux::Random::setSeed(42, true);
+    for (double p : {0.02, 0.025, 0.03}) {
+        const auto G = ErdosRenyiGenerator(100, p, true).generate();
+        auto lSCC = StronglyConnectedComponents::extractLargestStronglyConnectedComponent(G);
+        StronglyConnectedComponents scc(G);
+        scc.run();
+        const auto sizes = scc.getPartition().subsetSizes();
+        const count maxSize = *std::max_element(sizes.begin(), sizes.end());
+
+        EXPECT_EQ(lSCC.numberOfNodes(), maxSize);
+        StronglyConnectedComponents sccCheck(lSCC);
+        sccCheck.run();
+        EXPECT_EQ(sccCheck.numberOfComponents(), 1);
+
+        lSCC = StronglyConnectedComponents::extractLargestStronglyConnectedComponent(G, true);
+        node u = 0;
+        lSCC.forNodes([&u](node v) {
+            EXPECT_EQ(u, v);
+            ++u;
+        });
+    }
+}
 
 } /* namespace NetworKit */

--- a/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
@@ -10,7 +10,6 @@
 #include <networkit/components/ParallelConnectedComponents.hpp>
 #include <networkit/components/StronglyConnectedComponents.hpp>
 #include <networkit/components/DynConnectedComponents.hpp>
-#include <networkit/components/WeaklyConnectedComponents.hpp>
 #include <networkit/components/DynWeaklyConnectedComponents.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/graph/GraphTools.hpp>
@@ -30,10 +29,8 @@ class ConnectedComponentsGTest: public testing::Test{};
 
 TEST_F(ConnectedComponentsGTest, testConnectedComponentsTiny) {
     // construct graph
-    Graph g;
-    for (count i = 0; i < 20; i++) {
-        g.addNode();
-    }
+    Graph g(20);
+
     g.addEdge(0,1,0);
     g.addEdge(1,2,0);
     g.addEdge(2,4,0);
@@ -445,10 +442,8 @@ TEST_F(ConnectedComponentsGTest, testWeaklyConnectedComponents) {
 
 TEST_F(ConnectedComponentsGTest, testDynWeaklyConnectedComponentsTiny) {
     // construct graph
-    Graph g(0, false, true);
-    for (count i = 0; i < 20; i++) {
-        g.addNode();
-    }
+    Graph g(20, false, true);
+
     g.addEdge(0,1,0);
     g.addEdge(1,2,0);
     g.addEdge(2,4,0);
@@ -474,14 +469,14 @@ TEST_F(ConnectedComponentsGTest, testDynWeaklyConnectedComponentsTiny) {
 
     // check result
     EXPECT_EQ(5, dw.numberOfComponents());
-    EXPECT_TRUE(dw.componentOfNode(0) == dw.componentOfNode(19));
-    EXPECT_TRUE(dw.componentOfNode(3) == dw.componentOfNode(7));
+    EXPECT_EQ(dw.componentOfNode(0), dw.componentOfNode(19));
+    EXPECT_EQ(dw.componentOfNode(3), dw.componentOfNode(7));
 
     g.addEdge(13, 15, 0);
     dw.update(GraphEvent(GraphEvent::EDGE_ADDITION, 13, 15, 0));
     EXPECT_EQ(4, dw.numberOfComponents());
-    EXPECT_TRUE(dw.componentOfNode(14) == dw.componentOfNode(15));
-    EXPECT_TRUE(dw.componentOfNode(15) != dw.componentOfNode(0));
+    EXPECT_EQ(dw.componentOfNode(14), dw.componentOfNode(15));
+    EXPECT_NE(dw.componentOfNode(15), dw.componentOfNode(0));
 
     // Create batch and update
     std::vector<GraphEvent> batch {


### PR DESCRIPTION
- `WeaklyConnectedComponents` uses the same algorithm as `ConnectedComponents`, but it is re-implemented in a different file. This PR merges the two implementations in a single one using pimpl.
- A new class `ConnectedComponentsInterface` that inherits from `Algorithm` implements all methods needed for all algorithms that compute components in a graph.
- New method to extract the largest strongly connected component from a directed graph.