### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,109 +9,108 @@ env:
     - export CXX_STANDARD=11
     - export MONOLITH=ON
 
+stages:
+  - "Core tests"
+  - "Additional tests"
+
+cache:
+  timeout: 600
+  ccache: true
+  directories:
+    - $HOME/Library/Caches/Homebrew
+
 jobs:
   include:
+    - name: macOS 10.15, Apple Clang
+      env:
+        - CC=cc
+        - CXX=c++
+      os: osx
+      osx_image: xcode12
+      stage: "Core tests"
+      addons:
+        homebrew:
+          packages:
+            - libomp
+          update: false
+
+    - name: macOS 10.15, llvm 10
+      env:
+        - CC=/usr/local/opt/llvm@10/bin/clang
+        - CXX=/usr/local/opt/llvm@10/bin/clang++
+      os: osx
+      osx_image: xcode12
+      stage: "Additional tests"
+      addons:
+        homebrew:
+          packages:
+            - llvm
+            - libomp
+          update: true
+
+    - name: macOS 10.15, GCC 10
+      env:
+        - CC=/usr/local/opt/gcc@10/bin/gcc-10
+        - CXX=/usr/local/opt/gcc@10/bin/g++-10
+      os: osx
+      osx_image: xcode12
+      stage: "Additional tests"
+      addons:
+        homebrew:
+          packages:
+            - gcc@10
+          update: true
+      before_install:
+        - brew link gcc
+
     - name: macOS 10.14, Apple Clang
       env:
         - CC=cc
         - CXX=c++
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.3
+      stage: "Core tests"
       addons:
         homebrew:
           packages:
             - libomp
-          update: true
+          update: false
 
-    - name: macOS 10.14, llvm 8
+    - name: macOS 10.14, llvm 10
       env:
-        - CC=/usr/local/opt/llvm@8/bin/clang
-        - CXX=/usr/local/opt/llvm@8/bin/clang++
+        - CC=/usr/local/opt/llvm@10/bin/clang
+        - CXX=/usr/local/opt/llvm@10/bin/clang++
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.3
+      stage: "Additional tests"
       addons:
         homebrew:
           packages:
-            - llvm@8
+            - llvm
             - libomp
           update: true
 
-    - name: macOS 10.14, GCC 8
+    - name: macOS 10.14, GCC 10
       env:
-        - CC=/usr/local/opt/gcc@8/bin/gcc-8
-        - CXX=/usr/local/opt/gcc@8/bin/g++-8
+        - CC=/usr/local/opt/gcc@10/bin/gcc-10
+        - CXX=/usr/local/opt/gcc@10/bin/g++-10
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.3
+      stage: "Additional tests"
       addons:
         homebrew:
           packages:
-            - gcc@8
+            - gcc@10
           update: true
       before_install:
-        - brew link gcc@8
-
-    - name: macOS 10.14, Apple Clang, non-monolith
-      env:
-        - CC=cc
-        - CXX=c++
-      os: osx
-      osx_image: xcode10.2
-      addons:
-        homebrew:
-          packages:
-            - libomp
-          update: true
-      script:
-        - $CXX --version
-        - mkdir build_non_monolith && cd "$_"
-        - cmake -DNETWORKIT_MONOLITH=OFF -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug ..
-        - make -j2
-        - ctest -V
-
-    - name: macOS 10.13, llvm 8
-      env:
-        - CC=/usr/local/opt/llvm@8/bin/clang
-        - CXX=/usr/local/opt/llvm@8/bin/clang++
-      os: osx
-      osx_image: xcode10.1
-      addons:
-        homebrew:
-          packages:
-            - llvm@8
-            - libomp
-          update: true
-
-    - name: macOS 10.13, GCC 8
-      env:
-        - CC=/usr/local/opt/gcc@8/bin/gcc-8
-        - CXX=/usr/local/opt/gcc@8/bin/g++-8
-      os: osx
-      osx_image: xcode10.1
-      addons:
-        homebrew:
-          packages:
-            - gcc@8
-          update: true
-      before_install:
-        - brew link gcc@8
-
-    - name: macOS 10.13, Apple Clang
-      env:
-        - CC=cc
-        - CXX=c++
-      os: osx
-      osx_image: xcode10.1
-      addons:
-        homebrew:
-          packages:
-            - libomp
-          update: true
+        - brew link gcc
 
     - name: Linux, Clang 9 with clang-tidy
       env:
         - CC=clang
         - CXX=clang++
       os: linux
+      stage: "Core tests"
       dist: bionic
       addons:
         apt:
@@ -141,6 +140,7 @@ jobs:
     - name: "Linux, GCC 5: Core build, sanitizers, coverage"
       compiler: gcc
       os: linux
+      stage: "Core tests"
       dist: xenial
       addons: &gcc5
         apt:
