### PR TITLE
Documentation deployment: Publish branch only contains last commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,7 @@ jobs:
           external_repository: networkit/dev-docs
           publish_branch:  master
           publish_dir: ./core_build/htmldocs
+          force_orphan: true
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
 


### PR DESCRIPTION
Suggested changes:

- As suggested [here](https://github.com/networkit/networkit-website/pull/49), the publish branch of the documentation repository of NetworKit will now only contain the last commit.