### PR TITLE
Follow-up fixes for neighbors being swapped with the end

### DIFF
--- a/include/networkit/distance/AdamicAdarDistance.hpp
+++ b/include/networkit/distance/AdamicAdarDistance.hpp
@@ -22,8 +22,6 @@ class AdamicAdarDistance final : public NodeDistance {
 private:
     std::vector<double> aaDistance; //result vector
 
-    void removeNode(Graph& graph, node u);
-
 public:
 
     /**

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1845,8 +1845,8 @@ inline edgeid Graph::getInEdgeId<false>(node, index) const {
 
 // implementation for graphIsDirected == true
 template <bool graphIsDirected>
-inline bool Graph::useEdgeInIteration(node /* u */, node v) const {
-    return v != none;
+inline bool Graph::useEdgeInIteration(node /* u */, node /* v */) const {
+    return true;
 }
 
 // implementation for graphIsDirected == false

--- a/networkit/cpp/distance/AdamicAdarDistance.cpp
+++ b/networkit/cpp/distance/AdamicAdarDistance.cpp
@@ -49,7 +49,7 @@ void AdamicAdarDistance::preprocess() {
             nodeMarker[v] = false;
         });
 
-        removeNode(g, u);
+        g.removeNode(u);
     });
 
     G->parallelForEdges([&](node, node, edgeid eid) {
@@ -65,15 +65,6 @@ double AdamicAdarDistance::distance(node u, node v) {
 
 std::vector< double > AdamicAdarDistance::getEdgeScores() {
     return aaDistance;
-}
-
-void AdamicAdarDistance::removeNode(Graph& graph, node u) {
-    //isolate the node before removing it.
-    graph.forNeighborsOf(u, [&](node v) {
-        graph.removeEdge(u,v);
-    });
-
-    graph.removeNode(u);
 }
 
 } /* namespace NetworKit */


### PR DESCRIPTION
As neighbors are swapped with the last neighbor when they are removed, removing edges from within `forNeighborsOf()` is no longer safe but we also do not need to check for `none` there anymore. As `removeNode()` removes incident edges, this is also not necessary anymore in `AdamicAdarDistance`. I have briefly looked for other uses of `removeEdge()`, but on first glance they seem to be safe.