### PR TITLE
Remove bugprone-branch-clone check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 Checks: >
     -*,
     bugprone-assert-side-effect,
-    bugprone-branch-clone,
     bugprone-copy-constructor-init,
     bugprone-dangling-handle,
     bugprone-dynamic-static-initializers,


### PR DESCRIPTION
`bugprone-branch-clone` produces false positives if an if-else statement contains a omp parallel loop e.g.:
```
if (something)
#pragma omp parallel
{
    // some code
}
else
#pragma omp parallel
{
    // some other code         
}
```
triggers the warning, even if the the parallel blocks are different.