### PR TITLE
Update tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
           CXX_STANDARD: ${{ matrix.variant }}
 
   linux-build-clang-tidy:
-    name: "Linux (clang-9, Python 3.8): clang-tidy build"
+    name: "Linux (clang-11): clang-tidy build"
     runs-on: ubuntu-20.04
     env:
       CC: clang
@@ -219,9 +219,9 @@ jobs:
       - name: Install prerequisites
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-9 main" | sudo tee /etc/apt/sources.list.d/llvm9.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-11 main" | sudo tee /etc/apt/sources.list.d/llvm11.list
           sudo apt-get update
-          sudo apt-get install libomp-9-dev clang-9 clang-tidy-9 ninja-build
+          sudo apt-get install libomp-11-dev clang-11 clang-tidy-11 ninja-build
       - name: Checkout
         uses: actions/checkout@v2
       - name: Checkout submodules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,21 +231,21 @@ jobs:
         shell: bash
 
   linux-build-core-sanitizers-coverage:
-    name: "Linux (gcc-5, Python 3.6): core build, sanitizers, coverage"
-    runs-on: ubuntu-18.04
+    name: "Linux (gcc-10, Python 3.9): core build, sanitizers, coverage"
+    runs-on: ubuntu-20.04
     env:
-      CC: gcc-5
-      CXX: g++-5
+      CC: gcc-10
+      CXX: g++-10
     steps:
       - name: Install prerequisites
         run:  |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ninja-build gcc-5 g++-5
-      - name: Setup Python 3.6
+          sudo apt-get install ninja-build gcc-10 g++-10
+      - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.9
       - name: Checkout
         uses: actions/checkout@v2
       - name: Checkout submodules

--- a/.github/workflows/scripts/clang_tidy.sh
+++ b/.github/workflows/scripts/clang_tidy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 sudo rm -rf /usr/local/clang-*
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 9999
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 9999
-sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 9999
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 9999
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 9999
+sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-11 9999
 $CXX --version
 clang-tidy --version
 mkdir debug_test && cd "$_"


### PR DESCRIPTION
clang-tidy: updated to version 11
build with sanitizers: updated to gcc 10 (before we were using gcc 5 due to a Travis issue), and to the latest version of Python.