### PR TITLE
Deprecate Algorithm::isParallel()

### DIFF
--- a/include/networkit/base/Algorithm.hpp
+++ b/include/networkit/base/Algorithm.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <stdexcept>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 class Algorithm {
@@ -52,7 +54,7 @@ public:
     /**
      * @return True if algorithm can run multi-threaded.
      */
-    virtual bool isParallel() const;
+    virtual TLX_DEPRECATED(bool isParallel() const);
 };
 
 } /* NetworKit */

--- a/include/networkit/centrality/CoreDecomposition.hpp
+++ b/include/networkit/centrality/CoreDecomposition.hpp
@@ -1,5 +1,5 @@
 /*
- * CoreDecomposition.h
+ * CoreDecomposition.hpp
  *
  *  Created on: Oct 28, 2013
  *      Author: Lukas Barth, David Weiss, Christian Staudt
@@ -11,11 +11,13 @@
 #include <vector>
 #include <string>
 #include <list>
+
 #include <networkit/graph/Graph.hpp>
 #include <networkit/centrality/Centrality.hpp>
 #include <networkit/structures/Partition.hpp>
 #include <networkit/structures/Cover.hpp>
 
+#include <tlx/define/deprecated.hpp>
 
 namespace NetworKit {
 
@@ -38,6 +40,9 @@ public:
      * @param normalized If set to @c true the scores are normalized in the interval [0,1].
      * @param enforceBucketQueueAlgorithm If set to @c true, uses a bucket priority queue data structure. This it is generally slower than ParK but may be more flexible. TODO check
      * @param storeNodeOrder If set to @c true, the order of the nodes in ascending order of the cores is stored and can later be returned using getNodeOrder(). Enforces the sequential bucket priority queue algorithm.
+     *
+     * The algorithm runs in parallel if the usage of a bucket priority queue is not enforced and
+     * if the node ids of the input graph are continuous (i.e., numberOfNodes() = upperNodeIdBound()).
      */
     CoreDecomposition(const Graph& G, bool normalized=false, bool enforceBucketQueueAlgorithm = false, bool storeNodeOrder = false);
 
@@ -87,7 +92,7 @@ public:
      * The algorithm ParK can run in parallel under certain conditions,
      * the bucket PQ based one cannot.
      */
-    bool isParallel() const override { return canRunInParallel; }
+    bool TLX_DEPRECATED(isParallel() const override) { return canRunInParallel; }
 
 private:
 

--- a/include/networkit/centrality/LocalPartitionCoverage.hpp
+++ b/include/networkit/centrality/LocalPartitionCoverage.hpp
@@ -5,6 +5,8 @@
 #include <networkit/centrality/Centrality.hpp>
 #include <networkit/structures/Partition.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -22,6 +24,7 @@ public:
 
     /**
      * Computes local partition coverage on the graph passed in constructor.
+     * This method runs in parallel.
      */
     void run() override;
 
@@ -36,7 +39,7 @@ public:
      * This algorithm is parallel.
      * @return true
      */
-    bool isParallel() const override;
+    bool TLX_DEPRECATED(isParallel() const override);
 
     /**
      * The name of this algorithm.

--- a/include/networkit/community/CoverF1Similarity.hpp
+++ b/include/networkit/community/CoverF1Similarity.hpp
@@ -3,6 +3,8 @@
 
 #include <networkit/community/LocalCoverEvaluation.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -35,7 +37,7 @@ public:
     CoverF1Similarity(const Graph& G, const Cover& C, const Cover& reference);
 
     /**
-     * Execute the algorithm.
+     * Execute the algorithm. The algorithm is not parallel.
      */
     void run() override;
 
@@ -47,7 +49,7 @@ public:
     /**
      * @return false - this algorithm has not been parallelized.
      */
-    bool isParallel() const override { return false; }
+    bool TLX_DEPRECATED(isParallel() const override) { return false; }
 private:
     const Cover *reference;
 };

--- a/include/networkit/community/CoverHubDominance.hpp
+++ b/include/networkit/community/CoverHubDominance.hpp
@@ -3,6 +3,8 @@
 
 #include <networkit/community/LocalCoverEvaluation.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -23,7 +25,7 @@ public:
     using LocalCoverEvaluation::LocalCoverEvaluation;
 
     /**
-     * Execute the algorithm.
+     * Execute the algorithm. The algorithm is not parallel.
      */
     void run() override;
 
