### PR TITLE
Restoring the documentation of GraphTools::subgraphFromNodes.

### DIFF
--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -195,6 +195,19 @@ Graph copyNodes(const Graph &G);
 /**
  * Returns an induced subgraph of this graph (including potential edge weights/directions)
  *
+ * The subgraph contains all nodes in Nodes and all edges which have one end point
+ * in Nodes and the other in Nodes.
+ *
+ * @param G The input graph.
+ * @param nodes Nodes of the induced subgraph.
+ *
+ * @return Induced subgraph.
+ */
+Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes);
+
+/**
+ * Returns an induced subgraph of this graph (including potential edge weights/directions)
+ *
  * There a two relevant sets of nodes:
  *  - Nodes are such passed as arguments.
  *  - Neighbors are empty by default.
@@ -210,8 +223,9 @@ Graph copyNodes(const Graph &G);
  *
  * @return Induced subgraph.
  */
-Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
-                        bool includeOutNeighbors = false, bool includeInNeighbors = false);
+Graph subgraphAndNeighborsFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
+                                    bool includeOutNeighbors = false,
+                                    bool includeInNeighbors = false);
 
 /**
  * Returns an undirected copy of the input graph.

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <tlx/define/deprecated.hpp>
 #include <tlx/unused.hpp>
 #include <networkit/graph/Graph.hpp>
 
@@ -203,6 +204,31 @@ Graph copyNodes(const Graph &G);
  * @return Induced subgraph.
  */
 Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes);
+
+/**
+ * Returns an induced subgraph of the input graph (including potential edge weights/directions)
+ *
+ * @deprecated Use subgraphFromNodesAndEdgesToTheirNeighbors instead.
+ *
+ * There a two relevant sets of nodes:
+ *  - Nodes are such passed as arguments.
+ *  - Neighbors are empty by default.
+ *
+ * The subgraph contains all nodes in Nodes + Neighbors and all edges which have one end point
+ * in Nodes and the other in Nodes or Neighbors.
+ *
+ *
+ * @param G The input graph.
+ * @param nodes The nodes of the induced subgraph.
+ * @param includeOutNeighbors If set to true, all out-neighbors will also be included.
+ * @param includeInNeighbors If set to true, all in-neighbors will also be included
+ * (relevant only for directed graphs).
+ *
+ *
+ * @return Induced subgraph.
+ */
+Graph TLX_DEPRECATED(subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
+                                       bool includeOutNeighbors, bool includeInNeighbors = false));
 
 /**
  * Returns an induced subgraph of the input graph (including potential edge weights/directions)

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -193,12 +193,20 @@ double inVolume(const Graph &G, InputIt first, InputIt last) {
 Graph copyNodes(const Graph &G);
 
 /**
- * Returns an induced subgraph of the input graph (including potential edge weights/directions).
+ * Returns an induced subgraph of this graph (including potential edge weights/directions)
+ *
+ * There a two relevant sets of nodes:
+ *  - Nodes are such passed as arguments.
+ *  - Neighbors are empty by default.
+ *
+ * The subgraph contains all nodes in Nodes + Neighbors and all edges which have one end point
+ * in Nodes and the other in Nodes or Neighbors.
  *
  * @param G The input graph.
  * @param nodes Nodes of the induced subgraph.
- * @param includeOutNeighbors If set to true, out-neighbors will also be included.
- * @param includeInNeighbors If set to true, in-neighbors will also be included.
+ * @param includeOutNeighbors If set to true, all out-neighbors will also be included.
+ * @param includeInNeighbors If set to true, all in-neighbors will also be included
+ * (relevant only for directed graphs).
  *
  * @return Induced subgraph.
  */

--- a/networkit/cpp/components/ConnectedComponentsImpl.cpp
+++ b/networkit/cpp/components/ConnectedComponentsImpl.cpp
@@ -93,11 +93,7 @@ Graph ConnectedComponentsImpl<WeaklyCC>::extractLargestConnectedComponent(const 
             ->first;
 
     const auto nodesInLCC = component.getMembers(largestCCIndex);
-    const auto largestCC = GraphTools::subgraphFromNodes(G, {nodesInLCC.begin(), nodesInLCC.end()});
-    if (compactGraph)
-        return GraphTools::getCompactedGraph(largestCC,
-                                             GraphTools::getContinuousNodeIds(largestCC));
-    return largestCC;
+    return GraphTools::subgraphFromNodes(G, nodesInLCC.begin(), nodesInLCC.end(), compactGraph);
 }
 
 template class ConnectedComponentsImpl<false>;

