### PR TITLE
Integrate various versions of DynApproxBetweeness code

### DIFF
--- a/include/networkit/centrality/DynApproxBetweenness.hpp
+++ b/include/networkit/centrality/DynApproxBetweenness.hpp
@@ -1,6 +1,5 @@
-// no-networkit-format
 /*
- * DynApproxBetweenness.h
+ * DynApproxBetweenness.hpp
  *
  *  Created on: 31.07.2014
  *      Author: ebergamini
@@ -9,10 +8,11 @@
 #ifndef NETWORKIT_CENTRALITY_DYN_APPROX_BETWEENNESS_HPP_
 #define NETWORKIT_CENTRALITY_DYN_APPROX_BETWEENNESS_HPP_
 
-#include <networkit/centrality/Centrality.hpp>
 #include <networkit/base/DynAlgorithm.hpp>
-#include <networkit/dynamics/GraphEvent.hpp>
+#include <networkit/centrality/Centrality.hpp>
+#include <networkit/components/StronglyConnectedComponents.hpp>
 #include <networkit/distance/DynSSSP.hpp>
+#include <networkit/dynamics/GraphEvent.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -25,24 +25,24 @@ namespace NetworKit {
  * @ingroup centrality
  * Interface for dynamic approximated betweenness centrality algorithm.
  */
