### PR TITLE
Refactor Algorithm and deprecate toString()

### DIFF
--- a/include/networkit/base/Algorithm.hpp
+++ b/include/networkit/base/Algorithm.hpp
@@ -12,20 +12,11 @@ namespace NetworKit {
 
 class Algorithm {
 protected:
-    /**
-     * A boolean variable indicating whether an algorithm has finished its computation or not.
-     */
     bool hasRun = false;
 
 public:
-    /**
-     * Constructor to the algorithm base class.
-     */
     Algorithm() = default;
 
-    /**
-     * Virtual default destructor.
-     */
     virtual ~Algorithm() = default;
 
     /**

--- a/include/networkit/base/Algorithm.hpp
+++ b/include/networkit/base/Algorithm.hpp
@@ -34,7 +34,7 @@ public:
      * Indicates whether an algorithm has completed computation or not.
      * @return The value of @ref hasRun.
      */
-    bool hasFinished() const {
+    bool hasFinished() const noexcept {
         return hasRun;
     };
 

--- a/include/networkit/base/Algorithm.hpp
+++ b/include/networkit/base/Algorithm.hpp
@@ -1,3 +1,5 @@
+// networkit-format
+
 #ifndef NETWORKIT_BASE_ALGORITHM_HPP_
 #define NETWORKIT_BASE_ALGORITHM_HPP_
 
@@ -14,6 +16,7 @@ protected:
      * A boolean variable indicating whether an algorithm has finished its computation or not.
      */
     bool hasRun = false;
+
 public:
     /**
      * Constructor to the algorithm base class.
@@ -21,32 +24,35 @@ public:
     Algorithm() = default;
 
     /**
-     * Virtual default destructor
+     * Virtual default destructor.
      */
     virtual ~Algorithm() = default;
 
     /**
-     * The generic run method which calls runImpl() and takes care of setting @ref hasRun to the appropriate value.
+     * The generic run method which calls runImpl() and takes care of setting @ref hasRun to the
+     * appropriate value.
      */
     virtual void run() = 0;
 
     /**
      * Indicates whether an algorithm has completed computation or not.
+     *
      * @return The value of @ref hasRun.
      */
-    bool hasFinished() const noexcept {
-        return hasRun;
-    };
+    bool hasFinished() const noexcept { return hasRun; }
 
     /**
      * Assure that the algorithm has been run, throws a std::runtime_error otherwise.
      */
     void assureFinished() const {
-        if (!hasRun) throw std::runtime_error("Error, run must be called first");
-    };
+        if (!hasRun)
+            throw std::runtime_error("Error, run must be called first");
+    }
 
     /**
-     * Returns a string with the algorithm's name and its parameters, if there are any. Subclasses should override it.
+     * Returns a string with the algorithm's name and its parameters, if there
+     * are any. Subclasses should override it.
+     *
      * @return The string representation of the algorithm.
      */
     virtual std::string TLX_DEPRECATED(toString() const);
@@ -57,6 +63,6 @@ public:
     virtual bool isParallel() const;
 };
 
-} /* NetworKit */
+} // namespace NetworKit
 
 #endif // NETWORKIT_BASE_ALGORITHM_HPP_

--- a/include/networkit/base/Algorithm.hpp
+++ b/include/networkit/base/Algorithm.hpp
@@ -11,12 +11,12 @@ protected:
     /**
      * A boolean variable indicating whether an algorithm has finished its computation or not.
      */
-    bool hasRun;
+    bool hasRun = false;
 public:
     /**
      * Constructor to the algorithm base class.
      */
-    Algorithm();
+    Algorithm() = default;
 
     /**
      * Virtual default destructor

--- a/include/networkit/base/Algorithm.hpp
+++ b/include/networkit/base/Algorithm.hpp
@@ -1,8 +1,10 @@
 #ifndef NETWORKIT_BASE_ALGORITHM_HPP_
 #define NETWORKIT_BASE_ALGORITHM_HPP_
 
-#include <string>
 #include <stdexcept>
+#include <string>
+
+#include <tlx/define/deprecated.hpp>
 
 namespace NetworKit {
 
@@ -47,7 +49,7 @@ public:
      * Returns a string with the algorithm's name and its parameters, if there are any. Subclasses should override it.
      * @return The string representation of the algorithm.
      */
