### PR TITLE
ApproxElectricalCloseness: Fix minor issue with pivot lpinv column

### DIFF
--- a/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
@@ -507,6 +507,13 @@ void ApproxElectricalCloseness::run() {
             G.forNodes([&](node u) { rhs[u] = -1.0 / static_cast<double>(n); });
             rhs[root] += 1.;
             cg.solve(rhs, sol);
+
+            // ensure column sum of entries is 0.
+            double columnSum = 0.;
+            for (int i = 0; i < n; i++) {
+                columnSum += sol[i];
+            }
+            sol -= columnSum / n;
         }
 
         // All threads sample and aggregate USTs in parallel

--- a/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
@@ -510,10 +510,8 @@ void ApproxElectricalCloseness::run() {
 
             // ensure column sum of entries is 0.
             double columnSum = 0.;
-            for (int i = 0; i < n; i++) {
-                columnSum += sol[i];
-            }
-            sol -= columnSum / n;
+            G.forNodes([&](node u) { columnSum += sol[u]; });
+            sol -= columnSum / static_cast<double>(n);
         }
 
         // All threads sample and aggregate USTs in parallel


### PR DESCRIPTION
The vector that is computed as the column of the lpinv may differ by a constant from the actual column of the lpinv since L vanishes on constant vectors. This is not addressed explicitly in the part of the paper which explains how the pivot column is computed, but may affect the output centrality and diagonal entry values.