### PR TITLE
Warning fix: performance-noexcept-move-constructor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -72,6 +72,7 @@ WarningsAsErrors:  >
     performance-inefficient-algorithm,
     performance-inefficient-vector-operation,
     performance-move-const-arg,
+    performance-noexcept-move-constructor,
     performance-trivially-destructible,
     performance-type-promotion-in-math-fn,
     performance-unnecessary-copy-initialization,

--- a/include/networkit/algebraic/DynamicMatrix.hpp
+++ b/include/networkit/algebraic/DynamicMatrix.hpp
@@ -70,13 +70,13 @@ public:
     DynamicMatrix(const DynamicMatrix &other) = default;
 
     /** Default move constructor */
-    DynamicMatrix(DynamicMatrix &&other) = default;
+    DynamicMatrix(DynamicMatrix &&other) noexcept = default;
 
     /** Default destructor */
      ~DynamicMatrix() = default;
 
     /** Default move assignment operator */
-    DynamicMatrix& operator=(DynamicMatrix &&other) = default;
+    DynamicMatrix& operator=(DynamicMatrix &&other) noexcept = default;
 
     /** Default copy assignment operator */
     DynamicMatrix& operator=(const DynamicMatrix &other) = default;

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -983,13 +983,13 @@ public:
     Graph(const Graph &other) = default;
 
     /** Default move constructor */
-    Graph(Graph &&other) = default;
+    Graph(Graph &&other) noexcept = default;
 
     /** Default destructor */
     ~Graph() = default;
 
     /** Default move assignment operator */
-    Graph &operator=(Graph &&other) = default;
+    Graph &operator=(Graph &&other) noexcept = default;
 
     /** Default copy assignment operator */
     Graph &operator=(const Graph &other) = default;

--- a/include/networkit/io/DibapGraphReader.hpp
+++ b/include/networkit/io/DibapGraphReader.hpp
@@ -29,7 +29,7 @@ public:
 
     Graph read(const std::string &path) override;
 
-    const std::vector<Point<coordinate>> &getCoordinates() const { return coordinates; }
+    const std::vector<Point<coordinate>> &getCoordinates() const noexcept { return coordinates; }
 
     std::vector<Point<coordinate>> moveCoordinates() { return std::move(coordinates); }
 

--- a/include/networkit/numerics/LAMG/SolverLamg.hpp
+++ b/include/networkit/numerics/LAMG/SolverLamg.hpp
@@ -72,11 +72,11 @@ public:
 
     SolverLamg (const SolverLamg<Matrix>& other) = default;
 
-    SolverLamg (SolverLamg<Matrix>&& other) = default;
+    SolverLamg (SolverLamg<Matrix>&& other) noexcept = default;
 
     virtual ~SolverLamg() = default;
 
-    SolverLamg& operator=(SolverLamg<Matrix>&& other) = default;
+    SolverLamg& operator=(SolverLamg<Matrix>&& other) noexcept = default;
 
     SolverLamg& operator=(const SolverLamg<Matrix>& other) = default;
 

--- a/include/networkit/randomization/GlobalTradeSequence.hpp
+++ b/include/networkit/randomization/GlobalTradeSequence.hpp
@@ -69,9 +69,9 @@ public:
           ainv(static_cast<value_type>((std::get<1>(gcdExtended(a, p)) + p) % p)), b(b) {}
 
     LinearCongruentialMap(const LinearCongruentialMap &) = default;
-    LinearCongruentialMap(LinearCongruentialMap &&) = default;
+    LinearCongruentialMap(LinearCongruentialMap &&) noexcept = default;
     LinearCongruentialMap &operator=(const LinearCongruentialMap &) = default;
-    LinearCongruentialMap &operator=(LinearCongruentialMap &&) = default;
+    LinearCongruentialMap &operator=(LinearCongruentialMap &&) noexcept = default;
 
     //! Hashes [n] to [p] with (a*x+b) mod p
     value_type hash(value_type n) const { return (a * n + b) % p; }
@@ -190,9 +190,9 @@ public:
           b(b) {}
 
     FixedLinearCongruentialMap(const FixedLinearCongruentialMap &) = default;
-    FixedLinearCongruentialMap(FixedLinearCongruentialMap &&) = default;
+    FixedLinearCongruentialMap(FixedLinearCongruentialMap &&) noexcept = default;
     FixedLinearCongruentialMap &operator=(const FixedLinearCongruentialMap &) = default;
-    FixedLinearCongruentialMap &operator=(FixedLinearCongruentialMap &&) = default;
+    FixedLinearCongruentialMap &operator=(FixedLinearCongruentialMap &&) noexcept = default;
 
     //! Hashes [n] to [p] with (a*x+b) mod p
     value_type hash(value_type n) const { return (a * n + b) % p; }

--- a/include/networkit/viz/Point.hpp
+++ b/include/networkit/viz/Point.hpp
@@ -27,6 +27,9 @@ namespace PointImpl {
 template <typename T, size_t Dimensions>
 class Storage {
     Storage() { std::fill(data.begin(), data.end(), T{0}); }
+    Storage(const Storage &) = default;
+    Storage(Storage &&) noexcept = default;
+    Storage &operator=(Storage &&) noexcept = default;
 
 protected:
     std::array<T, Dimensions> data;
@@ -37,6 +40,10 @@ class Storage<T, 2> {
 public:
     Storage() : data{{0, 0}} {};
     Storage(T x, T y) : data{{x, y}} {}
+
+    Storage(const Storage &) = default;
+    Storage(Storage &&) noexcept = default;
+    Storage &operator=(Storage &&) noexcept = default;
 
     std::pair<T, T> asPair() const noexcept { return {data[0], data[1]}; }
 
@@ -52,6 +59,9 @@ public:
         data[0] = x;
         data[1] = y;
     }
+
+    Storage(Storage &&) noexcept = default;
+    Storage &operator=(Storage &&) noexcept = default;
 
     explicit Storage(count dimension) : data(dimension) {}
     explicit Storage(const std::vector<T> &values) : data(values.size()) {
@@ -96,8 +106,8 @@ public:
     Point(const Point &) = default;
     Point &operator=(const Point &) = default;
 
-    Point(Point &&) = default;
-    Point &operator=(Point &&) = default;
+    Point(Point &&) noexcept = default;
+    Point &operator=(Point &&) noexcept = default;
 
     /// Type conversion between points of different size
     template <size_t otherDim>


### PR DESCRIPTION
As reported here [1], move constructors and assignment operators should be declared `noexcept` at least when used with STL containers, otherwise STL will choose copy constructors and thus there is a performance loss.

This PR adds the `noexcept` specifier to user-defined move constructors and assignment operators.

[1] https://clang.llvm.org/extra/clang-tidy/checks/performance-noexcept-move-constructor.html