@@ -35,7 +37,7 @@ public:
     /**
      * @return true - this algorithm is partially parallel (but \f$\Omega(n)\f$ sequential work remains)
      */
-    bool isParallel() const override { return true; }
+    bool TLX_DEPRECATED(isParallel() const override) { return true; }
 };
 
 }

--- a/include/networkit/community/IntrapartitionDensity.hpp
+++ b/include/networkit/community/IntrapartitionDensity.hpp
@@ -3,6 +3,8 @@
 
 #include <networkit/community/LocalPartitionEvaluation.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -14,7 +16,7 @@ public:
     using LocalPartitionEvaluation::LocalPartitionEvaluation;
 
     /**
-     * Execute the algorithm.
+     * Execute the algorithm. The algorithm is not parallel.
      */
     void run() override;
 
@@ -28,7 +30,7 @@ public:
     /**
      * @return false - this algorithm is not parallel.
      */
-    bool isParallel() const override { return false; }
+    bool TLX_DEPRECATED(isParallel() const override) { return false; }
 
     /**
      * This value should be high in a good clustering.

--- a/include/networkit/community/IsolatedInterpartitionConductance.hpp
+++ b/include/networkit/community/IsolatedInterpartitionConductance.hpp
@@ -3,6 +3,8 @@
 
 #include <networkit/community/LocalPartitionEvaluation.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -25,7 +27,7 @@ public:
     using LocalPartitionEvaluation::LocalPartitionEvaluation;
 
     /**
-     * Execute the algorithm.
+     * Execute the algorithm. The algorithm is not parallel.
      */
     void run() override;
 
@@ -37,7 +39,7 @@ public:
     /**
      * @return false - only minor parts of this implementation are parallel.
      */
-    bool isParallel() const override { return false; };
+    bool TLX_DEPRECATED(isParallel() const override) { return false; };
 
     /**
      * Get the name of the algorithm.

--- a/include/networkit/community/IsolatedInterpartitionExpansion.hpp
+++ b/include/networkit/community/IsolatedInterpartitionExpansion.hpp
@@ -3,6 +3,8 @@
 
 #include <networkit/community/LocalPartitionEvaluation.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -25,7 +27,7 @@ public:
     using LocalPartitionEvaluation::LocalPartitionEvaluation;
 
     /**
-     * Execute the algorithm.
+     * Execute the algorithm. The algorithm is not parallel.
      */
     void run() override;
 
@@ -37,7 +39,7 @@ public:
     /**
      * @return false - this algorithm is not parallel.
      */
-    bool isParallel() const override { return false; };
+    bool TLX_DEPRECATED(isParallel() const override) { return false; };
 
     /**
      * Get the name of the algorithm.

--- a/include/networkit/community/PartitionFragmentation.hpp
+++ b/include/networkit/community/PartitionFragmentation.hpp
@@ -3,6 +3,8 @@
 
 #include <networkit/community/LocalPartitionEvaluation.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -14,7 +16,7 @@ public:
     using LocalPartitionEvaluation::LocalPartitionEvaluation;
 
     /**
-     * Execute the algorithm.
+     * Execute the algorithm. The algorithm is not parallel.
      */
     void run() override;
 
@@ -26,7 +28,7 @@ public:
     /**
      * @return false - only minor parts of this implementation are parallel.
      */
-    bool isParallel() const override { return false; };
+    bool TLX_DEPRECATED(isParallel() const override) { return false; };
 };
 
 }

--- a/include/networkit/community/PartitionHubDominance.hpp
+++ b/include/networkit/community/PartitionHubDominance.hpp
@@ -3,6 +3,8 @@
 
 #include <networkit/community/LocalPartitionEvaluation.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -22,7 +24,7 @@ public:
     using LocalPartitionEvaluation::LocalPartitionEvaluation;
 
     /**
-     * Execute the algorithm.
+     * Execute the algorithm. The algorithm is not parallel.
      */
     void run() override;
 
@@ -34,7 +36,7 @@ public:
     /**
      * @return false - this implementation is not paralle.
      */
-    bool isParallel() const override { return false; }
+    bool TLX_DEPRECATED(isParallel() const override) { return false; }
 };
 
 }

--- a/include/networkit/correlation/Assortativity.hpp
+++ b/include/networkit/correlation/Assortativity.hpp
@@ -12,6 +12,7 @@
 #include <networkit/graph/Graph.hpp>
 #include <networkit/structures/Partition.hpp>
 