-    virtual std::string toString() const;
+    virtual std::string TLX_DEPRECATED(toString() const);
 
     /**
      * @return True if algorithm can run multi-threaded.

--- a/include/networkit/centrality/LocalPartitionCoverage.hpp
+++ b/include/networkit/centrality/LocalPartitionCoverage.hpp
@@ -42,7 +42,7 @@ public:
      * The name of this algorithm.
      * @return "Local partition coverage"
      */
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
 protected:
     const Partition& P;

--- a/include/networkit/community/CommunityDetectionAlgorithm.hpp
+++ b/include/networkit/community/CommunityDetectionAlgorithm.hpp
@@ -52,7 +52,7 @@ public:
     /**
      * @return string representation of algorithm and parameters.
      */
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
 protected:
     const Graph* G;

--- a/include/networkit/community/CutClustering.hpp
+++ b/include/networkit/community/CutClustering.hpp
@@ -33,7 +33,7 @@ public:
     /**
      * @return string representation of algorithm and parameters.
      */
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
     /**
      * Get the complete hierarchy with all possible parameter values.

--- a/include/networkit/community/IsolatedInterpartitionConductance.hpp
+++ b/include/networkit/community/IsolatedInterpartitionConductance.hpp
@@ -42,7 +42,7 @@ public:
     /**
      * Get the name of the algorithm.
      */
-    std::string toString() const override { return "Isolated inter-partition conductance"; };
+    std::string TLX_DEPRECATED(toString() const override) { return "Isolated inter-partition conductance"; };
 };
 
 }

--- a/include/networkit/community/IsolatedInterpartitionExpansion.hpp
+++ b/include/networkit/community/IsolatedInterpartitionExpansion.hpp
@@ -42,7 +42,7 @@ public:
     /**
      * Get the name of the algorithm.
      */
-    std::string toString() const override { return "Isolated inter-partition expansion"; };
+    std::string TLX_DEPRECATED(toString() const override) { return "Isolated inter-partition expansion"; };
 };
 
 }

--- a/include/networkit/community/LPDegreeOrdered.hpp
+++ b/include/networkit/community/LPDegreeOrdered.hpp
@@ -43,7 +43,7 @@ public:
     */
     count numberOfIterations();
 
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
 };
 

--- a/include/networkit/community/PLM.hpp
+++ b/include/networkit/community/PLM.hpp
@@ -42,7 +42,7 @@ public:
      *
      * @return String representation of this algorithm.
      */
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
     /**
      * Detect communities.

--- a/include/networkit/community/PLP.hpp
+++ b/include/networkit/community/PLP.hpp
@@ -59,7 +59,7 @@ public:
     /**
      * @return String representation of algorithm and parameters.
      */
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
     /**
      * The algorithm runs until a number of nodes less than

--- a/include/networkit/community/ParallelAgglomerativeClusterer.hpp
+++ b/include/networkit/community/ParallelAgglomerativeClusterer.hpp
@@ -31,7 +31,7 @@ public:
      */
     void run() override;
 
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/correlation/Assortativity.hpp
+++ b/include/networkit/correlation/Assortativity.hpp
@@ -58,7 +58,7 @@ public:
      * Returns a string with the algorithm's name and its parameters, if there are any. Subclasses should override it.
      * @return The string representation of the algorithm.
      */
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
     bool isParallel() const override;
 