-class DynApproxBetweenness: public Centrality, public DynAlgorithm {
+class DynApproxBetweenness : public Centrality, public DynAlgorithm {
 
 public:
     /**
-      * The algorithm approximates the betweenness of all vertices so that the scores are
-      * within an additive error @a epsilon with probability at least (1- @a delta).
-      * The values are normalized by default.
-      *
-      * @param	G			the graph
-      * @param	storePredecessors   keep track of the lists of predecessors?
-      * @param	epsilon		maximum additive error
-      * @param	delta		probability that the values are within the error guarantee
-      * @param	universalConstant	the universal constant to be used in
-      * computing the sample size. It is 1 by default. Some references suggest
-      * using 0.5, but there is no guarantee in this case.
+     * Implementation from the algorithm from "Approximating Betweenness Centrality in Fully-dynamic
+     * Networks" from Internet Mathematics vol. 5 by Elisabetta Bergamini and Henning Meyerhenke
+     * approximates the betweenness of all vertices so that the scores are within an additive error
+     * @a epsilon with probability at least (1- @a delta). The values are normalized by default.
+     *
+     * @param	G			the graph
+     * @param  storePredecessors   keep track of the lists of predecessors?
+     * @param	epsilon		maximum additive error
+     * @param	delta		probability that the values are within the error guarantee
+     * @param	universalConstant	the universal constant to be used in
+     * computing the sample size. It is 0.5 by default.
      */
     DynApproxBetweenness(const Graph &G, double epsilon = 0.01, double delta = 0.1,
-                         bool storePredecessors = true, double universalConstant = 1.0);
+                         bool storePredecessors = true, double universalConstant = 0.5);
 
     /**
      * Runs the static approximated betweenness centrality algorithm on the initial graph.
@@ -50,36 +50,43 @@ public:
     void run() override;
 
     /**
-    * Updates the betweenness centralities after an edge insertions on the graph.
-    * Notice: it works only with edge insertions and the graph has to be connected.
-    *
-    * @param e The edge insertions.
-    */
+     * Updates the betweenness centralities after an edge insertions on the graph.
+     *
+     * @param e The edge insertion or deletion.
+     */
     void update(GraphEvent e) override;
 
     /**
-    * Updates the betweenness centralities after a batch of edge insertions on the graph.
-    * Notice: it works only with edge insertions and the graph has to be connected.
-    *
-    * @param batch The batch of edge insertions.
-    */
-    void updateBatch(const std::vector<GraphEvent>& batch) override;
+     * Updates the betweenness centralities after a batch of edge insertions on the graph.
+     *
+     * @param batch The batch of edge insertions and/or deletions.
+     */
+    void updateBatch(const std::vector<GraphEvent> &batch) override;
 
     /**
-    * Get number of path samples used for last calculation
-    */
-    count getNumberOfSamples();
+     * Get number of path samples used for last calculation
+     */
+    count getNumberOfSamples() const noexcept;
 
 private:
-    bool storePreds = true;
+    void sampleNewPaths(count start, count end);
     double epsilon; //!< maximum error
     double delta;
-    double universalConstant;
+    bool storePreds;
+    const double universalConstant;
     count r;
     std::vector<std::unique_ptr<DynSSSP>> sssp;
+    std::vector<std::vector<count>> npaths;
+
     std::vector<node> u;
     std::vector<node> v;
-    std::vector <std::vector<node>> sampledPaths;
+    std::vector<std::vector<node>> sampledPaths;
+
+    static constexpr edgeweight infDist = std::numeric_limits<edgeweight>::max();
+
+    std::vector<node> sortComponentsTopologically(Graph &sccDAG, StronglyConnectedComponents &scc);
+
+    count computeVDdirected();
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/distance/DynBFS.hpp
+++ b/include/networkit/distance/DynBFS.hpp
@@ -18,6 +18,8 @@ namespace NetworKit {
  */
 class DynBFS final : public DynSSSP {
 
+    static constexpr edgeweight infDist = std::numeric_limits<edgeweight>::max();
+
 public:
     /**
      * Creates the object for @a G and source @a s.

--- a/include/networkit/distance/DynDijkstra.hpp
+++ b/include/networkit/distance/DynDijkstra.hpp
@@ -8,6 +8,9 @@
 #ifndef NETWORKIT_DISTANCE_DYN_DIJKSTRA_HPP_
 #define NETWORKIT_DISTANCE_DYN_DIJKSTRA_HPP_
 
+#include <tlx/container/d_ary_addressable_int_heap.hpp>
+
+#include <networkit/auxiliary/VectorComparator.hpp>
 #include <networkit/distance/DynSSSP.hpp>
 
 namespace NetworKit {
@@ -39,8 +42,14 @@ public:
     void updateBatch(const std::vector<GraphEvent> &batch) override;
 
 private:
-    enum Color { WHITE, BLACK };
+    enum Color { WHITE, GRAY, BLACK };
     std::vector<Color> color;
+    static constexpr edgeweight infDist = std::numeric_limits<edgeweight>::max();
+    static constexpr edgeweight distEpsilon = 0.000001;
+
+    tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<edgeweight>> heap;
+    std::vector<edgeweight> updateDistances;
+    tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<edgeweight>> updateHeap;
 };
 
 } /* namespace NetworKit */

--- a/networkit/cpp/centrality/DynApproxBetweenness.cpp
+++ b/networkit/cpp/centrality/DynApproxBetweenness.cpp
@@ -1,4 +1,3 @@
-// no-networkit-format
 /*
  * DynApproxBetweenness.cpp
  *
@@ -6,173 +5,268 @@
  *      Author: ebergamini
  */
 
-#include <networkit/centrality/DynApproxBetweenness.hpp>
-#include <networkit/auxiliary/Random.hpp>
-#include <networkit/distance/Diameter.hpp>
-#include <networkit/graph/GraphTools.hpp>
-#include <networkit/distance/DynDijkstra.hpp>
-#include <networkit/distance/DynBFS.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/NumericTools.hpp>
-
+#include <networkit/auxiliary/Random.hpp>
+#include <networkit/centrality/Centrality.hpp>
+#include <networkit/centrality/DynApproxBetweenness.hpp>
+#include <networkit/components/StronglyConnectedComponents.hpp>
+#include <networkit/distance/Diameter.hpp>
+#include <networkit/distance/DynBFS.hpp>
+#include <networkit/distance/DynDijkstra.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/graph/TopologicalSort.hpp>
 
 namespace NetworKit {
 
-DynApproxBetweenness::DynApproxBetweenness(const Graph& G, const double epsilon, const double delta, const bool storePredecessors, const double universalConstant) : Centrality(G, true),
-storePreds(storePredecessors), epsilon(epsilon), delta(delta), universalConstant(universalConstant) {
+DynApproxBetweenness::DynApproxBetweenness(const Graph &G, double epsilon, double delta,
+                                           bool storePredecessors, double universalConstant)
+    : Centrality(G, true), epsilon(epsilon), delta(delta), storePreds(storePredecessors),
+      universalConstant(universalConstant) {}
+
+std::vector<node>
+DynApproxBetweenness::sortComponentsTopologically(Graph &sccDAG, StronglyConnectedComponents &scc) {
+    G.forEdges([&](node u, node v) {
+        if (scc.componentOfNode(u) != scc.componentOfNode(v)) {
+            if (!sccDAG.hasEdge(scc.componentOfNode(u) - 1, scc.componentOfNode(v) - 1)) {
+                sccDAG.addEdge(scc.componentOfNode(u) - 1, scc.componentOfNode(v) - 1);
+            }
+        }
+    });
+
+    TopologicalSort topSort(sccDAG);
+    topSort.run();
+    return topSort.getResult();
 }
 
+count DynApproxBetweenness::computeVDdirected() {
+    StronglyConnectedComponents scc(G);
+    scc.run();
+    count sccNum = scc.numberOfComponents();
+    Graph sccDAG(sccNum, false, true);
 
-count DynApproxBetweenness::getNumberOfSamples() {
+    std::vector<node> sorted = sortComponentsTopologically(sccDAG, scc);
+
+    std::vector<bool> marked1(G.upperNodeIdBound()), marked2(G.upperNodeIdBound());
+    std::vector<node> sources(sccNum, 0);
+    G.forNodes([&](node u) {
+        count x = scc.componentOfNode(u) - 1;
+        if (sources[x] == 0) {
+            sources[x] = u;
+        }
+    });
+    // we compute the bound on VD for each SCC
+    std::vector<count> vdapproxs(sccNum);
+    std::queue<node> q, qNext;
+    for (count i = 0; i < sccNum; i++) {
+        count source = sources[sorted[i]];
+        // forward BFS
+        marked1[source] = true;
+        count dist1 = 0;
+        q.push(source);
+        do {
+            node u = q.front();
+            q.pop();
+            G.forNeighborsOf(u, [&](node v) {
+                if (!marked1[v] && scc.componentOfNode(u) == scc.componentOfNode(v)) {
+                    qNext.push(v);
+                    marked1[v] = true;
+                }
+            });
+            if (q.empty() && !qNext.empty()) {
+                q.swap(qNext);
+                ++dist1;
+            }
+        } while (!q.empty());
+
+        // backward BFS
+        marked2[source] = true;
+        count dist2 = 0;
+        q.push(source);
+        do {
+            node u = q.front();
+            q.pop();
+            G.forInNeighborsOf(u, [&](node v) {
+                if (!marked2[v] && scc.componentOfNode(u) == scc.componentOfNode(v)) {
+                    qNext.push(v);
+                    marked2[v] = true;
+                }
+            });
+            if (q.empty() && !qNext.empty()) {
+                q.swap(qNext);
+                ++dist2;
+            }
+        } while (!q.empty());
+        // source node is not taken into account in any of the two approximations
+        vdapproxs[sorted[i]] = dist1 + dist2 + 1;
+        if (vdapproxs[sorted[i]] == 0) // for singletons
+            vdapproxs[sorted[i]] = 1;
+    }
+    // starting from the bottom, we compute all the cumulative vd approximations
+    count vd = vdapproxs[0];
+    std::vector<count> vdSuccessors(sccNum, 0);
+    for (count i = 0; i < sccNum; i++) {
+        node c = sorted[sccNum - i];
+        if (sccDAG.degreeOut(c) > 0) {
+            vdapproxs[c] += vdSuccessors[c];
+        }
+        if (vdapproxs[c] > vd) {
+            vd = vdapproxs[c];
+        }
+        sccDAG.forInEdgesOf(c, [&](node c, node c_pred) {
+            if (vdSuccessors[c_pred] < vdapproxs[c])
+                vdSuccessors[c_pred] = vdapproxs[c];
+        });
+    }
+    return vd;
+}
+
+count DynApproxBetweenness::getNumberOfSamples() const noexcept {
     return r;
 }
 
-
 void DynApproxBetweenness::run() {
-    if (G.isDirected()) {
-        throw std::runtime_error("Invalid argument: G must be undirected.");
-    }
     scoreData.clear();
     scoreData.resize(G.upperNodeIdBound());
     u.clear();
     v.clear();
     sampledPaths.clear();
-
-    Diameter diam(G, DiameterAlgo::estimatedPedantic);
-    diam.run();
-    edgeweight vd = diam.getDiameter().first;
-
-    INFO("estimated diameter: ", vd);
-    r = std::ceil((universalConstant / (epsilon * epsilon)) * (std::floor(std::log2(vd - 2)) + 1 - std::log(delta)));
-    INFO("taking ", r, " path samples");
+    count vd;
+    if (G.isDirected()) {
+        vd = computeVDdirected();
+    } else {
+        Diameter diam(G, DiameterAlgo::estimatedPedantic);
+        diam.run();
+        vd = diam.getDiameter().first;
+    }
+    r = std::ceil((universalConstant / (epsilon * epsilon))
+                  * (tlx::integer_log2_floor(vd - 2) + 1.0 + std::log(1.0 / delta)));
     sssp.clear();
     sssp.resize(r);
-    u.resize(r);
-    v.resize(r);
-    sampledPaths.resize(r);
+    sampleNewPaths(0, r);
+    hasRun = true;
+}
 
-    for (count i = 0; i < r; i++) {
-        DEBUG("sample ", i);
+void DynApproxBetweenness::update(GraphEvent e) {
+    std::vector<GraphEvent> batch = {e};
+    updateBatch(batch);
+}
+
+void DynApproxBetweenness::updateBatch(const std::vector<GraphEvent> &batch) {
+    assert(sssp.size() == r);
+    for (node i = 0; i < r; i++) {
+        sssp[i]->updateBatch(batch);
+        if (!sssp[i]->modified()) // Skip unaffected node i
+            continue;
+        // subtract contributions to nodes in the old sampled path
+        for (node z : sampledPaths[i]) {
+            scoreData[z] -= 1 / (double)r;
+        }
+        if (sssp[i]->distance(v[i]) == infDist) // Skip unreachable node v[i]
+            continue;
+        // sample a new shortest path
+        sampledPaths[i].clear();
+        node t = v[i];
+        while (t != u[i]) {
+            // sample z in P_u(t) with probability sigma_uz / sigma_us
+            std::vector<std::pair<node, double>> choices;
+            G.forInEdgesOf(t, [&](node t, node z, edgeweight w) {
+                if (Aux::NumericTools::logically_equal(sssp[i]->distance(t),
+                                                       sssp[i]->distance(z) + w)) {
+                    // workaround for integer overflow in large graphs
+                    double weight =
+                        (sssp[i]->getNumberOfPaths(z) / sssp[i]->getNumberOfPaths(t)).ToDouble();
+                    choices.emplace_back(z, weight);
+                }
+            });
+            assert(!choices.empty()); // this should fail only if the graph is not connected
+            node z = Aux::Random::weightedChoice(choices);
+            assert(G.hasNode(z));
+            if (z != u[i]) {
+                scoreData[z] += 1 / (double)r;
+                sampledPaths[i].push_back(z);
+            }
+            t = z;
+        }
+    }
+    count new_vd;
+    if (G.isDirected()) {
+        new_vd = computeVDdirected();
+    } else { // case for undirected already present
+        Diameter diam(G, DiameterAlgo::estimatedPedantic);
+        diam.run();
+        new_vd = diam.getDiameter().first;
+    }
+    count new_r = std::ceil((universalConstant / (epsilon * epsilon))
+                            * (tlx::integer_log2_floor(new_vd - 2) + 1.0 + std::log(1.0 / delta)));
+    if (new_r > r) {
+        sampleNewPaths(r, new_r);
+        // multiply all scores by r/new_r
+        G.forNodes([&](node n) { scoreData[n] *= r / double(new_r); });
+        r = new_r;
+    }
+}
+
+void DynApproxBetweenness::sampleNewPaths(count start, count end) {
+    for (count i = start; i < end; i++) {
         // sample random node pair
-        u[i] = GraphTools::randomNode(G);
+        node u1, u2;
+        u1 = GraphTools::randomNode(G);
         do {
-            v[i] = GraphTools::randomNode(G);
-        } while (v[i] == u[i]);
+            u2 = GraphTools::randomNode(G);
+        } while (u1 == u2);
+        u.push_back(u1);
+        v.push_back(u2);
         if (G.isWeighted()) {
             sssp[i] = std::make_unique<DynDijkstra>(G, u[i], storePreds);
         } else {
             sssp[i] = std::make_unique<DynBFS>(G, u[i], storePreds);
         }
-        DEBUG("running shortest path algorithm for node ", u[i]);
-
-        sssp[i]->setTargetNode(v[i]);
         sssp[i]->run();
-        if (sssp[i]->distances[v[i]] > 0) { // at least one path between {u, v} exists
-            DEBUG("updating estimate for path ", u[i], " <-> ", v[i]);
+        std::vector<node> path;
+        if (sssp[i]->distance(v[i]) < infDist) { // at least one path between {u, v} exists
             // random path sampling and estimation update
-            sampledPaths[i].clear();
             node t = v[i];
-            while (t != u[i])  {
+            while (t != u[i]) {
                 // sample z in P_u(t) with probability sigma_uz / sigma_us
-                std::vector<std::pair<node, double> > choices;
+                std::vector<std::pair<node, double>> choices;
                 if (storePreds) {
                     for (node z : sssp[i]->previous[t]) {
                         // workaround for integer overflow in large graphs
-                        bigfloat tmp = sssp[i]->numberOfPaths(z) / sssp[i]->numberOfPaths(t);
-                        double weight;
-                        tmp.ToDouble(weight);
-
-                        choices.emplace_back(z, weight); 	// sigma_uz / sigma_us
+                        double weight =
+                            (sssp[i]->getNumberOfPaths(z) / sssp[i]->getNumberOfPaths(t))
+                                .ToDouble();
+                        assert(weight != 0);
+                        choices.emplace_back(z, weight); // sigma_uz / sigma_us
                     }
-                }
-                else {
-                  G.forInEdgesOf(t, [&](node t, node z, edgeweight w){
-                        if (Aux::NumericTools::logically_equal(sssp[i]->distances[t], sssp[i]->distances[z] + w)) {
+                } else {
+                    G.forInEdgesOf(t, [&](node t, node z, edgeweight w) {
+                        if (Aux::NumericTools::logically_equal(sssp[i]->distance(t),
+                                                               sssp[i]->distance(z) + w)) {
                             // workaround for integer overflow in large graphs
-                            bigfloat tmp = sssp[i]->numberOfPaths(z) / sssp[i]->numberOfPaths(t);
-                            double weight;
-                            tmp.ToDouble(weight);
-
+                            double weight =
+                                (sssp[i]->getNumberOfPaths(z) / sssp[i]->getNumberOfPaths(t))
+                                    .ToDouble();
+                            assert(weight != 0);
                             choices.emplace_back(z, weight);
                         }
-
                     });
                 }
-                DEBUG("Node: ", t);
-                DEBUG("Source: ", u[i]);
+
                 assert(!choices.empty());
                 node z = Aux::Random::weightedChoice(choices);
-                assert (z <= G.upperNodeIdBound());
+                assert(G.hasNode(z));
                 if (z != u[i]) {
-                    scoreData[z] += 1 / (double) r;
-                    sampledPaths[i].push_back(z);
+                    scoreData[z] += 1 / (double)r;
+                    path.push_back(z);
                 }
                 t = z;
             }
         }
-    }
-
-    hasRun = true;
-
-}
-
-void DynApproxBetweenness::update(GraphEvent e) {
-  std::vector<GraphEvent> batch(1);
-  batch[0] = e;
-  updateBatch(batch);
-}
-
-
-void DynApproxBetweenness::updateBatch(const std::vector<GraphEvent>& batch) {
-    DEBUG ("Updating");
-    for (node i = 0; i < r; i++) {
-        sssp[i]->updateBatch(batch);
-        if (sssp[i]->modified()) {
-            // subtract contributions to nodes in the old sampled path
-            for (node z: sampledPaths[i]) {
-                scoreData[z] -= 1 / (double) r;
-            }
-            // sample a new shortest path
-            sampledPaths[i].clear();
-            node t = v[i];
-            while (t != u[i])  {
-                // sample z in P_u(t) with probability sigma_uz / sigma_us
-                std::vector<std::pair<node, double> > choices;
-                if (storePreds) {
-                    for (node z : sssp[i]->previous[t]) {
-                        // workaround for integer overflow in large graphs
-                        bigfloat tmp = sssp[i]->numberOfPaths(z) / sssp[i]->numberOfPaths(t);
-                        double weight;
-                        tmp.ToDouble(weight);
-
-                        choices.emplace_back(z, weight);
-                    }
-                }
-                else {
-                    G.forInEdgesOf(t, [&](node t, node z, edgeweight w){
-                        if (Aux::NumericTools::logically_equal(sssp[i]->distances[t], sssp[i]->distances[z] + w)) {
-                            // workaround for integer overflow in large graphs
-                            bigfloat tmp = sssp[i]->numberOfPaths(z) / sssp[i]->numberOfPaths(t);
-                            double weight;
-                            tmp.ToDouble(weight);
-
-                            choices.emplace_back(z, weight);
-                        }
-                    });
-                }
-                assert(!choices.empty()); // this should fail only if the graph is not connected
-                node z = Aux::Random::weightedChoice(choices);
-                assert (z <= G.upperNodeIdBound());
-                if (z != u[i]) {
-                    scoreData[z] += 1 / (double) r;
-                    sampledPaths[i].push_back(z);
-                }
-                t = z;
-            }
-
-        }
-
+        sampledPaths.emplace_back(std::move(path));
     }
 }
 
-} /* namespace NetworKit */
+constexpr edgeweight DynApproxBetweenness::infDist;
+
+} // namespace NetworKit


### PR DESCRIPTION
There is some old `DynApproxBetweenness` that is no longer compatible with the current NetworKit version that is supposed to be integrated into NetworKit. It supports deletion for various types of graphs.

After discussing with @angriman, we decided to use the `PImpl`-pattern and have different implementations for the different cases. There is still a bit of long way to go before this code can be merged into the NetworKit code base. 
The aim of this draft PR is to make my work and the `DynApproxBetweeness` code available to anyone who will takeover from here and discussions about whether using `PImpl` is the best solution going forward.

A brief explanation of the commits:
- bc230e7: Converts the current `DynApproxBetweennness` code to pimpl pattern so that `DynApproxBetweennness.h` can be used with the other code.
- e077d49: `DynApproxBetweennnessImplDir` - although not entirely complete, this is the first class to be ported to the current NetworKit version. There is still an unsolved error in the code + no tests. This corresponds to the class `DynApproxBetweennessDir` mentioned below.
- d2be1cb: This commit just adds all the files containing the code that should be integrated in its unaltered form. 