+#include <tlx/define/deprecated.hpp>
 
 namespace NetworKit {
 
@@ -44,7 +45,7 @@ public:
     Assortativity(const Graph& G, const Partition& partition);
 
     /**
-    *
+    * Runs the algorithm. The algorithm is not parallel.
     */
     void run() override;
 
@@ -60,7 +61,7 @@ public:
      */
     std::string toString() const override;
 
-    bool isParallel() const override;
+    bool TLX_DEPRECATED(isParallel() const override);
 
 
 private:

--- a/include/networkit/distance/APSP.hpp
+++ b/include/networkit/distance/APSP.hpp
@@ -14,6 +14,8 @@
 #include <networkit/distance/SSSP.hpp>
 #include <networkit/graph/Graph.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -32,7 +34,10 @@ class APSP : public Algorithm {
 
     ~APSP() override = default;
 
-    /** Computes the shortest paths from each node to all other nodes. */
+    /**
+     * Computes the shortest paths from each node to all other nodes.
+     * The algorithm is parallel.
+     */
     void run() override;
 
     /**
@@ -64,7 +69,7 @@ class APSP : public Algorithm {
     /**
      * @return True if algorithm can run multi-threaded.
      */
-    bool isParallel() const override { return true; }
+    bool TLX_DEPRECATED(isParallel() const override) { return true; }
 
 protected:
     const Graph &G;

--- a/include/networkit/distance/SPSP.hpp
+++ b/include/networkit/distance/SPSP.hpp
@@ -50,7 +50,10 @@ public:
 
     ~SPSP() override = default;
 
-    /** Computes the shortest paths from the source nodes to all other nodes. */
+    /**
+     * Computes the shortest paths from the source nodes to all other nodes.
+     * The algorithm is parallel.
+     */
     void run() override;
 
     /**
@@ -87,7 +90,7 @@ public:
     /**
      * @return True: the algorithm is parallel.
      */
-    bool isParallel() const override { return true; }
+    bool TLX_DEPRECATED(isParallel() const override) { return true; }
 
 private:
     const Graph *G;

--- a/include/networkit/generators/LFRGenerator.hpp
+++ b/include/networkit/generators/LFRGenerator.hpp
@@ -6,6 +6,8 @@
 #include <networkit/graph/Graph.hpp>
 #include <networkit/structures/Partition.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -95,7 +97,7 @@ public:
     void setMuWithBinomialDistribution(double mu);
 
     /**
-     * Generates the graph and the community structure.
+     * Generates the graph and the community structure. The algorithm is not parallel.
      */
     void run() override;
 
@@ -144,7 +146,7 @@ public:
      *
      * @return false, only minor parts are parallelized
      */
-    bool isParallel() const override;
+    bool TLX_DEPRECATED(isParallel() const override);
 
 private:
     /*

--- a/include/networkit/graph/RandomMaximumSpanningForest.hpp
+++ b/include/networkit/graph/RandomMaximumSpanningForest.hpp
@@ -1,12 +1,15 @@
 #ifndef NETWORKIT_GRAPH_RANDOM_MAXIMUM_SPANNING_FOREST_HPP_
 #define NETWORKIT_GRAPH_RANDOM_MAXIMUM_SPANNING_FOREST_HPP_
 
-#include <networkit/graph/Graph.hpp>
 #include <limits>
+
+#include <networkit/graph/Graph.hpp>
 #include <networkit/structures/UnionFind.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/base/Algorithm.hpp>
+
+#include <tlx/define/deprecated.hpp>
 
 namespace NetworKit {
 
@@ -34,7 +37,7 @@ public:
     RandomMaximumSpanningForest(const Graph &G, const std::vector<A> &attribute);
 
     /**
-     * Execute the algorithm.
+     * Execute the algorithm. The algorithm is not parallel.
      */
     void run() override;
 
@@ -76,7 +79,7 @@ public:
     /**
      * @return false - this algorithm is not parallelized
      */
-    bool isParallel() const override;
+    bool TLX_DEPRECATED(isParallel() const override);
 
     /**
      * @return The name of this algorithm.

--- a/include/networkit/graph/UnionMaximumSpanningForest.hpp
+++ b/include/networkit/graph/UnionMaximumSpanningForest.hpp
@@ -2,10 +2,13 @@
 #define NETWORKIT_GRAPH_UNION_MAXIMUM_SPANNING_FOREST_HPP_
 
 #include <limits>
+
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
 #include <networkit/structures/UnionFind.hpp>
+
+#include <tlx/define/deprecated.hpp>
 
 namespace NetworKit {
 
@@ -33,7 +36,7 @@ public:
     UnionMaximumSpanningForest(const Graph &G, const std::vector<A> &attribute);
 
     /**
-     * Execute the algorithm.
+     * Execute the algorithm. The algorithm is not parallel.
      */
     void run() override;
 
@@ -75,7 +78,7 @@ public:
     /**
      * @return false - this algorithm is not parallelized.
      */
-    bool isParallel() const override;
+    bool TLX_DEPRECATED(isParallel() const override);
 
     /**
      * @return The name of the algorithm.

--- a/include/networkit/randomization/Curveball.hpp
+++ b/include/networkit/randomization/Curveball.hpp
@@ -16,6 +16,8 @@
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 // pImpl
@@ -33,13 +35,14 @@ public:
         throw std::runtime_error("run() is not supported by this algorithm; use run(trades)");
     };
 
+    /* The algorithm is not parallel. */
     void run(const std::vector<std::pair<node, node>> &trades);
 
     Graph getGraph(bool parallel = false);
 
     std::string toString() const final;
 
-    bool isParallel() const final { return false; }
+    bool TLX_DEPRECATED(isParallel() const final) { return false; }
 
     count getNumberOfAffectedEdges() const;
 

--- a/include/networkit/randomization/DegreePreservingShuffle.hpp
+++ b/include/networkit/randomization/DegreePreservingShuffle.hpp
@@ -12,6 +12,8 @@
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -47,7 +49,7 @@ public:
     ~DegreePreservingShuffle() override;
 
     /**
-     * Execute trades as configured in the constructor.
+     * Execute trades as configured in the constructor. The algorithm is parallel.
      * @warning This function has to be called exactly once before invoking getGraph()
      */
     void run() final;
@@ -68,7 +70,7 @@ public:
 
     std::string toString() const final;
 
-    bool isParallel() const final { return true; }
+    bool TLX_DEPRECATED(isParallel() const final) { return true; }
 
 private:
     const Graph *G;

--- a/include/networkit/randomization/GlobalCurveball.hpp
+++ b/include/networkit/randomization/GlobalCurveball.hpp
@@ -15,6 +15,8 @@
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 // pImpl
@@ -48,7 +50,7 @@ public:
     ~GlobalCurveball() override;
 
     /**
-     * Execute trades as configured in the constructor.
+     * Execute trades as configured in the constructor. The algorithm is not parallel.
      * @warning This function has to be called exactly one before invoking getGraph()
      */
     void run() final;
@@ -61,7 +63,7 @@ public:
 
     std::string toString() const final;
 
-    bool isParallel() const final { return false; }
+    bool TLX_DEPRECATED(isParallel() const final) { return false; }
 
 private:
     std::unique_ptr<CurveballDetails::GlobalCurveballImpl> impl;

--- a/networkit/base.pyx
+++ b/networkit/base.pyx
@@ -62,6 +62,8 @@ cdef class Algorithm:
 		bool
 			True if algorithm can run multi-threaded.
 		"""
+		from warning import warn
+		warn("isParallel() is deprecated and will be removed in upcoming releases.")
 		if self._this == NULL:
 			raise RuntimeError("Error, object not properly initialized")
 		return self._this.isParallel()

--- a/networkit/cpp/distance/test/APSPGTest.cpp
+++ b/networkit/cpp/distance/test/APSPGTest.cpp
@@ -62,7 +62,6 @@ TEST_F(APSPGTest, testAPSP) {
     ASSERT_EQ(distances[1][4],2);
     ASSERT_EQ(distances[1][5],3);
     ASSERT_EQ(distances[1][6],3);
-    ASSERT_TRUE(apsp.isParallel());
 }
 
 TEST_F(APSPGTest, testAPSPUnweightedER) {


### PR DESCRIPTION
As for `toString()` in #631, `isParallel()` is implemented by only a small subset of NetworKit algorithms and by default it throws a `std::runtime_error`. Internally it is never used and I do not see a use case where someone wants to find out whether an algorithm is parallel at runtime.