### PR TITLE
Refactor ApproxBetweenness

### DIFF
--- a/include/networkit/centrality/ApproxBetweenness.hpp
+++ b/include/networkit/centrality/ApproxBetweenness.hpp
@@ -18,7 +18,7 @@ namespace NetworKit {
  * Approximation of betweenness centrality according to algorithm described in
  * Matteo Riondato and Evgenios M. Kornaropoulos: Fast Approximation of Betweenness Centrality through Sampling
  */
-class ApproxBetweenness: public Centrality {
+class ApproxBetweenness final: public Centrality {
 
 public:
 

--- a/include/networkit/centrality/ApproxBetweenness.hpp
+++ b/include/networkit/centrality/ApproxBetweenness.hpp
@@ -1,5 +1,5 @@
 /*
- * ApproxBetweenness.h
+ * ApproxBetweenness.hpp
  *
  *  Created on: 09.04.2014
  *      Author: cls

--- a/include/networkit/centrality/ApproxBetweenness.hpp
+++ b/include/networkit/centrality/ApproxBetweenness.hpp
@@ -53,8 +53,8 @@ public:
 
 private:
 
-    double epsilon;
-    double delta;
+    const double epsilon;
+    const double delta;
     count r; // number of samples taken in last run
     double universalConstant;
 };

--- a/include/networkit/centrality/ApproxBetweenness.hpp
+++ b/include/networkit/centrality/ApproxBetweenness.hpp
@@ -48,7 +48,7 @@ public:
     /**
      * @return number of samples taken in last run
      */
-    count numberOfSamples();
+    count numberOfSamples() const;
 
 
 private:

--- a/networkit/cpp/centrality/ApproxBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxBetweenness.cpp
@@ -22,7 +22,7 @@
 
 namespace NetworKit {
 
-ApproxBetweenness::ApproxBetweenness(const Graph& G, const double epsilon, const double delta, const double universalConstant) : Centrality(G, true), epsilon(epsilon), delta(delta), universalConstant(universalConstant) {
+ApproxBetweenness::ApproxBetweenness(const Graph& G, double epsilon, double delta, double universalConstant) : Centrality(G, true), epsilon(epsilon), delta(delta), universalConstant(universalConstant) {
 
 }
 

--- a/networkit/cpp/centrality/ApproxBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxBetweenness.cpp
@@ -47,69 +47,54 @@ void ApproxBetweenness::run() {
     r = ceil((universalConstant / (epsilon * epsilon)) * (floor(log2(vd - 2)) + 1 - log(delta)));
 
     INFO("taking ", r, " path samples");
-    // parallelization:
-    count maxThreads = omp_get_max_threads();
-    DEBUG("max threads: ", maxThreads);
-    std::vector<std::vector<double> > scorePerThread(maxThreads, std::vector<double>(G.upperNodeIdBound()));
-    DEBUG("score per thread size: ", scorePerThread.size());
     handler.assureRunning();
-    #pragma omp parallel for
-    for (omp_index i = 1; i <= static_cast<omp_index>(r); i++) {
-        count thread = omp_get_thread_num();
-        DEBUG("sample ", i);
-        // if (i >= 1000) throw std::runtime_error("too many iterations");
-        // DEBUG
-        // sample random node pair
-        node u, v;
-        u = GraphTools::randomNode(G);
-        do {
-            v = GraphTools::randomNode(G);
-        } while (v == u);
+    #pragma omp parallel
+    {
+        auto ssspPtr = G.isWeighted() ? std::unique_ptr<SSSP>(new Dijkstra(G, 0, true, false))
+                                      : std::unique_ptr<SSSP>(new BFS(G, 0, true, false));
 
-        // runs faster for unweighted graphs
-        std::unique_ptr<SSSP> sssp;
-        if (G.isWeighted()) {
-            sssp.reset(new Dijkstra(G, u, true, false, v));
-        } else {
-            sssp.reset(new BFS(G, u, true, false, v));
-        }
-        DEBUG("running shortest path algorithm for node ", u);
-        if (!handler.isRunning()) continue;
-        sssp->run();
-        if (!handler.isRunning()) continue;
-        if (sssp->numberOfPaths(v) > 0) { // at least one path between {u, v} exists
-            DEBUG("updating estimate for path ", u, " <-> ", v);
-            // random path sampling and estimation update
-            // node s = v;
-            node t = v;
-            while (t != u)  {
-                // sample z in P_u(t) with probability sigma_uz / sigma_us
-                std::vector<std::pair<node, double> > choices;
-                for (node z : sssp->getPredecessors(t)) {
-                    bigfloat tmp = sssp->numberOfPaths(z) / sssp->numberOfPaths(t);
-                    double weight;
-                    tmp.ToDouble(weight);
-                    choices.emplace_back(z, weight); 	// sigma_uz / sigma_us
+#pragma omp for
+        for (omp_index i = 1; i <= static_cast<omp_index>(r); i++) {
+            DEBUG("sample ", i);
+            // sample random node pair
+            node u, v;
+            u = GraphTools::randomNode(G);
+            do {
+                v = GraphTools::randomNode(G);
+            } while (v == u);
+
+            auto &sssp = *ssspPtr;
+            sssp.setSource(u);
+            sssp.setTarget(v);
+
+            DEBUG("running shortest path algorithm for node ", u);
+            if (!handler.isRunning()) continue;
+            sssp.run();
+            if (!handler.isRunning()) continue;
+            if (sssp.numberOfPaths(v) > 0) { // at least one path between {u, v} exists
+                DEBUG("updating estimate for path ", u, " <-> ", v);
+                // random path sampling and estimation update
+                node t = v;
+                while (t != u)  {
+                    // sample z in P_u(t) with probability sigma_uz / sigma_us
+                    std::vector<std::pair<node, double> > choices;
+                    for (node z : sssp.getPredecessors(t)) {
+                        bigfloat tmp = sssp.numberOfPaths(z) / sssp.numberOfPaths(t);
+                        double weight;
+                        tmp.ToDouble(weight);
+                        choices.emplace_back(z, weight); 	// sigma_uz / sigma_us
+                    }
+                    node z = Aux::Random::weightedChoice(choices);
+                    assert (z <= G.upperNodeIdBound());
+                    if (z != u)
+#pragma omp atomic
+                        scoreData[z] += 1. / static_cast<double>(r);
+                    t = z;
                 }
-                node z = Aux::Random::weightedChoice(choices);
-                assert (z <= G.upperNodeIdBound());
-                if (z != u) {
-                    scorePerThread[thread][z] += 1 / (double) r;
-                }
-                // s = t;
-                t = z;
             }
         }
     }
     handler.assureRunning();
-
-    INFO("adding thread-local scores");
-    // add up all thread-local values
-    for (auto &local : scorePerThread) {
-        G.parallelForNodes([&](node v){
-            scoreData[v] += local[v];
-        });
-    }
 
     hasRun = true;
 }

--- a/networkit/cpp/centrality/ApproxBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxBetweenness.cpp
@@ -100,7 +100,8 @@ void ApproxBetweenness::run() {
 }
 
 
-count ApproxBetweenness::numberOfSamples() {
+count ApproxBetweenness::numberOfSamples() const {
+    assureFinished();
     INFO("Estimated number of samples", r);
     return r;
 }

--- a/networkit/cpp/distance/Dijkstra.cpp
+++ b/networkit/cpp/distance/Dijkstra.cpp
@@ -45,6 +45,7 @@ void Dijkstra::run() {
 
     // priority queue with distance-node pairs
     distances[source] = 0.;
+    heap.clear();
     heap.push(source);
 
     auto initPath = [&](node u, node v) {


### PR DESCRIPTION
This PR improves the performance of `ApproxBetweenness`:
- Atomic updates of vertex scores instead of keeping thread-local vectors (as discussed in #532)
- Preallocate memory for `SSSP` to avoid dynamic memory allocations inside the main loop

It also fixes a bug in `Dijkstra` (if `run` is called multiple times, the algorithm could start with a non-empty heap and yield wrong results).

Additional changes:
- Make `ApproxBetweenness` final
- Make member variables `epsilon` and `delta` const (they cannot be changed from outside)
- Make `numberOfSamples()` const
- Remove `const` from value parameters