@@ -159,26 +159,28 @@ jobs:
         - cd ..
         - coveralls -E ".*test/.*" -E ".*CMakeFiles.*" --exclude extlibs --exclude pyenv --exclude scripts --root .
 
-    - name: Linux, GCC 8
+    - name: Linux, GCC 10
       env:
-        - CC=gcc-8
-        - CXX=g++-8
+        - CC=gcc-10
+        - CXX=g++-10
       os: linux
-      dist: xenial
-      addons: &gcc8
+      stage: "Additional tests"
+      dist: bionic
+      addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-8
+            - g++-10
             - python3-pip
-            - python3.5-venv
+            - python3-venv
 
     - name: Linux, GCC 4.9
       env:
         - CC=gcc-4.9
         - CXX=g++-4.9
       os: linux
+      stage: "Core tests"
       dist: xenial
       addons:
         apt:
@@ -195,6 +197,7 @@ jobs:
         - CC=clang-3.8
         - CXX=clang++-3.8
       os: linux
+      stage: "Core tests"
       dist: xenial
       addons:
         apt:
@@ -208,13 +211,19 @@ jobs:
             - python3.5-venv
 
     # Test more exotic builds only on Linux.
-    - name: "Linux, GCC 8: Core build, debugging"
+    - name: "Linux, GCC 10: Core build, debugging"
       env:
-        - CC=gcc-8
-        - CXX=g++-8
+        - CC=gcc-10
+        - CXX=g++-10
       os: linux
-      dist: xenial
-      addons: *gcc8
+      stage: "Additional tests"
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-10
       script: &script_cpp_only
         - $CXX --version
         - mkdir debug_test && cd "$_"
@@ -222,51 +231,86 @@ jobs:
         - make -j2
         - ctest -V
 
-    - name: "Linux, GCC 8: Core build, non-monolithic"
+    - name: "Linux, GCC 10: Core build, non-monolithic"
       env:
-        - CC=gcc-8
-        - CXX=g++-8
+        - CC=gcc-10
+        - CXX=g++-10
         - MONOLITH=OFF
       os: linux
-      dist: xenial
-      addons: *gcc8
-      script: *script_cpp_only
-
-    # Finally, test conformance to newer versions of the C++ standard.
-    - name: "Linux, GCC 8: C++14 conformance"
-      env:
-        - CC=gcc-8
-        - CXX=g++-8
-        - CXX_STANDARD=14
-      os: linux
-      dist: xenial
-      addons: *gcc8
-      script: *script_cpp_only
-
-    - name: "Linux, GCC 8: C++17 conformance"
-      env:
-        - CC=gcc-8
-        - CXX=g++-8
-        - CXX_STANDARD=17
-      os: linux
-      dist: xenial
-      addons: *gcc8
-      script: *script_cpp_only
-
-    - name: Documentation only
-      env:
-        - CC=gcc-8
-        - CXX=g++-8
-      os: linux
-      dist: xenial
+      stage: "Additional tests"
+      dist: bionic
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-8
+            - g++-10
+      script: *script_cpp_only
+
+    # Finally, test conformance to newer versions of the C++ standard.
+    - name: "Linux, GCC 10: C++14 conformance"
+      env:
+        - CC=gcc-10
+        - CXX=g++-10
+        - CXX_STANDARD=14
+      os: linux
+      stage: "Additional tests"
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-10
+      script: *script_cpp_only
+
+    - name: "Linux, GCC 10: C++17 conformance"
+      env:
+        - CC=gcc-10
+        - CXX=g++-10
+        - CXX_STANDARD=17
+      os: linux
+      stage: "Additional tests"
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-10
+      script: *script_cpp_only
+
+    - name: "Linux, GCC 10: C++20 conformance"
+      env:
+        - CC=gcc-10
+        - CXX=g++-10
+        - CXX_STANDARD=20
+      os: linux
+      stage: "Additional tests"
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-10
+      script: *script_cpp_only
+
+    - name: Documentation only
+      env:
+        - CC=gcc-10
+        - CXX=g++-10
+      os: linux
+      stage: "Core tests"
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-10
             - python3-pip
-            - python3.5-venv
+            - python3-venv
             - doxygen
       script:
         - set -e
@@ -303,6 +347,7 @@ jobs:
 
     - name: "Style guide compliance"
       os: linux
+      stage: "Core tests"
       dist: bionic
       addons:
         apt:
@@ -343,6 +388,9 @@ script:
 
  # Test Jupyter-notebooks
  - python3 notebooks/test_notebooks.py 'notebooks/'
+
+before_cache:   
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ stages:
   - "Core tests"
   - "Additional tests"
 
-cache:
-  timeout: 600
-  ccache: true
-  directories:
-    - $HOME/Library/Caches/Homebrew
-
 jobs:
   include:
     - name: macOS 10.15, Apple Clang
