### PR TITLE
Fix case configuration in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -89,10 +89,12 @@ CheckOptions:
   - key:   readability-identifier-naming.FunctionCase
     value: camelBack
   - key:   readability-identifier-naming.MemberCase
-    value: CamelCase
+    value: camelBack
   - key:   readability-identifier-naming.ParameterCase
-    value: CamelCase
+    value: camelBack
   - key:   readability-identifier-naming.UnionCase
     value: CamelCase
   - key:   readability-identifier-naming.VariableCase
+    value: camelBack
+  - key:   readability-identifier-naming.TemplateParameterCase
     value: CamelCase


### PR DESCRIPTION
As described in #653