### PR TITLE
Parallelize ClusteredRandomGraphGenerator

### DIFF
--- a/include/networkit/generators/ClusteredRandomGraphGenerator.hpp
+++ b/include/networkit/generators/ClusteredRandomGraphGenerator.hpp
@@ -3,7 +3,10 @@
  *
  *  Created on: 28.02.2014
  *      Author: cls
+ *              Eugenio Angriman <angrimae@hu-berlin.de>
  */
+
+// networkit-format
 
 #ifndef NETWORKIT_GENERATORS_CLUSTERED_RANDOM_GRAPH_GENERATOR_HPP_
 #define NETWORKIT_GENERATORS_CLUSTERED_RANDOM_GRAPH_GENERATOR_HPP_
@@ -26,10 +29,10 @@ public:
      *
      * @param[in]	n	number of nodes
      * @param[in]	k	number of clusters
-     * @param[in]	pin		intra-cluster edge probability
-     * @param[in]	pout	inter-cluster edge probability
+     * @param[in]	pIntra		intra-cluster edge probability
+     * @param[in]	pInter	inter-cluster edge probability
      */
-    ClusteredRandomGraphGenerator(count n, count k, double pin, double pout);
+    ClusteredRandomGraphGenerator(count n, count k, double pIntra, double pInter);
 
     /**
      * Generates a clustered random graph with the properties given in the constructor.
@@ -44,11 +47,8 @@ public:
     Partition getCommunities();
 
 private:
-
-    count n;
-    count k;
-    double pin;
-    double pout;
+    const count n, k;
+    const double pIntra, pInter;
     Partition zeta;
 };
 

--- a/include/networkit/generators/ClusteredRandomGraphGenerator.hpp
+++ b/include/networkit/generators/ClusteredRandomGraphGenerator.hpp
@@ -21,6 +21,7 @@ namespace NetworKit {
  * The ClusteredRandomGraphGenerator class is used to create a clustered random graph.
  * The number of nodes and the number of edges are adjustable as well as the probabilities
  * for intra-cluster and inter-cluster edges.
+ * In parallel the generated graph is not deterministic. To ensure determinism, use a single thread.
  */
 class ClusteredRandomGraphGenerator final : public StaticGraphGenerator {
 public:

--- a/include/networkit/generators/ErdosRenyiEnumerator.hpp
+++ b/include/networkit/generators/ErdosRenyiEnumerator.hpp
@@ -201,7 +201,7 @@ private:
         Aux::SignalHandler handler;
 
         if (prob < std::pow(n, -3.0)) {
-            // Even with a union bound over all candidates, WHP no edge will be emited
+            // Even with a union bound over all candidates, WHP no edge will be emitted
             return 0;
         }
 

--- a/networkit/cpp/community/test/CommunityGTest.cpp
+++ b/networkit/cpp/community/test/CommunityGTest.cpp
@@ -65,7 +65,7 @@ TEST_F(CommunityGTest, testLabelPropagationOnUniformGraph) {
 
 
 TEST_F(CommunityGTest, testLabelPropagationOnClusteredGraph_ForNumberOfClusters) {
-    int64_t n = 100;
+    count n = 100;
     count k = 3; // number of clusters
 
     ClusteredRandomGraphGenerator graphGen(n, k, 1.0, 0.00);
@@ -129,7 +129,7 @@ TEST_F(CommunityGTest, testLabelPropagationOnManySmallClusters) {
     double pout = 0.0;
 
     ClusteredRandomGraphGenerator graphGen(n, k, pin, pout);
-  Aux::Random::setSeed(42, false);
+    Aux::Random::setSeed(42, false);
     Graph G = graphGen.generate();
     Partition reference = graphGen.getCommunities();
 
@@ -145,32 +145,6 @@ TEST_F(CommunityGTest, testLabelPropagationOnManySmallClusters) {
     EXPECT_TRUE(GraphClusteringTools::equalClusterings(zeta, reference, G)) << "Can LabelPropagation detect the reference clustering?";
 
 }
-
-
-
-/*
-TEST_F(CommunityGTest, testLouvainParallel2Naive) {
-    count n = 1000;
-    count k = 100;
-    double pin = 1.0;
-    double pout = 0.005;
-    GraphGenerator graphGen;
-    Graph G = graphGen.makeClusteredRandomGraph(n, k, pin, pout);
-
-    LouvainParallel louvain(G);
-    louvain.run();
-    Partition zeta = louvain.getPartition();
-
-    INFO("number of clusters: " , zeta.numberOfSubsets());
-
-    Modularity modularity;
-    INFO("modularity: " , modularity.getQuality(zeta, G));
-
-}
-*/
-
-
-
 
 TEST_F(CommunityGTest, testPLM) {
     METISGraphReader reader;

--- a/networkit/cpp/generators/ClusteredRandomGraphGenerator.cpp
+++ b/networkit/cpp/generators/ClusteredRandomGraphGenerator.cpp
@@ -3,55 +3,137 @@
  *
  *  Created on: 28.02.2014
  *      Author: cls
+ *              Eugenio Angriman <angrimae@hu-berlin.de>
  */
+
+// networkit-format
+
+#ifndef NDEBUG
+#include <algorithm>
+#endif
+
+#include <omp.h>
+#include <random>
+#include <stdexcept>
+#include <unordered_set>
 
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/generators/ClusteredRandomGraphGenerator.hpp>
-#include <networkit/structures/Partition.hpp>
+#include <networkit/graph/GraphBuilder.hpp>
 
 namespace NetworKit {
 
-ClusteredRandomGraphGenerator::ClusteredRandomGraphGenerator(count n, count k, double pin, double pout) : n(n), k(k), pin(pin), pout(pout) {
+ClusteredRandomGraphGenerator::ClusteredRandomGraphGenerator(count n, count k, double pIntra,
+                                                             double pInter)
+    : n(n), k(k), pIntra(pIntra), pInter(pInter), zeta(n) {
+
+    if (k == 0)
+        throw std::runtime_error("Error: k must be positive");
+
+    const auto isProbability = [](double p) noexcept -> bool { return (p >= 0) && (p <= 1); };
+
+    if (!isProbability(pIntra))
+        throw std::runtime_error("Error: pIntra must be in [0, 1]");
+
+    if (!isProbability(pInter))
+        throw std::runtime_error("Error: pInter must be in [0, 1]");
+
+    if (pIntra < pInter)
+        WARN("Intra-cluster probability is lower than inter-cluster probability.");
+
+    zeta.setUpperBound(k);
 }
 
 Graph ClusteredRandomGraphGenerator::generate() {
-    assert(pin >= pout);
+    GraphBuilder graphBuilder(n);
 
-    Graph G(n);
-    // assign nodes evenly to clusters
-    Partition zeta(n);
-    zeta.setUpperBound(k);
-    G.forNodes([&](node v){
-        index c = Aux::Random::integer(k-1);
-        zeta.addToSubset(c, v);
-    });
+    // Sequence of all nodes grouped by cluster. Here the vertices of each cluster are stored
+    // sequentially one after the other
+    std::vector<node> clustersSequence(n);
 
-    assert (zeta.numberOfSubsets() == k);
+    // Index in `clustersSequence` where each cluster ends. E.g., clusterEnd[i] is the index in
+    // `clustersSequence` of the first vertex in the (i + 1)-th cluster.
+    std::vector<size_t> clusterEnd(k);
 
-    G.forNodePairs([&](node u, node v){
-        if (zeta.subsetOf(u) == zeta.subsetOf(v)) {
-            if (Aux::Random::probability() <= pin) {
-                G.addEdge(u, v);
-            }
-        } else {
-            if (Aux::Random::probability() <= pout) {
-                G.addEdge(u, v);
-            }
+    {
+        // To assign vertices to clusters uniformly at random
+        std::uniform_int_distribution<index> clusterDistr{0, k - 1};
+
+        std::vector<count> clusterSizes(k);
+
+        // Assign nodes to clusters
+        graphBuilder.parallelForNodes([&zeta = zeta, &clusterDistr, &clusterSizes](node u) {
+            const index cluster = clusterDistr(Aux::Random::getURNG());
+            zeta.addToSubset(cluster, u);
+#pragma omp atomic
+            ++clusterSizes[cluster];
+        });
+
+        // Last cluster ends at n, each cluster i \in [0, ..., k - 2] ends at
+        // n - \sum_{j = i + 1}^{k - 1} cluster[j].size()
+        clusterEnd[k - 1] = n;
+        for (int64_t i = k - 2; i >= 0; --i)
+            clusterEnd[i] = clusterEnd[i + 1] - clusterSizes[i + 1];
+
+        // Counting sort
+        graphBuilder.forNodes(
+            [&zeta = zeta, &clustersSequence, &clusterEnd, &clusterSizes](node u) {
+                const index cluster = zeta.subsetOf(u);
+                // Position of u in the sorted array: position where u's cluster ends minus how many
+                // vertices are left to be counted in u's cluster.
+                const index uIdx = clusterEnd[cluster] - clusterSizes[cluster]--;
+                clustersSequence[uIdx] = u;
+            });
+        assert(std::is_sorted(
+            clustersSequence.begin(), clustersSequence.end(),
+            [&zeta = zeta](node u, node v) { return zeta.subsetOf(u) < zeta.subsetOf(v); }));
+    }
+
+    // Add all the half-out edges from a node u to all the other nodes in the given sequence.
+    // To avoid self-loops and multiple edges, only the half-out edges from u to the vertices in
+    // (start, end) interval of clustersSequence are added.
+    const auto addHalfOutEdges = [&graphBuilder, &clustersSequence](node u, index start, index end,
+                                                                    double p) -> void {
+        if (end - start <= 1 || p == 0) // No edges to add
+            return;
+
+        if (p == 1) { // Add all edges in the interval
+            for (index i = start + 1; i < end; ++i)
+                graphBuilder.addHalfOutEdge(u, clustersSequence[i]);
+            return;
         }
-    });
 
-    this->zeta = std::move(zeta);
+        std::geometric_distribution<index> geom(p);
+        do {
+            start += geom(Aux::Random::getURNG()) + 1;
+            if (start < end)
+                graphBuilder.addHalfEdge(u, clustersSequence[start]);
+            else
+                return;
+        } while (true);
+    };
 
-    G.shrinkToFit();
-    return G;
+#pragma omp parallel for schedule(guided)
+    for (omp_index i = 0; i < static_cast<omp_index>(n); ++i) {
+        // Current node
+        const node u = clustersSequence[i];
+        // Index in `clustersSequence` where the cluster of node `u` ends.
+        const index end = clusterEnd[zeta.subsetOf(u)];
 
+        // Add intra-cluster half-out edges.
+        addHalfOutEdges(u, i, end, pIntra);
+
+        // Add inter-cluster half-out edges.
+        // end - 1 because addHalfOutEdges discards the first vertex in the given sequence, but in
+        // this case an edge between u and the first one in the next cluster is possible.
+        addHalfOutEdges(u, end - 1, n, pInter);
+    }
+
+    return graphBuilder.toGraph(true, true);
 }
 
 Partition ClusteredRandomGraphGenerator::getCommunities() {
     return zeta;
 }
 
-
-} /* namespace NetworKit */
-
-
+} // namespace NetworKit

--- a/networkit/cpp/generators/test/GeneratorsGTest.cpp
+++ b/networkit/cpp/generators/test/GeneratorsGTest.cpp
@@ -76,7 +76,8 @@ TEST_F(GeneratorsGTest, testClusteredRandomGraphGenerator) {
     count nCommunities = part.getSubsetIds().size();
     EXPECT_EQ(n, G.numberOfNodes());
     EXPECT_EQ(n, G.upperNodeIdBound());
-    EXPECT_TRUE(nCommunities >= 1 && nCommunities <= c);
+    EXPECT_GE(nCommunities, 1);
+    EXPECT_LE(nCommunities, c);
 }
 
 TEST_F(GeneratorsGTest, testClusteredRandomGraphGeneratorCompleteIsolatedCommunities) {

--- a/networkit/generators.pyx
+++ b/networkit/generators.pyx
@@ -278,6 +278,8 @@ cdef class ClusteredRandomGraphGenerator(StaticGraphGenerator):
 	The number of nodes and the number of edges are adjustable as well as the probabilities
 	for intra-cluster and inter-cluster edges.
 
+	In parallel the generated graph is not deterministic. To ensure determinism, use a single thread.
+
 	ClusteredRandomGraphGenerator(count, count, pin, pout)
 
 	Creates a clustered random graph.

--- a/networkit/test/test_generators.py
+++ b/networkit/test/test_generators.py
@@ -49,5 +49,16 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(G.numberOfNodes(), n)
         self.assertEqual(G.numberOfEdges(), n*nbrs)
 
+    def testClusteredRandomGraphGenerator(self):
+        n, k = 100, 10
+        pIntra, pInter = 0.1, 0.05
+        gen = nk.generators.ClusteredRandomGraphGenerator(n, k, pIntra, pInter)
+        G = gen.generate()
+        self.assertEqual(G.numberOfNodes(), n)
+        nCommunities = len(set(gen.getCommunities().getVector()))
+        self.assertGreater(nCommunities, 0)
+        self.assertLessEqual(nCommunities, k)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`ClusteredRandomGraphGenerator` is an O(m^2) algorithm and it is implemented sequentially.
A simple idea to parallelize it is to add all half-out edges in parallel (this is thread-safe), and then to use `GraphBuilder` to complete the work.

This already gives us some speedup, generating a graph with 15K nodes and 50 clusters took ~10s with the previous implementation and just ~130ms with the new one (on a 24 cores machine).