### PR TITLE
Fixes missing Stemmer-module for doc-search

### DIFF
--- a/extrafiles/sphinx-style/_templates/layout.html
+++ b/extrafiles/sphinx-style/_templates/layout.html
@@ -1,7 +1,7 @@
 {# Import the theme's layout. #}
 {% extends "!layout.html" %}
 
-{% set script_files = script_files + ["_static/particles.min.js", "_static/custom.js"] %}
+{% set script_files = script_files + ["_static/particles.min.js", "_static/custom.js", "_static/language_data.js"] %}
 
 {# Custom CSS overrides #}
 {% set css_files = css_files + ['_static/style.css'] %}


### PR DESCRIPTION
### What happens?

In the current version of the documentation build, the search-feature is broken due to a missing Javascript object (`Stemmer`).

### How to Fix

Likely an error in the bootstrap-theme. Until this is fixed, a workaround is to include `_static/language_data.js` as an additional js-file in the theme. In this way, the file is included before the js-searchlibrary. This produces a minimal overhead, since `Stemmer` is now defined on all pages, not just the search page.