### PR TITLE
clang-format: algebraic/algorithms

### DIFF
--- a/include/networkit/algebraic/algorithms/AlgebraicBFS.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicBFS.hpp
@@ -1,17 +1,19 @@
 /*
- * AlgebraicBFS.h
+ * AlgebraicBFS.hpp
  *
  *  Created on: Jun 7, 2016
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_BFS_HPP_
 #define NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_BFS_HPP_
 
+#include <networkit/algebraic/GraphBLAS.hpp>
+#include <networkit/algebraic/Vector.hpp>
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
-#include <networkit/algebraic/Vector.hpp>
-#include <networkit/algebraic/GraphBLAS.hpp>
 
 namespace NetworKit {
 
@@ -19,15 +21,17 @@ namespace NetworKit {
  * @ingroup algebraic
  * Implementation of Breadth-First-Search using the GraphBLAS interface.
  */
-template<class Matrix>
+template <class Matrix>
 class AlgebraicBFS : public Algorithm {
 public:
     /**
-     * Constructs an instance of the AlgebraicBFS algorithm for the given Graph @a graph and the given @a source node.
+     * Constructs an instance of the AlgebraicBFS algorithm for the given Graph @a graph and the
+     * given @a source node.
      * @param graph
      * @param source
      */
-    AlgebraicBFS(const Graph& graph, node source) : At(Matrix::adjacencyMatrix(graph, MinPlusSemiring::zero()).transpose()), source(source) {}
+    AlgebraicBFS(const Graph &graph, node source)
+        : At(Matrix::adjacencyMatrix(graph, MinPlusSemiring::zero()).transpose()), source(source) {}
 
     /**
      * Runs a bfs using the GraphBLAS interface from the source node.
@@ -50,7 +54,7 @@ private:
     Vector distances;
 };
 
-template<class Matrix>
+template <class Matrix>
 void AlgebraicBFS<Matrix>::run() {
     count n = At.numberOfRows();
     distances = Vector(n, std::numeric_limits<double>::infinity());
@@ -66,7 +70,5 @@ void AlgebraicBFS<Matrix>::run() {
 }
 
 } /* namespace NetworKit */
-
-
 
 #endif // NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_BFS_HPP_

--- a/include/networkit/algebraic/algorithms/AlgebraicBellmanFord.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicBellmanFord.hpp
@@ -1,18 +1,20 @@
 /*
- * AlgebraicBellmanFord.h
+ * AlgebraicBellmanFord.hpp
  *
  *  Created on: Jun 6, 2016
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
+
+// networkit-format
 
 #ifndef NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_BELLMAN_FORD_HPP_
 #define NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_BELLMAN_FORD_HPP_
 
 #include <cassert>
 
+#include <networkit/algebraic/GraphBLAS.hpp>
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
-#include <networkit/algebraic/GraphBLAS.hpp>
 
 namespace NetworKit {
 
@@ -20,15 +22,18 @@ namespace NetworKit {
  * @ingroup algebraic
  * Implementation of the Bellman-Ford algorithm using the GraphBLAS interface.
  */
-template<class Matrix>
+template <class Matrix>
 class AlgebraicBellmanFord : public Algorithm {
 public:
     /**
-     * Construct an instance of the BellmanFord algorithm for the Graph @a graph and the given @a source node.
+     * Construct an instance of the BellmanFord algorithm for the Graph @a graph and the given @a
+     * source node.
      * @param graph
      * @param source
      */
-    AlgebraicBellmanFord(const Graph& graph, node source) : At(Matrix::adjacencyMatrix(graph, MinPlusSemiring::zero()).transpose()), source(source), negCycle(false) {}
+    AlgebraicBellmanFord(const Graph &graph, node source)
+        : At(Matrix::adjacencyMatrix(graph, MinPlusSemiring::zero()).transpose()), source(source),
+          negCycle(false) {}
 
     /** Default destructor */
     ~AlgebraicBellmanFord() = default;
@@ -64,7 +69,7 @@ private:
     bool negCycle;
 };
 
-template<class Matrix>
+template <class Matrix>
 void AlgebraicBellmanFord<Matrix>::run() {
     count n = At.numberOfRows();
     distances = Vector(n, std::numeric_limits<double>::infinity());
@@ -79,7 +84,6 @@ void AlgebraicBellmanFord<Matrix>::run() {
     negCycle = (oldDist != distances);
     hasRun = true;
 }
-
 
 } /* namespace NetworKit */
 

--- a/include/networkit/algebraic/algorithms/AlgebraicMatchingCoarsening.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicMatchingCoarsening.hpp
@@ -5,6 +5,8 @@
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_MATCHING_COARSENING_HPP_
 #define NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_MATCHING_COARSENING_HPP_
 
@@ -16,21 +18,23 @@ namespace NetworKit {
 
 /**
  * @ingroup algebraic
- * Implements an algebraic version of the MatchingCoarsening algorithm by computing a projection matrix from fine to
- * coarse.
+ * Implements an algebraic version of the MatchingCoarsening algorithm by computing a projection
+ * matrix from fine to coarse.
  */
-template<class Matrix>
+template <class Matrix>
 class AlgebraicMatchingCoarsening final : public GraphCoarsening {
 public:
     /**
-     * Constructs an instance of AlgebraicMatchingCoarsening for the given Graph @a graph and the corresponding
-     * Matching @a matching. If @a noSelfLoops is set to true (false by default), no self-loops are created
-     * during the coarsening.
+     * Constructs an instance of AlgebraicMatchingCoarsening for the given Graph @a graph and the
+     * corresponding Matching @a matching. If @a noSelfLoops is set to true (false by default), no
+     * self-loops are created during the coarsening.
+     *
      * @param graph
      * @param matching
      * @param noSelfLoops
      */
-    AlgebraicMatchingCoarsening(const Graph& graph, const Matching& matching, bool noSelfLoops = false);
+    AlgebraicMatchingCoarsening(const Graph &graph, const Matching &matching,
+                                bool noSelfLoops = false);
 
     /**
      * Computes the coarsening for the graph using the given matching.
@@ -43,9 +47,13 @@ private:
     bool noSelfLoops;
 };
 
-template<class Matrix>
-AlgebraicMatchingCoarsening<Matrix>::AlgebraicMatchingCoarsening(const Graph& graph, const Matching& matching, bool noSelfLoops) : GraphCoarsening(graph), A(Matrix::adjacencyMatrix(graph)), noSelfLoops(noSelfLoops) {
-    if (G->isDirected()) throw std::runtime_error("Only defined for undirected graphs.");
+template <class Matrix>
+AlgebraicMatchingCoarsening<Matrix>::AlgebraicMatchingCoarsening(const Graph &graph,
+                                                                 const Matching &matching,
+                                                                 bool noSelfLoops)
+    : GraphCoarsening(graph), A(Matrix::adjacencyMatrix(graph)), noSelfLoops(noSelfLoops) {
+    if (G->isDirected())
+        throw std::runtime_error("Only defined for undirected graphs.");
     nodeMapping.resize(graph.numberOfNodes());
     std::vector<Triplet> triplets(graph.numberOfNodes());
 
@@ -57,8 +65,7 @@ AlgebraicMatchingCoarsening<Matrix>::AlgebraicMatchingCoarsening(const Graph& gr
             // vertex u is carried over to the new level
             nodeMapping[u] = idx;
             ++idx;
-        }
-        else {
+        } else {
             // vertex u is not carried over, receives ID of mate
             nodeMapping[u] = nodeMapping[mate];
         }
@@ -69,9 +76,10 @@ AlgebraicMatchingCoarsening<Matrix>::AlgebraicMatchingCoarsening(const Graph& gr
     P = Matrix(graph.numberOfNodes(), numCoarse, triplets); // dimensions: fine x coarse
 }
 
-template<class Matrix>
+template <class Matrix>
 void AlgebraicMatchingCoarsening<Matrix>::run() {
-    Matrix coarseAdj = P.transpose() * A * P; // Matrix::mTmMultiply performs worse due to high sparsity of P (nnz = n)
+    // Matrix::mTmMultiply performs worse due to high sparsity of P (nnz = n)
+    Matrix coarseAdj = P.transpose() * A * P;
 
     Gcoarsened = Graph(coarseAdj.numberOfRows(), true);
     coarseAdj.forNonZeroElementsInRowOrder([&](node u, node v, edgeweight weight) {

--- a/include/networkit/algebraic/algorithms/AlgebraicPageRank.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicPageRank.hpp
@@ -1,19 +1,21 @@
 /*
- * AlgebraicPageRank.h
+ * AlgebraicPageRank.hpp
  *
  *  Created on: Jun 20, 2016
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_PAGE_RANK_HPP_
 #define NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_PAGE_RANK_HPP_
 
-#include <networkit/centrality/Centrality.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
+#include <networkit/centrality/Centrality.hpp>
 
-#include <networkit/graph/Graph.hpp>
 #include <networkit/algebraic/GraphBLAS.hpp>
 #include <networkit/algebraic/Vector.hpp>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
@@ -21,31 +23,30 @@ namespace NetworKit {
  * @ingroup algebraic
  * Implementation of PageRank using the GraphBLAS interface.
  */
-template<class Matrix>
+template <class Matrix>
 class AlgebraicPageRank final : public Centrality {
 public:
-
     /**
-     * Constructs an instance of AlgebraicPageRank for the given @a graph. Page rank uses the damping factor @a damp
-     * and the tolerance @a tol.
+     * Constructs an instance of AlgebraicPageRank for the given @a graph. Page rank uses the
+     * damping factor @a damp and the tolerance @a tol.
      * @param graph
      * @param damp
      * @param tol
      */
-    AlgebraicPageRank(const Graph& graph, const double damp = 0.85, const double tol = 1e-8)
+    AlgebraicPageRank(const Graph &graph, const double damp = 0.85, const double tol = 1e-8)
         : Centrality(graph), damp(damp), tol(tol) {
         Matrix A = Matrix::adjacencyMatrix(graph);
         // normalize At by out-degree
         Vector invOutDeg = GraphBLAS::rowReduce(A);
 #pragma omp parallel for
         for (omp_index i = 0; i < static_cast<omp_index>(invOutDeg.getDimension()); ++i) {
-            invOutDeg[i] = 1.0/invOutDeg[i];
+            invOutDeg[i] = 1.0 / invOutDeg[i];
         }
 
         std::vector<Triplet> mTriplets(A.nnz());
         index idx = 0;
         A.forNonZeroElementsInRowOrder([&](index i, index j, double value) {
-            mTriplets[idx++] = {j,i, damp * value * invOutDeg[i]};
+            mTriplets[idx++] = {j, i, damp * value * invOutDeg[i]};
         });
         M = std::move(Matrix(A.numberOfRows(), mTriplets));
     }
@@ -60,8 +61,8 @@ public:
     const std::vector<double> &scores() const override;
 
     /**
-     * Get a vector of pairs sorted into descending order. Each pair contains a node and the corresponding score
-     * calculated by @ref run().
+     * Get a vector of pairs sorted into descending order. Each pair contains a node and the
+     * corresponding score calculated by @ref run().
      * @return A vector of pairs.
      */
     std::vector<std::pair<node, double>> ranking() override;
@@ -79,9 +80,7 @@ public:
      *
      * @return The maximum centrality score.
      */
-    double maximum() override {
-        return 1.0;
-    }
+    double maximum() override { return 1.0; }
 
 private:
     Matrix M;
@@ -90,21 +89,21 @@ private:
     const double tol;
 };
 
-template<class Matrix>
+template <class Matrix>
 void AlgebraicPageRank<Matrix>::run() {
     count n = M.numberOfRows();
-    double teleportProb = (1.0 - damp) / (double) n;
-    Vector rank(n, 1.0/(double)n);
+    double teleportProb = (1.0 - damp) / (double)n;
+    Vector rank(n, 1.0 / (double)n);
     Vector lastRank;
 
     do {
         lastRank = rank;
         rank = M * rank;
-        rank.apply([&](double value) {return value += teleportProb;});
+        rank.apply([&](double value) { return value += teleportProb; });
     } while ((rank - lastRank).length() > tol);
 
     double sum = 0.0;
-#pragma omp parallel for reduction(+:sum)
+#pragma omp parallel for reduction(+ : sum)
     for (omp_index i = 0; i < static_cast<omp_index>(rank.getDimension()); ++i) {
         sum += rank[i];
     }
@@ -118,24 +117,26 @@ void AlgebraicPageRank<Matrix>::run() {
     hasRun = true;
 }
 
-template<class Matrix>
+template <class Matrix>
 const std::vector<double> &AlgebraicPageRank<Matrix>::scores() const {
     assureFinished();
     return scoreData;
 }
 
-template<class Matrix>
+template <class Matrix>
 std::vector<std::pair<node, double>> AlgebraicPageRank<Matrix>::ranking() {
     assureFinished();
-    std::vector<std::pair<node, double> > ranking;
+    std::vector<std::pair<node, double>> ranking;
     for (index i = 0; i < scoreData.size(); ++i) {
         ranking.push_back({i, scoreData[i]});
     }
-    Aux::Parallel::sort(ranking.begin(), ranking.end(), [](std::pair<node, double> x, std::pair<node, double> y) { return x.second > y.second; });
+    Aux::Parallel::sort(
+        ranking.begin(), ranking.end(),
+        [](std::pair<node, double> x, std::pair<node, double> y) { return x.second > y.second; });
     return ranking;
 }
 
-template<class Matrix>
+template <class Matrix>
 double AlgebraicPageRank<Matrix>::score(node v) {
     assureFinished();
     return scoreData.at(v);

--- a/include/networkit/algebraic/algorithms/AlgebraicSpanningEdgeCentrality.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicSpanningEdgeCentrality.hpp
@@ -1,9 +1,11 @@
 /*
- * AlgebraicSpanningEdgeCentrality.h
+ * AlgebraicSpanningEdgeCentrality.hpp
  *
  *  Created on: Jul 12, 2016
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
+
+// networkit-format
 
 #ifndef NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_SPANNING_EDGE_CENTRALITY_HPP_
 #define NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_SPANNING_EDGE_CENTRALITY_HPP_
@@ -19,18 +21,18 @@ namespace NetworKit {
  * @ingroup algebraic
  * Implementation of Spanning edge centrality with algebraic notation.
  */
-template<class Matrix>
+template <class Matrix>
 class AlgebraicSpanningEdgeCentrality : public Centrality {
 public:
     /**
-     * Constructs an instance of the AlgebraicSpanningEdgeCentrality algorithm for the given Graph @a graph.
-     * The tolerance @a tol is used to control the approximation error when approximating the spanning edge
-     * centrality for @a graph.
+     * Constructs an instance of the AlgebraicSpanningEdgeCentrality algorithm for the given Graph
+     * @a graph. The tolerance @a tol is used to control the approximation error when approximating
+     * the spanning edge centrality for @a graph.
      * @param graph
      * @param tol
      */
-    AlgebraicSpanningEdgeCentrality(const Graph& graph, double tol = 0.1) : Centrality(graph), tol(tol) {}
-
+    AlgebraicSpanningEdgeCentrality(const Graph &graph, double tol = 0.1)
+        : Centrality(graph), tol(tol) {}
 
     /**
      * Compute spanning edge centrality exactly.
@@ -46,13 +48,12 @@ private:
     double tol;
 };
 
-template<class Matrix>
+template <class Matrix>
 void AlgebraicSpanningEdgeCentrality<Matrix>::run() {
     const count n = G.numberOfNodes();
     const count m = G.numberOfEdges();
     scoreData.clear();
     scoreData.resize(m, 0.0);
-
 
     std::vector<Vector> rhs(m, Vector(n));
     this->G.parallelForEdges([&](node u, node v, edgeid e) {
@@ -74,7 +75,7 @@ void AlgebraicSpanningEdgeCentrality<Matrix>::run() {
     hasRun = true;
 }
 
-template<class Matrix>
+template <class Matrix>
 void AlgebraicSpanningEdgeCentrality<Matrix>::runApproximation() {
     const count n = G.numberOfNodes();
     const count m = G.numberOfEdges();
@@ -82,7 +83,7 @@ void AlgebraicSpanningEdgeCentrality<Matrix>::runApproximation() {
     scoreData.resize(m, 0.0);
     double epsilon2 = tol * tol;
     const count k = ceil(log2(n)) / epsilon2;
-    double randTab[3] = {1.0/sqrt(k), -1.0/sqrt(k)};
+    double randTab[3] = {1.0 / sqrt(k), -1.0 / sqrt(k)};
 
     std::vector<Vector> yRows(k, Vector(n));
     std::vector<Vector> zRows(k, Vector(n));
@@ -95,7 +96,6 @@ void AlgebraicSpanningEdgeCentrality<Matrix>::runApproximation() {
             yRows[i][v] -= w * rand;
         }
     });
-
 
     Lamg<Matrix> lamg(1e-5);
     lamg.setupConnected(Matrix::laplacianMatrix(this->G));
@@ -114,9 +114,6 @@ void AlgebraicSpanningEdgeCentrality<Matrix>::runApproximation() {
     hasRun = true;
 }
 
-
 } /* namespace NetworKit */
-
-
 
 #endif // NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_SPANNING_EDGE_CENTRALITY_HPP_

--- a/include/networkit/algebraic/algorithms/AlgebraicTriangleCounting.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicTriangleCounting.hpp
@@ -1,9 +1,11 @@
 /*
- * AlgebraicTriangleCounting.h
+ * AlgebraicTriangleCounting.hpp
  *
  *  Created on: Jul 12, 2016
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
+
+// networkit-format
 
 #ifndef NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_TRIANGLE_COUNTING_HPP_
 #define NETWORKIT_ALGEBRAIC_ALGORITHMS_ALGEBRAIC_TRIANGLE_COUNTING_HPP_
@@ -16,18 +18,19 @@ namespace NetworKit {
  * @ingroup algebraic
  * Implements a triangle counting algorithm for nodes based on algebraic methods.
  */
-template<class Matrix>
+template <class Matrix>
 class AlgebraicTriangleCounting : public Algorithm {
 public:
     /**
      * Creates an instance of AlgebraicTriangleCounting for the given Graph @a graph.
      * @param graph
      */
-    AlgebraicTriangleCounting(const Graph& graph) : A(Matrix::adjacencyMatrix(graph)), directed(graph.isDirected()) {}
+    AlgebraicTriangleCounting(const Graph &graph)
+        : A(Matrix::adjacencyMatrix(graph)), directed(graph.isDirected()) {}
 
     /**
-     * Computes the number of triangles each node is part of. A triangle is considered as a set of nodes (i.e. if there
-     * is a triangle (u,v,w) it only counts as one triangle at each node).
+     * Computes the number of triangles each node is part of. A triangle is considered as a set of
+     * nodes (i.e. if there is a triangle (u,v,w) it only counts as one triangle at each node).
      */
     void run() override;
 
@@ -55,7 +58,7 @@ private:
     std::vector<count> nodeScores;
 };
 
-template<class Matrix>
+template <class Matrix>
 void AlgebraicTriangleCounting<Matrix>::run() {
     Matrix powA = A * A * A;
 
@@ -64,7 +67,7 @@ void AlgebraicTriangleCounting<Matrix>::run() {
 
 #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(powA.numberOfRows()); ++i) {
-        nodeScores[i] = directed? powA(i,i) : powA(i,i) / 2.0;
+        nodeScores[i] = directed ? powA(i, i) : powA(i, i) / 2.0;
     }
 
     hasRun = true;

--- a/networkit/cpp/algebraic/algorithms/test/AlgebraicBFSGTest.cpp
+++ b/networkit/cpp/algebraic/algorithms/test/AlgebraicBFSGTest.cpp
@@ -5,11 +5,13 @@
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
 
+// networkit-format
+
 #include <gtest/gtest.h>
 
 #include <networkit/algebraic/CSRMatrix.hpp>
-#include <networkit/distance/BFS.hpp>
 #include <networkit/algebraic/algorithms/AlgebraicBFS.hpp>
+#include <networkit/distance/BFS.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 
 #include <networkit/auxiliary/Timer.hpp>
@@ -41,19 +43,19 @@ TEST(AlgebraicBFSGTest, testOnToyGraph) {
     EXPECT_EQ(2, bfs.distance(4));
 
     G = Graph(7, false, true);
-    G.addEdge(0,1);
-    G.addEdge(0,3);
-    G.addEdge(1,4);
-    G.addEdge(1,6);
-    G.addEdge(2,5);
-    G.addEdge(3,0);
-    G.addEdge(3,2);
-    G.addEdge(4,5);
-    G.addEdge(5,2);
-    G.addEdge(6,2);
-    G.addEdge(6,3);
+    G.addEdge(0, 1);
+    G.addEdge(0, 3);
+    G.addEdge(1, 4);
+    G.addEdge(1, 6);
+    G.addEdge(2, 5);
+    G.addEdge(3, 0);
+    G.addEdge(3, 2);
+    G.addEdge(4, 5);
+    G.addEdge(5, 2);
+    G.addEdge(6, 2);
+    G.addEdge(6, 3);
 
-    bfs = AlgebraicBFS<CSRMatrix>(G,3);
+    bfs = AlgebraicBFS<CSRMatrix>(G, 3);
     bfs.run();
 
     EXPECT_EQ(1, bfs.distance(0));
@@ -90,7 +92,6 @@ TEST(AlgebraicBFSGTest, benchmarkBFS) {
             EXPECT_EQ(bfs.distance(u), algebraicBfs.distance(u));
         }
     });
-
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/algebraic/algorithms/test/AlgebraicBellmanFordGTest.cpp
+++ b/networkit/cpp/algebraic/algorithms/test/AlgebraicBellmanFordGTest.cpp
@@ -5,17 +5,19 @@
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
 
+// networkit-format
+
 #include <gtest/gtest.h>
 
-#include <networkit/io/METISGraphReader.hpp>
 #include <networkit/auxiliary/Timer.hpp>
 #include <networkit/graph/Graph.hpp>
+#include <networkit/io/METISGraphReader.hpp>
 
 #include <networkit/algebraic/CSRMatrix.hpp>
 
-#include <networkit/distance/Dijkstra.hpp>
 #include <networkit/algebraic/DynamicMatrix.hpp>
 #include <networkit/algebraic/algorithms/AlgebraicBellmanFord.hpp>
+#include <networkit/distance/Dijkstra.hpp>
 
 namespace NetworKit {
 
@@ -25,7 +27,7 @@ public:
     virtual ~AlgebraicBellmanFordGTest() = default;
 
 protected:
-    std::vector<double> classicBF(const Graph& graph, node s) const;
+    std::vector<double> classicBF(const Graph &graph, node s) const;
 };
 
 TEST_F(AlgebraicBellmanFordGTest, testOnToyGraph) {
@@ -87,16 +89,15 @@ TEST_F(AlgebraicBellmanFordGTest, benchmark) {
     }
 }
 
-std::vector<double> AlgebraicBellmanFordGTest::classicBF(const Graph& graph, node s) const {
+std::vector<double> AlgebraicBellmanFordGTest::classicBF(const Graph &graph, node s) const {
     std::vector<double> dist(graph.numberOfNodes(), std::numeric_limits<double>::infinity());
     dist[s] = 0;
 
     for (index i = 1; i < graph.numberOfNodes(); ++i) {
         graph.forNodes([&](node u) {
             if (dist[u] != std::numeric_limits<double>::infinity()) {
-                graph.forNeighborsOf(u, [&](node v, edgeweight w) {
-                    dist[v] = std::min(dist[v], dist[u]+w);
-                });
+                graph.forNeighborsOf(
+                    u, [&](node v, edgeweight w) { dist[v] = std::min(dist[v], dist[u] + w); });
             }
         });
     }

--- a/networkit/cpp/algebraic/algorithms/test/AlgebraicMatchingCoarseningGTest.cpp
+++ b/networkit/cpp/algebraic/algorithms/test/AlgebraicMatchingCoarseningGTest.cpp
@@ -5,19 +5,20 @@
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
 
+// networkit-format
+
 #include <gtest/gtest.h>
 
-#include <networkit/auxiliary/Timer.hpp>
-#include <networkit/algebraic/algorithms/AlgebraicMatchingCoarsening.hpp>
 #include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/algebraic/algorithms/AlgebraicMatchingCoarsening.hpp>
+#include <networkit/auxiliary/Timer.hpp>
+#include <networkit/coarsening/MatchingCoarsening.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/matching/LocalMaxMatcher.hpp>
-#include <networkit/coarsening/MatchingCoarsening.hpp>
 
 namespace NetworKit {
 
 class AlgebraicMatchingCoarseningGTest : public testing::Test {};
-
 
 TEST(AlgebraicMatchingCoarseningGTest, testContraction) {
     METISGraphReader reader;
@@ -44,11 +45,9 @@ TEST(AlgebraicMatchingCoarseningGTest, testContraction) {
     INFO("Graph theoretic matching coarsening took ", t.elapsedTag());
     std::vector<node> mcFineToCoarse = mc.getFineToCoarseNodeMapping();
 
-    G.forNodes([&](node u) {
-        EXPECT_EQ(mcFineToCoarse[u], amcFineToCoarse[u]);
-    });
+    G.forNodes([&](node u) { EXPECT_EQ(mcFineToCoarse[u], amcFineToCoarse[u]); });
 
-    EXPECT_GE(coarseG.numberOfNodes(), 0.5*G.numberOfNodes());
+    EXPECT_GE(coarseG.numberOfNodes(), 0.5 * G.numberOfNodes());
     EXPECT_EQ(G.totalEdgeWeight(), coarseG.totalEdgeWeight());
     if (G.numberOfEdges() > 0) {
         EXPECT_LT(coarseG.numberOfNodes(), G.numberOfNodes());

--- a/networkit/cpp/algebraic/algorithms/test/AlgebraicPageRankGTest.cpp
+++ b/networkit/cpp/algebraic/algorithms/test/AlgebraicPageRankGTest.cpp
@@ -5,12 +5,14 @@
  *      Author: Michael
  */
 
+// networkit-format
+
 #include <gtest/gtest.h>
 
-#include <networkit/algebraic/algorithms/AlgebraicPageRank.hpp>
-#include <networkit/io/SNAPGraphReader.hpp>
 #include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/algebraic/algorithms/AlgebraicPageRank.hpp>
 #include <networkit/auxiliary/Timer.hpp>
+#include <networkit/io/SNAPGraphReader.hpp>
 
 #include <networkit/centrality/PageRank.hpp>
 
@@ -33,7 +35,7 @@ TEST(AlgebraicPageRankGTest, testPageRankDirected) {
     apr.run();
     t.stop();
     INFO("Computing page rank algebraically took ", t.elapsedMicroseconds() / 1000.0);
-    std::vector<std::pair<node, double> > pr_ranking = apr.ranking();
+    std::vector<std::pair<node, double>> pr_ranking = apr.ranking();
 
     const double tol = 1e-3;
     EXPECT_EQ(pr_ranking[0].first, 699u);
@@ -52,17 +54,17 @@ TEST(AlgebraicPageRankGTest, testPageRankDirected) {
 }
 
 TEST(AlgebraicPageRankGTest, testPageRankCentrality) {
- /* Graph:
-    0    3   6
-     \  / \ /
-      2 -- 5
-     /  \ / \
-    1    4   7
+    /* Graph:
+       0    3   6
+        \  / \ /
+         2 -- 5
+        /  \ / \
+       1    4   7
 
-    Edges in the upper row have weight 3,
-    the edge in the middle row has weight 1.5,
-    edges in the lower row have weight 2.
- */
+       Edges in the upper row have weight 3,
+       the edge in the middle row has weight 1.5,
+       edges in the lower row have weight 2.
+    */
     count n = 8;
     Graph G(n, true);
 

--- a/networkit/cpp/algebraic/algorithms/test/AlgebraicSpanningEdgeCentralityGTest.cpp
+++ b/networkit/cpp/algebraic/algorithms/test/AlgebraicSpanningEdgeCentralityGTest.cpp
@@ -5,19 +5,19 @@
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
 
+// networkit-format
 
 #include <gtest/gtest.h>
 
-#include <networkit/algebraic/algorithms/AlgebraicSpanningEdgeCentrality.hpp>
 #include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/algebraic/algorithms/AlgebraicSpanningEdgeCentrality.hpp>
 
-#include <networkit/io/METISGraphReader.hpp>
 #include <networkit/centrality/SpanningEdgeCentrality.hpp>
+#include <networkit/io/METISGraphReader.hpp>
 
 namespace NetworKit {
 
 class AlgebraicSpanningEdgeCentralityGTest : testing::Test {};
-
 
 TEST(AlgebraicSpanningEdgeCentralityGTest, testOnToyGraph) {
     /* Graph:
@@ -30,7 +30,6 @@ TEST(AlgebraicSpanningEdgeCentralityGTest, testOnToyGraph) {
     count n = 6;
     Graph G(n, false, false);
     G.indexEdges();
-
 
     G.addEdge(0, 2);
     G.addEdge(1, 2);
@@ -55,7 +54,7 @@ TEST(AlgebraicSpanningEdgeCentralityGTest, benchmarkSpanning) {
 
     std::string graphFiles[2] = {"input/karate.graph", "input/tiny_01.graph"};
 
-    for (auto graphFile: graphFiles) {
+    for (auto graphFile : graphFiles) {
         Graph G = reader.read(graphFile);
         G.indexEdges();
         Aux::Timer timer;
@@ -76,7 +75,8 @@ TEST(AlgebraicSpanningEdgeCentralityGTest, benchmarkSpanning) {
         double error = 0.0;
         G.forEdges([&](node, node, edgeid e) {
             double relError = fabs(asp.score(e) - exact.score(e));
-            if (fabs(exact.score(e)) > 1e-9) relError /= exact.score(e);
+            if (fabs(exact.score(e)) > 1e-9)
+                relError /= exact.score(e);
             error += relError;
         });
         error /= G.numberOfEdges();
@@ -88,12 +88,11 @@ TEST(AlgebraicSpanningEdgeCentralityGTest, benchmarkSpanning) {
         timer.stop();
         INFO("graph theoretical spanning edge centrality time: ", timer.elapsedTag());
 
-
-
         error = 0.0;
         G.forEdges([&](node, node, edgeid e) {
             double relError = fabs(sp.score(e) - exact.score(e));
-            if (fabs(exact.score(e)) > 1e-9) relError /= exact.score(e);
+            if (fabs(exact.score(e)) > 1e-9)
+                relError /= exact.score(e);
             error += relError;
         });
         error /= G.numberOfEdges();

--- a/networkit/cpp/algebraic/algorithms/test/AlgebraicTriangleCountingGTest.cpp
+++ b/networkit/cpp/algebraic/algorithms/test/AlgebraicTriangleCountingGTest.cpp
@@ -5,13 +5,15 @@
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
 
+// networkit-format
+
 #include <gtest/gtest.h>
 
 #include <networkit/algebraic/CSRMatrix.hpp>
 #include <networkit/algebraic/algorithms/AlgebraicTriangleCounting.hpp>
 #include <networkit/auxiliary/Timer.hpp>
-#include <networkit/io/METISGraphReader.hpp>
 #include <networkit/centrality/LocalClusteringCoefficient.hpp>
+#include <networkit/io/METISGraphReader.hpp>
 
 namespace NetworKit {
 
@@ -20,9 +22,9 @@ class AlgebraicTriangleCountingGTest : public testing::Test {};
 TEST(AlgebraicTriangleCountingGTest, testToyGraphOne) {
     Graph graph(5);
 
-    graph.addEdge(0,1);
-    graph.addEdge(0,2);
-    graph.addEdge(1,2);
+    graph.addEdge(0, 1);
+    graph.addEdge(0, 2);
+    graph.addEdge(1, 2);
 
     AlgebraicTriangleCounting<CSRMatrix> atc(graph);
     atc.run();
@@ -39,12 +41,12 @@ TEST(AlgebraicTriangleCountingGTest, testToyGraphOne) {
 TEST(AlgebraicTriangleCountingGTest, testToyGraphTwo) {
     Graph graph(5);
 
-    graph.addEdge(0,1);
-    graph.addEdge(0,2);
-    graph.addEdge(1,2);
-    graph.addEdge(1,3);
-    graph.addEdge(3,4);
-    graph.addEdge(2,4);
+    graph.addEdge(0, 1);
+    graph.addEdge(0, 2);
+    graph.addEdge(1, 2);
+    graph.addEdge(1, 3);
+    graph.addEdge(3, 4);
+    graph.addEdge(2, 4);
 
     AlgebraicTriangleCounting<CSRMatrix> atc(graph);
     atc.run();
@@ -58,7 +60,7 @@ TEST(AlgebraicTriangleCountingGTest, testToyGraphTwo) {
     EXPECT_EQ(0u, nodeScores[3]) << "wrong triangle count";
     EXPECT_EQ(0u, nodeScores[4]) << "wrong triangle count";
 
-    graph.addEdge(2,3);
+    graph.addEdge(2, 3);
     atc = AlgebraicTriangleCounting<CSRMatrix>(graph);
     atc.run();
 
@@ -72,9 +74,9 @@ TEST(AlgebraicTriangleCountingGTest, testToyGraphTwo) {
 TEST(AlgebraicTriangleCountingGTest, testDirectedToyGraphOne) {
     Graph graph(5, false, true);
 
-    graph.addEdge(0,1);
-    graph.addEdge(1,2);
-    graph.addEdge(2,0);
+    graph.addEdge(0, 1);
+    graph.addEdge(1, 2);
+    graph.addEdge(2, 0);
 
     AlgebraicTriangleCounting<CSRMatrix> atc(graph);
     atc.run();
@@ -91,9 +93,9 @@ TEST(AlgebraicTriangleCountingGTest, testDirectedToyGraphOne) {
 TEST(AlgebraicTriangleCountingGTest, testDirectedToyGraphTwo) {
     Graph graph(5, false, true);
 
-    graph.addEdge(0,1);
-    graph.addEdge(0,2);
-    graph.addEdge(1,2);
+    graph.addEdge(0, 1);
+    graph.addEdge(0, 2);
+    graph.addEdge(1, 2);
 
     AlgebraicTriangleCounting<CSRMatrix> atc(graph);
     atc.run();
@@ -110,12 +112,12 @@ TEST(AlgebraicTriangleCountingGTest, testDirectedToyGraphTwo) {
 TEST(AlgebraicTriangleCountingGTest, testDirectedToyGraphThree) {
     Graph graph(5, false, true);
 
-    graph.addEdge(0,1);
-    graph.addEdge(1,0);
-    graph.addEdge(0,2);
-    graph.addEdge(2,0);
-    graph.addEdge(1,2);
-    graph.addEdge(2,1);
+    graph.addEdge(0, 1);
+    graph.addEdge(1, 0);
+    graph.addEdge(0, 2);
+    graph.addEdge(2, 0);
+    graph.addEdge(1, 2);
+    graph.addEdge(2, 1);
 
     AlgebraicTriangleCounting<CSRMatrix> atc(graph);
     atc.run();
@@ -132,7 +134,8 @@ TEST(AlgebraicTriangleCountingGTest, testDirectedToyGraphThree) {
 TEST(AlgebraicTriangleCountingGTest, testLocalClusteringCoefficient) {
     METISGraphReader reader;
     Graph graph = reader.read("input/celegans_metabolic.graph");
-    INFO("graph has ", graph.numberOfNodes(), " nodes and ", graph.numberOfEdges(), " edges and directed? ", graph.isDirected());
+    INFO("graph has ", graph.numberOfNodes(), " nodes and ", graph.numberOfEdges(),
+         " edges and directed? ", graph.isDirected());
 
     Aux::Timer timer;
     AlgebraicTriangleCounting<CSRMatrix> atc(graph);
@@ -145,7 +148,7 @@ TEST(AlgebraicTriangleCountingGTest, testLocalClusteringCoefficient) {
         if (graph.degree(u) < 2) {
             lccAlgebraic[u] = 0.0;
         } else {
-            lccAlgebraic[u] = 2.0 * nodeScores[u] / (graph.degree(u) * (graph.degree(u)-1));
+            lccAlgebraic[u] = 2.0 * nodeScores[u] / (graph.degree(u) * (graph.degree(u) - 1));
         }
     });
     timer.stop();
@@ -160,9 +163,7 @@ TEST(AlgebraicTriangleCountingGTest, testLocalClusteringCoefficient) {
 
     INFO("Graph theoretic local clustering coefficient took ", timer.elapsedTag());
 
-    graph.forNodes([&](node u) {
-        EXPECT_EQ(lccValues[u], lccAlgebraic[u]);
-    });
+    graph.forNodes([&](node u) { EXPECT_EQ(lccValues[u], lccAlgebraic[u]); });
 }
 
 } /* namespace NetworKit */


### PR DESCRIPTION
Right now only a small subset of C++ source files (123 over 697) comply with our coding style and this is checked in new PRs only if the authors add `// networkit-format` in new source files.
I think that this is a good temporary solution but it would be desirable to make the whole codebase adhere to the coding style. This would be helpful especially when refactoring, which is sometimes tedious to do if the file is not formatted.

I wrote a simple script to format and add `// networkit-format` to all the non-compliant files and my plan would be to format a few files per time (always excluding the ones involved in other PRs) until we cover the whole codebase. Afterwards I would remove `// networkit-format` and enforce our coding style to all source files. Here I started with `algebraic/algorithms`.