### PR TITLE
Raises minimum requirement for clang 3.8 -> 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Furthermore, NetworKit's core can be built and used as a native library if neede
 You will need the following software to install NetworKit as a python
 package:
 
-- A modern C++ compiler, e.g.: [g++] (&gt;= 5.3) or [clang++] (&gt;= 3.7)
+- A modern C++ compiler, e.g.: [g++] (&gt;= 5.3) or [clang++] (&gt;= 3.9)
 - OpenMP for parallelism (usually ships with the compiler)
 - Python3 (3.5 or higher is supported)
   - Development libraries for Python3. The package name depends on your distribution. Examples: 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ sys.argv = [__file__] + args
 # compiler identification
 ################################################
 
-candidates = ["g++", "g++-8", "g++-7", "g++-6.1", "g++-6", "g++-5.5", "g++-5.4", "g++-5.3", "g++-5", "clang++", "clang++-3.8", "clang++3.7"]
+candidates = ["g++", "g++-8", "g++-7", "g++-6.1", "g++-6", "g++-5.5", "g++-5.4", "g++-5.3", "g++-5", "clang++", "clang++-3.9"]
 
 def determineCompiler(candidates, std, flags):
 	sample = open("sample.cpp", "w")


### PR DESCRIPTION
This PR raises minimum support for clang. 

This is 0.5 years earlier, then it would be usually done. However it is expected, that clang 3.8 is not really used anymore (See discussion #703). Blocking of needed feature-PRs (#516, #359) is the main motivation for doing the shift to 3.9.

Update PR for the website is here: https://github.com/networkit/networkit-website/pull/51