### PR TITLE
BFSfrom: std::array for single source

### DIFF
--- a/include/networkit/graph/BFS.hpp
+++ b/include/networkit/graph/BFS.hpp
@@ -3,6 +3,7 @@
 #ifndef NETWORKIT_GRAPH_BFS_HPP_
 #define NETWORKIT_GRAPH_BFS_HPP_
 
+#include <array>
 #include <queue>
 #include <vector>
 
@@ -73,7 +74,7 @@ void BFSfrom(const Graph &G, InputIt first, InputIt last, L handle) {
  */
 template <typename L>
 void BFSfrom(const Graph &G, node source, L handle) {
-    std::vector<node> startNodes({source});
+    std::array<node, 1> startNodes{{source}};
     BFSfrom(G, startNodes.begin(), startNodes.end(), handle);
 }
 


### PR DESCRIPTION
When `BFSfrom` is called from a single source, this is inserted into a `std::vector<node>` and the multi-source `BFSfrom` is called. Since we already know that we have a single source at compile time, it makes more sense to use a `std::array<node, 1>` rather than a vector.