### PR TITLE
Fixes publishing of doc- and coverage-build. Temp. removes gcc-10 tests for macOS 11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
     strategy:
       matrix:
         os: ['11.0', '10.15']
-        variant: ['llvm-11', 'gcc-10']
+        variant: ['llvm-11'] # 'gcc-10' is disabled for now, since the workflow exits randomly during test-phase
+        # Will be resumed once the 11.0 image is final. 
     continue-on-error: ${{ matrix.os == '11.0' }}
     steps:
       - name: Install prerequisites 📦
@@ -257,8 +258,9 @@ jobs:
       - name: Update Coveralls 🚀
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
+          cd ${{ github.workspace }}
           . pyenv/bin/activate
-          coveralls -E ".*test/.*" -E ".*CMakeFiles.*" --exclude extlibs --exclude pyenv --exclude scripts --root .
+          coveralls -E ".*test/.*" -E ".*CMakeFiles.*" --exclude extlibs --exclude pyenv --exclude scripts --root ${{ github.workspace }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -310,14 +312,14 @@ jobs:
         shell: bash
       - name: Deploy networkit.github.io 🚀
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          ACCESS_TOKEN: ${{ secrets.SECRET_DEPLOY_GITHUB_PAGES }}
-          BRANCH: master
-          BASE_BRANCH: master
-          FOLDER: core_build/htmldocs
-          REPOSITORY_NAME: networkit/dev-docs
-          CLEAN: false
+          personal_token: ${{ secrets.SECRET_DEPLOY_GITHUB_PAGES }}
+          external_repository: networkit/dev-docs
+          publish_branch:  master
+          publish_dir: ./core_build/htmldocs
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
 
   style-guide-compliance-build:
     name: "Style guide compliance build"

--- a/.github/workflows/scripts/core_sanitizers_coverage.sh
+++ b/.github/workflows/scripts/core_sanitizers_coverage.sh
@@ -5,7 +5,8 @@ pip3 install --upgrade pip
 pip3 install setuptools cpp-coveralls
 
 mkdir build && cd "$_"
-cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_WITH_SANITIZERS=leak -DNETWORKIT_COVERAGE=ON ..
-ninja
+export CPU_COUNT=$(python3 $GITHUB_WORKSPACE/.github/workflows/scripts/get_core_count.py)
+cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_WITH_SANITIZERS=leak -DNETWORKIT_COVERAGE=ON ..
+make -j$CPU_COUNT
 
 ctest -V

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -312,3 +312,7 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
+
+# -- Options for Bibtex output -------------------------------------------------
+
+bibtex_bibfiles = ['refs.bib']


### PR DESCRIPTION
(Hopefully) the last PR for ironing out the remaining problems with github actions. The following changes were made:

- Coverage build: Switched from ninja to make, since there are some problems with folder redirection and therefore detection of code-files for `cpp-coveralls`. This problems caused a report of 0% coverage in some cases.
- Documentation build: Moved from using `JamesIves/github-pages-deploy-action` to `peaceiris/actions-gh-pages` for publishing to github pages. Even though JamesIves-plugin seems to stable and well-known (and runs a set of common git-commands), it fails to publish in our case. The new plugin works very similar, is also well known and [tests](https://github.com/fabratu/networkit/runs/1558485371?check_suite_focus=true) publishing in our case is successful. 

Minor stuff:
- Documentation build: Removed the `continue-on-error` option for the build.
- macOS 11.0: For macOS 11.0 the gcc-10 build seems to fail at random points during the tests (with a process abort). Since the 11.0 image is preview anyway, the gcc-10 is commented out until the image is final. Reason: Github Actions as of now has no option to mark a job a really optional. The `continue-on-error` option let the build continue for other tests and also mark them as successful in the Actions-tab. However PRs and Pushes are marked as failed.