### PR TITLE
check_code.py: check version of clang-format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,14 +320,14 @@ jobs:
 
   style-guide-compliance-build:
     name: "Style guide compliance build"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install prerequisites 📦
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/bionic llvm-toolchain-bionic-8 main" | sudo tee /etc/apt/sources.list.d/llvm8.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-11 main" | sudo tee /etc/apt/sources.list.d/llvm11.list
           sudo apt-get update
-          sudo apt-get install clang-format-8
+          sudo apt-get install clang-format-11
       - name: Checkout
         uses: actions/checkout@v2
       - name: Checkout submodules

--- a/extrafiles/tooling/nktooling/__init__.py
+++ b/extrafiles/tooling/nktooling/__init__.py
@@ -7,6 +7,8 @@ import subprocess
 READONLY = True
 VERBOSE = False
 SHOW_DIFFS = True
+MIN_CLANG_FORMAT_VERSION = 8
+MAX_CLANG_FORMAT_VERSION = 11
 
 def setup(args = None):
 	"""


### PR DESCRIPTION
Currently, `./check_code.py` checks the coding style by calling `clang-format-8` but this does not work with newer versions of clang-format and even with clang-format 8 if it can only be invoked using `clang-format`.

This PR fixes this issue and updates the coding style CI build to clang-format-11. Further, as suggested in #576, `CppClangFormat.py` will throw a `FileNotFoundError` upon failure.