### PR TITLE
Added getComponents for ParallelComponents

### DIFF
--- a/include/networkit/components/ParallelConnectedComponents.hpp
+++ b/include/networkit/components/ParallelConnectedComponents.hpp
@@ -44,21 +44,25 @@ public:
     /**
      * This method returns the number of connected components.
      */
-    count numberOfComponents();
+    count numberOfComponents() const;
 
     /**
      * This method returns the the component in which node query is situated.
      *
      * @param[in]	query	the node whose component is asked for
      */
-    count componentOfNode(node u);
+    count componentOfNode(node u) const;
 
 
     /**
      * Return a Partition that represents the components
      */
-    Partition getPartition();
+    Partition getPartition() const;
 
+    /**
+     * @return Vector of components, each stored as (unordered) set of nodes.
+     */
+    std::vector<std::vector<node>> getComponents() const;
 
 private:
     const Graph* G;

--- a/networkit/components.pyx
+++ b/networkit/components.pyx
@@ -127,6 +127,7 @@ cdef extern from "<networkit/components/ParallelConnectedComponents.hpp>":
 		count numberOfComponents() except +
 		count componentOfNode(node query) except +
 		_Partition getPartition() except +
+		vector[vector[node]] getComponents() except +
 
 
 cdef class ParallelConnectedComponents(Algorithm):
@@ -140,13 +141,42 @@ cdef class ParallelConnectedComponents(Algorithm):
 		self._this = new _ParallelConnectedComponents(G._this, coarsening)
 
 	def getPartition(self):
+		""" Get a Partition that represents the components.
+
+		Returns:
+		--------
+		networkit.Partition
+			A partition representing the found components.
+		"""
 		return Partition().setThis((<_ParallelConnectedComponents*>(self._this)).getPartition())
 
 	def numberOfComponents(self):
+		""" Get the number of connected components.
+
+		Returns:
+		--------
+		count:
+			The number of connected components.
+		"""
 		return (<_ParallelConnectedComponents*>(self._this)).numberOfComponents()
 
 	def componentOfNode(self, v):
+		"""  Get the the component in which node `v` is situated.
+
+		v : node
+			The node whose component is asked for.
+		"""
 		return (<_ParallelConnectedComponents*>(self._this)).componentOfNode(v)
+
+	def getComponents(self):
+		""" Get the connected components, each as a list of nodes.
+
+		Returns:
+		--------
+		list:
+			The connected components.
+		"""
+		return (<_ParallelConnectedComponents*>(self._this)).getComponents()
 
 
 cdef extern from "<networkit/components/StronglyConnectedComponents.hpp>":

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -67,7 +67,6 @@ Partition ConnectedComponents::getPartition() const {
 std::vector<std::vector<node>> ConnectedComponents::getComponents() const {
     assureFinished();
 
-    // transform partition into vector of unordered_set
     std::vector<std::vector<node>> result(numComponents);
 
     G->forNodes([&](node u) { result[component[u]].push_back(u); });

--- a/networkit/cpp/components/ParallelConnectedComponents.cpp
+++ b/networkit/cpp/components/ParallelConnectedComponents.cpp
@@ -92,6 +92,8 @@ void ParallelConnectedComponents::run() {
             component[u] = cc.componentOfNode(nodeMapping[u]);
         });
     }
+
+    hasRun = true;
 }
 
 void ParallelConnectedComponents::runSequential() {
@@ -164,20 +166,32 @@ void ParallelConnectedComponents::runSequential() {
             component[u] = cc.componentOfNode(nodeMapping[u]);
         });
     }
+
+    hasRun = true;
 }
 
 
-Partition ParallelConnectedComponents::getPartition() {
+Partition ParallelConnectedComponents::getPartition() const {
+    assureFinished();
     return this->component;
 }
 
-count ParallelConnectedComponents::numberOfComponents() {
+count ParallelConnectedComponents::numberOfComponents() const {
+    assureFinished();
     return this->component.numberOfSubsets();
 }
 
-count ParallelConnectedComponents::componentOfNode(node u) {
+count ParallelConnectedComponents::componentOfNode(node u) const {
+    assureFinished();
     assert (component[u] != none);
     return component[u];
+}
+
+std::vector<std::vector<node>> ParallelConnectedComponents::getComponents() const {
+
+    std::vector<std::vector<node>> result(this->numberOfComponents());
+    G->forNodes([&](node u) { result[component[u]].push_back(u); });
+    return result;
 }
 
 }


### PR DESCRIPTION
From #579:
Adresses missing `getComponents()` for `ParallelComponents` (other component-variants do implement/expose this functionality)