### PR TITLE
Katz centrality: edge direction

### DIFF
--- a/include/networkit/centrality/KatzCentrality.hpp
+++ b/include/networkit/centrality/KatzCentrality.hpp
@@ -12,6 +12,8 @@
 
 namespace NetworKit {
 
+enum EdgeDirection : char { InEdges = 0, OutEdges = 1 };
+
 /**
  * @ingroup centrality
  * Computes the Katz centrality of the graph.
@@ -20,6 +22,7 @@ namespace NetworKit {
  * edges (as opposed to outgoing ones).
  */
 class KatzCentrality: public Centrality {
+    std::vector<double> values;
 protected:
     const double alpha; // damping
     const double beta; // constant centrality amount
@@ -41,6 +44,9 @@ public:
      * Computes katz centrality on the graph passed in constructor.
      */
     void run() override;
+
+    // Whether to count in-edges or out-edges
+    EdgeDirection edgeDirection = EdgeDirection::InEdges;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/centrality/KatzCentrality.hpp
+++ b/include/networkit/centrality/KatzCentrality.hpp
@@ -1,5 +1,5 @@
 /*
- * KatzCentrality.h
+ * KatzCentrality.hpp
  *
  *  Created on: 09.01.2015
  *      Author: Henning
@@ -21,9 +21,9 @@ namespace NetworKit {
  */
 class KatzCentrality: public Centrality {
 protected:
-    double alpha; // damping
-    double beta; // constant centrality amount
-    double tol; // error tolerance
+    const double alpha; // damping
+    const double beta; // constant centrality amount
+    const double tol; // error tolerance
 
 public:
     /**

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -1727,7 +1727,6 @@ cdef extern from "<networkit/centrality/PageRank.hpp>" namespace "NetworKit::Pag
 		L1Norm = 0
 		L2Norm = 1
 
-#class _PageRankNorm(object):
 class Norm(object):
 	l1norm = L1Norm
 	l2norm = L2Norm
@@ -1774,7 +1773,7 @@ cdef class PageRank(Centrality):
 		def __get__(self):
 			""" Get the norm used as stopping criterion. """
 			return (<_PageRank*>(self._this)).norm
-		def __set__(self, norm):
+		def __set__(self, _Norm norm):
 			""" Set the norm used as stopping criterion. """
 			(<_PageRank*>(self._this)).norm = norm
 

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -1413,10 +1413,21 @@ cdef class KPathCentrality(Centrality):
 		self._G = G
 		self._this = new _KPathCentrality(G._this, alpha, k)
 
+cdef extern from "<networkit/centrality/KatzCentrality.hpp>" namespace "NetworKit":
+
+	cdef enum _EdgeDirection"NetworKit::EdgeDirection":
+		OutEdges = 0
+		InEdges = 1
+
+class EdgeDirection(object):
+	inEdges = InEdges
+	outEdges = OutEdges
+
 cdef extern from "<networkit/centrality/KatzCentrality.hpp>":
 
 	cdef cppclass _KatzCentrality "NetworKit::KatzCentrality" (_Centrality):
 		_KatzCentrality(_Graph, double, double, double) except +
+		_EdgeDirection edgeDirection
 
 cdef class KatzCentrality(Centrality):
 	"""
@@ -1442,6 +1453,14 @@ cdef class KatzCentrality(Centrality):
 	def __cinit__(self, Graph G, alpha=0.2, beta=0.1, tol=1e-8):
 		self._G = G
 		self._this = new _KatzCentrality(G._this, alpha, beta, tol)
+
+	property edgeDirection:
+		def __get__(self):
+			""" Get the used edge direction. """
+			return (<_KatzCentrality*>(self._this)).edgeDirection
+		def __set__(self, _EdgeDirection edgeDirection):
+			""" Use a different edge direction. """
+			(<_KatzCentrality*>(self._this)).edgeDirection = edgeDirection
 
 cdef extern from "<networkit/centrality/DynKatzCentrality.hpp>":
 


### PR DESCRIPTION
This PR allows the user to count in-edges or out-edges when computing Katz centrality.
It also includes additional minor fixes.