### PR TITLE
Bugfix& Code Improvement: GlobalTradeSequence

### DIFF
--- a/include/networkit/randomization/GlobalTradeSequence.hpp
+++ b/include/networkit/randomization/GlobalTradeSequence.hpp
@@ -272,7 +272,7 @@ public:
         hashFunctors.reserve(num_global_trades);
         hashFunctors.push_back(Hash{num_nodes, prng});
 
-        for (size_t i = 0; i < num_global_trades; i++) {
+        while (hashFunctors.size() < num_global_trades) {
             // we copy the hash function, rather than constructing a new one,
             // to avoid repeated computations, such as the next larger prime
             // number

--- a/include/networkit/randomization/GlobalTradeSequence.hpp
+++ b/include/networkit/randomization/GlobalTradeSequence.hpp
@@ -1,6 +1,9 @@
 /*
  * GlobalTradeSequence.hpp
  *
+ * This header file is deprecated and will eventually be removed.
+ * Do not included it directly.
+ *
  *  Created on: 23.05.2018
  *      Author: Manuel Penschuck <networkit@manuel.jetzt>
  */
@@ -8,6 +11,14 @@
 
 #ifndef NETWORKIT_RANDOMIZATION_GLOBAL_TRADE_SEQUENCE_HPP_
 #define NETWORKIT_RANDOMIZATION_GLOBAL_TRADE_SEQUENCE_HPP_
+
+#ifndef NETWORKIT_PRIVATE_RANDOMIZATION_GLOBAL_TRADE_SEQUENCE_HPP_
+#if defined(__clang__) || defined(__GNUG__)
+#warning "This header file is deprecated. Do not included it directly."
+#elif defined(_MSC_VER)
+#pragma message("This header file is deprecated. Do not included it directly.")
+#endif
+#endif // NETWORKIT_PRIVATE_RANDOMIZATION_GLOBAL_TRADE_SEQUENCE_HPP_
 
 #include <cassert>
 #include <cmath>

--- a/include/networkit/randomization/GlobalTradeSequence.hpp
+++ b/include/networkit/randomization/GlobalTradeSequence.hpp
@@ -198,6 +198,9 @@ public:
 
     //! randomly samples parameters a and b
     void sampleParameters(std::mt19937_64 &prng) {
+        if (n >= p)
+            throw std::runtime_error("Support only up to 2147483646 nodes");
+
         a = std::uniform_int_distribution<value_type>{1, p - 1}(prng);
         ainv = static_cast<value_type>(
             (std::get<1>(LinearCongruentialMap<T>::gcdExtended(a, p)) + p) % p);
@@ -218,8 +221,7 @@ public:
 
 private:
     value_type n; //< number of elements to be mapped
-    static constexpr value_type p =
-        (1 || sizeof(value_type) == 4) ? 2147483647 : 2305843009213693951ll;
+    static constexpr value_type p = 2147483647;
 
     value_type a;    //< multiplicative parameter in hash
     value_type ainv; //< multiplicative invert

--- a/networkit/cpp/randomization/GlobalCurveballImpl.hpp
+++ b/networkit/cpp/randomization/GlobalCurveballImpl.hpp
@@ -25,7 +25,8 @@
 #include <networkit/graph/Graph.hpp>
 #include <networkit/graph/GraphBuilder.hpp>
 #include <networkit/randomization/GlobalCurveball.hpp>
-#include <networkit/randomization/GlobalTradeSequence.hpp>
+
+#include "GlobalTradeSequence.hpp"
 
 namespace NetworKit {
 namespace CurveballDetails {

--- a/networkit/cpp/randomization/GlobalTradeSequence.hpp
+++ b/networkit/cpp/randomization/GlobalTradeSequence.hpp
@@ -1,0 +1,7 @@
+// This header file is a temporary wrapper to until /include/networkit/randomization/GlobalTradeSequence.hpp
+// will have been moved from the public API into the private source directory
+
+// TODO: Move public header file into private source directory
+
+#define NETWORKIT_PRIVATE_RANDOMIZATION_GLOBAL_TRADE_SEQUENCE_HPP_
+#include <networkit/randomization/GlobalTradeSequence.hpp>

--- a/networkit/cpp/randomization/test/GlobalCurveballBenchmark.cpp
+++ b/networkit/cpp/randomization/test/GlobalCurveballBenchmark.cpp
@@ -8,12 +8,12 @@
 
 #include <gtest/gtest.h>
 
-#include <networkit/randomization/GlobalCurveball.hpp>
-#include <networkit/randomization/GlobalTradeSequence.hpp>
-
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/generators/HyperbolicGenerator.hpp>
 #include <networkit/graph/Graph.hpp>
+#include <networkit/randomization/GlobalCurveball.hpp>
+
+#include "../GlobalTradeSequence.hpp"
 
 namespace NetworKit {
 

--- a/networkit/cpp/randomization/test/GlobalTradeSequenceGTest.cpp
+++ b/networkit/cpp/randomization/test/GlobalTradeSequenceGTest.cpp
@@ -10,7 +10,8 @@
 #include <gtest/gtest.h>
 
 #include <networkit/auxiliary/Random.hpp>
-#include <networkit/randomization/GlobalTradeSequence.hpp>
+
+#include "../GlobalTradeSequence.hpp"
 
 namespace NetworKit {
 


### PR DESCRIPTION
This PR addresses the following issues:
- `GlobalTradeSequence` produced one global trade too many. As a result, `GlobalCurveball` performed k+1 global trade if k were configured. For users this should have little implications (algorithms performs is slightly slower, but "adds more entropy" which I found when comparing the Markov Chain's mixing times)
- `FixedLinearCongruentialMap` requires ~2n bits to deal with n bit node ids, so it cannot process more than ~2 Billion nodes with 64bit arithmetic. This was previously ignored and is now explicitly checked.
- Small code improvements and deduplication.

**Question**: `randomization/GlobalTradeSequence.hpp` contains only implementation details  and only adds to the `networkit::CurveballDetails` namespace. So I suggest moving the header file into the source directory `networkit/cpp/randomization` (similarly to e.g. `CurveballImpl.hpp`). Should I do this in this PR, or do we need some deprecation period. The file is never referenced in a public interface (and I cannot think of a reason why it should be).