### PR TITLE
Simple doc fixes

### DIFF
--- a/include/networkit/algebraic/algorithms/AlgebraicPageRank.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicPageRank.hpp
@@ -55,19 +55,19 @@ public:
     /**
      * Get a vector containing the betweenness score for each node in the graph.
      *
-     * @return The betweenness scores calculated by @link run().
+     * @return The betweenness scores calculated by @ref run().
      */
     const std::vector<double> &scores() const override;
 
     /**
      * Get a vector of pairs sorted into descending order. Each pair contains a node and the corresponding score
-     * calculated by @link run().
+     * calculated by @ref run().
      * @return A vector of pairs.
      */
     std::vector<std::pair<node, double>> ranking() override;
 
     /**
-     * Get the betweenness score of node @a v calculated by @link run().
+     * Get the betweenness score of node @a v calculated by @ref run().
      *
      * @param v A node.
      * @return The betweenness score of node @a v.

--- a/include/networkit/base/Algorithm.hpp
+++ b/include/networkit/base/Algorithm.hpp
@@ -24,13 +24,13 @@ public:
     virtual ~Algorithm() = default;
 
     /**
-     * The generic run method which calls runImpl() and takes care of setting @hasRun to the appropriate value.
+     * The generic run method which calls runImpl() and takes care of setting @ref hasRun to the appropriate value.
      */
     virtual void run() = 0;
 
     /**
      * Indicates whether an algorithm has completed computation or not.
-     * @return The Value of @hasRun.
+     * @return The value of @ref hasRun.
      */
     bool hasFinished() const {
         return hasRun;

--- a/include/networkit/centrality/Centrality.hpp
+++ b/include/networkit/centrality/Centrality.hpp
@@ -40,25 +40,25 @@ public:
     /**
      * Get a vector containing the centrality score for each node in the graph.
      *
-     * @return The centrality scores calculated by @link run().
+     * @return The centrality scores calculated by @ref run().
      */
     virtual const std::vector<double> &scores() const;
 
     /**
      * Get a vector containing the edge centrality score for each edge in the graph (where applicable).
-     * @return The edge betweenness scores calculated by @link run().
+     * @return The edge betweenness scores calculated by @ref run().
      */
     virtual std::vector<double> edgeScores();
 
     /**
      * Get a vector of pairs sorted into descending order. Each pair contains a node and the corresponding score
-     * calculated by @link run().
+     * calculated by @ref run().
      * @return A vector of pairs.
      */
     virtual std::vector<std::pair<node, double> > ranking();
 
     /**
-     * Get the centrality score of node @a v calculated by @link run().
+     * Get the centrality score of node @a v calculated by @ref run().
      *
      * @param v A node.
      * @return The betweenness score of node @a v.

--- a/include/networkit/centrality/Sfigality.hpp
+++ b/include/networkit/centrality/Sfigality.hpp
@@ -14,7 +14,8 @@ namespace NetworKit {
 
 /**
  * @ingroup centrality
- * A
+ * The sfigality of a node is the ratio of neighboring nodes that have
+ * a higher degree than the node itself.
  */
 class Sfigality: public Centrality {
 public:
@@ -22,7 +23,7 @@ public:
      * Constructs the Sfigality class for the given Graph @a G. Sfigality is a new type of
      * node centrality measures that is high if neighboring nodes have a higher degree, e.g. in social networks, if your friends have more friends than you. Formally:
      *
-     * $$\sigma(u) = \frac{| \{ v: \{u,v\} \in E, deg(u) < deg(v) \} |}{ deg(u) }$$
+     * $$\\sigma(u) = \\frac{| \\{ v: \\{u,v\\} \\in E, deg(u) < deg(v) \\} |}{ deg(u) }$$
      *
      * @param G The graph.
 
@@ -32,7 +33,8 @@ public:
     void run() override;
 
     /**
-     * @return the theoretical maximum degree centrality, which is $n - 1$ (including the possibility of a self-loop)
+     * Not implemented.
+     * The maximum sfigality is 1, when all neighbors of a node have a higher degree.
      */
     double maximum() override;
 };

--- a/include/networkit/community/Modularity.hpp
+++ b/include/networkit/community/Modularity.hpp
@@ -21,8 +21,8 @@ namespace NetworKit {
  *
  * Modularity is defined as:
  *
- * $$mod(\zeta) := \frac{\sum_{C \in \zeta} \sum_{ e \in E(C) } \omega(e)}{\sum_{e \in E} \omega(e)}
- * \frac{ \sum_{C \in \zeta}( \sum_{v \in C} \omega(v) )^2 }{4( \sum_{e \in E} \omega(e) )^2 }$$
+ * $$mod(\\zeta) := \\frac{\\sum_{C \\in \\zeta} \\sum_{ e \\in E(C) } \\omega(e)}{\\sum_{e \\in E} \\omega(e)}
+ * \\frac{ \\sum_{C \\in \\zeta}( \\sum_{v \\in C} \\omega(v) )^2 }{4( \\sum_{e \\in E} \\omega(e) )^2 }$$
  */
 class Modularity final : public QualityMeasure {
 

--- a/include/networkit/distance/AffectedNodes.hpp
+++ b/include/networkit/distance/AffectedNodes.hpp
@@ -66,7 +66,7 @@ namespace NetworKit {
         /**
          * Runs a complete BFS from @a source while ignoring the edge between 
          * @a source and @a startNeighbor. This is equivalent to running a
-         * BFS in G \setminus (source, startNeighbor).
+         * BFS in G $\\setminus$ (source, startNeighbor).
          * 
          * @param source The source node.
          * @param startNeighbor The neighbor node to be ignored on level 1.

--- a/include/networkit/edgescores/EdgeScore.hpp
+++ b/include/networkit/edgescores/EdgeScore.hpp
@@ -30,7 +30,7 @@ public:
 
     /** Get a vector containing the score for each edge in the graph.
      *
-     * @return the edge scores calculated by @link run().
+     * @return the edge scores calculated by @ref run().
      */
     virtual std::vector<T> scores() const;
 

--- a/include/networkit/global/ClusteringCoefficient.hpp
+++ b/include/networkit/global/ClusteringCoefficient.hpp
@@ -24,8 +24,8 @@ public:
      * This calculates the average local clustering coefficient of graph @a G.
      *
      * @param G The graph (may not contain self-loops).
-     * @note $$c(G) := \frac{1}{n} \sum_{u \in V} c(u)$$
-     * where $c(u) := \frac{2 \cdot |E(N(u))| }{\deg(u) \cdot ( \deg(u) - 1)}$
+     * @note $$c(G) := \\frac{1}{n} \\sum_{u \\in V} c(u)$$
+     * where $c(u) := \\frac{2 \\cdot |E(N(u))| }{\\deg(u) \\cdot ( \\deg(u) - 1)}$
      */
     static double avgLocal(Graph& G, bool turbo = false);
     static double sequentialAvgLocal(const Graph &G);

--- a/include/networkit/scoring/ModularityScoring.hpp
+++ b/include/networkit/scoring/ModularityScoring.hpp
@@ -42,7 +42,7 @@ public:
      * modularity increase which can be gained by merging
      * the clusters of u and v.
      *
-     *     $$\Delta mod(c, d) := \frac{1}{2 \omega(E)} \left ( 2 \omega(E) \omega(c,d) - \omega(c) \omega(d) \right ) $$
+     * $$\\Delta mod(c, d) := \\frac{1}{2 \\omega(E)} \\left ( 2 \\omega(E) \\omega(c,d) - \\omega(c) \\omega(d) \\right ) $$
      *
      * @param[in]  u  source node id
      * @param[out]  v  target node id

--- a/include/networkit/structures/UnionFind.hpp
+++ b/include/networkit/structures/UnionFind.hpp
@@ -30,7 +30,7 @@ class UnionFind final {
 public:
 
     /**
-     * Create a new set representation with not more the @max_element elements.
+     * Create a new set representation with not more than @p max_element elements.
      * Initially every element is in its own set.
      * @param max_element maximum number of elements
      */


### PR DESCRIPTION
Hi!
I'm an engineer on https://github.com/lynxkite/lynxkite. It's an open-source graph analytics tool with a GUI. For the next release we plan to make a bunch of algorithms from NetworKit available. I have wrapped 24 so far and we love everything about NetworKit. ❤️ 

My first step was to list the algorithms and figure out what is what, so I looked a lot at the docs. I found some mistakes that were easy to fix and that's this PR.

| Before | After |
|---|---|
|![image](https://user-images.githubusercontent.com/1268018/101663172-a7138f80-3a4a-11eb-928d-61f0b9d80ee5.png)|![image](https://user-images.githubusercontent.com/1268018/101663212-b4c91500-3a4a-11eb-9d62-4c7067133b88.png)|

I will make more small fixes if I find anything.

But as I wrap the algorithms I also write the LynxKite documentation for them. I try to include a loosely worded description of what the algorithm does and explain why someone would want to use it. It's a bit different from the NetworKit docs style. E.g. my description for HyperbolicGenerator is way more verbose than the NetworKit page:

- https://networkit.github.io/dev-docs/cpp_api/classNetworKit_1_1HyperbolicGenerator.html
- https://github.com/lynxkite/lynxkite/blob/master/web/app/help/operations/create-hyperbolic-random-graph.asciidoc

(You can see more in https://github.com/lynxkite/lynxkite/pull/102/files.)

We would be happy to contribute these descriptions to NetworKit if there's interest. (We are AGPL licensed, but we can dual license these docs under MIT.) But I also understand if you want to keep NetworKit docs more concise. I just wanted to float this idea!

Thanks very much for maintaining this excellent project!