### PR TITLE
Fix alpha default initialization in Katz centrality

### DIFF
--- a/include/networkit/centrality/KatzCentrality.hpp
+++ b/include/networkit/centrality/KatzCentrality.hpp
@@ -27,6 +27,7 @@ protected:
     const double alpha; // damping
     const double beta; // constant centrality amount
     const double tol; // error tolerance
+    static double defaultAlpha(const Graph& G);
 
 public:
     /**

--- a/networkit/cpp/centrality/KatzCentrality.cpp
+++ b/networkit/cpp/centrality/KatzCentrality.cpp
@@ -12,12 +12,14 @@
 
 namespace NetworKit {
 
-double defaultAlpha(const Graph& G) {
-  return 1. / (1. + GraphTools::maxDegree(G));
+double KatzCentrality::defaultAlpha(const Graph& G) {
+    return 1. / (1. + GraphTools::maxDegree(G));
 }
 
 KatzCentrality::KatzCentrality(const Graph& G, double alpha, double beta, double tol):
-        Centrality(G, true), alpha(alpha == 0 ? defaultAlpha(G) : alpha), beta(beta), tol(tol)
+        Centrality(G, true),
+        alpha(alpha == 0 ? KatzCentrality::defaultAlpha(G) : alpha),
+        beta(beta), tol(tol)
 {
     if (alpha < 0)
         throw std::runtime_error("Alpha must be non negative.");

--- a/networkit/cpp/centrality/KatzCentrality.cpp
+++ b/networkit/cpp/centrality/KatzCentrality.cpp
@@ -12,13 +12,15 @@
 
 namespace NetworKit {
 
+double defaultAlpha(const Graph& G) {
+  return 1. / (1. + GraphTools::maxDegree(G));
+}
+
 KatzCentrality::KatzCentrality(const Graph& G, double alpha, double beta, double tol):
-        Centrality(G, true), alpha(alpha), beta(beta), tol(tol)
+        Centrality(G, true), alpha(alpha == 0 ? defaultAlpha(G) : alpha), beta(beta), tol(tol)
 {
     if (alpha < 0)
         throw std::runtime_error("Alpha must be non negative.");
-    if (alpha == 0)
-        alpha = 1. / (1. + GraphTools::maxDegree(G));
 }
 
 void KatzCentrality::run() {


### PR DESCRIPTION
Good news! A unit test in LynxKite caught this issue when I rebuilt after https://github.com/networkit/networkit/commit/e568f803a2862a43a514169225649bc1834e5bc7.

That commit looks super innocent. But instead of setting the `alpha` field of `KatzCentrality` it just changes the local `alpha` variable. I tried setting `this->alpha`, but it's `const`. We have to set it correctly right away in the initializer.

Without this fix, `alpha` is zero by default. This causes all the edges to be ignored and every node gets the same centrality.