### PR TITLE
Add binder-support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM jupyter/base-notebook:latest
+
+LABEL maintainer="Fabian Brandt-Tumescheit <brandtfa@hu-berlin.de>"
+
+# Install requirements
+USER root
+RUN mkdir /var/lib/apt/lists/partial && \
+    apt-get update && \
+    apt-get install -y  --no-install-recommends cmake git build-essential && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# UID 1000 (jovyan) is the default user for jupyter-images. The default group for correct permission-level is GID 100 (users)
+# Also see: https://jupyter.readthedocs.io/en/latest/community/content-community.html#what-is-a-jovyan
+USER 1000
+RUN pip install --upgrade pip 
+RUN pip install setuptools cython powerlaw sklearn seaborn pandas tabulate matplotlib networkx ipycytoscape
+
+# Create working environment
+# This has to be done as root in order to avoid access denied errors.
+USER root
+RUN mkdir -p ${HOME}/networkit
+COPY . ${HOME}/networkit/
+RUN ln -s ${HOME}/networkit/input ${HOME} && ln -s ${HOME}/networkit/notebooks ${HOME}
+RUN rm -rf ${HOME}/work
+RUN chown -R jovyan:users ${HOME}/*
+
+# Build and install networkit from current branch
+USER 1000
+RUN cd ${HOME}/networkit && python3 setup.py build_ext && pip install -e .
+
+# Configure Jupyter to enable ipycytoscape
+RUN conda install -y nodejs
+RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build && jupyter labextension install jupyter-cytoscape
+RUN jupyter lab build

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   <a href="https://github.com/networkit/networkit/actions"><img src="https://github.com/networkit/networkit/workflows/build/badge.svg"></a>
   <a href="https://badge.fury.io/py/networkit"><img src="https://badge.fury.io/py/networkit.svg"></a>
   <a href="https://coveralls.io/github/networkit/networkit?branch=master"><img src="https://coveralls.io/repos/github/networkit/networkit/badge.svg?branch=master"></a>
+  <a href="https://mybinder.org/v2/gh/networkit/networkit/master?urlpath=lab/tree/notebooks/User-Guide.ipynb"><img src="https://mybinder.org/badge_logo.svg"></a>
 </p>
 
 ## 
@@ -77,7 +78,9 @@ used for compilation.
 
 ## Usage example
 
-To get an overview and learn about NetworKit's different functions/classes, have a look at our interactive [notebooks-section][notebooks], especially the [Networkit UserGuide]. Note: To view and edit the computed output from the notebooks, it is recommended to use [Jupyter Notebook][jupyter-notebooks]. This requires the prior installation of NetworKit. You should really check that out before start working on your network analysis.
+To get an overview and learn about NetworKit's different functions/classes, have a look at our interactive [notebooks-section][notebooks], especially the [Networkit UserGuide]. Note: To view and edit the computed output from the notebooks, it is recommended to use [Jupyter Notebook][jupyter-notebooks]. This requires the prior installation of NetworKit. You should really check that out before start working on your network analysis. 
+
+We also provide a Binder-instance of our notebooks. To access this service, you can either click on the badge at the top or follow this [link][binder]. Disclaimer: Due to rebuilds of the underlying image, it can takes some time until your Binder instance is ready for usage.
 
 If you only want to see in short how NetworKit is used - the following example provides a climpse at that. Here we generate a random hyperbolic graph with 100k nodes and compute its communities with the PLM method:
 
@@ -237,3 +240,4 @@ in NetworKit, and simply using NetworKit. We ask you to cite the appropriate one
 [devguide]: https://networkit.github.io/dev-docs/DevGuide.html#devGuide
 [issues]: https://github.com/networkit/networkit/issues
 [jupyter-notebooks]: https://jupyter.org/install.html
+[binder]: https://mybinder.org/v2/gh/networkit/networkit/master?urlpath=lab/tree/notebooks


### PR DESCRIPTION
This PR adds supports for binder-integration.

In the past afaik, binder supported only direct repo integration. Additional packages would then be installed via configuration like environment.yml (conda) or requirements.txt (python). The final environment then included the complete repo, which is not minimal (since only `input` and `notebooks` are needed) and the repo2docker-build process also triggered errors due to missing Cython.

With direct Dockerfile-support we can supply a custom pre-build jupyter-notebook/lab instance with pre-defined content. This version build up on the latest release (8.0) and is a derivate of the image used for the upcoming cloud-instances.

A build (same Dockerfile, just from the fork) can be seen here: https://mybinder.org/v2/gh/fabratu/networkit/binder-support?urlpath=lab/tree/notebooks

Something to consider:
Binder uses its own mechanism to determine whether an Docker image should be rebuilt or not. Normally this is triggered by a new commit on the given branch. This commit does not have to include changes in the Dockerfile itself. The rebuilt could be partial (fast: just a diff on the image) or complete (approx. 20 minutes: new image). To avoid waiting time for the user, maybe it is a good idea to push the Dockerfile not directly to the `master`-branch, but to another branch like `binder`. The final link would then be: https://mybinder.org/v2/gh/networkit/networkit/binder?urlpath=lab/tree/notebooks (link includes the branch name). In this way one could also create new branches for special Dockerfile-versions, containing other documents or workflows. For example when doing a tutorial at a conference etc. 

