### PR TITLE
Fix isolated conductance algorithm

### DIFF
--- a/include/networkit/community/IsolatedInterpartitionConductance.hpp
+++ b/include/networkit/community/IsolatedInterpartitionConductance.hpp
@@ -17,7 +17,7 @@ namespace NetworKit {
  * is used.
  *
  * See also Experiments on Density-Constrained Graph Clustering,
- * Robert Grke, Andrea Kappes and  Dorothea Wagner, JEA 2015:
+ * Robert Gorke, Andrea Kappes and  Dorothea Wagner, JEA 2015:
  * http://dx.doi.org/10.1145/2638551
  */
 class IsolatedInterpartitionConductance final : public LocalPartitionEvaluation {

--- a/networkit/cpp/community/IsolatedInterpartitionConductance.cpp
+++ b/networkit/cpp/community/IsolatedInterpartitionConductance.cpp
@@ -14,7 +14,7 @@ void NetworKit::IsolatedInterpartitionConductance::run() {
     std::vector<edgeweight> clusterVolume(P->upperBound(), 0);
     edgeweight totalVolume = 0;
     G->forEdges([&](node u, node v, edgeweight w) {
-        if (&P[u] != &P[v]) {
+        if ((*P)[u] != (*P)[v]) {
             values[(*P)[u]] += w;
             values[(*P)[v]] += w;
         }


### PR DESCRIPTION
I noticed that conductance came out as 1 for all clusters. Turns out #472 changed this comparison in the wrong direction by accident. (I'm surprised this even managed to run without crashing.) With this fix I'm getting reasonable-looking conductance values.