--- a/networkit/cpp/components/StronglyConnectedComponents.cpp
+++ b/networkit/cpp/components/StronglyConnectedComponents.cpp
@@ -135,7 +135,7 @@ Graph StronglyConnectedComponents::extractLargestStronglyConnectedComponent(cons
 
     const auto compSizes = component.subsetSizeMap();
     if (compSizes.size() == 1) {
-        if (compactGraph)
+        if (compactGraph && G.upperNodeIdBound() != G.numberOfNodes())
             return GraphTools::getCompactedGraph(G, GraphTools::getContinuousNodeIds(G));
         return G;
     }

--- a/networkit/cpp/components/StronglyConnectedComponents.cpp
+++ b/networkit/cpp/components/StronglyConnectedComponents.cpp
@@ -148,12 +148,7 @@ Graph StronglyConnectedComponents::extractLargestStronglyConnectedComponent(cons
                                      ->first;
 
     const auto nodesInLSCC = component.getMembers(largestSCCIndex);
-    const auto largestSCC =
-        GraphTools::subgraphFromNodes(G, {nodesInLSCC.begin(), nodesInLSCC.end()});
-    if (compactGraph)
-        return GraphTools::getCompactedGraph(largestSCC,
-                                             GraphTools::getContinuousNodeIds(largestSCC));
-    return largestSCC;
+    return GraphTools::subgraphFromNodes(G, nodesInLSCC.begin(), nodesInLSCC.end(), compactGraph);
 }
 
 } // namespace NetworKit

