### PR TITLE
Fixes coverage build number detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,9 +282,12 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           . pyenv/bin/activate
-          coveralls -E ".*test/.*" -E ".*CMakeFiles.*" --exclude extlibs --exclude pyenv --exclude scripts --root ${{ github.workspace }}
+          coveralls -E ".*test/.*" -E ".*CMakeFiles.*" --exclude extlibs --exclude pyenv --exclude scripts --root ${{ github.workspace }} --dump $COVERALLS_DUMP_FILE
+          python3 ${{ github.workspace }}/.github/workflows/scripts/upload_coverage.py
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_DUMP_FILE: coveralls.dump
+          COVERALLS_SVC_NUM: ${{ github.run_number }}
 
   windows-build-msvc:
     name: "Windows Server 2019 (msvc 14.28): ${{ matrix.type }} build, ${{ matrix.variant }}"

--- a/.github/workflows/scripts/upload_coverage.py
+++ b/.github/workflows/scripts/upload_coverage.py
@@ -1,0 +1,21 @@
+import requests
+import json
+import os
+
+URL = os.getenv('COVERALLS_ENDPOINT', 'https://coveralls.io') + "/api/v1/jobs"
+
+# Append additional data to the coveralls-API request
+with open(os.getenv('COVERALLS_DUMP_FILE')) as dump:
+    dumpdata = json.load(dump)
+    dumpdata['service_name'] = 'Github Actions'
+    dumpdata['service_number'] = os.getenv('COVERALLS_SVC_NUM')
+    response = requests.post(URL, files={'json_file': json.dumps(dumpdata)},
+                             verify=True)
+    try:
+        result = response.json()
+    except ValueError:
+        result = {'error': 'Failure to submit data. '
+                  'Response [%(status)s]: %(text)s' % {
+                      'status': response.status_code,
+                      'text': response.text}}
+    print(result)


### PR DESCRIPTION
This PR fixes a current problem with Coveralls.

#### What is wrong?

The NetworKit-coveralls [repo](https://coveralls.io/github/networkit/networkit) shows the 9.12.2020 as the last push date. New builds in Github Actions doesn't trigger new major builds in Coveralls, instead minor-builds are added to #935. Details on the progress of coverage for certain commits are therefore very much hidden in the frontend. This error happens, because pushes to the API of Coveralls are tied to a `TRAVIS_JOB_ID`, which of course isn't provided by Github Actions.

#### How to fix

To redeem this, it not sufficient to map the Github Actions `runner_num` to `TRAVIS_JOB_ID`, since this Coveralls further matches these numbers not only against their system, but also match them against a travis-runner. Instead we have to upload a json-based data-structure (dumped by cpp-coveralls and further appended), consisting of a custom `service_number` and `service_name`. Working example using the updated code can be seen here: https://coveralls.io/github/fabratu/networkit

