### PR TITLE
New Algorithm: Overlapping Normalized Mutual Information

### DIFF
--- a/include/networkit/auxiliary/HashUtils.hpp
+++ b/include/networkit/auxiliary/HashUtils.hpp
@@ -1,0 +1,29 @@
+#ifndef NETWORKIT_AUXILIARY_HASH_UTILS_HPP_
+#define NETWORKIT_AUXILIARY_HASH_UTILS_HPP_
+// networkit-format
+
+#include <utility>
+
+namespace Aux {
+
+template <typename T>
+void hashCombine(std::size_t &seed, T const &v) {
+    // The Boost Software License, Version 1.0 applies to this function.
+    // See https://www.boost.org/LICENSE_1_0.txt
+    // https://www.boost.org/doc/libs/1_75_0/doc/html/hash/reference.html#boost.hash_combine
+    seed ^= std::hash<T>()(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+struct PairHash {
+    template <typename A, typename B>
+    std::size_t operator()(const std::pair<A, B> &pair) const {
+        std::size_t seed = 0;
+        hashCombine(seed, pair.first);
+        hashCombine(seed, pair.second);
+        return seed;
+    }
+};
+
+} // namespace Aux
+
+#endif // NETWORKIT_AUXILIARY_HASH_UTILS_HPP_

--- a/include/networkit/community/OverlappingNMIDistance.hpp
+++ b/include/networkit/community/OverlappingNMIDistance.hpp
@@ -1,0 +1,176 @@
+#ifndef NETWORKIT_COMMUNITY_OVERLAPPING_NMI_DISTANCE_HPP_
+#define NETWORKIT_COMMUNITY_OVERLAPPING_NMI_DISTANCE_HPP_
+// networkit-format
+
+#include <unordered_map>
+
+#include <networkit/auxiliary/HashUtils.hpp>
+#include <networkit/community/DissimilarityMeasure.hpp>
+
+namespace NetworKit {
+
+/**
+ * @ingroup community
+ * 	Compare two covers using the overlapping normalized mutual information measure. This is a
+ * 	dissimilarity measure with a range of [0, 1]. A value of 0 indicates a perfect agreement while
+ * 	a 1 indicates complete disagreement.
+ *
+ * 	For the `MAX` normalization, this is the measure introduced in [NMI13]. Other normalization
+ * 	methods result in similar measures.
+ *
+ * 	Please note that non-overlapping NMIDistance uses another definition of the normalized mutual
+ * 	information. See NMIDistance for details on its computation. Both NMIDistance and
+ * 	OverlappingNMIDistance can be used with partitions, but produce different values.
+ *
+ * [NMI13]
+ *      McDaid, Aaron F., Derek Greene, and Neil Hurley.
+ *      “Normalized Mutual Information to Evaluate Overlapping Community Finding Algorithms.”
+ *      ArXiv:1110.2515 [Physics], August 2, 2013. http://arxiv.org/abs/1110.2515.
+ */
+class OverlappingNMIDistance final : public DissimilarityMeasure {
+
+public:
+    enum Normalization { MIN, GEOMETRIC_MEAN, ARITHMETIC_MEAN, MAX, JOINT_ENTROPY };
+
+private:
+    Normalization mNormalization{Normalization::MAX};
+
+public:
+    OverlappingNMIDistance() = default;
+
+    explicit OverlappingNMIDistance(Normalization normalization) : mNormalization(normalization) {}
+
+    void setNormalization(Normalization normalization) { mNormalization = normalization; }
+
+    double getDissimilarity(const Graph &G, const Partition &zeta, const Partition &eta) override;
+    double getDissimilarity(const Graph &G, const Cover &zeta, const Cover &eta) override;
+
+private:
+    struct SizesAndIntersections {
+        std::vector<count> sizesX;
+        std::vector<count> sizesY;
+        std::unordered_map<std::pair<index, index>, count, Aux::PairHash> intersectionSizes;
+    };
+
+    /**
+     * Calculating cluster sizes of covers and intersection sizes between two covers.
+     *
+     * @param X
+     * @param Y
+     * @return The cluster and intersection sizes of X and Y.
+     */
+    static SizesAndIntersections
+    calculateClusterAndIntersectionSizes(const Graph &graph, const Cover &X, const Cover &Y);
+
+    /**
+     * Calculates partial entropy.
+     *
+     * $$
+     *   h(w, n) = -w \log_2\left(\frac{w}{n}\right)
+     * $$
+     *
+     * @param w  Number of occurrences.
+     * @param n  Total number of nodes.
+     * @return
+     */
+    static double h(count w, count n);
+
+    /**
+     * Calculates the entropy of a cluster.
+     *
+     * $$
+     *   H(X_i) = h(|\{ u | u \in X_i \}, n) + h(\{ u | u \notin X_i \}, n)
+     * $$
+     *
+     * @param size  Cluster size.
+     * @param n  Total number of nodes.
+     * @return
+     */
+    static double entropy(count size, count n);
+
+    /**
+     * Calculates the entropy of a clustering.
+     *
+     * $$
+     *   H(X) = \sum_{X_i \in X} H(X_i)
+     * $$
+     *
+     * @param sizesX  The sizes of the clusters in X.
+     * @param n  Total number of nodes.
+     * @return
+     */
+    static double entropy(const std::vector<count> &sizesX, count n);
+
+    /**
+     * Calculates the adjusted conditional entropy between two clusters.
+     *
+     * $$
+     *   H^*(X_i|Y_j) =
+     *   \begin{cases}
+     *       H(X_i|Y_j), & \text{if $h(a, n) + h(d, n) \geq h(b, n) + h(c, n)$}\\
+     *       H(X_i), & \text{otherwise}
+     *   \end{cases}
+     * $$
+     * where
+     * $$
+     *   H(X_i|Y_j) &= H(X_i, Y_j) - H(Y_j)\\
+     *       &= h(a, n) + h(b, n) + h(c, n) + h(d, n) - h(b + d, n) - h(a + c, n),
+     * $$
+     * $a = \sum_u \[X_{i,u} = 0 and Y_{j,u} = 0\]$, $b = \sum_u \[X_{i,u} = 0 and Y_{j,u} = 1\]$,
+     * $c = \sum_u \[X_{i,u} = 1 and Y_{j,u} = 0\]$ and $d = \sum_u \[X_{i,u} = 1 and Y_{j,u} =
+     * 1\]$.
+     *
+     * @param sizeXi  Size of cluster X_i.
+     * @param sizeYj  Size of cluster Y_j.
+     * @param intersectionSize  Size of the intersection of X_i and Y_j.
+     * @param n  Total number of nodes.
+     * @return
+     */
+    static double adjustedConditionalEntropy(count sizeXi, count sizeYj, count intersectionSize,
+                                             count n);
+
+    /**
+     * Calculates the entropy of the clustering X conditioned by the clustering Y.
+     *
+     * $$
+     *   H(X|Y) = \sum_{X_i \in X} \min_{Y_j \in Y} H^*(X_i|Y_j)
+     * $$
+     *
+     * @param sizesX
+     * @param sizesY
+     * @param intersectionSizes
+     *      A map which stores the the intersection size between clusters X[i] and Y[j] with indices
+     * i and j as keys.
+     * @param invertPairIndices
+     *      Whether to invert the indices of the intersectionSizes map entries.
+     *      This allows reusing the same map for H(X|Y) and H(Y|X).
+     * @param n  Total number of nodes.
+     * @return
+     */
+    static double conditionalEntropy(
+        const std::vector<count> &sizesX, const std::vector<count> &sizesY,
+        const std::unordered_map<std::pair<index, index>, count, Aux::PairHash> &intersectionSizes,
+        bool invertPairIndices, count n);
+
+    static void clampBelow(double &value, double lowerBound, const char *format,
+                           int printPrecision = 20);
+
+    static void clampAbove(double &value, double upperBound, const char *format,
+                           int printPrecision = 20);
+
+    /**
+     * Normalize the given mutual information value.
+     *
+     * @param normalization
+     * @param mutualInformation
+     * @param entropyX
+     * @param entropyY
+     * @return
+     */
+    static double normalize(OverlappingNMIDistance::Normalization normalization,
+                            double mutualInformation, double entropyX, double entropyY);
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_COMMUNITY_OVERLAPPING_NMI_DISTANCE_HPP_

--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -1236,8 +1236,8 @@ cdef extern from "<networkit/community/OverlappingNMIDistance.hpp>":
 		_OverlappingNMIDistance() except +
 		_OverlappingNMIDistance(_Normalization normalization) except +
 		void setNormalization(_Normalization normalization) except +
-		double getDissimilarity(_Graph G, _Partition first, _Partition second) except +
-		double getDissimilarity(_Graph G, _Cover first, _Cover second) except +
+		double getDissimilarity(_Graph G, _Partition first, _Partition second) nogil except +
+		double getDissimilarity(_Graph G, _Cover first, _Cover second) nogil except +
 
 cdef class OverlappingNMIDistance(DissimilarityMeasure):
 	"""
@@ -1315,9 +1315,11 @@ cdef class OverlappingNMIDistance(DissimilarityMeasure):
 		"""
 		cdef double ret
 		if isinstance(first, Partition) and isinstance(second, Partition):
-			ret = self._this.getDissimilarity(G._this, (<Partition>(first))._this, (<Partition>(second))._this)
+			with nogil:
+				ret = self._this.getDissimilarity(G._this, (<Partition>(first))._this, (<Partition>(second))._this)
 		elif isinstance(first, Cover) and isinstance(second, Cover):
-			ret = self._this.getDissimilarity(G._this, (<Cover>(first))._this, (<Cover>(second))._this)
+			with nogil:
+				ret = self._this.getDissimilarity(G._this, (<Cover>(first))._this, (<Cover>(second))._this)
 		else:
 			raise TypeError("Error, first and second must both be either a Partition or a Cover")
 		return ret

--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -1219,3 +1219,110 @@ class InfomapAdapter:
 	def getPartition(self):
 		return self.result
 """
+
+
+cdef extern from "<networkit/community/OverlappingNMIDistance.hpp>" namespace "NetworKit::OverlappingNMIDistance":
+
+	cdef enum _Normalization "NetworKit::OverlappingNMIDistance::Normalization":
+		MIN,
+		GEOMETRIC_MEAN,
+		ARITHMETIC_MEAN,
+		MAX,
+		JOINT_ENTROPY
+
+cdef extern from "<networkit/community/OverlappingNMIDistance.hpp>":
+
+	cdef cppclass _OverlappingNMIDistance "NetworKit::OverlappingNMIDistance":
+		_OverlappingNMIDistance() except +
+		_OverlappingNMIDistance(_Normalization normalization) except +
+		void setNormalization(_Normalization normalization) except +
+		double getDissimilarity(_Graph G, _Partition first, _Partition second) except +
+		double getDissimilarity(_Graph G, _Cover first, _Cover second) except +
+
+cdef class OverlappingNMIDistance(DissimilarityMeasure):
+	"""
+	Compare two covers using the overlapping normalized mutual information measure. This is a dissimilarity measure with
+	a range of [0, 1]. A value of 0 indicates a perfect agreement while a 1 indicates complete disagreement.
+
+	For the `OverlappingNMIDistance.Max` normalization, this is the measure introduced in [NMI13]. Other normalization
+	methods result in similar measures.
+
+	Parameters
+	----------
+	normalization : {Min, GeometricMean, ArithmeticMean, Max, JointEntropy}, optional
+		The default is OverlappingNMIDistance.Max.
+
+	Raises
+	------
+	ValueError
+	    If `normalization` is not one of the available methods.
+
+	References
+	----------
+	[NMI13]
+		McDaid, Aaron F., Derek Greene, and Neil Hurley. "Normalized Mutual Information to Evaluate Overlapping
+		Community Finding Algorithms." ArXiv:1110.2515 [Physics], August 2, 2013. http://arxiv.org/abs/1110.2515.
+	"""
+	cdef _OverlappingNMIDistance _this
+
+	Min = _Normalization.MIN
+	GeometricMean = _Normalization.GEOMETRIC_MEAN
+	ArithmeticMean = _Normalization.ARITHMETIC_MEAN
+	Max = _Normalization.MAX
+	JointEntropy = _Normalization.JOINT_ENTROPY
+
+	def __cinit__(self, _Normalization normalization = _Normalization.MAX):
+		self._validateNormalization(normalization)
+		self._this = _OverlappingNMIDistance(normalization)
+
+	def setNormalization(self, _Normalization normalization):
+		"""
+		Set the normalization method.
+
+		Parameters
+		----------
+		normalization : {Min, GeometricMean, ArithmeticMean, Max, JointEntropy}
+
+		Raises
+		------
+		ValueError
+		    If `normalization` is not one of the available methods.
+		"""
+		self._validateNormalization(normalization)
+		self._this.setNormalization(normalization)
+
+	def getDissimilarity(self, Graph G, PartitionCover first, PartitionCover second):
+		"""
+		Calculate the dissimilarity.
+
+		Parameters
+		----------
+		G : networkit.Graph
+		first : networkit.Partition or networkit.Cover
+		second : networkit.Partition or networkit.Cover
+			Must be the same type as `first`.
+
+		Raises
+		------
+		TypeError
+		    If `first` and `second` do not have the same type.
+		ValueError
+		    If `G`, `first` and `second` do not have the matching number of nodes.
+
+		Returns
+		-------
+		distance : float
+		"""
+		cdef double ret
+		if isinstance(first, Partition) and isinstance(second, Partition):
+			ret = self._this.getDissimilarity(G._this, (<Partition>(first))._this, (<Partition>(second))._this)
+		elif isinstance(first, Cover) and isinstance(second, Cover):
+			ret = self._this.getDissimilarity(G._this, (<Cover>(first))._this, (<Cover>(second))._this)
+		else:
+			raise TypeError("Error, first and second must both be either a Partition or a Cover")
+		return ret
+
+	def _validateNormalization(self, _Normalization normalization):
+		if normalization not in {OverlappingNMIDistance.Min, OverlappingNMIDistance.GeometricMean,
+				OverlappingNMIDistance.ArithmeticMean, OverlappingNMIDistance.Max, OverlappingNMIDistance.JointEntropy}:
+			raise ValueError("Error, invalid normalization method")

--- a/networkit/cpp/community/CMakeLists.txt
+++ b/networkit/cpp/community/CMakeLists.txt
@@ -5,6 +5,7 @@ networkit_add_module(community
     Conductance.cpp
     CoverHubDominance.cpp
     CoverF1Similarity.cpp
+    OverlappingNMIDistance.cpp
     Coverage.cpp
     CutClustering.cpp
     DissimilarityMeasure.cpp

--- a/networkit/cpp/community/OverlappingNMIDistance.cpp
+++ b/networkit/cpp/community/OverlappingNMIDistance.cpp
@@ -1,0 +1,270 @@
+// networkit-format
+
+#include <cmath>
+#include <iomanip>
+#include <numeric>
+
+#include <networkit/auxiliary/NumericTools.hpp>
+#include <networkit/auxiliary/SignalHandling.hpp>
+#include <networkit/community/OverlappingNMIDistance.hpp>
+
+namespace NetworKit {
+
+OverlappingNMIDistance::SizesAndIntersections
+OverlappingNMIDistance::calculateClusterAndIntersectionSizes(const Graph &graph, const Cover &X,
+                                                             const Cover &Y) {
+    SizesAndIntersections result;
+    result.sizesX.resize(X.upperBound());
+    result.sizesY.resize(Y.upperBound());
+
+    // nodeRange() ignores deleted nodes.
+    for (node u : graph.nodeRange()) {
+        for (auto i : X[u]) {
+            for (auto j : Y[u]) {
+                ++result.intersectionSizes[{i, j}];
+            }
+
+            ++result.sizesX[i];
+        }
+        for (auto j : Y[u]) {
+            ++result.sizesY[j];
+        }
+    }
+
+    return result;
+}
+
+double OverlappingNMIDistance::h(count w, count n) {
+    auto v = static_cast<double>(w);
+    auto value = v > 0.0 ? -v * std::log2(v / n) : 0.0;
+    assert(!std::isnan(value));
+    return value;
+}
+
+double OverlappingNMIDistance::entropy(count size, count n) {
+    assert(0 <= size && size <= n);
+    auto value = h(size, n) + h(n - size, n);
+    assert(value >= 0.0);
+    return value;
+}
+
+double OverlappingNMIDistance::entropy(const std::vector<count> &sizesX, count n) {
+    double entropyX = 0.0;
+    for (auto sizeXi : sizesX) {
+        if (sizeXi == 0)
+            continue;
+        entropyX += entropy(sizeXi, n);
+    }
+    assert(!std::isnan(entropyX));
+    assert(entropyX >= 0.0);
+    return entropyX;
+}
+
+double OverlappingNMIDistance::adjustedConditionalEntropy(count sizeXi, count sizeYj,
+                                                          count intersectionSize, count n) {
+    count a = n + intersectionSize - sizeXi - sizeYj; // X_{i,u} = 0 and Y_{j,u} = 0
+    count b = sizeYj - intersectionSize;              // X_{i,u} = 0 and Y_{j,u} = 1
+    count c = sizeXi - intersectionSize;              // X_{i,u} = 1 and Y_{j,u} = 0
+    count d = intersectionSize;                       // X_{i,u} = 1 and Y_{j,u} = 1
+
+    auto entropyXiYj = h(a, n) + h(b, n) + h(c, n) + h(d, n);
+    auto entropyYj = entropy(sizeYj, n);
+    auto entropyXi = entropy(sizeXi, n);
+
+    if (h(a, n) + h(d, n) >= h(b, n) + h(c, n)) {
+        return entropyXiYj - entropyYj;
+    } else {
+        return entropyXi;
+    }
+}
+
+double OverlappingNMIDistance::conditionalEntropy(
+    const std::vector<count> &sizesX, const std::vector<count> &sizesY,
+    const std::unordered_map<std::pair<index, index>, count, Aux::PairHash> &intersectionSizes,
+    bool invertPairIndices, count n) {
+
+    // Choice to initialize H(X_i|Y) with H(X_i), same as reference implementation
+    // https://github.com/aaronmcdaid/Overlapping-NMI/blob/master/onmi.cpp#L232
+    // This is different to the mathematical definition.
+    // For example: X = {{1..80}}, Y = {{81..83}}, n = 100
+    // H^*(X_1|Y_1) ~= 64.95 is lower than H(X_i) ~= 72.19, but H^*(X_1|Y_1) is not calculated,
+    // because X_1 and Y_1 do not intersect.
+    // NOTE: Handle clusters which do not intersect any cluster of the other cover
+    //       Check if a cluster X_i does not intersect with any cluster Y_j from the other cover.
+    //       For Y_j in increasing size calculate H^*(X_i|Y_j) to find the minimum.
+    //       Stop as soon as h(n - |X_i| - |Y_j|, n) >= h(|Y_j|, n) + h(|X_i|, n) no longer holds.
+
+    // Stores H(X_i|Y) = \min_{Y_j \in Y} H^*(X_i|Y_j) for each i
+    std::vector<double> conditionalEntropiesXiGivenY(sizesX.size(), 0.0);
+    for (index i = 0; i < sizesX.size(); ++i) {
+        if (sizesX[i] == 0)
+            continue;
+        conditionalEntropiesXiGivenY[i] = entropy(sizesX[i], n);
+    }
+
+    for (const auto &entry : intersectionSizes) {
+        auto i = entry.first.first;
+        auto j = entry.first.second;
+        if (invertPairIndices)
+            std::swap(i, j);
+        auto intersectionSize = entry.second;
+
+        conditionalEntropiesXiGivenY[i] =
+            std::min(conditionalEntropiesXiGivenY[i],
+                     adjustedConditionalEntropy(sizesX[i], sizesY[j], intersectionSize, n));
+    }
+
+    auto conditionalEntropyXGivenY = std::accumulate(conditionalEntropiesXiGivenY.begin(),
+                                                     conditionalEntropiesXiGivenY.end(), 0.0);
+
+    assert(!std::isnan(conditionalEntropyXGivenY));
+    return conditionalEntropyXGivenY;
+}
+
+void OverlappingNMIDistance::clampBelow(double &value, double lowerBound, const char *const format,
+                                        int printPrecision) {
+    if (value < lowerBound) {
+        if (!Aux::NumericTools::ge(value, lowerBound, Aux::NumericTools::acceptableError)) {
+            std::stringstream ss;
+            ss << std::fixed << std::setprecision(printPrecision) << value;
+            const auto s = ss.str();
+            ERRORF(format, s.c_str());
+        }
+        value = lowerBound;
+    }
+}
+
+void OverlappingNMIDistance::clampAbove(double &value, double upperBound, const char *const format,
+                                        int printPrecision) {
+    if (value > upperBound) {
+        if (!Aux::NumericTools::le(value, upperBound, Aux::NumericTools::acceptableError)) {
+            std::stringstream ss;
+            ss << std::fixed << std::setprecision(printPrecision) << value;
+            const auto s = ss.str();
+            ERRORF(format, s.c_str());
+        }
+        value = upperBound;
+    }
+}
+
+double OverlappingNMIDistance::normalize(OverlappingNMIDistance::Normalization normalization,
+                                         double mutualInformation, double entropyX,
+                                         double entropyY) {
+    // Numerical errors less than Aux::NumericTools::acceptableError are corrected silently.
+    // Larger errors are also corrected, but they are logged as an ERROR.
+    clampBelow(entropyX, 0.0, "Set entropyX lower than 0.0 to 0.0: %s");
+    clampBelow(entropyY, 0.0, "Set entropyY lower than 0.0 to 0.0: %s");
+
+    // Assumption: Empty covers were already dealt with.
+    // At this point, H(X) = 0 implies that X has only clusters with all nodes.
+    if (entropyX == 0.0 && entropyY == 0.0) {
+        // Duplicate clusters should not exist, but its not explicitly checked.
+        // De-duplicating clusters results in two covers that are equal.
+        return 1.0;
+    } else if ((entropyX == 0.0 || entropyY == 0.0)
+               && (normalization == OverlappingNMIDistance::Normalization::MIN
+                   || normalization == OverlappingNMIDistance::Normalization::GEOMETRIC_MEAN)) {
+        // Prevent division by zero.
+        // One of the covers has only clusters with all nodes. The other cover is different.
+        return 0.0;
+    }
+
+    double nmi;
+    switch (normalization) {
+    case OverlappingNMIDistance::Normalization::MIN:
+        nmi = mutualInformation / std::min(entropyX, entropyY);
+        break;
+    case OverlappingNMIDistance::Normalization::GEOMETRIC_MEAN:
+        nmi = mutualInformation / std::sqrt(entropyX * entropyY);
+        break;
+    case OverlappingNMIDistance::Normalization::ARITHMETIC_MEAN:
+        nmi = 2 * mutualInformation / (entropyX + entropyY);
+        break;
+    case OverlappingNMIDistance::Normalization::MAX:
+        nmi = mutualInformation / std::max(entropyX, entropyY);
+        break;
+    case OverlappingNMIDistance::Normalization::JOINT_ENTROPY: {
+        auto entropyXY = entropyX + entropyY - mutualInformation;
+        nmi = mutualInformation / entropyXY;
+        break;
+    }
+    default:
+        throw std::logic_error("normalization method is not covered");
+    }
+
+    if (std::isnan(nmi)) {
+        ERROR("Set nmi ", nmi, " to 0.0");
+        nmi = 0.0;
+    }
+    clampBelow(nmi, 0.0, "Set nmi lower than 0.0 to 0.0: %s");
+    clampAbove(nmi, 1.0, "Set nmi larger than 1.0 to 1.0: %s");
+
+    return nmi;
+}
+
+double OverlappingNMIDistance::getDissimilarity(const Graph &G, const Partition &zeta,
+                                                const Partition &eta) {
+    return getDissimilarity(G, Cover(zeta), Cover(eta));
+}
+
+double OverlappingNMIDistance::getDissimilarity(const Graph &G, const Cover &zeta,
+                                                const Cover &eta) {
+
+    // Assumptions:
+    //   All clusters are non-empty. When encountering one (due to non-consecutive ids), they are
+    //   ignored.
+    //   The clusters of a cover are unique. The code does not check that explicitly. The assumption
+    //   is used when dealing with edge cases.
+
+    // Edge cases:
+    //   For H(X) = 0, X is either an empty cover or X has only clusters with all nodes.
+    //   This leads to numerical problems with the normalization.
+
+    Aux::SignalHandler handler;
+
+    const auto n = G.numberOfNodes();
+
+    if (zeta.numberOfElements() != G.upperNodeIdBound()
+        || eta.numberOfElements() != G.upperNodeIdBound()) {
+        // numberOfElements() and upperNodeIdBound() both also count deleted nodes.
+        throw std::invalid_argument("Covers must have the same number of nodes as the graph.");
+    }
+
+    const auto sizes = calculateClusterAndIntersectionSizes(G, zeta, eta);
+    const auto &sizesX = sizes.sizesX;
+    const auto &sizesY = sizes.sizesY;
+    const auto &intersectionSizes = sizes.intersectionSizes;
+
+    // Edge cases for empty covers.
+    const auto isEmpty = [](count size) { return size == 0; };
+    const auto XisEmpty = std::all_of(sizesX.begin(), sizesX.end(), isEmpty);
+    const auto YisEmpty = std::all_of(sizesY.begin(), sizesY.end(), isEmpty);
+    if (XisEmpty != YisEmpty) {
+        // The covers are different and one is empty.
+        return 1.0;
+    } else if (XisEmpty && YisEmpty) {
+        // Both covers are empty.
+        return 0.0;
+    }
+
+    handler.assureRunning();
+
+    auto conditionalEntropyXGivenY =
+        conditionalEntropy(sizesX, sizesY, intersectionSizes, false, n);
+    auto conditionalEntropyYGivenX = conditionalEntropy(sizesY, sizesX, intersectionSizes, true, n);
+
+    auto entropyX = entropy(sizesX, n);
+    auto entropyY = entropy(sizesY, n);
+
+    auto mutualInformation =
+        0.5 * (entropyX - conditionalEntropyXGivenY + entropyY - conditionalEntropyYGivenX);
+
+    auto nmi = normalize(mNormalization, mutualInformation, entropyX, entropyY);
+    auto nmiDistance = 1.0 - nmi;
+
+    assert(0.0 <= nmiDistance && nmiDistance <= 1.0);
+
+    return nmiDistance;
+}
+
+} // namespace NetworKit


### PR DESCRIPTION
This implements the Overlapping Normalized Mutual Information from [NMI13]. I'm happy to receive some feedback.

There are some points which might need to be changed.

1. Documentation. Most of the algorithm is implemented in separate functions. Some of the doc comments might be unnecessary. The inclusion of LaTeX formulas could be too much and the formatting could also be wrong.
2. Naming conventions. The public methods conform to camelCase, but the hidden functions and variable names are in snake_case. The only attribute is called `m_normalization`. The string parameters for normalization are also in snake_case.
3. Normalization (`normalize`). The current implementation allows the specification of the method used to normalize the mutual information. The authors use "max". My impression is that it is the most useful choice. It could be better to remove the ability to choose the normalization method.
4. Numerical error handling (`clamp_below`, `clamp_above`). To make sure that the value actually is in [0, 1], it is clamped. Discrepancies less than `Aux::NumericTools::acceptableError` are silently corrected, otherwise they are corrected and an error is logged with `ERRORF`. I have only seen errors within the acceptable error range, but this might not be true for all inputs.
5. Only looking at intersections (`conditional_entropy`). I(X;Y) is defined as a sum of minima of H\*(X_i|Y_j) over all cluster pairs (X_i, Y_j) between the covers. The [reference implementation](https://github.com/aaronmcdaid/Overlapping-NMI) from [NMI13] and my code only calculate H\*(X_i|Y_j) if X_i and Y_j intersect. In the case that there exists a X_i that does not intersect with any Y_j, the entropy of X_i is used. This can lead to different results. A fix for that case should be possible as described in the comments of `conditional_entropy`, but I'm not sure if it is worth the additional complexity. A simple fix would be to iterate over all pairs of clusters, but this would make the algorithm very inefficient for covers with a lot of clusters, O(|X||Y|) instead of O(number of intersecting pairs of clusters).

[NMI13]
McDaid, Aaron F., Derek Greene, and Neil Hurley. "Normalized Mutual Information to Evaluate Overlapping
Community Finding Algorithms." ArXiv:1110.2515 [Physics], August 2, 2013. http://arxiv.org/abs/1110.2515.