### PR TITLE
Refactor Betweenness

### DIFF
--- a/networkit/cpp/centrality/Betweenness.cpp
+++ b/networkit/cpp/centrality/Betweenness.cpp
@@ -113,7 +113,7 @@ void Betweenness::run() {
             pairs = pairs / 2;
             edges = edges / 2;
         }
-        G.forNodes([&](node u){
+        G.parallelForNodes([&](node u){
             scoreData[u] = scoreData[u] / pairs;
         });
         if (computeEdgeCentrality) {

--- a/networkit/cpp/centrality/Betweenness.cpp
+++ b/networkit/cpp/centrality/Betweenness.cpp
@@ -109,10 +109,6 @@ void Betweenness::run() {
         count n = G.numberOfNodes();
         count pairs = (n-2) * (n-1);
         count edges =  n    * (n-1);
-        if (!G.isDirected()) {
-            pairs = pairs / 2;
-            edges = edges / 2;
-        }
         G.parallelForNodes([&](node u){
             scoreData[u] = scoreData[u] / pairs;
         });

--- a/networkit/cpp/centrality/Betweenness.cpp
+++ b/networkit/cpp/centrality/Betweenness.cpp
@@ -90,9 +90,11 @@ void Betweenness::run() {
         G.parallelForNodes([&](node u){
             scoreData[u] = scoreData[u] / pairs;
         });
+
         if (computeEdgeCentrality) {
-            for (count edge = 0; edge < edgeScoreData.size(); edge++) {
-                edgeScoreData[edge] =  edgeScoreData[edge] / edges;
+#pragma omp parallel for
+            for (omp_index i = 0; i < static_cast<omp_index>(edgeScoreData.size()); ++i) {
+                edgeScoreData[i] =  edgeScoreData[i] / static_cast<double>(edges);
             }
         }
     }

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -85,14 +85,20 @@ TEST_F(CentralityGTest, testBetweennessCentrality) {
     Betweenness centrality(G);
     centrality.run();
     std::vector<double> bc = centrality.scores();
+    std::vector<double> result = {0., 0., 15., 3., 3., 1.};
 
     const double tol = 1e-3;
-    EXPECT_NEAR(0.0, bc[0], tol);
-    EXPECT_NEAR(0.0, bc[1], tol);
-    EXPECT_NEAR(15.0, bc[2], tol);
-    EXPECT_NEAR(3.0, bc[3], tol);
-    EXPECT_NEAR(3.0, bc[4], tol);
-    EXPECT_NEAR(1.0, bc[5], tol);
+    G.forNodes([&](node u) {
+        EXPECT_NEAR(result[u], bc[u], tol);
+    });
+
+    Betweenness centralityNorm(G, true);
+    centralityNorm.run();
+    bc = centralityNorm.scores();
+    const double pairs = (n - 1) * (n - 2);
+    G.forNodes([&](node u) {
+        EXPECT_NEAR(result[u] / pairs, bc[u], tol);
+    });
 }
 
 TEST_F(CentralityGTest, testBetweenness2Centrality) {


### PR DESCRIPTION
This PR brings the following changes to `Betweenness`:
- Fix the normalization for unweighted graphs as suggested in #592 
- Faster parallel performances by aggregating the vertex and edge scores using `omp atomic` operations instead of using thread-local vectors as done in #607 
- Parallel score normalization
- Additional tests for the normalized betweenness