@@ -33,6 +27,26 @@ jobs:
           packages:
             - libomp
           update: false
+
+    - name: macOS 10.15, Apple Clang, non-monolithic
+      env:
+        - CC=cc
+        - CXX=c++
+        - MONOLITH=off
+      os: osx
+      osx_image: xcode12
+      stage: "Additional tests"
+      addons:
+        homebrew:
+          packages:
+            - libomp
+          update: true
+      script: &script_cpp_only
+        - $CXX --version
+        - mkdir debug_test && cd "$_"
+        - cmake -DNETWORKIT_BUILD_TESTS=ON -DNETWORKIT_MONOLITH=$MONOLITH -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD -DNETWORKIT_WARNINGS=ON -DCMAKE_BUILD_TYPE=Debug ..
+        - make -j2
+        - ctest -V
 
     - name: macOS 10.15, llvm 10
       env:
@@ -224,12 +238,7 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             - g++-10
-      script: &script_cpp_only
-        - $CXX --version
-        - mkdir debug_test && cd "$_"
-        - cmake -DNETWORKIT_BUILD_TESTS=ON -DNETWORKIT_MONOLITH=$MONOLITH -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD -DNETWORKIT_WARNINGS=ON -DCMAKE_BUILD_TYPE=Debug ..
-        - make -j2
-        - ctest -V
+      script: *script_cpp_only
 
     - name: "Linux, GCC 10: Core build, non-monolithic"
       env:
@@ -388,9 +397,6 @@ script:
 
  # Test Jupyter-notebooks
  - python3 notebooks/test_notebooks.py 'notebooks/'
-
-before_cache:   
- - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 
 notifications:
   email: false

--- a/extlibs/ttmath/ttmath/ttmathuint.hpp
+++ b/extlibs/ttmath/ttmath/ttmathuint.hpp
@@ -1281,7 +1281,7 @@ private:
         }
 
 
