### PR TITLE
clang tidy: check private headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -85,7 +85,7 @@ WarningsAsErrors:  >
     readability-container-size-empty
 
 FormatStyle: 'file'
-HeaderFilterRegex: '.*\/include\/networkit\/.*\.hpp'
+HeaderFilterRegex: '.*\/(include\/networkit|networkit\/cpp)\/.*\.hpp'
 CheckOptions:
   - key:   readability-identifier-naming.ClassCase
     value: CamelCase

--- a/networkit/cpp/randomization/CurveballImpl.hpp
+++ b/networkit/cpp/randomization/CurveballImpl.hpp
@@ -60,7 +60,7 @@ public:
 
     neighbour_it begin(node node_id) { return neighbours.begin() + begins[node_id]; }
 
-    neighbour_it end(const node node_id) {
+    neighbour_it end(node node_id) {
         return neighbours.begin() + begins[node_id] + offsets[node_id];
     }
 
@@ -131,7 +131,7 @@ private:
     const node numNodes;
 
 public:
-    TradeList(const node num_nodes);
+    TradeList(node num_nodes);
 
     // Receives the edge_vector to initialize
     TradeList(const trade_vector &trades, node num_nodes);


### PR DESCRIPTION
The header filter of our `.clang-tidy` does not match private headers, so private implementations are not checked.
This PR updates our configuration to also match private implementations and fixes a warning.