### PR TITLE
Suitor matcher

### DIFF
--- a/include/networkit/auxiliary/ArrayTools.hpp
+++ b/include/networkit/auxiliary/ArrayTools.hpp
@@ -1,0 +1,87 @@
+#ifndef NETWORKIT_AUXILIARY_ARRAY_TOOLS_HPP_
+#define NETWORKIT_AUXILIARY_ARRAY_TOOLS_HPP_
+
+// networkit-format
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include <networkit/Globals.hpp>
+
+#include <tlx/math/integer_log2.hpp>
+
+namespace Aux {
+namespace ArrayTools {
+
+template <class ArrayIt, class PermIt>
+void applyPermutation(ArrayIt first, ArrayIt last, PermIt permFirst) {
+
+    using PermType = typename std::iterator_traits<PermIt>::value_type;
+    static_assert(std::is_integral<PermType>::value, "Elements of permutation must be integral.");
+
+    const size_t arraySize =
+        static_cast<typename std::iterator_traits<ArrayIt>::difference_type>(last - first);
+
+    const size_t usedBitsInPerm = tlx::integer_log2_ceil(arraySize);
+    // Avoid to use the sign bit if signed integral
+    const size_t bitsInPerm = sizeof(PermType) * 8 - (std::is_signed<PermType>::value ? 1 : 0);
+
+    if (bitsInPerm == usedBitsInPerm) {
+        // All bits in permutation are needed, we mark swapped elements with a bool vector
+        std::vector<bool> swapped(arraySize);
+        for (size_t i = 0; i < arraySize; ++i) {
+            if (swapped[i])
+                continue;
+
+            size_t cur = i;
+            swapped[cur] = true;
+            auto tmp = std::move(first[cur]);
+
+            while (static_cast<size_t>(permFirst[cur]) != i) {
+                first[cur] = std::move(first[permFirst[cur]]);
+                cur = permFirst[cur];
+                swapped[cur] = true;
+            }
+
+            first[cur] = std::move(tmp);
+        }
+    } else {
+        // Not all bits in the permutation are needed, we use the last (or, if signed integral,
+        // second to last) bit in the permutation to mark swapped elements
+        const auto mask = PermType{1} << (bitsInPerm - (std::is_signed<PermType>::value ? 2 : 1));
+
+        const auto swapped = [&permFirst, mask = mask](size_t i) -> bool {
+            return (permFirst[i] & mask) != 0;
+        };
+
+        const auto markSwapped = [&permFirst, mask = mask](size_t i) -> void {
+            permFirst[i] |= mask;
+        };
+
+        for (size_t i = 0; i < arraySize; ++i) {
+            if (swapped(i))
+                continue;
+
+            size_t cur = i;
+            markSwapped(cur);
+            auto tmp = std::move(first[cur]);
+
+            while (static_cast<size_t>(permFirst[cur] & ~mask) != i) {
+                first[cur] = std::move(first[permFirst[cur] & ~mask]);
+                cur = permFirst[cur] & ~mask;
+                markSwapped(cur);
+            }
+
+            first[cur] = std::move(tmp);
+        }
+
+        for (size_t i = 0; i < arraySize; ++i)
+            permFirst[i] &= ~mask;
+    }
+}
+
+} // namespace ArrayTools
+} // namespace Aux
+
+#endif // NETWORKIT_AUXILIARY_ARRAY_TOOLS_HPP_

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1561,7 +1561,7 @@ public:
      *
      * @param u Node.
      * @param i index; should be in [0, degreeOut(u))
