### PR TITLE
Profiling: remove broken features

### DIFF
--- a/include/networkit/centrality/DynKatzCentrality.hpp
+++ b/include/networkit/centrality/DynKatzCentrality.hpp
@@ -1,5 +1,5 @@
 /*
- * DynKatzCentrality.h
+ * DynKatzCentrality.hpp
  *
  *  Created on: April 2018
  *      Author: Alexander van der Grinten

--- a/include/networkit/centrality/KatzCentrality.hpp
+++ b/include/networkit/centrality/KatzCentrality.hpp
@@ -34,11 +34,12 @@ public:
      * Each iteration of the algorithm requires O(m) time. The number of iterations depends on how long it takes to reach the convergence.
      *
      * @param[in] G The graph.
-     * @param[in] alpha Damping of the matrix vector product result
+     * @param[in] alpha Damping of the matrix vector product result, must be non negative.
+     * Leave this parameter to 0 to use the default value 1 / (max_degree + 1).
      * @param[in] beta Constant value added to the centrality of each vertex
      * @param[in] tol The tolerance for convergence.
      */
-    KatzCentrality(const Graph& G, double alpha = 5e-4, double beta = 0.1, double tol = 1e-8);
+    KatzCentrality(const Graph& G, double alpha = 0, double beta = 0.1, double tol = 1e-8);
 
     /**
      * Computes katz centrality on the graph passed in constructor.

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -1431,7 +1431,7 @@ cdef extern from "<networkit/centrality/KatzCentrality.hpp>":
 
 cdef class KatzCentrality(Centrality):
 	"""
-	KatzCentrality(G, alpha=5e-4, beta=0.1, tol=1e-8)
+	KatzCentrality(G, alpha=0, beta=0.1, tol=1e-8)
 
 	Constructs a KatzCentrality object for the given Graph `G`.
 	Each iteration of the algorithm requires O(m) time.
@@ -1443,14 +1443,15 @@ cdef class KatzCentrality(Centrality):
  	G : networkit.Graph
  		The graph.
  	alpha : double
-		Damping of the matrix vector product result
+		Damping of the matrix vector product result, must be non negative.
+		Leave this parameter to 0 to use the default value 1 / (max_degree + 1).
 	beta : double
 		Constant value added to the centrality of each vertex
 	tol : double
 		The tolerance for convergence.
 	"""
 
-	def __cinit__(self, Graph G, alpha=0.2, beta=0.1, tol=1e-8):
+	def __cinit__(self, Graph G, alpha=0, beta=0.1, tol=1e-8):
 		self._G = G
 		self._this = new _KatzCentrality(G._this, alpha, beta, tol)
 

--- a/networkit/cpp/centrality/DynKatzCentrality.cpp
+++ b/networkit/cpp/centrality/DynKatzCentrality.cpp
@@ -1,5 +1,5 @@
 /*
- * DynKatzCentrality.h
+ * DynKatzCentrality.cpp
  *
  *  Created on: April 2018
  *      Author: Alexander van der Grinten

--- a/networkit/cpp/centrality/DynKatzCentrality.cpp
+++ b/networkit/cpp/centrality/DynKatzCentrality.cpp
@@ -9,22 +9,20 @@
 #include <cfloat>
 #include <cmath>
 #include <omp.h>
+
 #include <networkit/auxiliary/NumericTools.hpp>
 #include <networkit/auxiliary/Timer.hpp>
 #include <networkit/centrality/DynKatzCentrality.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
 DynKatzCentrality::DynKatzCentrality(const Graph& G, count k, bool groupOnly, double tolerance)
 : Centrality(G, false), k(k), groupOnly(groupOnly), rankTolerance(tolerance),
         activeQueue(G.upperNodeIdBound()) {
-    maxdeg = 0;
-    G.forNodes([&](node u){
-        if (G.degree(u) > maxdeg) {
-            maxdeg = G.degree(u);
-        }
-    });
-    assert(maxdeg && "Alpha is chosen based on the max. degree; therefore, that degree must not be zero");
+    maxdeg = static_cast<count>(GraphTools::maxDegree(G));
+    if (maxdeg == 0)
+        throw std::runtime_error("Alpha is chosen based on the max. degree; therefore, that degree must not be zero");
 
     alpha = 1.0 / (maxdeg + 1.0);
     DEBUG("alpha: ", alpha);

--- a/networkit/cpp/centrality/KatzCentrality.cpp
+++ b/networkit/cpp/centrality/KatzCentrality.cpp
@@ -28,7 +28,7 @@ void KatzCentrality::run() {
     double length = 0.0;
     double oldLength = 0.0;
 
-    auto converged  = [&](double val, double other) -> bool {
+    auto converged = [&](double val, double other) -> bool {
         // compute residual
         return Aux::NumericTools::equal(val, other, tol);
     };

--- a/networkit/cpp/centrality/KatzCentrality.cpp
+++ b/networkit/cpp/centrality/KatzCentrality.cpp
@@ -8,13 +8,17 @@
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/NumericTools.hpp>
 #include <networkit/centrality/KatzCentrality.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
 KatzCentrality::KatzCentrality(const Graph& G, double alpha, double beta, double tol):
         Centrality(G, true), alpha(alpha), beta(beta), tol(tol)
 {
-
+    if (alpha < 0)
+        throw std::runtime_error("Alpha must be non negative.");
+    if (alpha == 0)
+        alpha = 1. / (1. + GraphTools::maxDegree(G));
 }
 
 void KatzCentrality::run() {

--- a/networkit/profiling/html/profile.html
+++ b/networkit/profiling/html/profile.html
@@ -20,7 +20,6 @@
 	<br>
 	<!--- END HELP --->
 	<div class="Category" data-title="Global Properties">
-		<div class="Value" data-title="Name">{properties[Name]}</div>
 		<div class="Value" data-title="Nodes">{properties[Nodes]}</div>
 		<div class="Value" data-title="Edges">{properties[Edges]}</div>
 		<div class="Value" data-title="Density">{properties[Density]:g}</div>

--- a/networkit/profiling/profiling.py
+++ b/networkit/profiling/profiling.py
@@ -641,10 +641,10 @@ class Profile:
 									value = self.__correlations[category][keyA][keyB]
 								except:
 									value = self.__correlations[category][keyB][keyA]
-								if outputType == "HTML":
-									result += "<div class=\"Thumbnail_ScatterPlot\" data-title=\"" + keyB + "\" data-title-second=\"" + keyA + "\"><img src=\"data:image/svg+xml;utf8," + value["image"] + "\" /></div>"
-								elif outputType == "LaTeX":
-									result += "\n\\includegraphics[width=0.5\\textwidth]{{\"" + value["image"] + "\"}.pdf}"
+#								if outputType == "HTML":
+#									result += "<div class=\"Thumbnail_ScatterPlot\" data-title=\"" + keyB + "\" data-title-second=\"" + keyA + "\"><img src=\"data:image/svg+xml;utf8," + value["image"] + "\" /></div>"
+#								elif outputType == "LaTeX":
+#									result += "\n\\includegraphics[width=0.5\\textwidth]{{\"" + value["image"] + "\"}.pdf}"
 				return result
 			results[category]["Correlations"]["ScatterPlots"] += funcScatterPlot(category)
 

--- a/notebooks/User-Guide.ipynb
+++ b/notebooks/User-Guide.ipynb
@@ -1104,6 +1104,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Profiling\n",
+    "\n",
+    "The [profiling module](https://networkit.github.io/dev-docs/python_api/profiling.html?highlight=profiling#) allows to get an overall picture of a network with a single line of code. Detailed statistics of the main properties of the network are shown both graphically and numerically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nk.profiling.Profile.create(G).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Support"
    ]
   },


### PR DESCRIPTION
The profiling module was broken some time ago (see #241). This PR removes (temporarily) the features that cause the crashes so that this module can be used again.
Further, it corrects the default value for the `alpha` parameter in the `KatzCentrality` python interface (which did not match the one used in the C++ implementation).