### PR TITLE
Refactor: top harmonic closeness

### DIFF
--- a/include/networkit/centrality/TopHarmonicCloseness.hpp
+++ b/include/networkit/centrality/TopHarmonicCloseness.hpp
@@ -27,21 +27,21 @@ class TopHarmonicCloseness final : public Algorithm {
 public:
     /**
      * Finds the top k nodes with highest harmonic closeness centrality faster
-     * than computing it for all nodes. The implementation is based on "Computing
-     * Top-k Centrality Faster in Unweighted Graphs", Bergamini et al., ALENEX16.
-     * The algorithms are based on two heuristics. We recommend to use
-     * useNBbound = false for complex networks (or networks with small diameter)
-     * and useNBbound = true for street networks (or networks with large
+     * than computing it for all nodes. The implementation is based on
+     * "Computing Top-k Centrality Faster in Unweighted Graphs", Bergamini et
+     * al., ALENEX16. The algorithm also works with weighted graphs but only
+     * with the NBcut variation. We recommend to use useNBbound = false for
+     * (weighted) complex networks (or networks with small diameter) and
+     * useNBbound = true for street networks (or networks with large
      * diameters). Notice that the worst case running time of the algorithm is
      * O(nm), where n is the number of nodes and m is the number of edges.
-     * However, for most real-world networks the empirical running time is O(m).
+     * However, for most real-world networks the empirical running time is
+     * O(m).
      *
-     * @param G An unweighted graph.
-     * @param k Number of nodes with highest harmonic closeness that have to be
-     * found. For example, k = 10, the top 10 nodes with highest harmonic
-     * closeness will be computed.
-     * @param useNBbound If true, BFSbound is re-computed at each iteration. If
-     * false, BFScut is used
+     * @param G The input graph. If useNBbound is set to true, edge weights will be ignored.
+     * @param k Number of nodes with highest harmonic closeness that have to be found.
+     * For example, k = 10, the top 10 nodes with highest harmonic closeness will be computed.
+     * @param useNBbound If true, the NBbound variation will be used, otherwise NBcut.
      */
     explicit TopHarmonicCloseness(const Graph &G, count k = 1, bool useNBbound = false);
 
@@ -124,10 +124,10 @@ private:
     tlx::d_ary_addressable_int_heap<node, 2, Less<double>> topKNodesPQ;
     std::vector<node> trail;
 
-	// For weighted graphs
-	std::vector<tlx::d_ary_addressable_int_heap<node, 2, Less<edgeweight>>> dijkstraHeaps;
-	std::vector<std::vector<edgeweight>> distanceGlobal;
-	edgeweight minEdgeWeight;
+    // For weighted graphs
+    std::vector<tlx::d_ary_addressable_int_heap<node, 2, Less<edgeweight>>> dijkstraHeaps;
+    std::vector<std::vector<edgeweight>> distanceGlobal;
+    edgeweight minEdgeWeight;
 
     omp_lock_t lock;
 

--- a/include/networkit/centrality/TopHarmonicCloseness.hpp
+++ b/include/networkit/centrality/TopHarmonicCloseness.hpp
@@ -1,5 +1,5 @@
 /*
- * TopHarmonicCloseness.h
+ * TopHarmonicCloseness.hpp
  *
  * Created on: 25.02.2018
  *		Authors: nemes, Eugenio Angriman
@@ -8,160 +8,145 @@
 #ifndef NETWORKIT_CENTRALITY_TOP_HARMONIC_CLOSENESS_HPP_
 #define NETWORKIT_CENTRALITY_TOP_HARMONIC_CLOSENESS_HPP_
 
+// networkit-format
+
+#include <memory>
+
 #include <networkit/base/Algorithm.hpp>
-#include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/components/WeaklyConnectedComponents.hpp>
 #include <networkit/graph/Graph.hpp>
-#include <networkit/structures/Partition.hpp>
+
+#include <tlx/container/d_ary_addressable_int_heap.hpp>
 
 namespace NetworKit {
 
 /**
  * @ingroup centrality
  */
-class TopHarmonicCloseness : public Algorithm {
+class TopHarmonicCloseness final : public Algorithm {
 public:
-  /**
-   * Finds the top k nodes with highest harmonic closeness centrality faster
-   * than computing it for all nodes. The implementation is based on "Computing
-   * Top-k Centrality Faster in Unweighted Graphs", Bergamini et al., ALENEX16.
-   * The algorithms are based on two heuristics. We recommend to use
-   * useBFSbound = false for complex networks (or networks with small diameter)
-   * and useBFSbound = true for street networks (or networks with large
-   * diameters). Notice that the worst case running time of the algorithm is
-   * O(nm), where n is the number of nodes and m is the number of edges.
-   * However, for most real-world networks the empirical running time is O(m).
-   *
-   * @param G An unweighted graph.
-   * @param k Number of nodes with highest harmonic closeness that have to be
-   * found. For example, k = 10, the top 10 nodes with highest harmonic
-   * closeness will be computed.
-   * @param useBFSbound If true, BFSbound is re-computed at each iteration. If
-   * false, BFScut is used
-   */
-  TopHarmonicCloseness(const Graph &G, count k = 1, bool useBFSbound = false);
+    /**
+     * Finds the top k nodes with highest harmonic closeness centrality faster
+     * than computing it for all nodes. The implementation is based on "Computing
+     * Top-k Centrality Faster in Unweighted Graphs", Bergamini et al., ALENEX16.
+     * The algorithms are based on two heuristics. We recommend to use
+     * useNBbound = false for complex networks (or networks with small diameter)
+     * and useNBbound = true for street networks (or networks with large
+     * diameters). Notice that the worst case running time of the algorithm is
+     * O(nm), where n is the number of nodes and m is the number of edges.
+     * However, for most real-world networks the empirical running time is O(m).
+     *
+     * @param G An unweighted graph.
+     * @param k Number of nodes with highest harmonic closeness that have to be
+     * found. For example, k = 10, the top 10 nodes with highest harmonic
+     * closeness will be computed.
+     * @param useNBbound If true, BFSbound is re-computed at each iteration. If
+     * false, BFScut is used
+     */
+    explicit TopHarmonicCloseness(const Graph &G, count k = 1, bool useNBbound = false);
 
-  /**
-   * Computes top-k harmonic closeness on the graph passed in the constructor.
-   */
-  void run() override;
+    ~TopHarmonicCloseness() override;
 
-  /**
-   * Returns a list with the k nodes with highest harmonic closeness.
-   * WARNING: closeness centrality of some nodes below the top-k could be equal
-   * to the k-th closeness, we call them trail. Set the parameter includeTrail
-   * to true to also include those nodes but consider that the resulting vector
-   * could be longer than k.
-   *
-   * @param includeTrail Whether or not to include trail nodes.
-   * @return The list of the top-k nodes.
-   */
-  std::vector<node> topkNodesList(bool includeTrail = false);
+    /**
+     * Computes top-k harmonic closeness on the graph passed in the constructor.
+     */
+    void run() override;
 
-  /**
-   * Returns a list with the scores of the k nodes with highest harmonic
-   * closeness.
-   * WARNING: closeness centrality of some nodes below the top-k could
-   * be equal to the k-th closeness, we call them trail. Set the parameter
-   * includeTrail to true to also include those centrality values but consider
-   * that the resulting vector could be longer than k.
-   *
-   * @param includeTrail Whether or not to include trail centrality value.
-   * @return The closeness centralities of the k most central nodes.
-   */
-  std::vector<edgeweight> topkScoresList(bool includeTrail = false);
+    /**
+     * Returns a list with the k nodes with highest harmonic closeness.
+     * WARNING: closeness centrality of some nodes below the top-k could be equal
+     * to the k-th closeness, we call them trail. Set the parameter includeTrail
+     * to true to also include those nodes but consider that the resulting vector
+     * could be longer than k.
+     *
+     * @param includeTrail Whether or not to include trail nodes.
+     * @return The list of the top-k nodes.
+     */
+    std::vector<node> topkNodesList(bool includeTrail = false);
 
-protected:
-  /**
-   * Runs a pruned BFS from the node @a u. The search is aborted once the
-   * closeness centrality of @a u must be smaller than @a x.
-   *
-   * @param v The start node.
-   * @param x The harmonic closeness centrality of the k-th most central node.
-   * @param n The number of nodes in the graph.
-   * @param r The number of reachable nodes (or an upper bound in directed
-   * graphs) for each node.
-   * @param visited The vector containing the visited status.
-   * @param distances The vector containing the distances.
-   * @param pred The vector containing the predecessor of each node.
-   * @param visitedEdges The number of visited edges.
-   * @return
-   */
-  std::pair<edgeweight, bool> BFScut(node v, edgeweight x, count n, count r,
-                                     std::vector<uint8_t> &visited,
-                                     std::vector<count> &distances,
-                                     std::vector<node> &pred,
-                                     count &visitedEdges);
+    /**
+     * Returns a list with the scores of the k nodes with highest harmonic
+     * closeness.
+     * WARNING: closeness centrality of some nodes below the top-k could
+     * be equal to the k-th closeness, we call them trail. Set the parameter
+     * includeTrail to true to also include those centrality values but consider
+     * that the resulting vector could be longer than k.
+     *
+     * @param includeTrail Whether or not to include trail centrality value.
+     * @return The closeness centralities of the k most central nodes.
+     */
+    std::vector<edgeweight> topkScoresList(bool includeTrail = false);
 
-  /**
-   * Computes the exact harmonic closeness centrality of the node @a x and
-   * stores upper bounds for all other nodes in @a S2.
-   *
-   * @param x The start node.
-   * @param S2 The upper bounds for all other nodes.
-   * @param visEdges The number of visited edges.
-   */
-  void BFSbound(node x, std::vector<double> &S2, count *visEdges);
+private:
+    const Graph *G;
+    const count k;
+    const bool useNBbound;
 
-  /**
-   * Computes the number of reachable nodes or an upper bound in directed
-   * graphs.
-   */
-  void computeReachableNodes();
+    std::vector<double> hCloseness;
+    std::vector<count> reachableNodes;
+    std::vector<std::vector<uint8_t>> visitedGlobal;
+    std::vector<uint8_t> tsGlobal;
 
-  /**
-   * Computes an upper bound for the number of reachable nodes for each node
-   * in a directed graph.
-   */
-  void computeReachableNodesDirected();
+    std::vector<node> topKNodes;
+    std::vector<double> topKScores;
 
-  /**
-   * Computes the number of reachable nodes in an undirected graph.
-   */
-  void computeReachableNodesUndirected();
+    // For NBbound
+    std::vector<count> reachU, reachL;
+    std::vector<std::vector<count>> numberOfNodesAtLevelGlobal;
+    std::vector<std::vector<node>> nodesAtCurrentLevelGlobal;
+    std::vector<std::vector<std::vector<node>>> nodesAtLevelGlobal;
+    std::vector<double> levelImprovement;
+    std::unique_ptr<WeaklyConnectedComponents> wccPtr;
+    void updateTimestamp() {
+        auto &visited = visitedGlobal[omp_get_thread_num()];
+        auto &ts = tsGlobal[omp_get_thread_num()];
+        if (ts++ == std::numeric_limits<uint8_t>::max()) {
+            ts = 1;
+            std::fill(visited.begin(), visited.end(), 0);
+        }
+    }
 
-  void init();
+    template <class Type>
+    struct Greater {
+        Greater(const std::vector<Type> &vec) : vec(&vec) {}
+        bool operator()(node u, node v) const noexcept { return (*vec)[u] > (*vec)[v]; }
+        const std::vector<Type> *vec;
+    };
 
-  Graph G;
-  count k;
-  count n;
-  count trail = 0;
-  double minCloseness = std::numeric_limits<double>::max();
-  count nMinCloseness = 0;
-  bool useBFSbound;
-  std::vector<node> topk;
-  std::vector<edgeweight> topkScores;
-  std::vector<edgeweight> allScores;
-  std::vector<uint8_t> isExact;
-  std::vector<uint8_t> isValid;
-  std::vector<edgeweight> cutOff;
-  std::vector<uint8_t> exactCutOff;
-  Partition component;
-  std::vector<count> r;
-  std::vector<count> rOld;
+    template <class Type>
+    struct Less {
+        Less(const std::vector<Type> &vec) : vec(&vec) {}
+        bool operator()(node u, node v) const noexcept { return (*vec)[u] < (*vec)[v]; }
+        const std::vector<Type> *vec;
+    };
+
+    tlx::d_ary_addressable_int_heap<node, 2, Greater<double>> prioQ;
+    tlx::d_ary_addressable_int_heap<node, 2, Less<double>> topKNodesPQ;
+    std::vector<node> trail;
+
+	// For weighted graphs
+	std::vector<tlx::d_ary_addressable_int_heap<node, 2, Less<edgeweight>>> dijkstraHeaps;
+	std::vector<std::vector<edgeweight>> distanceGlobal;
+	edgeweight minEdgeWeight;
+
+    omp_lock_t lock;
+
+    void runNBcut();
+    void runNBbound();
+    bool bfscutUnweighted(node source, double kthCloseness);
+    bool bfscutWeighted(node source, double kthCloseness);
+    void bfsbound(node source);
+    void computeReachableNodes();
+    void computeReachableNodesBounds();
+    void computeNeighborhoodBasedBound();
+    void updateTopkPQ(node u);
+
+    double initialBoundNBcutUnweighted(node u) const noexcept;
+    double initialBoundNBcutWeighted(node u) const noexcept;
+
+    template <class Type>
+    std::vector<Type> resizedCopy(const std::vector<Type> &vec) const noexcept;
 };
-
-inline std::vector<node>
-TopHarmonicCloseness::topkNodesList(bool includeTrail) {
-  assureFinished();
-  if (!includeTrail) {
-    auto begin = topk.begin();
-    std::vector<node> topkNoTrail(begin, begin + k);
-    return topkNoTrail;
-  }
-
-  return topk;
-}
-
-inline std::vector<edgeweight>
-TopHarmonicCloseness::topkScoresList(bool includeTrail) {
-  assureFinished();
-  if (!includeTrail) {
-    auto begin = topkScores.begin();
-    std::vector<double> topkScoresNoTrail(begin, begin + k);
-    return topkScoresNoTrail;
-  }
-  return topkScores;
-}
 
 } // namespace NetworKit
 #endif // NETWORKIT_CENTRALITY_TOP_HARMONIC_CLOSENESS_HPP_

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -865,43 +865,52 @@ cdef extern from "<networkit/centrality/TopHarmonicCloseness.hpp>":
 
 
 cdef class TopHarmonicCloseness(Algorithm):
-	""" Finds the top k nodes with highest harmonic closeness centrality faster
-		than computing it for all nodes. The implementation is based on "Computing
-		Top-k Centrality Faster in Unweighted Graphs", Bergamini et al., ALENEX16.
-		The algorithms are based on two heuristics. We reccommend to use
-		useBFSbound = false for complex networks (or networks with small diameter)
-		and useBFSbound = true for street networks (or networks with large
-		diameters). Notice that the worst case running time of the algorithm is
-		O(nm), where n is the number of nodes and m is the number of edges.
-		However, for most real-world networks the empirical running time is O(m).
+	""" 
+	Finds the top k nodes with highest harmonic closeness centrality faster
+	than computing it for all nodes. The implementation is based on "Computing
+	Top-k Centrality Faster in Unweighted Graphs", Bergamini et al., ALENEX16.
+	The algorithm also works with weighted graphs but only if with the NBcut
+	variation. We recommend to use useNBbound = False for complex (weighted)
+	networks (or networks with small diameter) and useNBbound = True for
+	unweighted street networks (or networks with large diameters). Notice that
+	the worst case running time of the algorithm is O(nm), where n is the
+	number of nodes and m is the number of edges. However, for most real-world
+	networks the empirical running time is O(m).
 
 
-	TopCloseness(G, k=1, useBFSbound=True)
+	TopHarmonicCloseness(G, k=1, useNBbound=True)
 
-	Parameters:
-	-----------
-	G: An unweighted graph.
-	k: Number of nodes with highest closeness that have to be found. For example, if k = 10, the top 10 nodes with highest closeness will be computed.
-	useBFSbound: If true, the BFSbound is re-computed at each iteration. If false, BFScut is used.
-	The worst case running time of the algorithm is O(nm), where n is the number of nodes and m is the number of edges.
-	However, for most networks the empirical running time is O(m).
+	Parameters
+	----------
+	G : networkit.Graph
+		The graph. If useNBbound is set to 'True', edge weights will be ignored.
+	k : int
+		Number of nodes with highest closeness that have to be found. For example, if k = 10, the
+		top 10 nodes with highest closeness will be computed. useNBbound: If True, the NBbound is
+		re-computed at each iteration. If False, NBcut is used. The worst case running time of the
+		algorithm is O(nm), where n is the number of nodes and m is the number of edges.
+		However, for most networks the empirical running time is O(m).
+	useNBbound : bool
+		If True, the NBbound variation will be used, otherwise NBcut.
 	"""
 	cdef Graph _G
 
-	def __cinit__(self,  Graph G, k=1, useBFSbound=False):
+	def __cinit__(self,  Graph G, k=1, useNBbound=False):
 		self._G = G
-		self._this = new _TopHarmonicCloseness(G._this, k, useBFSbound)
+		self._this = new _TopHarmonicCloseness(G._this, k, useNBbound)
 
 	def topkNodesList(self, includeTrail=False):
-		""" Returns: a list with the k nodes with highest harmonic closeness.
+		"""
+		Returns a list with the k nodes with highest harmonic closeness.
 		WARNING: closeness centrality of some nodes below the top-k could be equal
 		to the k-th closeness, we call them trail. Set the parameter includeTrail
 		to true to also include those nodes but consider that the resulting vector
 		could be longer than k.
 
-		Parameters:
-		-----------
-		includeTrail: Whether or not to include trail nodes.
+		Parameters
+		----------
+		includeTrail : bool
+			Whether or not to include trail nodes.
 
 		Returns:
 		--------
@@ -911,15 +920,17 @@ cdef class TopHarmonicCloseness(Algorithm):
 		return (<_TopHarmonicCloseness*>(self._this)).topkNodesList(includeTrail)
 
 	def topkScoresList(self, includeTrail=False):
-		""" Returns: a list with the scores of the k nodes with highest harmonic closeness.
-		WARNING: closeness centrality of some nodes below the top-k could
-		be equal to the k-th closeness, we call them trail. Set the parameter
-		includeTrail to true to also include those centrality values but consider
-		that the resulting vector could be longer than k.
+		"""
+		Returns a list with the scores of the k nodes with highest harmonic
+		closeness. WARNING: closeness centrality of some nodes below the top-k
+		could be equal to the k-th closeness, we call them trail. Set the
+		parameter includeTrail to true to also include those centrality values
+		but consider that the resulting vector could be longer than k.
 
-		Parameters:
-		-----------
-		includeTrail: Whether or not to include trail centrality value.
+		Parameters
+		----------
+		includeTrail : bool
+			Whether or not to include trail centrality value.
 
 		Returns:
 		--------

--- a/networkit/cpp/centrality/TopHarmonicCloseness.cpp
+++ b/networkit/cpp/centrality/TopHarmonicCloseness.cpp
@@ -5,535 +5,637 @@
  *		 Author: nemes, Eugenio Angriman
  */
 
-#include <cmath>
-#include <omp.h>
+// networkit-format
 
-#include <networkit/auxiliary/PrioQueue.hpp>
-#include <networkit/components/StronglyConnectedComponents.hpp>
+#ifndef NDEBUG
+#include <algorithm>
+#endif
+#include <atomic>
+#include <omp.h>
+#include <queue>
+
 #include <networkit/centrality/TopHarmonicCloseness.hpp>
-#include <networkit/graph/BFS.hpp>
+#include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/components/StronglyConnectedComponents.hpp>
 
 namespace NetworKit {
 
-TopHarmonicCloseness::TopHarmonicCloseness(const Graph &G, count k,
-                                           bool useBFSbound)
-    : G(G), k(k), useBFSbound(useBFSbound),
-      allScores(G.upperNodeIdBound(), std::numeric_limits<edgeweight>::max()),
-      isExact(G.upperNodeIdBound(), false),
-      isValid(G.upperNodeIdBound(), false),
-      cutOff(G.upperNodeIdBound(), std::numeric_limits<edgeweight>::max()),
-      exactCutOff(G.upperNodeIdBound(), 0), component(G.upperNodeIdBound()),
-      rOld(G.upperNodeIdBound()) {}
+TopHarmonicCloseness::TopHarmonicCloseness(const Graph &G, count k, bool useNBbound)
+    : G(&G), k(k), useNBbound(useNBbound), prioQ(Greater<double>{hCloseness}),
+      topKNodesPQ(Less<double>{hCloseness}) {
 
-std::pair<edgeweight, bool>
-TopHarmonicCloseness::BFScut(node v, edgeweight x, count n, count r,
-                             std::vector<uint8_t> &visited,
-                             std::vector<count> &distances,
-                             std::vector<node> &pred, count &visitedEdges) {
+    if (k == 0 || k > G.numberOfNodes())
+        throw std::runtime_error("Error: k must be in [1,...,n].");
 
-  double d = 0;
-  int64_t gamma = 0, nd = 0;
-  distances[v] = 0;
-  std::queue<node> Q;
-  std::queue<node> toReset;
-  Q.push(v);
-  toReset.push(v);
-  nd++;
+    if (useNBbound && G.isWeighted())
+        WARN("NBbound only works with unweighted graphs, edge weights will be ignored!");
 
-  visited[v] = true;
+    const count n = G.upperNodeIdBound();
 
-  /* Clean up the visited vector for the next run.
-   * We don't need to do this for the distances and pred vector
-   * because those are only read after visited[u] is true.
-   */
-  auto cleanup = [&]() {
-    while (!toReset.empty()) {
-      node w = toReset.front();
-      toReset.pop();
-      visited[w] = false;
+    hCloseness.resize(n);
+    reachableNodes.resize(n);
+
+    if (!useNBbound && G.isWeighted()) {
+        distanceGlobal.resize(omp_get_max_threads(), std::vector<edgeweight>(n));
+        dijkstraHeaps.reserve(omp_get_max_threads());
+        for (int i = 0; i < omp_get_max_threads(); ++i)
+            dijkstraHeaps.emplace_back(Less<edgeweight>{distanceGlobal[i]});
+        minEdgeWeight = std::numeric_limits<edgeweight>::max();
+        G.forEdges([&](node, node, edgeweight ew) { minEdgeWeight = std::min(minEdgeWeight, ew); });
+    } else {
+        visitedGlobal.resize(omp_get_max_threads(), std::vector<uint8_t>(n));
+        tsGlobal.resize(omp_get_max_threads(), 0);
     }
-  };
 
-  edgeweight c = 0;
-  edgeweight ctilde = edgeweight(n - 1);
-
-  do {
-    node u = Q.front();
-    Q.pop();
-
-    if (distances[u] > d) {
-      d = d + 1;
-
-      double d2 = static_cast<double>(int64_t(r) - nd);
-      ctilde = c + (static_cast<edgeweight>(gamma) / ((d + 2.0) * (d + 1.0))) +
-               (d2 / (d + 2.0));
-
-      if (ctilde < x) {
-        exactCutOff[v] = true;
-        cutOff[v] = d;
-        cleanup();
-        return std::make_pair(ctilde, false);
-      }
-
-      gamma = 0;
-    }
-    bool cont = true;
-    G.forNeighborsOf(u, [&](node w) {
-      if (cont) {
-        visitedEdges++;
-        if (!visited[w]) {
-          distances[w] = distances[u] + 1;
-
-          Q.push(w);
-          toReset.push(w);
-          visited[w] = true;
-
-          c += 1.0 / distances[w];
-
-          if (!G.isDirected()) {
-            gamma += (G.degree(w) - 1); // notice: only because it's undirected
-          } else {
-            gamma += G.degree(w);
-          }
-
-          ++nd;
-          pred[w] = u;
-        } else if (distances[w] > 1 && (pred[u] != w)) {
-          ctilde = ctilde - 1.0 / (d + 1) + 1.0 / (d + 2);
-
-          if (ctilde < x) {
-            cont = false;
-          }
-        }
-      }
-    });
-    if (ctilde < x) {
-      exactCutOff[v] = false;
-      cutOff[v] = d;
-      cleanup();
-
-      return std::make_pair(ctilde, false);
-    }
-  } while (!Q.empty());
-
-  cleanup();
-  exactCutOff[v] = false;
-  cutOff[v] = std::numeric_limits<edgeweight>::max();
-
-  return std::make_pair(c, true);
+    topKNodesPQ.reserve(k);
+    prioQ.reserve(n);
+    omp_init_lock(&lock);
 }
 
-void TopHarmonicCloseness::BFSbound(node source, std::vector<double> &S2,
-                                    count *visEdges) {
-  count r = 0;
-  std::vector<std::vector<node>> levels(n);
-  // nodesPerLev[i] contains the number of nodes in level i
-  std::vector<count> nodesPerLev(n, 0);
-  // sumLevs[i] contains the sum of the nodes in levels j <= i
-  std::vector<count> sumLevs(n, 0);
-  count nLevs = 0;
-  levels[nLevs].clear();
-  double sum_dist = 0;
-  edgeweight level_bound;
+TopHarmonicCloseness::~TopHarmonicCloseness() = default;
 
-  auto inverseDistance = [&](edgeweight dist) { return 1.0 / dist; };
-
-  Traversal::BFSfrom(G, source, [&](node u, count dist) {
-    sum_dist += dist > 0 ? inverseDistance(dist) : 0;
-
-    r++;
-    if (dist > nLevs) {
-      sumLevs[nLevs] += nodesPerLev[nLevs];
-      sumLevs[nLevs + 1] = sumLevs[nLevs];
-      nLevs++;
-      levels[nLevs].clear();
-    }
-    levels[nLevs].push_back(u);
-    nodesPerLev[nLevs]++;
-  });
-  sumLevs[nLevs] += nodesPerLev[nLevs];
-  if (G.isDirected()) {
-    (*visEdges) += G.numberOfEdges();
-  } else {
-    (*visEdges) += 2 * G.numberOfEdges();
-  }
-
-  S2[source] = sum_dist;
-
-  // we compute the bound for the first level
-  double closeNodes = 0, farNodes = 0;
-  for (count j = 0; j <= nLevs; j++) {
-    if (j <= 2) {
-      closeNodes += nodesPerLev[j];
+void TopHarmonicCloseness::computeReachableNodes() {
+    if (G->isDirected()) {
+        wccPtr = std::unique_ptr<WeaklyConnectedComponents>(new WeaklyConnectedComponents(*G));
+        wccPtr->run();
+        const auto compSizes = wccPtr->getComponentSizes();
+        G->parallelForNodes(
+            [&](node u) { reachableNodes[u] = compSizes.at(wccPtr->componentOfNode(u)); });
     } else {
-      farNodes +=
-          nodesPerLev[j] * inverseDistance(double(std::abs((double)j - 1.)));
+        ConnectedComponents cc(*G);
+        cc.run();
+        const auto compSizes = cc.getComponentSizes();
+        G->parallelForNodes(
+            [&](node u) { reachableNodes[u] = compSizes.at(cc.componentOfNode(u)); });
     }
-  }
-
-  level_bound = inverseDistance(2.) * closeNodes + farNodes;
-
-  for (count j = 0; j < levels[1].size(); j++) {
-    node w = levels[1][j];
-    // we subtract 2 not to count the node itself
-    double bound = (level_bound - inverseDistance(2.) +
-                    (inverseDistance(1.) - inverseDistance(2.)) * G.degree(w));
-
-    if (bound < S2[w] &&
-        (!G.isDirected() || component[w] == component[source])) {
-      S2[w] = bound;
-    }
-  }
-
-  // now we compute it for the other levels
-  for (count i = 2; i <= nLevs; i++) {
-
-    level_bound = 0;
-    // TODO: OPTIMIZE?
-    if (!G.isDirected()) {
-      for (count j = 0; j <= nLevs; j++) {
-        level_bound += inverseDistance(std::max(
-                           2., double(std::abs((double)j - (double)i)))) *
-                       nodesPerLev[j];
-      }
-    } else {
-      for (count j = 0; j <= nLevs; j++) {
-        level_bound += inverseDistance(std::max(2., (double)j - (double)i)) *
-                       nodesPerLev[j];
-      }
-    }
-
-    for (count j = 0; j < levels[i].size(); ++j) {
-      node w = levels[i][j];
-      double bound =
-          (level_bound - inverseDistance(2.) +
-           (inverseDistance(1.) - inverseDistance(2.)) * G.degree(w));
-
-      if (bound < S2[w] &&
-          (!G.isDirected() || component[w] == component[source])) {
-        S2[w] = bound;
-      }
-    }
-  }
-}
-
-void TopHarmonicCloseness::init() {
-  n = G.upperNodeIdBound();
-  assert(n >= k);
-
-  topk.clear();
-  topk.resize(k);
-  topkScores.clear();
-  topkScores.resize(k);
-  nMinCloseness = 0;
-  minCloseness = std::numeric_limits<double>::max();
-  trail = 0;
 }
 
 void TopHarmonicCloseness::run() {
-  init();
-
-  std::vector<bool> toAnalyze(n, true);
-
-  // We compute the number of reachable nodes (or an upper bound)
-  // only if we use the algorithm for complex networks.
-  if (!useBFSbound) {
     computeReachableNodes();
-  }
+    if (useNBbound)
+        runNBbound();
+    else
+        runNBcut();
 
-  // Main priority queue with all nodes in order of decreasing degree
-  Aux::PrioQueue<edgeweight, node> Q1(n);
+    topKNodes.resize(k + trail.size());
+    topKScores.resize(k + trail.size());
+    count i = k;
+    do {
+        --i;
+        const node u = topKNodesPQ.extract_top();
+        topKNodes[i] = u;
+        topKScores[i] = hCloseness[u];
+    } while (!topKNodesPQ.empty());
 
-  G.forNodes([&](node v) { Q1.insert(n + G.degree(v), v); });
+    for (; i < trail.size(); ++i) {
+        topKNodes[k + i] = trail[i];
+        topKScores[k + i] = hCloseness[trail[i]];
+    }
 
-  Aux::PrioQueue<edgeweight, node> top(n);
+    hasRun = true;
+}
 
-  // protects accesses to all shared variables
-  omp_lock_t lock;
-  omp_init_lock(&lock);
+void TopHarmonicCloseness::runNBcut() {
+    if (G->isWeighted())
+        G->parallelForNodes([&](node u) { hCloseness[u] = initialBoundNBcutWeighted(u); });
+    else
+        G->parallelForNodes([&](node u) { hCloseness[u] = initialBoundNBcutUnweighted(u); });
 
-  edgeweight kth = 0;
+    prioQ.build_heap(G->nodeRange().begin(), G->nodeRange().end());
+
+    std::atomic_bool stop{false};
+    std::atomic<double> kthCloseness{-1};
+
 #pragma omp parallel
-  {
-    std::vector<uint8_t> visited(n, false);
-    std::vector<count> distances(n);
-    std::vector<node> pred(n, 0);
-
-    std::vector<edgeweight> S(n, std::numeric_limits<edgeweight>::max());
-    while (Q1.size() != 0) {
-
-      omp_set_lock(&lock);
-      if (Q1.size() == 0) { // The size of Q1 might have changed.
-        omp_unset_lock(&lock);
-        break;
-      }
-      std::pair<edgeweight, node> extracted = Q1.extractMin();
-
-      node v = extracted.second;
-      toAnalyze[v] = false;
-
-      omp_unset_lock(&lock);
-
-      // for networks with large diameters: break if the score of the
-      // current node is smaller than the k-th highest score
-      if (useBFSbound && allScores[v] < kth && isValid[v]) {
-        break;
-      }
-
-      if (G.degreeOut(v) == 0) {
+    while (!stop.load(std::memory_order_relaxed)) {
+        node u = none;
         omp_set_lock(&lock);
-        allScores[v] = 0;
-        isExact[v] = 0;
-        omp_unset_lock(&lock);
-      } else if (useBFSbound) {
-        count visEdges;
-
-        // Perform a complete BFS from v and obtain upper bounds
-        // for all nodes in the graph
-        BFSbound(v, S, &visEdges);
-
-        omp_set_lock(&lock);
-        allScores[v] = S[v];
-        isExact[v] = true;
-        isValid[v] = true;
-        omp_unset_lock(&lock);
-
-        // Update the scores of all nodes with the bounds obtained
-        // by the complete BFS
-        G.forNodes([&](node u) {
-          if (allScores[u] > S[u] &&
-              toAnalyze[u]) { // This part must be synchronized.
-            omp_set_lock(&lock);
-            if (allScores[u] > S[u] &&
-                toAnalyze[u]) { // Have to check again, because the variables
-              // might have changed
-              allScores[u] = S[u];
-              isValid[u] = true;
-              Q1.remove(u);
-              Q1.insert(allScores[u], u);
+        if (!prioQ.empty()) {
+            u = prioQ.extract_top();
+            if (topKNodesPQ.size() == k)
+                kthCloseness.store(hCloseness[topKNodesPQ.top()], std::memory_order_relaxed);
+            if (hCloseness[u] < kthCloseness) {
+                stop.store(true, std::memory_order_relaxed);
+                u = none;
             }
-            omp_unset_lock(&lock);
-          }
+        } else
+            stop.store(true, std::memory_order_relaxed);
+        omp_unset_lock(&lock);
+
+        if (u == none)
+            break;
+
+        if (G->isWeighted()) {
+            if (!bfscutWeighted(u, kthCloseness.load(std::memory_order_relaxed)))
+                continue;
+        } else {
+            if (!bfscutUnweighted(u, kthCloseness.load(std::memory_order_relaxed)))
+                continue;
+        }
+
+        omp_set_lock(&lock);
+        updateTopkPQ(u);
+        omp_unset_lock(&lock);
+    }
+}
+
+void TopHarmonicCloseness::runNBbound() {
+    numberOfNodesAtLevelGlobal.resize(omp_get_max_threads(),
+                                      std::vector<count>(G->numberOfNodes(), 0));
+    nodesAtLevelGlobal.resize(omp_get_max_threads(),
+                              std::vector<std::vector<count>>(G->numberOfNodes()));
+    nodesAtCurrentLevelGlobal.resize(omp_get_max_threads());
+
+    for (int i = 0; i < omp_get_max_threads(); ++i)
+        nodesAtCurrentLevelGlobal[i].reserve(G->numberOfNodes() - 1);
+
+    levelImprovement.resize(G->numberOfNodes());
+
+    if (G->isDirected())
+        computeReachableNodesBounds();
+    computeNeighborhoodBasedBound();
+
+    prioQ.build_heap(G->nodeRange().begin(), G->nodeRange().end());
+
+    std::atomic_bool stop{false};
+
+#pragma omp parallel
+    while (!stop.load(std::memory_order_relaxed)) {
+        node u = none;
+        omp_set_lock(&lock);
+        if (!prioQ.empty()) {
+            u = prioQ.extract_top();
+            if (topKNodes.size() == k && hCloseness[u] <= hCloseness[topKNodesPQ.top()]) {
+                stop.store(true, std::memory_order_relaxed);
+                u = none;
+            }
+        } else
+            stop.store(true, std::memory_order_relaxed);
+        omp_unset_lock(&lock);
+
+        if (u == none)
+            break;
+
+        bfsbound(u);
+
+        omp_set_lock(&lock);
+        updateTopkPQ(u);
+        omp_unset_lock(&lock);
+    }
+}
+
+void TopHarmonicCloseness::updateTopkPQ(node u) {
+    topKNodesPQ.push(u);
+    if (topKNodesPQ.size() <= k)
+        return;
+
+    assert(topKNodesPQ.size() == k + 1);
+    const node bottomNode = topKNodesPQ.extract_top();
+    const double kthCloseness = hCloseness[topKNodesPQ.top()];
+    if (kthCloseness == hCloseness[bottomNode]) {
+        if (trail.empty() || hCloseness[bottomNode] == hCloseness[trail[0]]) {
+            trail.push_back(bottomNode);
+        } else {
+            assert(hCloseness[bottomNode] > hCloseness[trail[0]]);
+            trail.clear();
+            trail.push_back(bottomNode);
+        }
+    } else
+        trail.clear();
+}
+
+bool TopHarmonicCloseness::bfscutUnweighted(node source, double kthCloseness) {
+    const count reachableFromSource = reachableNodes[source];
+    const count undirected = !G->isDirected();
+    updateTimestamp();
+    auto &visited = visitedGlobal[omp_get_thread_num()];
+    const auto ts = tsGlobal[omp_get_thread_num()];
+    visited[source] = ts;
+    count visitedNodes = 1, level = 1;
+
+    std::queue<node> q1, q2;
+    q1.push(source);
+
+    double h = 0, htilde = 0;
+
+    do {
+        count nodesAtNextLevelUB = 0;
+        do {
+            const node u = q1.front();
+            q1.pop();
+
+            G->forNeighborsOf(u, [&](node v) {
+                if (visited[v] == ts)
+                    return;
+                visited[v] = ts;
+                q2.push(v);
+                ++visitedNodes;
+                h += 1. / static_cast<double>(level);
+                nodesAtNextLevelUB += G->degree(v) - undirected;
+            });
+        } while (!q1.empty());
+
+        assert(reachableFromSource >= visitedNodes);
+        nodesAtNextLevelUB = std::min(nodesAtNextLevelUB, reachableFromSource - visitedNodes);
+        htilde = h;
+        htilde += static_cast<double>(nodesAtNextLevelUB) / static_cast<double>(level + 1);
+        htilde += static_cast<double>(reachableFromSource - visitedNodes - nodesAtNextLevelUB)
+                  / static_cast<double>(level + 2);
+
+#ifndef NDEBUG
+        if (q2.empty()) { // Finished the BFS
+            if (G->isDirected())
+                assert(reachableFromSource >= visitedNodes);
+            else
+                assert(reachableFromSource == visitedNodes);
+        }
+#endif
+
+        // Prune BFS
+        if (htilde < kthCloseness) {
+            hCloseness[source] = htilde;
+            return false;
+        }
+
+        ++level;
+        std::swap(q1, q2);
+    } while (!q1.empty());
+
+    hCloseness[source] = h;
+    return true;
+}
+
+bool TopHarmonicCloseness::bfscutWeighted(node source, double kthCloseness) {
+    auto &distance = distanceGlobal[omp_get_thread_num()];
+    std::fill(distance.begin(), distance.end(), std::numeric_limits<edgeweight>::max());
+    distance[source] = 0;
+    auto &pq = dijkstraHeaps[omp_get_thread_num()];
+    pq.clear();
+    const count reachableFromSource = reachableNodes[source];
+
+    // Visit the source immediately so we can avoid 'if (u != source) ... ' in the while loop below
+    G->forNeighborsOf(source, [&](node v, edgeweight ew) {
+        distance[v] = ew;
+        pq.update(v);
+    });
+
+    double h = 0, htilde = 0;
+    count visitedNodes = 1;
+
+    while (!pq.empty()) {
+        const node u = pq.extract_top();
+        assert(u != source);
+        assert(distance[u] > 0);
+
+        ++visitedNodes;
+        assert(reachableFromSource >= visitedNodes);
+        const double distU = distance[u];
+        h += 1. / distU;
+        // Simple upper bound for harmonic closeness: we assume that the distance from 'source' to
+        // all the remaining unvisited nodes is d(source, u).
+        htilde = h + static_cast<double>(reachableFromSource - visitedNodes) / distU;
+
+        // Prune SSSP
+        if (htilde < kthCloseness) {
+            hCloseness[source] = htilde;
+            return false;
+        }
+
+        G->forNeighborsOf(u, [&](node v, edgeweight ew) {
+            const double newDistV = distU + ew;
+            if (newDistV < distance[v]) {
+                distance[v] = newDistV;
+                pq.update(v);
+            }
         });
-      } else {
-        count edgeCount = 0;
-        // perform a pruned BFS from v in complex networks
-        std::pair<edgeweight, bool> c =
-            BFScut(v, kth, n, r[v], visited, distances, pred, edgeCount);
+    }
 
-        omp_set_lock(&lock);
-        allScores[v] = c.first;
-        isExact[v] = c.second;
-        isValid[v] = true;
-        omp_unset_lock(&lock);
-      }
-      // Insert v into the list with the k most central nodes if
-      // its score is larger than the k-th largest value
-      omp_set_lock(&lock);
-      if (isExact[v] && allScores[v] >= kth) {
-        top.insert(allScores[v], v);
-        if (top.size() > k) {
-          ++trail;
-          if (allScores[v] > kth) {
-            if (nMinCloseness == trail) {
-              while (top.size() > k) {
-                top.extractMin();
-              }
-              trail = 0;
-              nMinCloseness = 1;
-              if (k > 1) {
-                Aux::PrioQueue<edgeweight, node> tmp(n);
-                auto last = top.extractMin();
-                auto next = top.extractMin();
-                minCloseness = last.first;
+#ifndef NDEBUG
+    if (G->isDirected())
+        assert(reachableFromSource >= visitedNodes);
+    else
+        assert(reachableFromSource == visitedNodes);
+#endif
 
-                if (last.first == next.first) {
-                  tmp.insert(last.first, last.second);
-                  while (next.first == last.first) {
-                    tmp.insert(next.first, next.second);
-                    ++nMinCloseness;
-                    if (top.size() == 0) {
-                      break;
-                    }
-                    next = top.extractMin();
-                  }
-                  if (next.first != last.first) {
-                    top.insert(next.first, next.second);
-                  }
+    hCloseness[source] = h;
+    return true;
+}
 
-                  while (tmp.size() > 0) {
-                    auto elem = tmp.extractMin();
-                    top.insert(elem.first, elem.second);
-                  }
-                } else {
-                  top.insert(next.first, next.second);
-                  top.insert(last.first, last.second);
+void TopHarmonicCloseness::bfsbound(node source) {
+    updateTimestamp();
+    auto &visited = visitedGlobal[omp_get_thread_num()];
+    const auto ts = tsGlobal[omp_get_thread_num()];
+    visited[source] = ts;
+    auto &nodesAtLevel = nodesAtLevelGlobal[omp_get_thread_num()];
+    nodesAtLevel.clear();
+    auto &nodesAtCurrentLevel = nodesAtCurrentLevelGlobal[omp_get_thread_num()];
+    nodesAtCurrentLevel.clear();
+    auto &numberOfNodesAtLevel = numberOfNodesAtLevelGlobal[omp_get_thread_num()];
+
+    for (count i = 1; i < numberOfNodesAtLevel.size() && numberOfNodesAtLevel[i] > 0; ++i)
+        numberOfNodesAtLevel[i] = 0;
+
+    assert(std::count_if(numberOfNodesAtLevel.begin(), numberOfNodesAtLevel.end(),
+                         [](count i) { return i > 0; })
+           == 0);
+
+    std::queue<node> q1, q2;
+    q1.push(source);
+    count level = 1;
+    hCloseness[source] = 0;
+
+    do {
+        do {
+            const node u = q1.front();
+            q1.pop();
+            nodesAtCurrentLevel.push_back(u);
+
+            G->forNeighborsOf(u, [&](node v) {
+                if (visited[v] == ts)
+                    return;
+                visited[v] = ts;
+                q2.push(v);
+                ++numberOfNodesAtLevel[level];
+                hCloseness[source] += 1. / static_cast<double>(level);
+            });
+        } while (!q1.empty());
+
+        nodesAtLevel.emplace_back(std::move(nodesAtCurrentLevel));
+        nodesAtCurrentLevel.clear();
+        ++level;
+        std::swap(q1, q2);
+    } while (!q1.empty());
+
+    const double nearNodes = 1. + numberOfNodesAtLevel[1] + numberOfNodesAtLevel[2];
+    double farNodes = 0;
+    for (count i = 3; i < level; ++i)
+        farNodes += static_cast<double>(numberOfNodesAtLevel[i]) / static_cast<double>(i - 1);
+
+    double levelBound = nearNodes / 2. + farNodes;
+
+    const auto updateBound = [&](const node y) -> void {
+        // y has already been processed
+        if (!prioQ.contains(y))
+            return;
+        const double bound = levelBound + (static_cast<double>(G->degree(y)) - 1.) / 2.;
+        if (bound < hCloseness[y]) {
+            if (G->isDirected()) {
+                if (wccPtr->componentOfNode(source) == wccPtr->componentOfNode(y)) {
+                    hCloseness[y] = bound;
+                    prioQ.update(y);
                 }
-              }
+            } else {
+                hCloseness[y] = bound;
+                prioQ.update(y);
             }
-          } else {
-            ++nMinCloseness;
-          }
-        } else if (allScores[v] < minCloseness) {
-          minCloseness = allScores[v];
-          nMinCloseness = 1;
-        } else if (allScores[v] == minCloseness) {
-          ++nMinCloseness;
         }
-      }
+    };
 
-      // Update the k-th largest value for this thread
-      if (top.size() >= k) {
-        std::pair<edgeweight, node> elem = top.extractMin();
-        kth = elem.first;
-        top.insert(elem.first, elem.second);
-        if (nMinCloseness == 1) {
-          minCloseness = kth;
+    omp_set_lock(&lock);
+    // Update bound for vertices at level 1
+    G->forNeighborsOf(source, updateBound);
+    omp_unset_lock(&lock);
+
+    // Update bound for vertices at level >= 2
+    for (int64_t i = 2; i < static_cast<int64_t>(level); ++i) {
+        for (int64_t j = 0; j < static_cast<int64_t>(level); ++j) {
+            double denominator = 2;
+            if (G->isDirected())
+                denominator = j - i > 2 ? static_cast<double>(j - i) : denominator;
+            else
+                denominator = std::max(denominator, static_cast<double>(std::abs(j - i)));
+            levelBound += static_cast<double>(numberOfNodesAtLevel[j]) / denominator;
         }
-      }
-      omp_unset_lock(&lock);
+
+        if (static_cast<size_t>(i) <= nodesAtLevel.size()) {
+            omp_set_lock(&lock);
+            for (node y : nodesAtLevel[i - 1])
+                updateBound(y);
+            omp_unset_lock(&lock);
+        }
     }
-  }
-
-  // TODO This could go to another method
-  if (trail > 0) {
-    topk.resize(k + trail);
-    topkScores.resize(k + trail);
-  }
-
-  // Store the nodes and their closeness centralities
-  for (int64_t j = top.size() - 1; j >= 0; --j) {
-    std::pair<edgeweight, node> elem = top.extractMin();
-    topk[j] = elem.second;
-    topkScores[j] = elem.first;
-  }
-
-  for (count i = 0; i < topk.size() - 1; ++i) {
-    count toSort = 1;
-    while ((i + toSort) < topk.size() &&
-           topkScores[i] == topkScores[i + toSort]) {
-      ++toSort;
-    }
-    if (toSort > 1) {
-      auto begin = topk.begin() + i;
-      std::sort(begin, begin + toSort);
-      i += toSort - 1;
-    }
-  }
-
-  hasRun = true;
 }
 
-void TopHarmonicCloseness::computeReachableNodes() {
-  if (G.isDirected()) {
-    computeReachableNodesDirected();
-  } else {
-    computeReachableNodesUndirected();
-  }
+double TopHarmonicCloseness::initialBoundNBcutUnweighted(node u) const noexcept {
+    const count degU = G->degree(u);
+    if (degU == 0)
+        return 0;
+    return static_cast<double>(degU) + static_cast<double>(reachableNodes[u] - degU) / 2.;
 }
 
-void TopHarmonicCloseness::computeReachableNodesUndirected() {
-  ConnectedComponents comps(G);
-
-  r = std::vector<count>(n);
-
-  comps.run();
-  std::map<index, count> sizes = comps.getComponentSizes();
-  G.forNodes([&](node v) {
-    index cv = comps.componentOfNode(v);
-    component[v] = cv;
-    r[v] = sizes[cv];
-  });
+double TopHarmonicCloseness::initialBoundNBcutWeighted(node u) const noexcept {
+    if (G->degree(u) == 0)
+        return 0;
+    edgeweight minOutEdgeWeight = std::numeric_limits<edgeweight>::max();
+    G->forNeighborsOf(
+        u, [&](node, edgeweight ew) { minOutEdgeWeight = std::min(minOutEdgeWeight, ew); });
+    return 1. / minOutEdgeWeight
+           + static_cast<edgeweight>(reachableNodes[u] - 1) / (minOutEdgeWeight + minEdgeWeight);
 }
 
-void TopHarmonicCloseness::computeReachableNodesDirected() {
-  r = std::vector<count>(n);
-  StronglyConnectedComponents sccs(G);
-  sccs.run();
+template <class Type>
+std::vector<Type> TopHarmonicCloseness::resizedCopy(const std::vector<Type> &vec) const noexcept {
+    std::vector<Type> result = vec;
+    result.resize(k);
+    return result;
+}
 
-  count N = sccs.numberOfComponents();
-  std::vector<count> reachU_scc(N, 0);
-  std::vector<count> reachU_without_max_scc(N, 0);
-  std::vector<bool> reach_from_max_scc(N, false);
-  std::vector<bool> reaches_max_scc(N, false);
-  std::vector<std::vector<count>> sccs_vec(N, std::vector<count>());
-  Graph sccGraph(N, false, true);
-  std::vector<bool> found(N, false);
-  count maxSizeCC = 0;
-  // We compute the vector sccs_vec, where each component contains the list of
-  // its nodes
-  for (count v = 0; v < n; v++) {
-    component[v] = sccs.componentOfNode(v);
-    sccs_vec[sccs.componentOfNode(v)].push_back(v);
-  }
+std::vector<node> TopHarmonicCloseness::topkNodesList(bool includeTrail) {
+    if (!includeTrail && !trail.empty())
+        return resizedCopy(topKNodes);
+    return topKNodes;
+}
 
-  // We compute the SCC graph and store it in sccGraph
-  for (count V = 0; V < N; V++) {
-    for (node v : sccs_vec[V]) {
-      G.forNeighborsOf(v, [&](node w) {
-        count W = sccs.componentOfNode(w);
+std::vector<edgeweight> TopHarmonicCloseness::topkScoresList(bool includeTrail) {
+    if (!includeTrail && !trail.empty())
+        return resizedCopy(topKScores);
+    return topKScores;
+}
 
-        if (W != V && !found[W]) {
-          found[W] = true;
-          sccGraph.addEdge(V, W);
+void TopHarmonicCloseness::computeReachableNodesBounds() {
+    // As in TopCloseness
+    reachU.resize(G->upperNodeIdBound());
+    reachL.resize(G->upperNodeIdBound());
+    StronglyConnectedComponents sccs(*G);
+    sccs.run();
+
+    count N = sccs.numberOfComponents();
+    DEBUG("Number of components: ", N);
+    std::vector<count> reachL_scc(N, 0);
+    std::vector<count> reachU_scc(N, 0);
+    std::vector<count> reachU_without_max_scc(N, 0);
+    std::vector<bool> reach_from_max_scc(N, false);
+    std::vector<bool> reaches_max_scc(N, false);
+    std::vector<std::vector<count>> sccs_vec(N);
+    Graph sccGraph(N, false, true);
+    std::vector<bool> found(N, false);
+    count maxSizeCC = 0;
+    const auto n = G->numberOfNodes();
+
+    // We compute the vector sccs_vec, where each component contains the list of
+    // its nodes
+    for (count v = 0; v < n; v++) {
+        sccs_vec[sccs.componentOfNode(v)].push_back(v);
+    }
+
+    // We compute the SCC graph and store it in sccGraph
+    for (count V = 0; V < N; V++) {
+        for (count v : sccs_vec[V]) {
+            G->forNeighborsOf(v, [&](node w) {
+                count W = sccs.componentOfNode(w);
+
+                if (W != V && !found[W]) {
+                    found[W] = true;
+                    sccGraph.addEdge(V, W);
+                }
+            });
         }
-      });
+        sccGraph.forNeighborsOf(V, [&](node W) { found[W] = false; });
+        if (sccGraph.degreeOut(V) > sccGraph.degreeOut(maxSizeCC)) {
+            maxSizeCC = V;
+        }
     }
-    sccGraph.forNeighborsOf(V, [&](node W) { found[W] = false; });
-    if (sccGraph.degreeOut(V) > sccGraph.degreeOut(maxSizeCC)) {
-      maxSizeCC = V;
-    }
-    // ELISABETTA: maybe the code can be made simpler by running G.forEdges to
-    // scan all the edges. Would it be better to have a Graph object to store
-    // the SCC graph?
-  } // MICHELE: I have used a graph instead of scc_adjlist. About G.forEdges,
-  // I think it is
-  // a bit more complicated: I have to scan nodes, otherwise I do not know how
-  // to avoid multiple edges. This scan is made using variable "found". Do you
-  // have better ideas? Note that this is linear in the graph size.
 
-  // BFS from the biggest SCC.
-  std::queue<count> Q;
-  Q.push(maxSizeCC);
-  reach_from_max_scc[maxSizeCC] = true;
-  while (!Q.empty()) {
-    count V = Q.front();
-    Q.pop();
-    reachU_scc[maxSizeCC] += sccs_vec[V].size();
-    sccGraph.forNeighborsOf(V, [&](node W) {
-      if (!reach_from_max_scc[W]) {
-        reach_from_max_scc[W] = true;
-        Q.push(W);
-      }
+    // BFS from the biggest SCC.
+    std::queue<count> Q;
+    Q.push(maxSizeCC);
+    reach_from_max_scc[maxSizeCC] = true;
+    while (!Q.empty()) {
+        count V = Q.front();
+        Q.pop();
+        reachL_scc[maxSizeCC] += sccs_vec[V].size();
+        sccGraph.forNeighborsOf(V, [&](node W) {
+            if (!reach_from_max_scc[W]) {
+                reach_from_max_scc[W] = true;
+                Q.push(W);
+            }
+        });
+    }
+    reachU_scc[maxSizeCC] = reachL_scc[maxSizeCC];
+    reaches_max_scc[maxSizeCC] = true;
+
+    // so far only the largest SCC has reach_U and reach_L > 0
+
+    // Dynamic programming to compute number of reachable vertices
+    for (count V = 0; V < N; V++) {
+        if (V == maxSizeCC) {
+            continue;
+        }
+        sccGraph.forNeighborsOf(V, [&](node W) {
+            reachL_scc[V] = std::max(reachL_scc[V], reachL_scc[W]);
+            if (!reach_from_max_scc[W]) {
+                reachU_without_max_scc[V] += reachU_without_max_scc[W];
+            }
+            reachU_scc[V] += reachU_scc[W];
+            reachU_scc[V] = std::min(reachU_scc[V], n);
+            reaches_max_scc[V] = reaches_max_scc[V] || reaches_max_scc[W];
+        });
+
+        if (reaches_max_scc[V]) {
+            reachU_scc[V] = reachU_without_max_scc[V] + reachU_scc[V];
+        }
+        reachL_scc[V] += sccs_vec[V].size();
+        reachU_scc[V] += sccs_vec[V].size();
+        reachU_scc[V] = std::min(reachU_scc[V], n);
+    }
+
+    for (count v = 0; v < n; v++) {
+        reachL[v] = reachL_scc[sccs.componentOfNode(v)];
+        reachU[v] = reachU_scc[sccs.componentOfNode(v)];
+    }
+}
+
+void TopHarmonicCloseness::computeNeighborhoodBasedBound() {
+    const count n = G->upperNodeIdBound();
+    std::vector<count> nodesAtK(n);
+    std::vector<count> nodesAtKminusOne(n);
+    std::vector<count> nodesAtKminusTwo(n);
+    std::vector<count> visited(n);
+    std::vector<bool> finished(n);
+    std::vector<double> sumHCloseness(n);
+
+    count nFinished = 0;
+    G->forNodes([&](const node u) {
+        const count degOutU = G->degreeOut(u);
+        if (degOutU == 0) {
+            ++nFinished;
+            finished[u] = true;
+        }
+
+        nodesAtKminusOne[u] = degOutU;
+        sumHCloseness[u] = degOutU;
+        visited[u] = degOutU + 1;
+        hCloseness[u] = std::numeric_limits<double>::max();
     });
-  }
-  reaches_max_scc[maxSizeCC] = true;
 
-  // so far only the largest SCC has reach_U and reach_L > 0
+    count level = 2;
+    while (nFinished < G->numberOfNodes()) {
+        G->forNodes([&](const node u) {
+            if (finished[u])
+                return;
 
-  // Dynamic programming to compute number of reachable vertices
-  for (count V = 0; V < N; V++) {
-    if (V == maxSizeCC) {
-      continue;
+            nodesAtK[u] = 0;
+            G->forNeighborsOf(u, [&](node v) { nodesAtK[u] += nodesAtKminusOne[v]; });
+            if (!G->isDirected()) {
+                if (level == 2) {
+                    assert(nodesAtK[u] >= G->degree(u));
+                    nodesAtK[u] -= G->degree(u);
+                } else {
+                    assert(nodesAtK[u] >= nodesAtKminusTwo[u] * (G->degreeOut(u) - 1));
+                    nodesAtK[u] -= nodesAtKminusTwo[u] * (G->degreeOut(u) - 1);
+                }
+            }
+
+            const count nOld = visited[u];
+            visited[u] += nodesAtK[u];
+            sumHCloseness[u] += static_cast<double>(nodesAtK[u]) / static_cast<double>(level);
+
+            if (G->isDirected()) {
+                if (visited[u] >= reachL[u]) {
+                    if (nOld < reachL[u]) {
+                        // We have to consider the case in which the number of reachable
+                        // vertices is reachL.
+                        hCloseness[u] = sumHCloseness[u]
+                                        - static_cast<double>(visited[u] - reachL[u])
+                                              / static_cast<double>(level);
+                    }
+
+                    if (nodesAtK[u] == 0)
+                        reachU[u] = visited[u];
+
+                    if (visited[u] >= reachU[u]) {
+                        // We have to consider the case in which the number of reachable
+                        // vertices is reachU.
+                        hCloseness[u] = std::min(hCloseness[u],
+                                                 sumHCloseness[u]
+                                                     - static_cast<double>(visited[u] - reachU[u])
+                                                           / static_cast<double>(level));
+                        finished[u] = true;
+                        nFinished++;
+
+                        assert(visited[u] >= reachL[u] || nodesAtK[u] != 0);
+                    } else { // reachL < N < reachU
+                        // We have to consider the case in which the number of reachable is
+                        // N[u].
+                        hCloseness[u] = std::min(hCloseness[u], sumHCloseness[u]);
+                    }
+                }
+            } else if (visited[u] >= reachableNodes[u]) {
+                hCloseness[u] = std::min(hCloseness[u],
+                                         sumHCloseness[u]
+                                             - static_cast<double>(visited[u] - reachableNodes[u])
+                                                   / static_cast<double>(level));
+                finished[u] = true;
+                ++nFinished;
+            }
+        });
+
+        G->parallelForNodes([&](node u) {
+            nodesAtKminusTwo[u] = nodesAtKminusOne[u];
+            nodesAtKminusOne[u] = nodesAtK[u];
+        });
+        ++level;
     }
-    sccGraph.forNeighborsOf(V, [&](node W) {
-      if (!reach_from_max_scc[W]) {
-        reachU_without_max_scc[V] += reachU_without_max_scc[W];
-      }
-      reachU_scc[V] += reachU_scc[W];
-      reachU_scc[V] = std::min(reachU_scc[V], n);
-      reaches_max_scc[V] = reaches_max_scc[V] || reaches_max_scc[W];
-    });
-
-    if (reaches_max_scc[V]) {
-      reachU_scc[V] = reachU_without_max_scc[V] + reachU_scc[V];
-    }
-    reachU_scc[V] += sccs_vec[V].size();
-    reachU_scc[V] = std::min(reachU_scc[V], n);
-  }
-
-  for (count v = 0; v < n; v++) {
-    r[v] = reachU_scc[sccs.componentOfNode(v)];
-  }
 }
+
 } // namespace NetworKit

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -87,6 +87,25 @@ class TestSelfLoops(unittest.TestCase):
 		testTopKRanking(False)
 		testTopKRanking(True)
 
+	def testCentralityTopHarmonicCloseness(self):
+		CC = nk.centrality.HarmonicCloseness(self.L, False)
+		CC.run()
+		scores = CC.scores()
+		tol = 1e-6
+		k = 5
+
+		for useNBbound in [True, False]:
+			thc = nk.centrality.TopHarmonicCloseness(self.L, k, useNBbound).run()
+			self.assertEqual(len(thc.topkNodesList()), k)
+			self.assertEqual(len(thc.topkScoresList()), k)
+			self.assertGreaterEqual(len(thc.topkNodesList(True)), k)
+			self.assertGreaterEqual(len(thc.topkScoresList(True)), k)
+
+			for node, score in zip(thc.topkNodesList(True), thc.topkScoresList(True)):
+				self.assertAlmostEqual(score, scores[node], delta=tol)
+
+			for score_thc, score in zip(thc.topkScoresList(True), sorted(scores, reverse=True)):
+				self.assertAlmostEqual(score_thc, score, delta=tol)
 
 	def testCentralityCoreDecomposition(self):
 		CL = nk.centrality.CoreDecomposition(self.L)

--- a/notebooks/Centrality.ipynb
+++ b/notebooks/Centrality.ipynb
@@ -465,7 +465,7 @@
    "outputs": [],
    "source": [
     "# Initialize algorithm\n",
-    "topHarmClose = nk.centrality.TopHarmonicCloseness(G, 10, useBFSbound=False)\n",
+    "topHarmClose = nk.centrality.TopHarmonicCloseness(G, 10, useNBbound=False)\n",
     "topHarmClose.run()"
    ]
   },


### PR DESCRIPTION
`TopHarmonicCloseness` yields wrong rankings with the `NBbound` variation and this bug is not caught by CI because it is not tested. Plus, the algorithms can be improved by using a heap rather than an `Aux::PrioQueue`.

This PR brings a correct and simpler implementation for TopHarmonic closeness. Plus, it provides more extensive C++ unit tests (which fail with the previous implementation), and basic Python tests.

Furthermore, it extends the `NBcut` variation to weighted graphs.