-     * @return @a i -th (outgoing) neighbor of @a u, or @c none if no such
+     * @return @a i-th (outgoing) neighbor of @a u, or @c none if no such
      * neighbor exists.
      */
     node getIthNeighbor(node u, index i) const {
@@ -1575,7 +1575,7 @@ public:
      *
      * @param u Node.
      * @param i index; should be in [0, degreeOut(u))
-     * @return @a weight of the i-th (outgoing) neighbor of @a u, or @c +inf if no such
+     * @return @a edge weight to the i-th (outgoing) neighbor of @a u, or @c +inf if no such
      * neighbor exists.
      */
     edgeweight getIthNeighborWeight(node u, index i) const {

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -300,6 +300,17 @@ std::vector<node> invertContinuousNodeIds(const std::unordered_map<node, node> &
 Graph restoreGraph(const std::vector<node> &invertedIdMap, const Graph &G);
 
 /**
+ * Sorts the adjacency arrays by increasing or decreasing edge weight. Edge ids are used
+ * to break ties.
+ *
+ * @param G The input graph.
+ * @param decreasing If true the adjacency arrays are sorted by non-increasing edge weights, if
+ * false, the adjacency arrays are sorted by non-decreasing edge weights. Ties are broken by
+ * using node ids.
+ */
+void sortEdgesByWeight(Graph &G, bool decreasing = false);
+
+/**
  * Rename nodes in a graph using a callback which translates each old id to a new one.
  * For each node u in input graph, oldIdToNew(u) < numNodes.
  *

--- a/include/networkit/matching/SuitorMatcher.hpp
+++ b/include/networkit/matching/SuitorMatcher.hpp
@@ -1,0 +1,64 @@
+/*
+ *  SuitorMatcher.hpp
+ *
+ *  Created on: 27.08.2019
+ *  Authors: Michal Boron     <michal.s.boron@gmail.com>
+ *           Eugenio Angriman <angrimae@hu-berlin.de>
+ */
+
+// networkit-format
+
+#ifndef NETWORKIT_MATCHING_SUITOR_MATCHER_HPP_
+#define NETWORKIT_MATCHING_SUITOR_MATCHER_HPP_
+
+#include <vector>
+
+#include <networkit/graph/Graph.hpp>
+#include <networkit/matching/Matcher.hpp>
+
+namespace NetworKit {
+
+/**
+ * @ingroup matching
+ * Suitor matching finding algorithm.
+ */
+class SuitorMatcher final : public Matcher {
+
+    static bool hasEdgesSortedByWeight(const Graph &G);
+
+    void findSuitor(node current);
+    void findSortSuitor(node current);
+
+public:
+    /**
+     * Computes a 1/2-approximation of the maximum (weighted) matching of an undirected graph using
+     * the Suitor algorithm from Manne and Halappanavar presented in "New Effective Multithreaded
+     * Matching Algorithms", IPDPS 2014. The algorithm has two versions: SortSuitor (faster, but
+     * only works on graphs with adjacency lists sorted by non-increasing edge weight) and Suitor
+     * (works on generic graphs). If using SortSuitor, use GrapTools::sortEdgesByWeight(G, true) to
+     * sort the adjacency lists by non-increasing edge weight.
+     *
+     * @param G An undirected graph.
+     * @param sortSuitor If true uses the SortSuitor version, otherwise it uses Suitor.
+     * @param checkSortedEdges If true and sortSuitor is true it checks whether the adjacency lists
+     * of the input graph are sorted by non-increasing edge weight. If they are not, it throws a
+     * std::runtime_error.
+     */
+    SuitorMatcher(const Graph &G, bool sortSuitor = true, bool checkSortedEdges = false);
+
+    ~SuitorMatcher() override = default;
+
+    /**
+     * Runs the algorithm.
+     */
+    void run() override;
+
+private:
+    bool sortSuitor;
+    std::vector<node> suitor;
+    std::vector<edgeweight> ws;
+    std::vector<index> neighborIterators;
+};
+} // namespace NetworKit
+
+#endif // NETWORKIT_MATCHING_SUITOR_MATCHER_HPP_

--- a/networkit/cpp/auxiliary/test/AuxGTest.cpp
+++ b/networkit/cpp/auxiliary/test/AuxGTest.cpp
@@ -11,13 +11,17 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <array>
 #include <algorithm>
+#include <limits>
 #include <numeric>
 #include <chrono>
 #include <thread>
 #include <fstream>
 #include <set>
+#include <vector>
 
+#include <networkit/auxiliary/ArrayTools.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/auxiliary/Timer.hpp>
@@ -578,4 +582,38 @@ TEST_F(AuxGTest, testBloomFilter) {
     }
 }
 
+template <class Perm>
+void testPermutation(Perm perm) {
+    auto &urng = Aux::Random::getURNG();
+    std::iota(perm.begin(), perm.end(), 0);
+    std::shuffle(perm.begin(), perm.end(), urng);
+
+    std::vector<index> seq;
+    seq.resize(perm.size());
+    std::for_each(seq.begin(), seq.end(), [&seq](auto &elem) { elem = Aux::Random::integer(seq.size()); });
+    auto seqCopy = seq;
+
+    Aux::ArrayTools::applyPermutation(seq.begin(), seq.end(), perm.begin());
+    for (size_t i = 0; i < seq.size(); ++i)
+        EXPECT_EQ(seqCopy[perm[i]], seq[i]);
+}
+
+TEST_F(AuxGTest, testApplyPermutation) {
+    Aux::Random::setSeed(1, true);
+    constexpr int n = 100;
+
+    testPermutation(std::array<int8_t, n>{});
+    testPermutation(std::array<int8_t, 128>{});
+    testPermutation(std::array<uint8_t, n>{});
+    testPermutation(std::array<uint8_t, 256>{});
+    testPermutation(std::array<int16_t, n>{});
+    testPermutation(std::array<int16_t, static_cast<size_t>(std::numeric_limits<int16_t>::max()) + 1>{});
+    testPermutation(std::array<uint16_t, n>{});
+    testPermutation(std::array<uint16_t, static_cast<size_t>(std::numeric_limits<uint16_t>::max()) + 1>{});
+    testPermutation(std::array<uint32_t, n>{});
+    testPermutation(std::array<int, n>{});
+    testPermutation(std::array<int64_t, n>{});
+    testPermutation(std::vector<node>{n});
+    testPermutation(std::vector<int>{n});
+}
 } // ! namespace NetworKit

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -481,5 +481,20 @@ Graph restoreGraph(const std::vector<node> &invertedIdMap, const Graph &G) {
     return Goriginal;
 }
 
+void sortEdgesByWeight(Graph &G, bool decreasing) {
+    if (decreasing)
+        G.sortEdges([](auto e1, auto e2) {
+            if (e1.weight == e2.weight)
+                return e1.v < e2.v;
+            return e1.weight > e2.weight;
+        });
+    else
+        G.sortEdges([](auto e1, auto e2) {
+            if (e1.weight == e2.weight)
+                return e1.v < e2.v;
+            return e1.weight < e2.weight;
+        });
+}
+
 } // namespace GraphTools
 } // namespace NetworKit

