### PR TITLE
Migration from Travis CI to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,279 @@
+name: build
+
+on: [push, pull_request]
+
+env:
+  OMP_NUM_THREADS: 2
+  CXX_STANDARD: 11
+  MONOLITH: ON
+
+jobs:
+  macos-build-apple-clang:
+    name: "macOS ${{ matrix.os }} (latest apple-clang, Python 3.9): ${{ matrix.variant }}"
+    runs-on: macos-${{ matrix.os }}
+    env:
+      CC: cc
+      CXX: c++
+    strategy:
+      matrix:
+        os: ['11.0', '10.15']
+        variant: ['full build', 'non-monolithic']
+    continue-on-error: ${{ matrix.os == '11.0' }}
+    steps:
+      - name: Install prerequisites 📦
+        run: |
+          brew install libomp
+          brew install ninja
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare environment and run checks (full build)
+        if: matrix.variant == 'full build'
+        run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
+        shell: bash
+      - name: Prepare environment and run checks (non-monolithic)
+        if: matrix.variant == 'non-monolithic'
+        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
+        shell: bash
+        env:
+          MONOLITH: OFF
+
+  macos-build-misc-compiler:
+    name: "macOS ${{ matrix.os }} (latest ${{ matrix.variant }}, Python 3.9): core build"
+    runs-on: macos-${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['11.0', '10.15']
+        variant: ['llvm-11', 'gcc-10']
+    continue-on-error: ${{ matrix.os == '11.0' }}
+    steps:
+      - name: Install prerequisites 📦
+        run: |
+          brew install libomp
+          brew install ninja
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install compiler llvm
+        if: matrix.variant == 'llvm-11'
+        run: brew install llvm@11
+      - name: Install compiler gcc
+        if: matrix.variant == 'gcc-10'
+        run: | 
+          brew install gcc@10
+          brew link gcc
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare environment and run checks (llvm)
+        if: matrix.variant == 'llvm-11'
+        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
+        shell: bash
+        env:
+          CC: /usr/local/opt/llvm/bin/clang
+          CXX: /usr/local/opt/llvm/bin/clang++
+      - name: Prepare environment and run checks (gcc)
+        if: matrix.variant == 'gcc-10'
+        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
+        shell: bash
+        env:
+          CC: gcc-10
+          CXX: g++-10 
+
+  linux-build-latest-gcc:
+    name: "Linux (latest gcc-10, Python 3.8): ${{ matrix.variant }}"
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc-10
+      CXX: g++-10
+    strategy:
+      matrix:
+        variant: ['full build', 'core build', 'non-monolithic']
+    steps:
+      - name: Install prerequisites 📦
+        run:  |
+          sudo apt-get install ninja-build
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare environment and run checks (full build)
+        if: matrix.variant == 'full build'
+        run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
+        shell: bash
+      - name: Prepare environment and run checks (core build)
+        if: matrix.variant == 'core build'
+        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
+        shell: bash
+      - name: Prepare environment and run checks (non-monolithic)
+        if: matrix.variant == 'non-monolithic'
+        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
+        shell: bash
+
+  linux-build-basic-support:
+    name: "Linux (${{ matrix.variant }}, Python 3.6): full build"
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        variant: ['gcc-4.9', 'clang-3.8']
+    steps:
+      - name: Install prerequisites 📦
+        run:  |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install ninja-build gcc-4.9 g++-4.9 
+          sudo apt-get install libomp5 libomp-dev clang-3.8 clang++-3.8
+      - name: Setup Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare environment and run checks (gcc-4.9)
+        if: matrix.variant == 'gcc-4.9'
+        run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
+        shell: bash
+        env:
+          CC: gcc-4.9
+          CXX: g++-4.9
+      - name: Prepare environment and run checks (clang-3.8)
+        if: matrix.variant == 'clang-3.8'
+        run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
+        shell: bash
+        env:
+          CC: clang-3.8
+          CXX: clang++-3.8
+
+  linux-build-conformance:
+    name: "Linux (latest gcc-10): C++${{ matrix.variant }} conformance"
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc-10
+      CXX: g++-10
+    strategy:
+      matrix:
+        variant: ['14', '17', '20']
+    steps:
+      - name: Install prerequisites 📦
+        run:  |
+          sudo apt-get install ninja-build
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare environment and run checks (C++)
+        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
+        shell: bash
+        env:
+          CXX_STANDARD: ${{ matrix.variant }}
+
+  linux-build-clang-tidy:
+    name: "Linux (clang-9, Python 3.8): clang-tidy build"
+    runs-on: ubuntu-20.04
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+      - name: Install prerequisites
+        run: |
+          curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-9 main" | sudo tee /etc/apt/sources.list.d/llvm9.list
+          sudo apt-get update
+          sudo apt-get install libomp-9-dev clang-9 clang-tidy-9 ninja-build
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare environment and run checks
+        run:  ${{ github.workspace }}/.github/workflows/scripts/clang_tidy.sh
+        shell: bash
+
+  linux-build-core-sanitizers-coverage:
+    name: "Linux (gcc-5, Python 3.6): core build, sanitizers, coverage"
+    runs-on: ubuntu-18.04
+    env:
+      CC: gcc-5
+      CXX: g++-5
+    steps:
+      # gcc-5 has to be used with 18.04, because the integrated version from 16.04-image has a bug with linker flags:
+      # "unrecognized option '--push-state--no-as-needed'"
+      - name: Install prerequisites
+        run:  |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install ninja-build gcc-5 g++-5
+      - name: Setup Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare environment and run checks
+        run:  ${{ github.workspace }}/.github/workflows/scripts/core_sanitizers_coverage.sh
+        shell: bash
+      - name: Update Coveralls 🚀
+        run: |
+          . pyenv/bin/activate
+          coveralls -E ".*test/.*" -E ".*CMakeFiles.*" --exclude extlibs --exclude pyenv --exclude scripts --root .
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+
+  documentation-build:
+    name: "Documentation build"
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc-10
+      CXX: g++-10
+    continue-on-error: true
+    steps:
+      - name: Install prerequisites 📦
+        run:  |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install doxygen pandoc
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare environment and run checks
+        run:  ${{ github.workspace }}/.github/workflows/scripts/documentation.sh
+        shell: bash
+      - name: Deploy networkit.github.io 🚀
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          ACCESS_TOKEN: ${{ secrets.SECRET_DEPLOY_GITHUB_PAGES }}
+          BRANCH: master
+          BASE_BRANCH: master
+          FOLDER: core_build/htmldocs
+          REPOSITORY_NAME: networkit/dev-docs
+          CLEAN: false
+
+  style-guide-compliance-build:
+    name: "Style guide compliance build"
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Install prerequisites 📦
+        run: |
+          curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/bionic llvm-toolchain-bionic-8 main" | sudo tee /etc/apt/sources.list.d/llvm8.list
+          sudo apt-get update
+          sudo apt-get install clang-format-8
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare environment and run checks
+        run:  |
+          set -e
+          ./check_code.sh -v

--- a/.github/workflows/scripts/clang_tidy.sh
+++ b/.github/workflows/scripts/clang_tidy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+sudo rm -rf /usr/local/clang-*
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 9999
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 9999
+sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 9999
+$CXX --version
+clang-tidy --version
+mkdir debug_test && cd "$_"
+cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DNETWORKIT_CLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug ..
+ninja
+ctest -V

--- a/.github/workflows/scripts/core_sanitizers_coverage.sh
+++ b/.github/workflows/scripts/core_sanitizers_coverage.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+python3 -m venv pyenv && . pyenv/bin/activate
+pip3 install --upgrade pip
+pip3 install setuptools cpp-coveralls
+
+mkdir build && cd "$_"
+cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_WITH_SANITIZERS=leak -DNETWORKIT_COVERAGE=ON ..
+ninja
+
+ctest -V

--- a/.github/workflows/scripts/cpp_only.sh
+++ b/.github/workflows/scripts/cpp_only.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$CXX --version
+
+mkdir debug_test && cd "$_"
+cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DNETWORKIT_MONOLITH=$MONOLITH -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD -DNETWORKIT_WARNINGS=ON -DCMAKE_BUILD_TYPE=Debug ..
+ninja
+
+ctest -V

--- a/.github/workflows/scripts/documentation.sh
+++ b/.github/workflows/scripts/documentation.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+python3 -m venv pyenv && . pyenv/bin/activate
+pip3 install --upgrade pip
+ 
+# cython is required because git does not contain _NetworKit.
+pip3 install cython
+
+# Several modules are required to build the documentation.
+pip3 install sphinx sphinx_bootstrap_theme numpydoc breathe exhale nbsphinx
+pip3 install sphinx_copybutton sphinxcontrib.bibtex sphinx_gallery sphinx_last_updated_by_git 
+pip3 install ipykernel ipython matplotlib nbconvert jupyter-client networkx tabulate
+
+# Build the C++ core library (no need for optimizations).
+mkdir core_build && cd "$_"
+cmake -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD -DNETWORKIT_WARNINGS=ON ..
+make -j2
+cd ..
+
+# Build the Python extension.
+export CMAKE_LIBRARY_PATH=${CMAKE_LIBRARY_PATH:+$CMAKE_LIBRARY_PATH:}$(pwd)/core_build
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$(pwd)/core_build
+export CPU_COUNT=$(python3 $GITHUB_WORKSPACE/.github/workflows/scripts/get_core_count.py)
+NETWORKIT_PARALLEL_JOBS=$CPU_COUNT python3 ./setup.py build_ext --inplace --networkit-external-core
+NETWORKIT_PARALLEL_JOBS=$CPU_COUNT pip3 install -e .
+
+# Build the documentation.
+cd core_build
+make docs
+touch htmldocs/.nojekyll
+rm -rf htmldocs/{.buildinfo,.doctrees}

--- a/.github/workflows/scripts/full.sh
+++ b/.github/workflows/scripts/full.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+$CXX --version
+python3 --version
+cmake --version
+
+python3 -m venv pyenv && . pyenv/bin/activate
+pip3 install --upgrade pip
+pip3 install cython ipython jupyter
+
+mkdir core_build && cd "$_"
+cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD -DNETWORKIT_WARNINGS=ON -DNETWORKIT_WARNINGS_AS_ERRORS=ON ..
+ninja
+UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ASAN_OPTIONS=abort_on_error=1 ctest -V
+cd ..
+export CMAKE_LIBRARY_PATH=${CMAKE_LIBRARY_PATH:+$CMAKE_LIBRARY_PATH:}$(pwd)/core_build
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$(pwd)/core_build
+export CPU_COUNT=$(python3 $GITHUB_WORKSPACE/.github/workflows/scripts/get_core_count.py)
+
+NETWORKIT_PARALLEL_JOBS=$CPU_COUNT python3 ./setup.py build_ext --inplace --networkit-external-core
+NETWORKIT_PARALLEL_JOBS=$CPU_COUNT pip3 install -e .
+
+python3 -c 'import networkit'
+
+pip3 install -r requirements.txt
+
+python3 -m unittest discover -v networkit/test/
+
+python3 notebooks/test_notebooks.py 'notebooks/'

--- a/.github/workflows/scripts/get_core_count.py
+++ b/.github/workflows/scripts/get_core_count.py
@@ -1,0 +1,7 @@
+import os
+try:
+	# For Linux
+	print(len(os.sched_getaffinity(0)))
+except AttributeError:
+	# For macOS
+	print(os.cpu_count())

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <img width="60%" src="docs/logo/logo_color.png" alt="NetworKit - Lage-scale Network Analysis"><br>
-  <a href="https://travis-ci.org/networkit/networkit"><img src="https://travis-ci.org/networkit/networkit.svg?branch=master"></a>
+  <a href="https://github.com/networkit/networkit/actions"><img src="https://github.com/networkit/networkit/workflows/build/badge.svg"></a>
   <a href="https://ci.appveyor.com/project/networkit/networkit"><img src="https://ci.appveyor.com/api/projects/status/github/networkit/networkit?branch=master&svg=true"></a>
   <a href="https://badge.fury.io/py/networkit"><img src="https://badge.fury.io/py/networkit.svg"></a>
   <a href="https://coveralls.io/github/networkit/networkit?branch=master"><img src="https://coveralls.io/repos/github/networkit/networkit/badge.svg?branch=master"></a>


### PR DESCRIPTION
This migrates all tests from Travis CI to Github Actions. Motivation for this PR is the recently introduced price model for Travis CI and reoccuring test errors due to (likely) image problems.

- Windows tests are still done by appveyor
- Since Actions are only triggered / visible on the default branch, here is a preview from my fork: https://github.com/fabratu/networkit/actions (The documentation build fails, since the deployment token is not added to the fork)
- Added secrets for deployments to project settings

First impressions:
- There is more caching involved. Setup time therefore takes less time for consecutive runs.
- More concurrent jobs / cores per job.
- Reduced runtime: ~2h Travis CI vs. ~25min Github Actions
