### PR TITLE
Make CI fail on failed python test, fix failing python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Checkout networkit
+        uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Checkout tlx
         if: matrix.variant == 'full build'
         uses: actions/checkout@v2
         with: 
           repository: tlx/tlx
           path: tlx
-      - name: Checkout networkit
-        uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Prepare environment and run checks (full build)
         if: matrix.variant == 'full build'
         run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
@@ -113,16 +113,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Checkout networkit
+        uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Checkout tlx
         if: matrix.variant == 'full build'
         uses: actions/checkout@v2
         with: 
           repository: tlx/tlx
           path: tlx
-      - name: Checkout networkit
-        uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Prepare environment and run checks (full build)
         if: matrix.variant == 'full build'
         run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
@@ -153,15 +153,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Checkout networkit
+        uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Checkout tlx
         uses: actions/checkout@v2
         with: 
           repository: tlx/tlx
           path: tlx
-      - name: Checkout networkit
-        uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Prepare environment and run checks
         run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
         shell: bash
@@ -186,15 +186,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
+      - name: Checkout networkit
+        uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Checkout tlx
         uses: actions/checkout@v2
         with: 
           repository: tlx/tlx
           path: tlx
-      - name: Checkout networkit
-        uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Prepare environment and run checks (gcc-5)
         if: matrix.variant == 'gcc-5'
         run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh

--- a/.github/workflows/scripts/clang_tidy.sh
+++ b/.github/workflows/scripts/clang_tidy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -o pipefail
 
 sudo rm -rf /usr/local/clang-*
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 9999

--- a/.github/workflows/scripts/cpp_only.sh
+++ b/.github/workflows/scripts/cpp_only.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -o pipefail
 
 $CXX --version
 

--- a/.github/workflows/scripts/documentation.sh
+++ b/.github/workflows/scripts/documentation.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-
 set -e
+set -o pipefail
+
 python3 -m venv pyenv && . pyenv/bin/activate
 pip3 install --upgrade pip
  

--- a/.github/workflows/scripts/full.sh
+++ b/.github/workflows/scripts/full.sh
@@ -20,7 +20,6 @@ cd ../..
 
 
 # Build libnetworkit
-cd networkit
 mkdir core_build && cd "$_"
 cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD -DNETWORKIT_WARNINGS=ON -DNETWORKIT_WARNINGS_AS_ERRORS=ON -DNETWORKIT_EXT_TLX=$TLX_PATH ..
 ninja

--- a/.github/workflows/scripts/full.sh
+++ b/.github/workflows/scripts/full.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -o pipefail
 
 $CXX --version
 python3 --version

--- a/networkit/GraphMLIO.py
+++ b/networkit/GraphMLIO.py
@@ -177,7 +177,6 @@ class GraphMLWriter:
 		else:
 			graphElement.set('edgedefault', 'undirected')
 			self.dir_str = 'false'
-		graphElement.set('id', graph.getName())
 
 		# Add nodes
 		for n in graph.iterNodes():

--- a/networkit/flow.pyx
+++ b/networkit/flow.pyx
@@ -27,7 +27,7 @@ cdef extern from "<networkit/flow/EdmondsKarp.hpp>":
 		edgeweight getFlow(edgeid eid) const
 		vector[edgeweight] getFlowVector() except +
 
-cdef class EdmondsKarp:
+cdef class EdmondsKarp(Algorithm):
 	"""
 	The EdmondsKarp class implements the maximum flow algorithm by Edmonds and Karp.
 
@@ -40,15 +40,11 @@ cdef class EdmondsKarp:
 	sink : node
 		The sink node for the flow calculation
 	"""
-	cdef _EdmondsKarp* _this
 	cdef Graph _graph
 
 	def __cinit__(self, Graph graph not None, node source, node sink):
 		self._graph = graph # store reference of graph for memory management, so the graph is not deallocated before this object
 		self._this = new _EdmondsKarp(graph._this, source, sink)
-
-	def __dealloc__(self):
-		del self._this
 
 	def getMaxFlow(self):
 		"""
@@ -59,7 +55,7 @@ cdef class EdmondsKarp:
 		edgeweight
 			The maximum flow value
 		"""
