### PR TITLE
Segmentation fault fix on EdgeListReader in the case of firstNode > 0 and continuous = false

### DIFF
--- a/networkit/cpp/io/EdgeListReader.cpp
+++ b/networkit/cpp/io/EdgeListReader.cpp
@@ -20,7 +20,13 @@ namespace NetworKit {
 EdgeListReader::EdgeListReader(char separator, node firstNode, const std::string &commentPrefix,
                                bool continuous, bool directed)
     : separator(separator), commentPrefix(commentPrefix), firstNode(firstNode),
-      continuous(continuous), mapNodeIds(), directed(directed) {}
+      continuous(continuous), mapNodeIds(), directed(directed) {
+    if (!continuous && firstNode != 0) {
+        // firstNode not being 0 in the continuous = false case leads to a segmentation fault
+        WARN("firstNode set to 0 since continuous is false");
+        firstNode = 0;
+    }
+}
 
 const std::map<std::string, node> &EdgeListReader::getNodeMap() const {
     if (this->continuous)

--- a/networkit/graphio.pyx
+++ b/networkit/graphio.pyx
@@ -259,7 +259,7 @@ cdef class EdgeListReader(GraphReader):
 	and can be accessed using getNodeMap().
 
 	To shift continuous integer node labels which are not zero-indexed, set firstNode to
-	the smallest id used in the file.
+	the smallest id used in the file. firstNode will be ignored in the non-continuous case.
 
 	The file may also include line comments which start with the commentPrefix.
 


### PR DESCRIPTION
to especially tell that firstNode should be 0 if continuous = false to address the confusion in #725 .