-        if( (ss_size & 1) == 1 )
+        if( ss_size & 1 )
         {
             // ss_size is odd
             x0 = ss1;

--- a/include/networkit/viz/Point.hpp
+++ b/include/networkit/viz/Point.hpp
@@ -316,26 +316,26 @@ public:
 
     /// Access i-th coordintate without boundary check
     T &operator[](index i) noexcept {
-        assert(i >= 0 && i < data.size());
+        assert(i < data.size());
         return data[i];
     }
 
     /// Access i-th coordintate with boundary check
     T &at(index i) {
-        if (!(i >= 0 && i < data.size()))
+        if (!(i < data.size()))
             throw std::out_of_range{""};
         return data[i];
     }
 
     /// Access i-th coordintate without boundary check
     T operator[](index i) const noexcept {
-        assert(i >= 0 && i < data.size());
+        assert(i < data.size());
         return data[i];
     }
 
     /// Access i-th coordintate with boundary check
     T at(index i) const {
-        if (!(i >= 0 && i < data.size()))
+        if (!(i < data.size()))
             throw std::out_of_range{""};
         return data[i];
     }

--- a/networkit/cpp/distance/BidirectionalBFS.cpp
+++ b/networkit/cpp/distance/BidirectionalBFS.cpp
@@ -45,7 +45,7 @@ void BidirectionalBFS::run() {
     visited[target] = ts + ballMask;
 
     bool stop = false;
-    node s, t;
+    node s = none, t = none;
 
     // Expands a ball of a level; idx is the ball index (either 0 or 1<<7)
     auto expand = [&](std::queue<node> &q, std::queue<node> &q_, uint8_t idx) {
@@ -100,6 +100,8 @@ void BidirectionalBFS::run() {
     if (!stop)
         stDist = std::numeric_limits<count>::max();
     else if (storePred) {
+        assert(s != none);
+        assert(t != none);
 
         // Reverse predecessors to target
         node t1 = pred[t];

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -422,7 +422,7 @@ std::vector<node> invertContinuousNodeIds(const std::unordered_map<node, node> &
     // store upper node id bound
     invertedIdMap[G.numberOfNodes()] = G.upperNodeIdBound();
     // inverted node mapping
-    for (const auto x : nodeIdMap) {
+    for (const auto &x : nodeIdMap) {
         invertedIdMap[x.second] = x.first;
     }
     return invertedIdMap;

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -1181,7 +1181,7 @@ TEST_P(GraphGTest, testEdgeIterator) {
         ASSERT_EQ(postIter, G.edgeRange().end());
 
         G1 = G;
-        for (const auto &edge : Graph::EdgeRange(G)) {
+        for (const auto edge : Graph::EdgeRange(G)) {
             ASSERT_TRUE(G1.hasEdge(edge.u, edge.v));
             G1.removeEdge(edge.u, edge.v);
         }
@@ -1210,7 +1210,7 @@ TEST_P(GraphGTest, testEdgeIterator) {
         ASSERT_EQ(postIter, G.edgeWeightRange().end());
 
         G1 = G;
-        for (const auto &edge : Graph::EdgeWeightRange(G)) {
+        for (const auto edge : Graph::EdgeWeightRange(G)) {
             ASSERT_TRUE(G1.hasEdge(edge.u, edge.v));
             ASSERT_DOUBLE_EQ(G1.weight(edge.u, edge.v), edge.weight);
             G1.removeEdge(edge.u, edge.v);

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -259,7 +259,7 @@ TEST_P(GraphToolsGTest, testRandomEdges) {
     ASSERT_EQ(m, G.numberOfEdges());
 
     std::vector<count> drawCounts(m, 0);
-    for (const auto e : GraphTools::randomEdges(G, samples)) {
+    for (const auto &e : GraphTools::randomEdges(G, samples)) {
         const auto id = (e.first * e.second) % 5;
         ++drawCounts[id];
     }

--- a/networkit/cpp/randomization/CurveballImpl.cpp
+++ b/networkit/cpp/randomization/CurveballImpl.cpp
@@ -249,7 +249,7 @@ void TradeList::initialize(const trade_vector &trades) {
     std::vector<tradeid> trade_count(numNodes);
 
     // Push occurrences
-    for (const auto trade : trades) {
+    for (const auto &trade : trades) {
         assert(trade.first < numNodes);
         assert(trade.second < numNodes);
 
@@ -274,7 +274,7 @@ void TradeList::initialize(const trade_vector &trades) {
     std::fill(trade_count.begin(), trade_count.end(), 0);
     {
         tradeid trade_id = 0;
-        for (const auto trade : trades) {
+        for (const auto &trade : trades) {
             auto updateNode = [&](const node u) {
                 const node pos = offsets[u] + trade_count[u];
                 tradeList[pos] = trade_id;
@@ -298,7 +298,7 @@ TradeList::TradeList(const trade_vector &trades, const node num_nodes)
     std::vector<tradeid> trade_count(num_nodes);
 
     // Push occurences
-    for (const auto trade : trades) {
+    for (const auto &trade : trades) {
         assert(trade.first < num_nodes);
         assert(trade.second < num_nodes);
 
@@ -323,7 +323,7 @@ TradeList::TradeList(const trade_vector &trades, const node num_nodes)
     std::fill(trade_count.begin(), trade_count.end(), 0);
     {
         tradeid trade_id = 0;
-        for (const auto trade : trades) {
+        for (const auto &trade : trades) {
             auto updateNode = [&](const node u) {
                 const node pos = offsets[u] + trade_count[u];
                 tradeList[pos] = trade_id;
@@ -373,7 +373,7 @@ void CurveballIM::restructureGraph(const std::vector<std::pair<node, node>> &tra
     adjList.restructure();
     tradeList.initialize(trades);
 
-    for (const auto edge : edges) {
+    for (const auto &edge : edges) {
         update(edge.first, edge.second);
     }
 

--- a/networkit/cpp/viz/PostscriptWriter.cpp
+++ b/networkit/cpp/viz/PostscriptWriter.cpp
@@ -39,7 +39,7 @@ PostscriptWriter::PostscriptWriter(bool isTorus) : wrapAround(isTorus), ps_size{
 void PostscriptWriter::computeBoundaryBox(const std::vector<Point2D> &coordinates) {
     ps_min = {std::numeric_limits<coordinate>::max(), std::numeric_limits<coordinate>::max()};
     ps_max = {std::numeric_limits<coordinate>::min(), std::numeric_limits<coordinate>::min()};
-    for (const auto p : coordinates) {
+    for (const auto &p : coordinates) {
         ps_min = ps_min.min(p);
         ps_max = ps_max.max(p);
     }


### PR DESCRIPTION
This PR updates the travis-builds with the following addtions/removals:

- Add macOS 10.15 (AppleClang 12.0)
- Drops macOS 10.13
- Removes the forced update for AppleClang-based macOS images
- ~~Removes the non-monolithic case for macOS~~
- Updates compilers to most recent version: gcc 8 -> 10.1, llvm 8 -> 10
- ~~Adds basic caching for brew-packages. This can reduce the time for updating brew between runs.~~
- Splits the test-builds into two phases: "Core" and "Additional". Since the execution of "Additional" is depending on the success of "Core", we don't have to wait for the whole pipeline to finish if there is an error in one of the "Core"-builds. I know there is no clear rule on where to put each test. Did this on what the following reasoning. "Core" is everything like the basic minimum requirements (minimum compilers for Linux or an unchanged system for macOS) and contribution guidelines. The rest goes into "Additional".

By updating to the most recent compilers, I found some errors (mostly induced by clang-tidy). These are fixed in the second commit.