### PR TITLE
PathGrowingMatcher: throw if input graph is directed

### DIFF
--- a/include/networkit/matching/LocalMaxMatcher.hpp
+++ b/include/networkit/matching/LocalMaxMatcher.hpp
@@ -5,12 +5,12 @@
  *      Author: Christian Staudt
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_MATCHING_LOCAL_MAX_MATCHER_HPP_
 #define NETWORKIT_MATCHING_LOCAL_MAX_MATCHER_HPP_
 
-#include <algorithm>
-#include <set>
-
+#include <networkit/graph/Graph.hpp>
 #include <networkit/matching/Matcher.hpp>
 
 namespace NetworKit {
@@ -22,11 +22,15 @@ namespace NetworKit {
  */
 class LocalMaxMatcher final : public Matcher {
 public:
+    /**
+     * @param G Undirected graph with for which the matching is computed.
+     */
+    LocalMaxMatcher(const Graph &G);
 
-    LocalMaxMatcher(const Graph& G);
-
+    /**
+     * Runs the algorithm.
+     */
     void run() override;
-
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/matching/PathGrowingMatcher.hpp
+++ b/include/networkit/matching/PathGrowingMatcher.hpp
@@ -21,14 +21,16 @@ namespace NetworKit {
  * (Note that better algorithms in terms of approximation quality exist.)
  */
 class PathGrowingMatcher final: public Matcher {
+    void checkInput() const;
+
 public:
     /**
-     * @param[in] G Graph for which matching is computed.
+     * @param[in] G Undirected graph with no self-loops for which matching is computed.
      */
     PathGrowingMatcher(const Graph& G);
 
     /**
-     * @param[in] G Graph for which matching is computed.
+     * @param[in] G Undirected graph with no self-loops for which matching is computed.
      */
     PathGrowingMatcher(const Graph& G, const std::vector<double>& edgeScores);
 

--- a/networkit/cpp/matching/LocalMaxMatcher.cpp
+++ b/networkit/cpp/matching/LocalMaxMatcher.cpp
@@ -4,6 +4,8 @@
  *  Created on: 05.12.2012
  */
 
+#include <stdexcept>
+
 #include <networkit/matching/LocalMaxMatcher.hpp>
 
 namespace NetworKit {

--- a/networkit/cpp/matching/PathGrowingMatcher.cpp
+++ b/networkit/cpp/matching/PathGrowingMatcher.cpp
@@ -10,16 +10,21 @@
 
 namespace NetworKit {
 
-PathGrowingMatcher::PathGrowingMatcher(const Graph& G): Matcher(G) {
-    if (G.numberOfSelfLoops() > 0) {
-        throw std::invalid_argument("G has self-loops and cannot be processed");
-    }
+PathGrowingMatcher::PathGrowingMatcher(const Graph& G): Matcher(G) { checkInput(); }
+
+PathGrowingMatcher::PathGrowingMatcher(const Graph &G, const std::vector<double> &edgeScores)
+    : Matcher(G, edgeScores) {
+    checkInput();
 }
 
-PathGrowingMatcher::PathGrowingMatcher(const Graph& G, const std::vector<double>& edgeScores): Matcher(G, edgeScores) {
-    if (G.numberOfSelfLoops() > 0) {
-        throw std::invalid_argument("G has self-loops and cannot be processed");
-    }
+void PathGrowingMatcher::checkInput() const {
+    if (G->isDirected())
+        throw std::invalid_argument(
+            "The input graph is directed, this algorithm only supports undirected graphs.");
+
+    if (G->numberOfSelfLoops() > 0)
+        throw std::invalid_argument("The input graph has self-loops, this algorithm only supports "
+                                    "graphs without self-loops. ");
 }
 
 void PathGrowingMatcher::run() {

--- a/networkit/cpp/matching/test/MatcherGTest.cpp
+++ b/networkit/cpp/matching/test/MatcherGTest.cpp
@@ -21,6 +21,11 @@ namespace NetworKit {
 class MatcherGTest: public testing::Test {};
 
 TEST_F(MatcherGTest, testLocalMaxMatching) {
+    {
+        Graph G(10, true, true);
+        EXPECT_THROW(LocalMaxMatcher{G}, std::runtime_error);
+    }
+
     count n = 50;
     Graph G(n);
     G.forNodePairs([&](node u, node v){

--- a/networkit/matching.pyx
+++ b/networkit/matching.pyx
@@ -22,7 +22,7 @@ cdef class Matching:
 	def match(self, node u, node v):
 		"""
 		Set two nodes u and v as each others matching partners.
-		
+
 		Parameters:
 		-----------
 		u : node
@@ -33,7 +33,7 @@ cdef class Matching:
 	def unmatch(self, node u,  node v):
 		"""
 		Reset the two nodes u and v to unmatched.
-		
+
 		Parameters:
 		-----------
 		u : node
@@ -44,11 +44,11 @@ cdef class Matching:
 	def isMatched(self, node u):
 		"""
 		Check if node u is matched.
-		
+
 		Parameters:
 		-----------
 		u : node
-		
+
 		Returns:
 		-----------
 		bool
@@ -59,12 +59,12 @@ cdef class Matching:
 	def areMatched(self, node u, node v):
 		"""
 		Check if the nodes u and v are matched to each other.
-		
+
 		Parameters:
 		-----------
 		u : node
 		v : node
-		
+
 		Returns:
 		-----------
 		bool
@@ -76,7 +76,7 @@ cdef class Matching:
 		"""
 		Check whether this is a proper matching in the graph, i.e. there is an edge between
 		each pair and if the matching partner of v is u then the matching partner of u is v.
-		
+
 		Parameters:
 		-----------
 		G : networkit.Graph
@@ -91,11 +91,11 @@ cdef class Matching:
 	def size(self, Graph G):
 		"""
 		Get the number of edges in this matching.
-		
+
 		Parameters:
 		-----------
 		G : networkit.Graph
-		
+
 		Returns:
 		-----------
 		int
@@ -106,11 +106,11 @@ cdef class Matching:
 	def mate(self, node v):
 		"""
 		Get the matched neighbor of v if it exists, otherwise +inf.
-		
+
 		Parameters:
 		-----------
 		v : node
-		
+
 		Returns:
 		-----------
 		int
@@ -121,12 +121,12 @@ cdef class Matching:
 	def weight(self, Graph G):
 		"""
 		Get total weight of edges in this matching.
-		
+
 		Parameters:
 		-----------
 		G : networkit.Graph
 			The corresponding graph.
-		
+
 		Returns:
 		-----------
 		float
@@ -138,16 +138,16 @@ cdef class Matching:
 		"""
 		Convert matching to a Partition object where matched nodes belong to the same subset
 		and unmatched nodes belong to a singleton subset.
-		
+
 		Parameters:
 		-----------
 		G : networkit.Graph
 			The corresponding graph.
-			
+
 		Returns:
 		-----------
 		networkit.Partition
-			
+
 		"""
 		return Partition().setThis(self._this.toPartition(G._this))
 
@@ -176,7 +176,7 @@ cdef class Matcher(Algorithm):
 			raise RuntimeError("Instantiation of abstract base class")
 
 	def getMatching(self):
-		""" 
+		"""
 		Returns the matching.
 
 		Returns:
@@ -198,11 +198,11 @@ cdef class PathGrowingMatcher(Matcher):
 	"""
 	Path growing matching algorithm as described by  Hougardy and Drake.
 	Computes an approximate maximum weight matching with guarantee 1/2.
-	
+
 	Parameters:
 	-----------
 	G : networkit.Graph
-		Graph to apply matching.
+		The input graph (undirected and with no self-loops).
 	edgeScores : list, optional
 		list with edgeScores.
 	"""
@@ -212,4 +212,3 @@ cdef class PathGrowingMatcher(Matcher):
 			self._this = new _PathGrowingMatcher(G._this, edgeScores)
 		else:
 			self._this = new _PathGrowingMatcher(G._this)
-


### PR DESCRIPTION
`PathGrowingMatcher` does not seem to support directed graphs, when launched on a directed graph one gets an error like this ```IndexError: vector<bool>::_M_range_check: __n (which is 140354493912512) >= this->size() (which is 100)```.
I think that we should check in the constructor if the graph is undirected, and this should also be documented.