-		return self._this.getMaxFlow()
+		return (<_EdmondsKarp*>(self._this)).getMaxFlow()
 
 	def getSourceSet(self):
 		"""
@@ -70,7 +66,7 @@ cdef class EdmondsKarp:
 		list
 			The set of nodes that form the (smallest) source side of the flow/minimum cut.
 		"""
-		return self._this.getSourceSet()
+		return (<_EdmondsKarp*>(self._this)).getSourceSet()
 
 	def getFlow(self, node u, node v = none):
 		"""
@@ -90,9 +86,9 @@ cdef class EdmondsKarp:
 			The flow on the specified edge
 		"""
 		if v == none: # Assume that node and edge ids are the same type
-			return self._this.getFlow(u)
+			return (<_EdmondsKarp*>(self._this)).getFlow(u)
 		else:
-			return self._this.getFlow(u, v)
+			return (<_EdmondsKarp*>(self._this)).getFlow(u, v)
 
 	def getFlowVector(self):
 		"""
@@ -103,4 +99,4 @@ cdef class EdmondsKarp:
 		list
 			The flow values of all edges indexed by edge id
 		"""
-		return self._this.getFlowVector()
+		return (<_EdmondsKarp*>(self._this)).getFlowVector()

--- a/networkit/test/test_graphio.py
+++ b/networkit/test/test_graphio.py
@@ -83,24 +83,17 @@ class TestGEXFIO(unittest.TestCase):
 			if format == nk.Format.MAT:
 				filename += ".mat" # suffix required
 
-			try:
-				if os.path.exists(filename):
-					os.remove(filename)
+			if os.path.exists(filename):
+				os.remove(filename)
 
-				kargs = [' ', 0] if format == nk.Format.EdgeList else []
-				nk.graphio.writeGraph(G, filename, format, *kargs)
-				if format == nk.Format.GEXF:
-					G1, _ = nk.graphio.readGraph(filename, format, *kargs)
-				else:
-					G1 = nk.graphio.readGraph(filename, format, *kargs)
-				self.checkStatic(G, G1)
+			kargs = [' ', 0] if format == nk.Format.EdgeList else []
+			nk.graphio.writeGraph(G, filename, format, *kargs)
+			if format == nk.Format.GEXF:
+				G1, _ = nk.graphio.readGraph(filename, format, *kargs)
+			else:
+				G1 = nk.graphio.readGraph(filename, format, *kargs)
+			self.checkStatic(G, G1)
 
-			except Exception as e:
-				someFailed = True
-				print("Test failed for format {0}".format(format))
-				print(e)
-
-		# assert(not someFailed)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/test/test_graphio.py
+++ b/networkit/test/test_graphio.py
@@ -72,8 +72,10 @@ class TestGEXFIO(unittest.TestCase):
 		G = nk.generators.ErdosRenyiGenerator(100, 0.1).generate()
 		someFailed = False
 
+		excluded_formats = set([nk.Format.KONECT, nk.Format.DOT, nk.Format.GraphViz, nk.Format.SNAP])
+
 		for format in nk.Format:
-			if format == nk.Format.KONECT or format == nk.Format.DOT or format == nk.Format.GraphViz:
+			if format in excluded_formats:
 				# format do not support both reading and writing
 				continue
 
@@ -87,7 +89,10 @@ class TestGEXFIO(unittest.TestCase):
 
 				kargs = [' ', 0] if format == nk.Format.EdgeList else []
 				nk.graphio.writeGraph(G, filename, format, *kargs)
-				G1 = nk.graphio.readGraph(filename, format, *kargs)
+				if format == nk.Format.GEXF:
+					G1, _ = nk.graphio.readGraph(filename, format, *kargs)
+				else:
+					G1 = nk.graphio.readGraph(filename, format, *kargs)
 				self.checkStatic(G, G1)
 
 			except Exception as e:


### PR DESCRIPTION
The python interface of `EdmondsKarp` does not properly inherit from `Algorithm`, and thus the `run` method is not visible (#721).
The CI has system has been fixed so that it fails when a python test fails.
Further fixes in `test_graphio.py`.