--- a/networkit/cpp/components/test/BiconnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/BiconnectedComponentsGTest.cpp
@@ -45,7 +45,7 @@ TEST_F(BiconnectedComponentsGTest, testBiconnectedComponents) {
 
     for (auto component : bc.getComponents()) {
         std::unordered_set<node> subgraph(component.begin(), component.end());
-        const auto G1 = GraphTools::subgraphFromNodes(G, subgraph, false, false);
+        const auto G1 = GraphTools::subgraphFromNodes(G, subgraph);
 
         G1.forNodes([&](node v) {
             auto G2(G1);

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -259,8 +259,30 @@ Graph copyNodes(const Graph &G) {
     return C;
 }
 
-Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
-                        bool includeOutNeighbors, bool includeInNeighbors) {
+Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes) {
+
+    auto isRelevantNode = [&](const node u) { return nodes.find(u) != nodes.end(); };
+
+    Graph S(G.upperNodeIdBound(), G.isWeighted(), G.isDirected());
+    // delete all nodes that are not in the node set
+    S.forNodes([&](node u) {
+        if (!isRelevantNode(u)) {
+            S.removeNode(u);
+        }
+    });
+
+    G.forEdges([&](node u, node v, edgeweight w) {
+        // only include edges if at least one endpoint is in nodes
+        if (isRelevantNode(u) && isRelevantNode(v)) {
+            S.addEdge(u, v, w);
+        }
+    });
+
+    return S;
+}
+
+Graph subgraphAndNeighborsFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
+                                    bool includeOutNeighbors, bool includeInNeighbors) {
     const auto neighbors = [&] {
         std::unordered_set<node> neighbors;
 

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -263,6 +263,11 @@ Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes) {
     return subgraphFromNodes(G, nodes.begin(), nodes.end(), false);
 }
 
+Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
+                        bool includeOutNeighbors, bool includeInNeighbors) {
+    return subgraphAndNeighborsFromNodes(G, nodes, includeOutNeighbors, includeInNeighbors);
+}
+
 Graph subgraphAndNeighborsFromNodes(const Graph &G, const std::unordered_set<node> &nodes,
                                     bool includeOutNeighbors, bool includeInNeighbors) {
     const auto neighbors = [&] {

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -260,25 +260,7 @@ Graph copyNodes(const Graph &G) {
 }
 
 Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes) {
-
-    auto isRelevantNode = [&](const node u) { return nodes.find(u) != nodes.end(); };
-
-    Graph S(G.upperNodeIdBound(), G.isWeighted(), G.isDirected());
-    // delete all nodes that are not in the node set
-    S.forNodes([&](node u) {
-        if (!isRelevantNode(u)) {
-            S.removeNode(u);
-        }
-    });
-
-    G.forEdges([&](node u, node v, edgeweight w) {
-        // only include edges if at least one endpoint is in nodes
-        if (isRelevantNode(u) && isRelevantNode(v)) {
-            S.addEdge(u, v, w);
-        }
-    });
-
-    return S;
+    return subgraphFromNodes(G, nodes.begin(), nodes.end(), false);
 }
 
 Graph subgraphAndNeighborsFromNodes(const Graph &G, const std::unordered_set<node> &nodes,

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -7,6 +7,8 @@
 
 // networkit-format
 
+#include <array>
+
 #include <gtest/gtest.h>
 
 #include <networkit/auxiliary/Random.hpp>
@@ -672,9 +674,11 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesUndirected) {
     G.addEdge(3, 2, 5.0);
     G.addEdge(1, 2, 3.0);
 
-    {
+    std::array<bool, 2> compactOptions{{true, false}};
+
+    for (bool compact : compactOptions) {
         std::unordered_set<node> nodes = {0};
-        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        auto res = GraphTools::subgraphFromNodes(G, nodes.begin(), nodes.end(), compact);
         EXPECT_EQ(weighted(), res.isWeighted());
         EXPECT_FALSE(res.isDirected());
         EXPECT_EQ(res.numberOfNodes(), 1);
@@ -692,9 +696,9 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesUndirected) {
         EXPECT_DOUBLE_EQ(G.weight(0, 2), weighted() ? 2.0 : defaultEdgeWeight);
     }
 
-    {
+    for (bool compact : compactOptions) {
         std::unordered_set<node> nodes = {0, 1};
-        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        auto res = GraphTools::subgraphFromNodes(G, nodes.begin(), nodes.end(), compact);
         EXPECT_EQ(res.numberOfNodes(), 2);
         EXPECT_EQ(res.numberOfEdges(), 1); // 0 - 1
     }
@@ -704,6 +708,15 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesUndirected) {
         auto res = GraphTools::subgraphAndNeighborsFromNodes(G, nodes, true);
         EXPECT_EQ(res.numberOfNodes(), 4);
         EXPECT_EQ(res.numberOfEdges(), 4); // 0-1, 0-2, 1-2, 1-3
+    }
+
+    G.addEdge(0, 0);
+
+    for (bool compact : compactOptions) {
+        std::unordered_set<node> nodes = {0, 1};
+        auto res = GraphTools::subgraphFromNodes(G, nodes.begin(), nodes.end(), compact);
+        EXPECT_EQ(res.numberOfNodes(), 2);
+        EXPECT_EQ(res.numberOfEdges(), 2); // 0 - 1, 0 - 0
     }
 }
 
@@ -724,15 +737,23 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesDirected) {
     G.addEdge(3, 2, 5.0);
     G.addEdge(1, 2, 3.0);
 
-    {
+    std::array<bool, 2> compactOptions{{true, false}};
+
+    for (bool compact : compactOptions) {
         std::unordered_set<node> nodes = {0};
-        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        auto res = GraphTools::subgraphFromNodes(G, nodes.begin(), nodes.end(), compact);
 
         EXPECT_EQ(weighted(), res.isWeighted());
         EXPECT_TRUE(res.isDirected());
 
         EXPECT_EQ(res.numberOfNodes(), 1);
         EXPECT_EQ(res.numberOfEdges(), 0);
+
+        if (compact) {
+            EXPECT_EQ(res.upperNodeIdBound(), 1);
+        } else {
+            EXPECT_EQ(res.upperNodeIdBound(), G.upperNodeIdBound());
+        }
     }
 
     {
@@ -742,9 +763,9 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesDirected) {
         EXPECT_EQ(res.numberOfEdges(), 2); // 0->1, 0->2, NOT 1->2
     }
 
-    {
+    for (bool compact : compactOptions) {
         std::unordered_set<node> nodes = {0, 1};
-        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        auto res = GraphTools::subgraphFromNodes(G, nodes.begin(), nodes.end(), compact);
         EXPECT_EQ(res.numberOfNodes(), 2);
         EXPECT_EQ(res.numberOfEdges(), 1); // 0 -> 1
     }

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -683,7 +683,7 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesUndirected) {
 
     {
         std::unordered_set<node> nodes = {0};
-        auto res = GraphTools::subgraphFromNodes(G, nodes, true);
+        auto res = GraphTools::subgraphAndNeighborsFromNodes(G, nodes, true);
 
         EXPECT_EQ(res.numberOfNodes(), 3);
         EXPECT_EQ(res.numberOfEdges(), 2); // 0-1, 0-2, NOT 1-2
@@ -701,7 +701,7 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesUndirected) {
 
     {
         std::unordered_set<node> nodes = {0, 1};
-        auto res = GraphTools::subgraphFromNodes(G, nodes, true);
+        auto res = GraphTools::subgraphAndNeighborsFromNodes(G, nodes, true);
         EXPECT_EQ(res.numberOfNodes(), 4);
         EXPECT_EQ(res.numberOfEdges(), 4); // 0-1, 0-2, 1-2, 1-3
     }
@@ -737,7 +737,7 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesDirected) {
 
     {
         std::unordered_set<node> nodes = {0};
-        auto res = GraphTools::subgraphFromNodes(G, nodes, true);
+        auto res = GraphTools::subgraphAndNeighborsFromNodes(G, nodes, true);
         EXPECT_EQ(res.numberOfNodes(), 3);
         EXPECT_EQ(res.numberOfEdges(), 2); // 0->1, 0->2, NOT 1->2
     }
@@ -751,14 +751,14 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesDirected) {
 
     {
         std::unordered_set<node> nodes = {0, 1};
-        auto res = GraphTools::subgraphFromNodes(G, nodes, true);
+        auto res = GraphTools::subgraphAndNeighborsFromNodes(G, nodes, true);
         EXPECT_EQ(res.numberOfNodes(), 3);
         EXPECT_EQ(res.numberOfEdges(), 3); // 0->1, 0->2, 1->2
     }
 
     {
         std::unordered_set<node> nodes = {0, 1};
-        auto res = GraphTools::subgraphFromNodes(G, nodes, true, true);
+        auto res = GraphTools::subgraphAndNeighborsFromNodes(G, nodes, true, true);
         EXPECT_EQ(res.numberOfNodes(), 4);
         EXPECT_EQ(res.numberOfEdges(), 4); // 0->1, 0->2, 1->2, 3->1
     }

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -399,8 +399,15 @@ cdef class GraphTools:
 	@staticmethod
 	def subgraphFromNodes(Graph graph, nodes, includeOutNeighbors=False, includeInNeighbors=False):
 		"""
-		Returns an induced subgraph of the input graph (including potential edge
-		weights/directions).
+		Returns an induced subgraph of this graph (including potential edge
+        weights/directions)
+
+        There a two relevant sets of nodes:
+           - Nodes are such passed as arguments.
+           - Neighbors are empty by default.
+
+        The subgraph contains all nodes in Nodes + Neighbors and all edges which
+        have one end point in Nodes and the other in Nodes or Neighbors.
 
 		Parameters:
 		-----------

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -33,7 +33,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
 	_Graph toWeighted(_Graph G) nogil except +
-	_Graph subgraphFromNodes(_Graph G, unordered_set[node]) nogil except +
+	_Graph subgraphFromNodes[InputIt](_Graph G, InputIt first, InputIt last, bool_t compact) nogil except +
 	_Graph subgraphAndNeighborsFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
 	void append(_Graph G, _Graph G1) nogil except +
 	void merge(_Graph G, _Graph G1) nogil except +
@@ -356,7 +356,7 @@ cdef class GraphTools:
 	@staticmethod
 	def inVolume(Graph graph, nodes):
 		"""
-		Get the inVolume (for all incoming edges) of a subgraph, defined by the 
+		Get the inVolume (for all incoming edges) of a subgraph, defined by the
 		input graph and a corresponding subset of nodes.
 
 		Parameters
@@ -364,7 +364,7 @@ cdef class GraphTools:
 		graph : networkit.Graph
 			The input graph.
 		nodes : vector[node]
-			A vector of nodes from the graph. 
+			A vector of nodes from the graph.
 
 		Returns
 		-------
@@ -398,7 +398,7 @@ cdef class GraphTools:
 		return Graph().setThis(copyNodes(graph._this))
 
 	@staticmethod
-	def subgraphFromNodes(Graph graph, nodes):
+	def subgraphFromNodes(Graph graph, vector[node] nodes, bool_t compact = False):
 		"""
 		Returns an induced subgraph of this graph (including potential edge
 		weights/directions)
@@ -408,17 +408,19 @@ cdef class GraphTools:
 
 		Parameters:
 		-----------
-		graph : networkit.Graph
+		graph   : networkit.Graph
 			The input graph.
-		nodes : set
+		nodes   : iterable
 			Nodes in the induced subgraph.
+		compact : bool
+			If the resulting graph shall have compact, continuous node ids, alternatively, node ids of the input graph are kept.
 		Returns:
 		--------
 		graph : networkit.Graph
 			Induced subgraph.
 		"""
 		return Graph().setThis(subgraphFromNodes(
-			graph._this, nodes))
+			graph._this, nodes.begin(), nodes.end(), compact))
 
 	@staticmethod
 	def subgraphAndNeighborsFromNodes(Graph graph, nodes, includeOutNeighbors=False, includeInNeighbors=False):

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -33,7 +33,8 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
 	_Graph toWeighted(_Graph G) nogil except +
-	_Graph subgraphFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
+	_Graph subgraphFromNodes(_Graph G, unordered_set[node]) nogil except +
+	_Graph subgraphAndNeighborsFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
 	void append(_Graph G, _Graph G1) nogil except +
 	void merge(_Graph G, _Graph G1) nogil except +
 	void removeEdgesFromIsolatedSet[InputIt](_Graph G, InputIt first, InputIt last) except +
@@ -397,17 +398,40 @@ cdef class GraphTools:
 		return Graph().setThis(copyNodes(graph._this))
 
 	@staticmethod
-	def subgraphFromNodes(Graph graph, nodes, includeOutNeighbors=False, includeInNeighbors=False):
+	def subgraphFromNodes(Graph graph, nodes):
 		"""
 		Returns an induced subgraph of this graph (including potential edge
-        weights/directions)
+		weights/directions)
 
-        There a two relevant sets of nodes:
-           - Nodes are such passed as arguments.
-           - Neighbors are empty by default.
+		The subgraph contains all nodes in Nodes  and all edges which
+		have one end point in Nodes and the other in Nodes.
 
-        The subgraph contains all nodes in Nodes + Neighbors and all edges which
-        have one end point in Nodes and the other in Nodes or Neighbors.
+		Parameters:
+		-----------
+		graph : networkit.Graph
+			The input graph.
+		nodes : set
+			Nodes in the induced subgraph.
+		Returns:
+		--------
+		graph : networkit.Graph
+			Induced subgraph.
+		"""
+		return Graph().setThis(subgraphFromNodes(
+			graph._this, nodes))
+
+	@staticmethod
+	def subgraphAndNeighborsFromNodes(Graph graph, nodes, includeOutNeighbors=False, includeInNeighbors=False):
+		"""
+		Returns an induced subgraph of this graph (including potential edge
+		weights/directions)
+
+		There a two relevant sets of nodes:
+			- Nodes are such passed as arguments.
+			- Neighbors are empty by default.
+
+		The subgraph contains all nodes in Nodes + Neighbors and all edges which
+		have one end point in Nodes and the other in Nodes or Neighbors.
 
 		Parameters:
 		-----------
@@ -425,7 +449,7 @@ cdef class GraphTools:
 		graph : networkit.Graph
 			Induced subgraph.
 		"""
-		return Graph().setThis(subgraphFromNodes(
+		return Graph().setThis(subgraphAndNeighborsFromNodes(
 			graph._this, nodes, includeOutNeighbors, includeInNeighbors))
 
 	@staticmethod

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -398,7 +398,7 @@ cdef class GraphTools:
 		return Graph().setThis(copyNodes(graph._this))
 
 	@staticmethod
-	def subgraphFromNodes(Graph graph, vector[node] nodes, bool_t compact = False):
+	def subgraphFromNodes(Graph graph, vector[node] nodes, includeOutNeighbors=False, includeInNeighbors=False, bool_t compact = False):
 		"""
 		Returns an induced subgraph of this graph (including potential edge
 		weights/directions)
@@ -412,6 +412,10 @@ cdef class GraphTools:
 			The input graph.
 		nodes   : iterable
 			Nodes in the induced subgraph.
+		includeOutNeighbors : bool
+			If set to true, out-neighbors will also be included. DEPRECATED. Use subgraphAndNeighborsFromNodes instead.
+		includeInNeighbors : bool
+			If set to true, in-neighbors will also be included. DEPRECATED. Use subgraphAndNeighborsFromNodes instead.
 		compact : bool
 			If the resulting graph shall have compact, continuous node ids, alternatively, node ids of the input graph are kept.
 		Returns:
@@ -419,8 +423,21 @@ cdef class GraphTools:
 		graph : networkit.Graph
 			Induced subgraph.
 		"""
-		return Graph().setThis(subgraphFromNodes(
-			graph._this, nodes.begin(), nodes.end(), compact))
+		# Deprecated compatibility wrapper. We use "vector" to
+		# preserve the sorting of the nodes for compact
+		# subgraphs and only convert to unordered_set when
+		# needed.
+		cdef unordered_set[node] nodeSet
+
+		if includeInNeighbors or includeOutNeighbors:
+			if compact:
+				raise RuntimeError("Compaction is not supported with includeOutNeighbors or includeInNeighbors")
+			nodeSet.insert(nodes.begin(), nodes.end())
+			return Graph().setThis(subgraphAndNeighborsFromNodes(
+			    	graph._this, nodeSet, includeOutNeighbors, includeInNeighbors))
+		else:
+			return Graph().setThis(subgraphFromNodes(
+			    	graph._this, nodes.begin(), nodes.end(), compact))
 
 	@staticmethod
 	def subgraphAndNeighborsFromNodes(Graph graph, nodes, includeOutNeighbors=False, includeInNeighbors=False):

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -199,7 +199,7 @@ class TestGraphTools(unittest.TestCase):
 		self.assertEqual(res.numberOfNodes(), 1)
 		self.assertEqual(res.numberOfEdges(), 0)
 
-		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphAndNeighborsFromNodes(G, nodes, True)
 
 		self.assertEqual(res.numberOfNodes(), 3)
 		self.assertEqual(res.numberOfEdges(), 2) # 0-1, 0-2, NOT 1-2
@@ -212,7 +212,7 @@ class TestGraphTools(unittest.TestCase):
 		self.assertEqual(res.numberOfNodes(), 2)
 		self.assertEqual(res.numberOfEdges(), 1) # 0 - 1
 
-		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphAndNeighborsFromNodes(G, nodes, True)
 		self.assertEqual(res.numberOfNodes(), 4)
 		self.assertEqual(res.numberOfEdges(), 4) # 0-1, 0-2, 1-2, 1-3
 
@@ -229,7 +229,7 @@ class TestGraphTools(unittest.TestCase):
 		self.assertEqual(res.numberOfEdges(), 0)
 
 		nodes = set([0])
-		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphAndNeighborsFromNodes(G, nodes, True)
 		self.assertEqual(res.numberOfNodes(), 3)
 		self.assertEqual(res.numberOfEdges(), 2) # 0->1, 0->2, NOT 1->2
 
@@ -239,12 +239,12 @@ class TestGraphTools(unittest.TestCase):
 		self.assertEqual(res.numberOfEdges(), 1) # 0 -> 1
 
 		nodes = set([0, 1])
-		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphAndNeighborsFromNodes(G, nodes, True)
 		self.assertEqual(res.numberOfNodes(), 3)
 		self.assertEqual(res.numberOfEdges(), 3) # 0->1, 0->2, 1->2
 
 		nodes = set([0, 1])
-		res = nk.graphtools.subgraphFromNodes(G, nodes, True, True)
+		res = nk.graphtools.subgraphAndNeighborsFromNodes(G, nodes, True, True)
 		self.assertEqual(res.numberOfNodes(), 4)
 		self.assertEqual(res.numberOfEdges(), 4) # 0->1, 0->2, 1->2, 3->1
 


### PR DESCRIPTION
Addressing the unclarity in the function bought up in #651 . By bringing the documentation more in line with what was originally in #374 .