### PR TITLE
Remove addressed TODO in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ sys.argv = [__file__] + args
 candidates = ["g++", "g++-8", "g++-7", "g++-6.1", "g++-6", "g++-5.5", "g++-5.4", "g++-5.3", "g++-5", "clang++", "clang++-3.8", "clang++3.7"]
 
 def determineCompiler(candidates, std, flags):
-	#TODO: proper c++11 test?
 	sample = open("sample.cpp", "w")
 	sample.write("""
 	#include <omp.h>


### PR DESCRIPTION
While reviewing @fabratu PR #667 I noticed that we already check whether the candidate compiler supports C++14 features by passing the `-std=c++14` option.