### PR TITLE
Use Memory Mapped Files in EdgeListReader

### DIFF
--- a/include/networkit/io/EdgeListReader.hpp
+++ b/include/networkit/io/EdgeListReader.hpp
@@ -31,9 +31,9 @@ public:
     /**
      * @param[in]  separator  character used to separate nodes in an edge line
      * @param[in]  firstNode  index of the first node in the file
-     * @param[in]  commentChar  character used to mark comment lines
-     * @param[in]  continuous  boolean to specify, if node ids are continuous
-     * @param[in]  directed  treat graph as directed
+     * @param[in]  commentPrefix  prefix of comment lines
+     * @param[in]  continuous  boolean to specify if node ids are continuous
+     * @param[in]  directed  read graph as directed
      */
     EdgeListReader(char separator, node firstNode, const std::string &commentPrefix = "#",
                    bool continuous = true, bool directed = false);

--- a/include/networkit/io/EdgeListReader.hpp
+++ b/include/networkit/io/EdgeListReader.hpp
@@ -61,6 +61,8 @@ private:
     Graph readContinuous(const std::string &path);
 
     Graph readNonContinuous(const std::string &path);
+
+    static void malformedLineError(count lineNumber, const std::string &line);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/EdgeListReader.hpp
+++ b/include/networkit/io/EdgeListReader.hpp
@@ -57,12 +57,6 @@ private:
     bool continuous;
     std::map<std::string, node> mapNodeIds;
     bool directed;
-
-    Graph readContinuous(const std::string &path);
-
-    Graph readNonContinuous(const std::string &path);
-
-    static void malformedLineError(count lineNumber, const std::string &line);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/EdgeListReader.hpp
+++ b/include/networkit/io/EdgeListReader.hpp
@@ -48,7 +48,7 @@ public:
     /**
      * Return the node map, in case node ids are not continuous
      */
-    std::map<std::string, node> getNodeMap();
+    const std::map<std::string, node> &getNodeMap() const;
 
 private:
     char separator; //!< character separating nodes in an edge line

--- a/include/networkit/io/EdgeListReader.hpp
+++ b/include/networkit/io/EdgeListReader.hpp
@@ -35,7 +35,7 @@ public:
      * @param[in]  continuous  boolean to specify, if node ids are continuous
      * @param[in]  directed  treat graph as directed
      */
-    EdgeListReader(char separator, node firstNode, std::string commentPrefix = "#",
+    EdgeListReader(char separator, node firstNode, const std::string &commentPrefix = "#",
                    bool continuous = true, bool directed = false);
 
     /**

--- a/input/README.md
+++ b/input/README.md
@@ -10,6 +10,7 @@ This folder contains many smaller graphs. They are used in the testing suite and
 |----------------------------------|-------------------------|-------------------------|--------------------|-----------------|-----------------|----------|----------|---------|
 | airfoil1.gi                      | n/a                     | DibapGraphReader        | 149370             | 4253            | 12289           | FALSE    | FALSE    | n/a     |
 | airfoil1.graph                   | Format.METIS            | METISGraphReader        | 116538             | 4253            | 12289           | n/a      | n/a      | n/a     |
+| alphabet.edgelist                | Format.EdgeListTabOne   | EdgeListReader          | 69                 | 5               | 4               | FALSE    | TRUE     | n/a     |
 | astro-ph.graph                   | Format.METIS            | METISGraphReader        | 1259548            | 16706           | 121251          | FALSE    | FALSE    | n/a     |
 | caidaRouterLevel.graph           | Format.METIS            | METISGraphReader        | 7490360            | 192244          | 609066          | FALSE    | FALSE    | n/a     |
 | celegans_metabolic.graph         | Format.METIS            | METISGraphReader        | 16015              | 453             | 2025            | FALSE    | FALSE    | n/a     |

--- a/input/alphabet.edgelist
+++ b/input/alphabet.edgelist
@@ -1,0 +1,5 @@
+# weighted edgelist with non-numerical nodes
+a	b	3
+a	c	2
+c	d	1
+d	e	5

--- a/networkit/cpp/io/EdgeListReader.cpp
+++ b/networkit/cpp/io/EdgeListReader.cpp
@@ -29,7 +29,7 @@ Graph EdgeListReader::read(const std::string& path) {
     }
 }
 
-std::map<std::string,node> EdgeListReader::getNodeMap() {
+const std::map<std::string,node> &EdgeListReader::getNodeMap() const {
     if (this->continuous) throw std::runtime_error("Input files are assumed to have continuous node ids, therefore no node mapping has been created.");
     return this->mapNodeIds;
 }

--- a/networkit/cpp/io/EdgeListReader.cpp
+++ b/networkit/cpp/io/EdgeListReader.cpp
@@ -14,7 +14,7 @@
 
 namespace NetworKit {
 
-EdgeListReader::EdgeListReader(const char separator, const node firstNode, const std::string commentPrefix, const bool continuous, const bool directed) :
+EdgeListReader::EdgeListReader(char separator, node firstNode, const std::string &commentPrefix, bool continuous, bool directed) :
     separator(separator), commentPrefix(commentPrefix), firstNode(firstNode), continuous(continuous), mapNodeIds(), directed(directed) {}
 
 Graph EdgeListReader::read(const std::string& path) {

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -75,6 +75,7 @@ TEST_F(IOGTest, testEdgeListWriter){
     if (file) {
         exists = true;
     }
+    file.close();
     EXPECT_TRUE(exists) << "A file should have been created : " << path;
 
     EdgeListReader reader(' ', 1, "#", true, true);

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -381,6 +381,16 @@ TEST_F(IOGTest, testEdgeListReader) {
     EXPECT_EQ(10u, G4.numberOfEdges());
     EXPECT_TRUE(G4.hasEdge(0, 4));
 
+    path = "input/alphabet.edgelist";
+    DEBUG("reading file: " , path);
+    EdgeListReader reader5('\t', 0, "#", false, false);
+    Graph G5 = reader5.read(path);
+    EXPECT_EQ(5u, G5.numberOfNodes());
+    EXPECT_EQ(4u, G5.numberOfEdges());
+    EXPECT_TRUE(G5.hasEdge(0, 1));
+    EXPECT_TRUE(G5.hasEdge(0, 2));
+    EXPECT_EQ(5, G5.weight(3,4));
+    EXPECT_EQ(1, G5.weight(2,3));
 }
 
 TEST_F(IOGTest, testEdgeListPartitionReader) {


### PR DESCRIPTION
This PR refactors the `EdgeListReader` by using memory mapped files as suggested in #584 . The fixes from that PR are included here.
The `EdgeListReader` now handles continuous and non-continuous  edgelists in the same function, no longer needs to read the file twice and follows the style of the `KONECTGraphReader` and `SNAPGraphReader`.