### PR TITLE
io, numerics, global, linkprediction, scd, sparsification, viz: cpp coreguideline narrowing conversion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -61,6 +61,7 @@ WarningsAsErrors:  >
     bugprone-swapped-arguments,
     bugprone-unused-return-value,
     bugprone-use-after-move,
+    cppcoreguidelines-narrowing-conversions,
     bugprone-virtual-near-miss,
     modernize-deprecated-headers,
     modernize-use-emplace,

--- a/include/networkit/io/NetworkitBinaryGraph.hpp
+++ b/include/networkit/io/NetworkitBinaryGraph.hpp
@@ -86,7 +86,7 @@ inline size_t varIntEncode(uint64_t value, uint8_t *buffer) noexcept {
 
     } else {
         const auto bits = 64 - tlx::clz(value);
-        dataBytes = (bits - 1) / 7;
+        dataBytes = static_cast<int>((bits - 1) / 7);
 
         // number of bytes is encode by the number of trailing zeros
         buffer[0] = static_cast<uint8_t>(1 << dataBytes);
@@ -111,7 +111,7 @@ inline size_t varIntDecode(const uint8_t *data, uint64_t &value) noexcept {
     uint64_t decoded = 0;
 
     if (data[0]) {
-        n = tlx::ffs(data[0]) - 1;
+        n = static_cast<int>(tlx::ffs(data[0]) - 1);
         decoded = data[0] >> (n + 1);
         bitsRecovered = 7 - n;
     }

--- a/include/networkit/numerics/Preconditioner/DiagonalPreconditioner.hpp
+++ b/include/networkit/numerics/Preconditioner/DiagonalPreconditioner.hpp
@@ -33,7 +33,7 @@ public:
         inv_diag = A.diagonal();
 #pragma omp parallel for
         for (omp_index i = 0; i < static_cast<omp_index>(inv_diag.getDimension()); ++i) {
-            if (inv_diag[i]) inv_diag[i] = 1.0 / inv_diag[i];
+            if (inv_diag[i] > 0) inv_diag[i] = 1.0 / inv_diag[i];
         }
     }
 

--- a/networkit/cpp/global/ClusteringCoefficient.cpp
+++ b/networkit/cpp/global/ClusteringCoefficient.cpp
@@ -96,7 +96,7 @@ double ClusteringCoefficient::sequentialAvgLocal(const Graph &G) {
     G.forNodes([&](node u) {
         count d = G.degree(u);
         if (d > 1) {
-            coefficient += triangleCount[u] * 2.0 / (d * (d - 1));
+            coefficient += static_cast<double>(triangleCount[u]) * 2.0 / static_cast<double>(d * (d - 1));
             size++;
         }
     });

--- a/networkit/cpp/global/GlobalClusteringCoefficient.cpp
+++ b/networkit/cpp/global/GlobalClusteringCoefficient.cpp
@@ -16,7 +16,7 @@ int uniformRandom(int max) {
   int currentMax = 1;
   int currentValue = 0;
   while(currentMax < max) {
-    currentValue = currentValue * RAND_MAX + Aux::Random::integer();
+    currentValue = currentValue * RAND_MAX + static_cast<int>(Aux::Random::integer());
     currentMax *= RAND_MAX;
   }
   int value = currentValue % max;
@@ -28,7 +28,7 @@ unsigned int findIndex(const std::vector<int>& w, int v,
   if(upperIdx - lowerIdx <= 1) {
     return lowerIdx;
   }
-  int middleIdx = (upperIdx + lowerIdx) / 2;
+  int middleIdx = static_cast<int>((upperIdx + lowerIdx) / 2);
   if(v >= w[middleIdx]) {
     return findIndex(w, v, middleIdx, upperIdx);
   } else {
@@ -43,7 +43,7 @@ double GlobalClusteringCoefficient::approximate(const Graph& G, int k) {
   int sum = 0;
   for(node i = 0; i < n; i++) {
     w[i] = sum;
-    sum += (G.degree(i) * (G.degree(i) - 1)) / 2;
+    sum += static_cast<int>((G.degree(i) * (G.degree(i) - 1)) / 2);
   }
   w[n] = sum;
 

--- a/networkit/cpp/linkprediction/AdjustedRandIndex.cpp
+++ b/networkit/cpp/linkprediction/AdjustedRandIndex.cpp
@@ -33,7 +33,7 @@ double AdjustedRandIndex::runImpl(node u, node v) {
   double a = commonNeighbors.size();
   double b = uDifference.size();
   double c = vDifference.size();
-  double d = G->numberOfNodes() - unionNeighbors.size();
+  double d = static_cast<double>(G->numberOfNodes() - unionNeighbors.size());
   double ad = a*d;
   // Make sure to not divide by zero
   double denominator = (a*b + a*c + 2*ad + b*b + b*d + c*c + c*d);

--- a/networkit/cpp/linkprediction/EvaluationMetric.cpp
+++ b/networkit/cpp/linkprediction/EvaluationMetric.cpp
@@ -41,7 +41,7 @@ std::pair<std::vector<double>, std::vector<double>> EvaluationMetric::getCurve(s
     // Percentile calculation through nearest rank method.
     // This calculation is numerically instable. This is why we use a set to make sure that
     // we obtain pairwise different thresholds.
-    thresholdSet.insert(std::ceil(numPredictions * (1.0 * i / (numThresholds - 1))));
+    thresholdSet.insert(std::ceil(numPredictions * (1.0 * i / static_cast<double>(numThresholds - 1))));
   }
   thresholds.assign(thresholdSet.begin(), thresholdSet.end());
   // The extraction of statistical measures requires sorted predictions

--- a/networkit/cpp/linkprediction/PrecisionRecallMetric.cpp
+++ b/networkit/cpp/linkprediction/PrecisionRecallMetric.cpp
@@ -17,10 +17,10 @@ std::pair<std::vector<double>, std::vector<double>> PrecisionRecallMetric::gener
     double recall = 1;
     double precision = 1;
     if (truePositives.at(i) > 0 || falseNegatives.at(i) > 0) {
-      recall = 1.0 * truePositives.at(i) / (truePositives.at(i) + falseNegatives.at(i));
+      recall = 1.0 * static_cast<double>(truePositives.at(i)) / static_cast<double>(truePositives.at(i) + falseNegatives.at(i));
     }
     if (truePositives.at(i) > 0 || falsePositives.at(i) > 0) {
-      precision = 1.0 * truePositives.at(i) / (truePositives.at(i) + falsePositives.at(i));
+      precision = 1.0 * static_cast<double>(truePositives.at(i)) / static_cast<double>(truePositives.at(i) + falsePositives.at(i));
     }
     if (!points.first.empty() && points.first.back() == recall) {
       points.second.pop_back();

--- a/networkit/cpp/scd/GCE.cpp
+++ b/networkit/cpp/scd/GCE.cpp
@@ -226,8 +226,8 @@ std::set<node> expandseed_internal(const Graph&G, node s) {
 
     assert(boundary_diff == boundary_diff_debug);
 #endif
-    double numerator = 2.0 * (intWeight + degInt) * (currentBoundary.size() + boundary_diff);
-    double denominator = (C.size() + 1) * (extWeight - degInt + degExt);
+    double numerator = 2.0 * (intWeight + degInt) * static_cast<double>(currentBoundary.size() + boundary_diff);
+    double denominator = static_cast<double>(C.size() + 1) * (extWeight - degInt + degExt);
         return (numerator / denominator) - currentQ;
     };
 

--- a/networkit/cpp/sparsification/ChanceCorrectedTriangleScore.cpp
+++ b/networkit/cpp/sparsification/ChanceCorrectedTriangleScore.cpp
@@ -21,7 +21,7 @@ void ChanceCorrectedTriangleScore::run() {
 
     G->parallelForEdges([&](node u, node v, edgeid eid) {
         if ((*triangles)[eid] > 0) {
-            scoreData[eid] = (*triangles)[eid] * (G->numberOfNodes() - 2) * 1.0 / ((G->degree(u) - 1) * (G->degree(v) - 1));
+            scoreData[eid] = static_cast<double>((*triangles)[eid] * (G->numberOfNodes() - 2)) * 1.0 / static_cast<double>((G->degree(u) - 1) * (G->degree(v) - 1));
         } else if (G->degree(u) == 1 || G->degree(v) == 1) {
             scoreData[eid] = 1;
         }

--- a/networkit/cpp/sparsification/LocalSimilarityScore.cpp
+++ b/networkit/cpp/sparsification/LocalSimilarityScore.cpp
@@ -35,7 +35,7 @@ void LocalSimilarityScore::run() {
         std::vector<AttributizedEdge<double>> neighbors;
         neighbors.reserve(G->degree(i));
         G->forNeighborsOf(i, [&](node, node j, edgeid eid) {
-            double sim = (*triangles)[eid] * 1.0 / (G->degree(i) + G->degree(j) - (*triangles)[eid]);
+            double sim = static_cast<double>((*triangles)[eid]) * 1.0 / static_cast<double>(G->degree(i) + G->degree(j) - (*triangles)[eid]);
             neighbors.emplace_back(i, j, eid, sim);
         });
         std::sort(neighbors.begin(), neighbors.end());

--- a/networkit/cpp/sparsification/MultiscaleScore.cpp
+++ b/networkit/cpp/sparsification/MultiscaleScore.cpp
@@ -58,7 +58,7 @@ void MultiscaleScore::run() {
  * edges connected to a node of degree k are uniformly distributed.
  */
 double MultiscaleScore::getProbability(count degree, edgeweight normalizedWeight) {
-    return 1 - pow(1 - normalizedWeight, degree - 1);
+    return 1.0 - pow(1.0 - normalizedWeight, static_cast<double>(degree) - 1.0);
 }
 
 double MultiscaleScore::score(node, node) {

--- a/networkit/cpp/sparsification/SCANStructuralSimilarityScore.cpp
+++ b/networkit/cpp/sparsification/SCANStructuralSimilarityScore.cpp
@@ -8,7 +8,7 @@ void NetworKit::SCANStructuralSimilarityScore::run() {
     if (!G->hasEdgeIds()) throw std::runtime_error("Error, edges must be indexed");
 
     G->parallelForEdges([&](node u, node v, edgeid eid) {
-        workScores[eid] = ((*triangles)[eid] + 1) * 1.0 / std::sqrt((G->degree(u) + 1)*(G->degree(v) + 1));
+        workScores[eid] = static_cast<double>((*triangles)[eid] + 1) * 1.0 / std::sqrt(static_cast<double>((G->degree(u) + 1)*(G->degree(v) + 1)));
     });
 
     scoreData = std::move(workScores);

--- a/networkit/cpp/viz/MaxentStress.cpp
+++ b/networkit/cpp/viz/MaxentStress.cpp
@@ -587,7 +587,7 @@ void MaxentStress::computeAlgebraicDistances(const Graph& graph, const count k) 
                         if (algebraicDist == 0.0) {
                             algebraicDist = 1e-5;
                         }
-                        algebraicDist /= sqrt(G->degree(u) * G->degree(w));
+                        algebraicDist /= sqrt(static_cast<double>(G->degree(u) * G->degree(w)));
                         knownDistances[u].push_back({w, algebraicDist});
                         if (std::isnan(algebraicDist)) INFO("Warning: nan dist");
                         minDist[u] = std::min(minDist[u], algebraicDist);


### PR DESCRIPTION
`cppcoreguideline-narrowing-conversion` fixes for the aforementioned modules.
This is the last batch of fixes, hence narrowing conversions are now marked as errors in the `.clang-tidy` file.