### PR TITLE
Fix potential data races

### DIFF
--- a/networkit/cpp/generators/HyperbolicGenerator.cpp
+++ b/networkit/cpp/generators/HyperbolicGenerator.cpp
@@ -242,7 +242,7 @@ Graph HyperbolicGenerator::generate(const vector<double> &angles, const vector<d
     //get Graph
     GraphBuilder result(n, false, false);//no direct swap with probabilistic graphs
     count totalCandidates = 0;
-    #pragma omp parallel for
+    #pragma omp parallel for reduction(+: totalCandidates)
     for (omp_index i = 0; i < static_cast<omp_index>(n); i++) {
         vector<index> near;
         totalCandidates += quad.getElementsProbabilistically(HyperbolicSpace::polarToCartesian(angles[i], radii[i]), edgeProb, anglesSorted, near);


### PR DESCRIPTION
Fixes potential data races as reported in #622.

- `totalCandidates`: Added a reduction
- `queued`: ~~Make queued atomic~~ Since `msvc` does only support OpenMP 2.0, atomic writes are not available. Therefore a reduction for queued is used, which is equivalent to `queued = true`. Initial benchmarks on the artifical gtest graph instances also show better performance for reduction vs. atomic for this case. 
- `os_stack_trace_getter_`: This one is the most tricky one, since the error is not in NetworKit, but in googletest. From the report, the data race potentially occurs when executing `EXPECT_NE`. However from code-inspection (see https://github.com/google/googletest/blob/master/googletest/src/gtest.cc#L2670 which for every testcase calls https://github.com/google/googletest/blob/master/googletest/src/gtest.cc#L4859) it seems, that the problem may occur for every `EXPECT_*` or `ASSERT_*`, which is executed in parallel. One possibility would be to switch from `parallelForEdges` to `forEdges`. However other iterative methods like `parallelForNodes` are covered by their own test-cases. So instead of removing the parallel-tests, the PR refactors the test-cases in order to clearly distinquish between parallel and non-parallel functions. In addition all `EXPECT_*` and `ASSERT_*` are removed from parallel-sections.