### PR TITLE
Changes compiler detection to favor system default (macOS)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,9 +102,10 @@ def determineCompiler(candidates, std, flags):
 
 # only check for a compiler if none is specified
 if cmakeCompiler is None:
-	cmakeCompiler = determineCompiler(candidates, "c++14", ["-fopenmp"])
-	if cmakeCompiler is None and sys.platform == "darwin":
+	if sys.platform == "darwin":
 		cmakeCompiler = determineCompiler(["c++"], "c++14", ["-Xpreprocessor", "-fopenmp", "-lomp"])
+	if cmakeCompiler is None:
+		cmakeCompiler = determineCompiler(candidates, "c++14", ["-fopenmp"])
 	if cmakeCompiler is None:
 		print("ERROR: No suitable compiler found. Install any of these: ", candidates)
 		if sys.platform == "darwin":


### PR DESCRIPTION
Recognized a bug for NetworKit in macOS, which is triggered for certain types of local builds.

### What happens?

If more than one compiler is installed under macOS (e.g. certain versions of `g++`), `setup.py` and `cmake` detect different compilers. This can lead to missing symbols and failed builds.

### Example

If the regular `cmake` + `make` process is called, the system OS compiler is prioritized.
```
cmake -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=14 -DNETWORKIT_WARNINGS=ON ..
...
initializing NetworKit compilation with: 'cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/Users/fbt/Documents/maks/networkit/repos/networkit/build/lib.macosx-10.9-x86_64-3.9 -DCMAKE_CXX_COMPILER=c++ -DNETWORKIT_FLATINSTALL=ON -DNETWORKIT_PYTHON=/usr/local/anaconda3/envs/nktdoc/include/python3.9 -DNETWORKIT_PYTHON_SOABI=cpython-39-darwin -GNinja /Users/fbt/Documents/maks/networkit/repos/networkit'
-- The CXX compiler identification is AppleClang 12.0.0.12000032
...
```

`setup.py` is called afterwards, referencing the previously build core-lib:
```
NETWORKIT_PARALLEL_JOBS=4 python3 ./setup.py build_ext --external-core
...
initializing NetworKit compilation with: 'cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/Users/fbt/Documents/maks/networkit/repos/networkit/build/lib.macosx-10.9-x86_64-3.9 -DCMAKE_CXX_COMPILER=g++-7 -DNETWORKIT_FLATINSTALL=ON -DNETWORKIT_PYTHON=/usr/local/anaconda3/envs/nktdoc/include/python3.9 -DNETWORKIT_PYTHON_SOABI=cpython-39-darwin -GNinja /Users/fbt/Documents/maks/networkit/repos/networkit'
-- The CXX compiler identification is GNU 7.5.0
```

After installing the local build, the import of the networkit-module in python fails due to missing symbols.

Note: There are also warnings from Cython during linking phase, that different versions are used. However the process completes with no error.

### How to Fix

Reordering the compiler-detection in `setup.py`.