--- a/include/networkit/distance/APSP.hpp
+++ b/include/networkit/distance/APSP.hpp
@@ -38,7 +38,7 @@ class APSP : public Algorithm {
     /**
      * @return string representation of algorithm and parameters.
      */
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
     /**
      * Returns a vector of weighted distances between node pairs.

--- a/include/networkit/distance/Diameter.hpp
+++ b/include/networkit/distance/Diameter.hpp
@@ -25,7 +25,7 @@ public:
 
     void run() override;
 
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
     std::pair<count, count> getDiameter() const;
 

--- a/include/networkit/generators/LFRGenerator.hpp
+++ b/include/networkit/generators/LFRGenerator.hpp
@@ -137,7 +137,7 @@ public:
     /**
      * The name and parameters of the generator
      */
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
     /**
      * If the algorithm uses parallelism (no)

--- a/include/networkit/graph/RandomMaximumSpanningForest.hpp
+++ b/include/networkit/graph/RandomMaximumSpanningForest.hpp
@@ -81,7 +81,7 @@ public:
     /**
      * @return The name of this algorithm.
      */
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
 private:
     struct weightedEdge {

--- a/include/networkit/graph/UnionMaximumSpanningForest.hpp
+++ b/include/networkit/graph/UnionMaximumSpanningForest.hpp
@@ -80,7 +80,7 @@ public:
     /**
      * @return The name of the algorithm.
      */
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 
 private:
     struct weightedEdge {

--- a/include/networkit/independentset/IndependentSetFinder.hpp
+++ b/include/networkit/independentset/IndependentSetFinder.hpp
@@ -36,7 +36,7 @@ public:
      * Get string representation of the algorithm.
      * @return The string representation of the algorithm.
      */
-    virtual std::string toString() const;
+    virtual std::string TLX_DEPRECATED(toString() const);
 
     /**
      * Checks whether a set is independent.

--- a/include/networkit/independentset/Luby.hpp
+++ b/include/networkit/independentset/Luby.hpp
@@ -25,7 +25,7 @@ public:
     // FIXME: check correctness of implementation
     std::vector<bool> run(const Graph& G) override;
 
-    std::string toString() const override;
+    std::string TLX_DEPRECATED(toString() const override);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/randomization/Curveball.hpp
+++ b/include/networkit/randomization/Curveball.hpp
@@ -37,7 +37,7 @@ public:
 
     Graph getGraph(bool parallel = false);
 
-    std::string toString() const final;
+    std::string TLX_DEPRECATED(toString() const final);
 
     bool isParallel() const final { return false; }
 

--- a/include/networkit/randomization/DegreePreservingShuffle.hpp
+++ b/include/networkit/randomization/DegreePreservingShuffle.hpp
@@ -66,7 +66,7 @@ public:
      */
     const std::vector<node> &getPermutation() const noexcept { return permutation; }
 
-    std::string toString() const final;
+    std::string TLX_DEPRECATED(toString() const final);
 
     bool isParallel() const final { return true; }
 

--- a/include/networkit/randomization/GlobalCurveball.hpp
+++ b/include/networkit/randomization/GlobalCurveball.hpp
@@ -59,7 +59,7 @@ public:
      */
     Graph getGraph();
 
-    std::string toString() const final;
+    std::string TLX_DEPRECATED(toString() const final);
 
     bool isParallel() const final { return false; }
 

--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -1080,7 +1080,7 @@ def detectCommunities(G, algo=None, inspect=True):
 	algo.run()
 	zeta = algo.getPartition()
 	t.stop()
-	print("{0} detected communities in {1} [s]".format(algo.toString(), t.elapsed))
+	print("Communities detected in {:.5f} [s]".format(t.elapsed))
 	if inspect:
 		print ("solution properties:")
 		inspectCommunities(zeta, G)

--- a/networkit/cpp/base/Algorithm.cpp
+++ b/networkit/cpp/base/Algorithm.cpp
@@ -4,10 +4,6 @@
 #include <exception>
 
 namespace NetworKit {
-    Algorithm::Algorithm() : hasRun(false) {
-
-    }
-
     std::string Algorithm::toString() const {
         throw std::runtime_error("TODO: implement in subclass and return string representation");
     }

--- a/networkit/cpp/base/Algorithm.cpp
+++ b/networkit/cpp/base/Algorithm.cpp
@@ -1,16 +1,19 @@
-#include <networkit/base/Algorithm.hpp>
-#include <networkit/auxiliary/SignalHandling.hpp>
-#include <networkit/auxiliary/Log.hpp>
+// networkit-format
+
 #include <exception>
 
+#include <networkit/auxiliary/Log.hpp>
+#include <networkit/auxiliary/SignalHandling.hpp>
+#include <networkit/base/Algorithm.hpp>
+
 namespace NetworKit {
-    std::string Algorithm::toString() const {
-        throw std::runtime_error("TODO: implement in subclass and return string representation");
-    }
+std::string Algorithm::toString() const {
+    throw std::runtime_error("TODO: implement in subclass and return string representation");
+}
 
-    bool Algorithm::isParallel() const {
-        throw std::runtime_error("TODO: Implement in subclass");
-        return false;
-    }
+bool Algorithm::isParallel() const {
+    throw std::runtime_error("TODO: Implement in subclass");
+    return false;
+}
 
-} /* NetworKit */
+} // namespace NetworKit

--- a/networkit/cpp/community/test/CommunityGTest.cpp
+++ b/networkit/cpp/community/test/CommunityGTest.cpp
@@ -15,7 +15,6 @@
 #include <networkit/community/ClusteringGenerator.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/overlap/HashingOverlapper.hpp>
-#include <networkit/community/PLM.hpp>
 #include <networkit/community/GraphClusteringTools.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/structures/Partition.hpp>

--- a/networkit/cpp/graph/RandomMaximumSpanningForest.cpp
+++ b/networkit/cpp/graph/RandomMaximumSpanningForest.cpp
@@ -1,7 +1,3 @@
-/*
- *
- */
-
 #include <networkit/graph/RandomMaximumSpanningForest.hpp>
 #include <networkit/auxiliary/SignalHandling.hpp>
 #include <networkit/auxiliary/Parallel.hpp>

--- a/networkit/engineering.pyx
+++ b/networkit/engineering.pyx
@@ -98,18 +98,15 @@ def strongScaling(algorithmClass, threadSequence, inargs, inputTitle=None, repet
 		print("set number of threads to {0}".format(getMaxNumberOfThreads()))
 		for r in range(repetitions):
 			algorithm = algorithmClass(**inargs)
-			print("running {0}".format(algorithm.toString()))
+			print("running algorithm")
 			timer = stopwatch.Timer()
 			result = algorithm.run()
 			timer.stop()
 			print("elapsed time: {0}".format(timer.elapsed))
 			if inputTitle is None:
-				try:
-					inputTitle = input.toString()
-				except:
-					inputTitle = str(input)
+				inputTitle = str(input)
 			# append run data
-			data.append({"algo": algorithm.toString(), "input": inputTitle, "threads": nThreads, "time": timer.elapsed})
+			data.append({"input": inputTitle, "threads": nThreads, "time": timer.elapsed})
 	setNumberOfThreads(threadsAvailable)
 	if outPath:
 		with open(outPath, "w") as outFile:
@@ -133,12 +130,12 @@ def weakScaling(algorithmClass, inargs, threadSequence, inputSequence, inputTitl
 		print("set number of threads to {0}".format(getMaxNumberOfThreads()))
 		for r in range(repetitions):
 			algorithm = algorithmClass(input, **inargs)
-			print("running {0}".format(algorithm.toString()))
+			print("running algorithm")
 			timer = stopwatch.Timer()
 			result = algorithm.run()
 			timer.stop()
 			# append run data
-			data.append({"algo": algorithm.toString(), "input": inputTitles[i], "threads": nThreads, "time": timer.elapsed})
+			data.append({"input": inputTitles[i], "threads": nThreads, "time": timer.elapsed})
 	setNumberOfThreads(threadsAvailable)
 	if outPath:
 		with open(outPath, "w") as outFile:

--- a/networkit/independentset.pyx
+++ b/networkit/independentset.pyx
@@ -44,5 +44,7 @@ cdef class Luby:
 		string
 			The string representation of the algorithm.
 		"""
+		from warnings import warn
+		warn("toString() is deprecated")
 		return self._this.toString().decode("utf-8")
 


### PR DESCRIPTION
I don't see a real use case for the `toString()` method in Algorithm (an algorithm's name is already known from the class name and the parameters can be checked in the docs) and very few subclasses implement it.
In this PR:
- deprecate `toString()`
- set `hasRun` to `false` by default and use the default constructor
- other minor changes