--- a/networkit/cpp/graph/test/CMakeLists.txt
+++ b/networkit/cpp/graph/test/CMakeLists.txt
@@ -2,7 +2,7 @@ networkit_add_test(graph GraphBuilderAutoCompleteGTest auxiliary)
 networkit_add_test(graph GraphBuilderDirectSwapGTest auxiliary)
 networkit_add_test(graph GraphGTest
     auxiliary dyn_distance io generators)
-networkit_add_test(graph GraphToolsGTest generators)
+networkit_add_test(graph GraphToolsGTest generators io)
 networkit_add_test(graph TraversalGTest generators)
 networkit_add_test(graph SpanningGTest io)
 

--- a/networkit/cpp/matching/CMakeLists.txt
+++ b/networkit/cpp/matching/CMakeLists.txt
@@ -3,6 +3,7 @@ networkit_add_module(matching
     Matcher.cpp
     Matching.cpp
     PathGrowingMatcher.cpp
+    SuitorMatcher.cpp
     )
 
 networkit_module_link_modules(matching

--- a/networkit/cpp/matching/SuitorMatcher.cpp
+++ b/networkit/cpp/matching/SuitorMatcher.cpp
@@ -1,0 +1,150 @@
+/*
+ *  SuitorMatcher.cpp
+ *
+ *  Created on: 27.08.2019
+ *  Authors: Michal Boron     <michal.s.boron@gmail.com>
+ *           Eugenio Angriman <angrimae@hu-berlin.de>
+ */
+
+// networkit-format
+
+#include <algorithm>
+#include <atomic>
+#include <stdexcept>
+
+#include <networkit/matching/SuitorMatcher.hpp>
+
+namespace NetworKit {
+
+SuitorMatcher::SuitorMatcher(const Graph &G, bool sortSuitor, bool checkSortedEdges)
+    : Matcher(G), sortSuitor(sortSuitor) {
+
+    if (G.numberOfSelfLoops() > 0)
+        throw std::runtime_error("This algorithm does not graphs with self-loops.");
+
+    if (G.isDirected())
+        throw std::runtime_error("This algorithm does not support directed graphs.");
+
+    if (sortSuitor && checkSortedEdges && !hasEdgesSortedByWeight(G))
+        throw std::runtime_error("Edges are not sorted by weight");
+}
+
+bool SuitorMatcher::hasEdgesSortedByWeight(const Graph &G) {
+    std::atomic<bool> isSorted{true};
+
+    G.parallelForNodes([&](node u) {
+        if (G.degree(u) < 2 || !isSorted.load(std::memory_order_relaxed))
+            return;
+
+        bool uIsSorted;
+        if (G.isWeighted())
+            uIsSorted = std::is_sorted(
+                G.weightNeighborRange(u).begin(), G.weightNeighborRange(u).end(),
+                [](const auto &n1, const auto &n2) {
+                    return n1.second == n2.second ? n1.first < n2.first : n1.second > n2.second;
+                });
+        else
+            uIsSorted = std::is_sorted(G.neighborRange(u).begin(), G.neighborRange(u).end(),
+                                       [](node n1, node n2) { return n1 < n2; });
+
+        if (!uIsSorted)
+            isSorted.store(false, std::memory_order_relaxed);
+    });
+
+    return isSorted.load(std::memory_order_relaxed);
+}
+
+void SuitorMatcher::findSuitor(node current) {
+    bool done = false;
+
+    do {
+
+        node partner = suitor[current];
+        edgeweight heaviest = ws[current];
+
+        G->forNeighborsOf(current, [&](const node v, const edgeweight weight) {
+            if ((weight > heaviest || (weight == heaviest && v < partner))
+                && (weight > ws[v] || (weight == ws[v] && current < suitor[v]))) {
+                partner = v;
+                heaviest = weight;
+            }
+        });
+
+        done = true;
+
+        if (partner != none
+            && (heaviest > ws[partner] || (heaviest == ws[partner] && current < suitor[partner]))) {
+            node y = suitor[partner];
+            suitor[partner] = current;
+            ws[partner] = heaviest;
+
+            // if the current vertex already has a suitor
+            if (y != none) {
+                current = y;
+                done = false;
+            }
+        }
+    } while (!done);
+}
+
+void SuitorMatcher::findSortSuitor(node current) {
+    bool done = false;
+
+    do {
+        node partner = suitor[current];
+        edgeweight heaviest = ws[current];
+
+        for (index &iter = neighborIterators[current]; iter < G->degree(current); ++iter) {
+            const node v = G->getIthNeighbor(current, iter);
+            const edgeweight weight = G->getIthNeighborWeight(current, iter);
+            if ((weight > heaviest || (weight == heaviest && v < partner))
+                && (weight > ws[v] || (weight == ws[v] && current < suitor[v]))) {
+                partner = v;
+                heaviest = weight;
+                ++iter;
+                break;
+            }
+        }
+
+        done = true;
+
+        if (partner != none
+            && (heaviest > ws[partner] || (heaviest == ws[partner] && current < suitor[partner]))) {
+            const node y = suitor[partner];
+            suitor[partner] = current;
+            ws[partner] = heaviest;
+
+            // if the current vertex already has a suitor
+            if (y != none) {
+                current = y;
+                done = false;
+            }
+        }
+    } while (!done);
+}
+
+void SuitorMatcher::run() {
+    const auto n = G->upperNodeIdBound();
+    suitor.assign(n, none);
+    ws.assign(n, 0);
+
+    if (sortSuitor)
+        neighborIterators.assign(n, 0);
+
+    if (sortSuitor)
+        G->forNodes([&](node u) { findSortSuitor(u); });
+    else
+        G->forNodes([&](node u) { findSuitor(u); });
+
+    G->parallelForNodes([&suitor = suitor, &M = M](node u) {
+        if (suitor[u] == none) {
+            if (M.isMatched(u))
+                M.unmatch(u, M.mate(u));
+        } else if (u < suitor[u]) // Ensure we match a pair of nodes only once
+            M.match(u, suitor[u]);
+    });
+
+    hasRun = true;
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/matching/test/MatcherGTest.cpp
+++ b/networkit/cpp/matching/test/MatcherGTest.cpp
@@ -7,14 +7,16 @@
 
 #include <gtest/gtest.h>
 
+#include <networkit/auxiliary/Random.hpp>
 #include <networkit/matching/Matcher.hpp>
 #include <networkit/matching/Matching.hpp>
 #include <networkit/matching/PathGrowingMatcher.hpp>
 #include <networkit/matching/LocalMaxMatcher.hpp>
+#include <networkit/matching/SuitorMatcher.hpp>
 #include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/io/DibapGraphReader.hpp>
 #include <networkit/io/METISGraphReader.hpp>
-#include <networkit/auxiliary/Random.hpp>
 
 namespace NetworKit {
 
@@ -127,6 +129,73 @@ TEST_F(MatcherGTest, debugValidMatching) {
 
     bool isProper = M.isProper(G);
     EXPECT_TRUE(isProper);
+}
+
+TEST_F(MatcherGTest, testSuitorMatcher) {
+    {   // Directed graphs are not supported
+        Graph G(10, true, true);
+        EXPECT_THROW(SuitorMatcher{G}, std::runtime_error);
+    }
+
+    {   // Graphs with self loops are not supported
+        Graph G(10);
+        G.addEdge(0, 0);
+        G.addEdge(0, 0);
+        EXPECT_THROW(SuitorMatcher{G}, std::runtime_error);
+    }
+
+    const edgeweight maxWeight = 10;
+
+    const auto hasUnmatchedNeighbors = [](const Graph &G, const Matching &M) -> bool {
+        for (const auto e : G.edgeRange())
+            if (!M.isMatched(e.u) && !M.isMatched(e.v))
+                return true;
+        return false;
+    };
+
+    const auto doTest = [maxWeight, &hasUnmatchedNeighbors](Graph &G) -> void {
+        // Test suitor matcher
+        SuitorMatcher sm(G, false, true);
+        sm.run();
+        const auto M1 = sm.getMatching();
+        EXPECT_TRUE(M1.isProper(G));
+        EXPECT_FALSE(hasUnmatchedNeighbors(G, M1));
+
+        GraphTools::sortEdgesByWeight(G, true);
+        {
+            auto G1 = G;
+            G1.addEdge(0, 1, maxWeight);
+            G1.addEdge(0, 2, maxWeight);
+            EXPECT_THROW(SuitorMatcher(G1, true, true), std::runtime_error);
+        }
+
+        // Test sort suitor matcher
+        SuitorMatcher ssm(G, true, true);
+        ssm.run();
+        const auto M2 = ssm.getMatching();
+        EXPECT_TRUE(M2.isProper(G));
+        EXPECT_FALSE(hasUnmatchedNeighbors(G, M2));
+
+        // Matchings must be the same
+        G.forNodes([&M1, &M2](node u) { EXPECT_EQ(M1.mate(u), M2.mate(u)); });
+    };
+
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, true);
+
+        // Test unweighted
+        auto G = METISGraphReader{}.read("input/PGPgiantcompo.graph");
+        G.removeSelfLoops();
+        G.removeMultiEdges();
+        doTest(G);
+
+        // Test weighted
+        G = GraphTools::toWeighted(G);
+        G.forEdges([&G, maxWeight](node u, node v) {
+            G.setWeight(u, v, Aux::Random::real(maxWeight));
+        });
+        doTest(G);
+    }
 }
 
 } // namespace NetworKit

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -41,6 +41,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	_Graph transpose(_Graph G) nogil except +
 	unordered_map[node,node] getContinuousNodeIds(_Graph G) nogil except +
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
+	void sortEdgesByWeight(_Graph G, bool_t) nogil except +
 
 cdef class GraphTools:
 
@@ -500,3 +501,19 @@ cdef class GraphTools:
 		for elem in cResult:
 			result[elem.first] = elem.second
 		return result
+
+	@staticmethod
+	def sortEdgesByWeight(Graph G, decreasing = False):
+		"""
+		Sorts the adjacency arrays by edge weight.
+
+		Parameters:
+		----------
+		G : networkit.Graph
+			The input graph.
+		decreasing : bool
+			If True adjacency arrays are sorted by non-increasing edge weights, if False
+			adjacency arrays are sorted by non-decreasing edge weights. Ties are broken
+			by using node ids.
+		"""
+		sortEdgesByWeight(G._this, decreasing)

--- a/networkit/matching.pyx
+++ b/networkit/matching.pyx
@@ -212,3 +212,31 @@ cdef class PathGrowingMatcher(Matcher):
 			self._this = new _PathGrowingMatcher(G._this, edgeScores)
 		else:
 			self._this = new _PathGrowingMatcher(G._this)
+
+cdef extern from "<networkit/matching/SuitorMatcher.hpp>":
+	cdef cppclass _SuitorMather "NetworKit::SuitorMatcher"(_Matcher):
+		_SuitorMather(_Graph, bool_t, bool_t) except +
+
+cdef class SuitorMatcher(Matcher):
+	"""
+	Computes a 1/2-approximation of the maximum (weighted) matching of an undirected graph using
+	the Suitor algorithm from Manne and Halappanavar presented in "New Effective Multithreaded
+	Matching Algorithms", IPDPS 2014. The algorithm has two versions: SortSuitor (faster, but
+	only works on graphs with adjacency lists sorted by non-increasing edge weight) and Suitor
+	(works on generic graphs). If using SortSuitor, call nk.graphtools.sortEdgesByWeight(G, True)
+	to sort the adjacency lists by non-increasing edge weight.
+
+	Parameters:
+	-----------
+	G : networkit.Graph
+		The input graph, must be undirected.
+	sortSuitor : bool
+		If True uses the SortSuitor version, otherwise it uses Suitor.
+	checkSortedEdges : bool
+		If True and sortSuitor is True it checks whether the adjacency lists
+		of the input graph are sorted by non-increasing edge weight. If they are not it raises
+		a RuntimeError.
+	"""
+	def __cinit__(self, Graph G not None, sortSuitor = True, checkSortedEdges = False):
+		self.G = G
+		self._this = new _SuitorMather(G._this, sortSuitor, checkSortedEdges)

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -18,7 +18,8 @@ class TestGraphTools(unittest.TestCase):
 	def generateRandomWeights(self, G):
 		if not G.isWeighted():
 			G = nk.graphtools.toWeighted(G)
-		G.forEdges(lambda u, v, w, eid: G.setWeight(u, v, random.random()))
+		for e in G.iterEdges():
+			G.setWeight(e[0], e[1], random.random())
 
 		return G
 
@@ -453,6 +454,47 @@ class TestGraphTools(unittest.TestCase):
 				self.assertTrue(G.hasEdge(5, 3))
 				nk.graphtools.removeEdgesFromIsolatedSet(G, [3, 4, 5])
 				self.assertEqual(G.numberOfEdges(), 0)
+
+	def testSortEdgesByWeight(self):
+		def checkSortedEdges(g, decreasing):
+			for u in g.iterNodes():
+				prevNode = g.numberOfNodes() if decreasing else -1
+				prevWeight = 2 if decreasing else 0
+
+				for v in g.iterNeighbors(u):
+					w = g.weight(u, v)
+					if decreasing:
+						if w == prevWeight:
+							self.assertLess(prevNode, v)
+						else:
+							self.assertLess(w, prevWeight)
+					else:
+						if w == prevWeight:
+							self.assertLess(prevNode, v)
+						else:
+							self.assertGreater(w, prevWeight)
+
+					prevNode, prevWeight = v, w
+
+		def doTest(g):
+			nk.graphtools.sortEdgesByWeight(g, False)
+			checkSortedEdges(g, False)
+			nk.graphtools.sortEdgesByWeight(g, True)
+			checkSortedEdges(g, True)
+
+		g = nk.readGraph('input/PGPgiantcompo.graph', nk.Format.METIS)
+		g.removeSelfLoops()
+		g.removeMultiEdges()
+
+		# Test unweighted
+		doTest(g)
+
+		random.seed(1)
+		g = self.generateRandomWeights(g)
+		e = nk.graphtools.randomEdge(g)
+
+		# Test weighted
+		doTest(g)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/test/test_matching_algorithms.py
+++ b/networkit/test/test_matching_algorithms.py
@@ -18,22 +18,32 @@ class TestMatchingAlgorithms(unittest.TestCase):
 		self.g = nk.readGraph("input/PGPgiantcompo.graph", nk.Format.METIS)
 		self.gw = self.generateRandomWeights(self.g)
 
+	def hasUnmatchedNeighbors(self, g, m):
+		for e in g.iterEdges():
+			if not m.isMatched(e[0]) and not m.isMatched(e[1]):
+				return True
+		return False
+
+	def testPathGrowingMatcher(self):
+		def runAlgo(g):
+			pgm = nk.matching.PathGrowingMatcher(self.g)
+			pgm.run()
+			m = pgm.getMatching()
+
+		runAlgo(self.g)
+		runAlgo(self.gw)
+
 	def testSuitorMatcher(self):
-		def hasUnmatchedNeighbors(g, m):
-			for e in g.iterEdges():
-				if not m.isMatched(e[0]) and not m.isMatched(e[1]):
-					return True
-			return False
 
 		def doTest(g):
 			m1 = nk.matching.SuitorMatcher(g, False).run().getMatching()
 			nk.graphtools.sortEdgesByWeight(g, True)
 			self.assertTrue(m1.isProper(g))
-			self.assertFalse(hasUnmatchedNeighbors(g, m1))
+			self.assertFalse(self.hasUnmatchedNeighbors(g, m1))
 
 			m2 = nk.matching.SuitorMatcher(g, True).run().getMatching()
 			self.assertTrue(m2.isProper(g))
-			self.assertFalse(hasUnmatchedNeighbors(g, m2))
+			self.assertFalse(self.hasUnmatchedNeighbors(g, m2))
 			for u in g.iterNodes():
 				self.assertEqual(m1.mate(u), m2.mate(u))
 

--- a/networkit/test/test_matching_algorithms.py
+++ b/networkit/test/test_matching_algorithms.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import random
+import unittest
+
+import networkit as nk
+
+class TestMatchingAlgorithms(unittest.TestCase):
+
+	def generateRandomWeights(self, g):
+		if not g.isWeighted():
+			g = nk.graphtools.toWeighted(g)
+		for e in g.iterEdges():
+			g.setWeight(e[0], e[1], random.random())
+		return g
+
+	def setUp(self):
+		self.g = nk.readGraph("input/PGPgiantcompo.graph", nk.Format.METIS)
+		self.gw = self.generateRandomWeights(self.g)
+
+	def testSuitorMatcher(self):
+		def hasUnmatchedNeighbors(g, m):
+			for e in g.iterEdges():
+				if not m.isMatched(e[0]) and not m.isMatched(e[1]):
+					return True
+			return False
+
+		def doTest(g):
+			m1 = nk.matching.SuitorMatcher(g, False).run().getMatching()
+			nk.graphtools.sortEdgesByWeight(g, True)
+			self.assertTrue(m1.isProper(g))
+			self.assertFalse(hasUnmatchedNeighbors(g, m1))
+
+			m2 = nk.matching.SuitorMatcher(g, True).run().getMatching()
+			self.assertTrue(m2.isProper(g))
+			self.assertFalse(hasUnmatchedNeighbors(g, m2))
+			for u in g.iterNodes():
+				self.assertEqual(m1.mate(u), m2.mate(u))
+
+		doTest(self.g)
+		doTest(self.gw)
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
This PR brings the 1/2-approximation algorithm for maximum (weighted) matching by Manne and Halappanavar (New Effective Multithreaded Matching Algorithms, IPDPS 2014).
There are two versions of the algorithm, one of which only supports graphs where the adjacency lists of every vertex are sorted by edge weight in decreasing order. To this end I also added a new `sortEdgesByWeight` method in `Graph`, which allows to sort the edges of a graph by edge weight in increasing or decreasing order. This method uses a new generic `sortEdges` method in `Graph`, which allows to sort the edges of a graph according to a custom criterion.

I am a bit hesitant to add the new sorting methods to `Graph`, they are probably too specific. An alternative idea is to implement them in `GraphTools`.