### PR TITLE
New utility methods for (Bucket)PrioQueue

### DIFF
--- a/include/networkit/auxiliary/PrioQueue.hpp
+++ b/include/networkit/auxiliary/PrioQueue.hpp
@@ -95,6 +95,16 @@ public:
     virtual uint64_t size() const;
 
     /**
+     * @return Whether or not the PQ is empty.
+     */
+    virtual bool empty() const noexcept;
+
+    /**
+     * @return Whether or not the PQ contains the given value.
+     */
+    virtual bool contains(const Value &value) const;
+
+    /**
      * Removes key-value pair given by value @a val.
      */
     virtual void remove(const Value& val);
@@ -146,7 +156,7 @@ Aux::PrioQueue<Key, Value>::PrioQueue(uint64_t capacity) {
 }
 
 template<class Key, class Value>
-inline void Aux::PrioQueue<Key, Value>::insert(Key key, Value value) {
+void Aux::PrioQueue<Key, Value>::insert(Key key, Value value) {
     if (value >= mapValToKey.size()) {
         uint64_t doubledSize = 2 * mapValToKey.size();
         assert(value < doubledSize);
@@ -157,14 +167,13 @@ inline void Aux::PrioQueue<Key, Value>::insert(Key key, Value value) {
 }
 
 template<class Key, class Value>
-inline void Aux::PrioQueue<Key, Value>::remove(const ElemType& elem) {
+void Aux::PrioQueue<Key, Value>::remove(const ElemType& elem) {
     remove(elem.second);
 }
 
 template<class Key, class Value>
-inline void Aux::PrioQueue<Key, Value>::remove(const Value& val) {
+void Aux::PrioQueue<Key, Value>::remove(const Value& val) {
     Key key = mapValToKey.at(val);
-//	DEBUG("key: ", key);
     pqset.erase(std::make_pair(key, val));
     mapValToKey.at(val) = undefined;
 }
@@ -185,7 +194,7 @@ std::pair<Key, Value> Aux::PrioQueue<Key, Value>::extractMin() {
 }
 
 template<class Key, class Value>
-inline void Aux::PrioQueue<Key, Value>::changeKey(Key newKey, Value value) {
+void Aux::PrioQueue<Key, Value>::changeKey(Key newKey, Value value) {
     // find and remove element with given key
     remove(value);
 
@@ -194,17 +203,27 @@ inline void Aux::PrioQueue<Key, Value>::changeKey(Key newKey, Value value) {
 }
 
 template<class Key, class Value>
-inline uint64_t Aux::PrioQueue<Key, Value>::size() const {
+uint64_t Aux::PrioQueue<Key, Value>::size() const {
     return pqset.size();
 }
 
 template<class Key, class Value>
-inline std::set<std::pair<Key, Value>> Aux::PrioQueue<Key, Value>::content() const {
+bool Aux::PrioQueue<Key, Value>::empty() const noexcept {
+    return pqset.empty();
+}
+
+template<class Key, class Value>
+bool Aux::PrioQueue<Key, Value>::contains(const Value &value) const {
+    return value < mapValToKey.size() && mapValToKey.at(value) != undefined;
+}
+
+template<class Key, class Value>
+std::set<std::pair<Key, Value>> Aux::PrioQueue<Key, Value>::content() const {
     return pqset;
 }
 
 template<class Key, class Value>
-inline void Aux::PrioQueue<Key, Value>::clear() {
+void Aux::PrioQueue<Key, Value>::clear() {
     pqset.clear();
     auto capacity = mapValToKey.size();
     mapValToKey.clear();
@@ -213,7 +232,7 @@ inline void Aux::PrioQueue<Key, Value>::clear() {
 
 template<class Key, class Value>
 template<typename L>
-inline void Aux::PrioQueue<Key, Value>::forElements(L handle) const {
+void Aux::PrioQueue<Key, Value>::forElements(L handle) const {
     for (auto it = pqset.begin(); it != pqset.end(); ++it) {
         ElemType elem = *it;
         handle(elem.first, elem.second);
@@ -222,7 +241,7 @@ inline void Aux::PrioQueue<Key, Value>::forElements(L handle) const {
 
 template<class Key, class Value>
 template<typename C, typename L>
-inline void Aux::PrioQueue<Key, Value>::forElementsWhile(C condition,
+void Aux::PrioQueue<Key, Value>::forElementsWhile(C condition,
                                                          L handle) const {
     for (auto it = pqset.begin(); it != pqset.end(); ++it) {
         if (!condition()) {

--- a/networkit/cpp/centrality/ApproxCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxCloseness.cpp
@@ -145,7 +145,7 @@ void ApproxCloseness::computeClosenessForDirectedWeightedGraph(bool outbound) {
         dist[u] = 0.0;
         round[u] = t;
         pq.insert(dist[u], u);
-        while (pq.size() > 0) {
+        while (!pq.empty()) {
             node v = pq.extractMin().second;
             if (dist[v] == infDist) break;
             if (count[v] < nSamples) {  // only continue if count[v] < k
@@ -273,7 +273,7 @@ void ApproxCloseness::computeClosestPivot(const std::vector<node> &samples, std:
         pivot[samples[i]] = i; // sample node is its own pivot
         pq.insert(0.0, samples[i]);
     }
-    while (pq.size() > 0) {
+    while (!pq.empty()) {
         node u = pq.extractMin().second;
         G.forNeighborsOf(u, [&](node v, edgeweight w) {
             if (delta[u] + w < delta[v]) {
@@ -375,7 +375,7 @@ void ApproxCloseness::orderNodesByIncreasingDistance(node c, std::vector<node> &
         Aux::PrioQueue<edgeweight, node> pq(pivotDist.size());
         pq.insert(0.0, c);
         index idx = 0;
-        while (pq.size() > 0) {
+        while (!pq.empty()) {
             node u = pq.extractMin().second;
             order[idx++] = u;
             G.forNeighborsOf(u, [&](node v, edgeweight w) {

--- a/networkit/cpp/centrality/DynBetweenness.cpp
+++ b/networkit/cpp/centrality/DynBetweenness.cpp
@@ -13,7 +13,6 @@
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/NumericTools.hpp>
-#include <networkit/auxiliary/PrioQueue.hpp>
 #include <networkit/distance/BFS.hpp>
 #include <networkit/distance/Dijkstra.hpp>
 #include <networkit/distance/SSSP.hpp>
@@ -218,8 +217,6 @@ void DynBetweenness::update(GraphEvent event) {
         while (! stack.empty()) {
             node y = stack.top();
             if (!visited[y]) {
-                // Aux::PrioQueue<double, node> Qnew(G.upperNodeIdBound()); // TODO use prioqueue for ints?
-                // Aux::PrioQueue<double, node> Qold(G.upperNodeIdBound()); // TODO use prioqueue for ints?
                 std::priority_queue<std::pair<double, node>, std::vector<std::pair<double,node>>, CompareDist> Qnew;
                 std::priority_queue<std::pair<double, node>, std::vector<std::pair<double,node>>, CompareDist> Qold;
                 std::vector<bool> affected(G.upperNodeIdBound(), false);

--- a/networkit/cpp/centrality/GroupCloseness.cpp
+++ b/networkit/cpp/centrality/GroupCloseness.cpp
@@ -162,7 +162,7 @@ void GroupCloseness::run() {
         {
             while (!toInterrupt.load(std::memory_order_relaxed)) {
                 omp_set_lock(&lock);
-                if (Q.size() == 0) {
+                if (Q.empty()) {
                     omp_unset_lock(&lock);
                     toInterrupt.store(true, std::memory_order_relaxed);
                     break;

--- a/networkit/cpp/centrality/GroupDegree.cpp
+++ b/networkit/cpp/centrality/GroupDegree.cpp
@@ -9,10 +9,9 @@
 
 namespace NetworKit {
 GroupDegree::GroupDegree(const Graph &G, count k, bool countGroupNodes)
-    : G(G), k(k), countGroupNodes(countGroupNodes), n(G.upperNodeIdBound()),
-      queue(Aux::BucketPQ(n,
-                          -static_cast<int64_t>(n) + (countGroupNodes ? 0 : 1),
-                          countGroupNodes ? 0 : 1)) {
+    : G(G), k(k), countGroupNodes(countGroupNodes),
+      n(G.upperNodeIdBound()), queue{n, -static_cast<int64_t>(n) + (countGroupNodes ? 0 : 1),
+                                     countGroupNodes ? 0 : 1} {
     if (k > G.upperNodeIdBound() || k <= 0) {
         throw std::runtime_error("k must be between 1 and n");
     }

--- a/networkit/cpp/distance/DynAPSP.cpp
+++ b/networkit/cpp/distance/DynAPSP.cpp
@@ -13,7 +13,6 @@
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/NumericTools.hpp>
-#include <networkit/auxiliary/PrioQueue.hpp>
 #include <networkit/distance/APSP.hpp>
 #include <networkit/distance/BFS.hpp>
 #include <networkit/distance/Dijkstra.hpp>

--- a/networkit/cpp/distance/DynDijkstra.cpp
+++ b/networkit/cpp/distance/DynDijkstra.cpp
@@ -66,7 +66,7 @@ void DynDijkstra::updateBatch(const std::vector<GraphEvent>& batch) {
         updateQueue(edge.v, edge.u, edge.w);
     }
 
-    while(Q.size() != 0) {
+    while(!Q.empty()) {
         mod = true;
         node current = Q.extractMin().second;
         visited.push(current);

--- a/networkit/cpp/viz/MaxentStress.cpp
+++ b/networkit/cpp/viz/MaxentStress.cpp
@@ -521,7 +521,7 @@ void MaxentStress::addKNeighborhoodOfVertex(const node u, const count k) {
 
         dist[u] = 0;
         PQ.insert(0, u);
-        while (PQ.size() > 0 && numVerticesToVisit > 0) {
+        while (!PQ.empty() && numVerticesToVisit > 0) {
             node v = PQ.extractMin().second;
             if (1 < depth[v] && depth[v] <= k) {
                 knownDistances[u].push_back({v, dist[v]});

--- a/networkit/cpp/viz/PivotMDS.cpp
+++ b/networkit/cpp/viz/PivotMDS.cpp
@@ -27,7 +27,7 @@ void PivotMDS::run() {
 
         dist[pivots[j]] = 0;
         PQ.insert(0, pivots[j]);
-        while (PQ.size() > 0) {
+        while (!PQ.empty()) {
             node v = PQ.extractMin().second;
             triplets.push_back({v, j, dist[v]});
             G->forNeighborsOf(v, [&](node w, edgeweight weight) {


### PR DESCRIPTION
I've been working recently with `BucketPQ` and I've noticed that it does not support basic (constant time) utility methods that can simplify the usage of this data structure. This PR adds the following methods to `PrioQueue` and `BucketPQ`:
- `empty`
- `contains`: whether or not the pq contains a given element.
- `getMin`: returns the top element without removing it (only for `BucketPQ`, `PrioQueue` already has `peekMin`).

Further, it adds tests for BucketPQ.