### PR TITLE
Update google tests

### DIFF
--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -62,10 +62,10 @@ protected:
     bool isWeighted() const noexcept;
 };
 
-INSTANTIATE_TEST_CASE_P(InstantiationName, CentralityGTest,
+INSTANTIATE_TEST_SUITE_P(InstantiationName, CentralityGTest,
         testing::Values(std::make_pair(false, false), std::make_pair(true, false),
                         std::make_pair(false, true),
-                        std::make_pair(true, true)), ); // comma required for variadic macro
+                        std::make_pair(true, true)));
 
 bool CentralityGTest::isWeighted() const noexcept { return GetParam().first; }
 

--- a/networkit/cpp/generators/test/ErdosRenyiEnumeratorGTest.cpp
+++ b/networkit/cpp/generators/test/ErdosRenyiEnumeratorGTest.cpp
@@ -4,9 +4,12 @@
  *  Created on: 09. Aug. 2018
  *      Author: Manuel Penschuck
  */
+
 #include <gtest/gtest.h>
-#include <tuple>
+
+#include <algorithm>
 #include <numeric>
+#include <tuple>
 
 #include <networkit/Globals.hpp>
 #include <networkit/auxiliary/Random.hpp>
@@ -114,7 +117,7 @@ TEST_P(ErdosRenyiEnumeratorGTest, TestFixedPointParallel) {
 }
 
 
-INSTANTIATE_TEST_CASE_P(ErdosRenyiEnumeratorGTest, ErdosRenyiEnumeratorGTest,
+INSTANTIATE_TEST_SUITE_P(ErdosRenyiEnumeratorGTest, ErdosRenyiEnumeratorGTest,
                         ::testing::Values(
                          std::make_tuple(false, 100, 0.0),  std::make_tuple(true, 100, 0.0),
                          std::make_tuple(false, 100, 0.1),  std::make_tuple(true, 100, 0.1),
@@ -122,6 +125,6 @@ INSTANTIATE_TEST_CASE_P(ErdosRenyiEnumeratorGTest, ErdosRenyiEnumeratorGTest,
                          std::make_tuple(false, 100, 0.7),  std::make_tuple(true, 100, 0.7),
                          std::make_tuple(false, 100, 1.0),  std::make_tuple(true, 100, 1.0),
                          std::make_tuple(false, 200, 0.01), std::make_tuple(true, 200, 0.01)
-                        ),);
+                        ));
 
 } // ! namespace NetworKit

--- a/networkit/cpp/graph/test/GraphBuilderAutoCompleteGTest.cpp
+++ b/networkit/cpp/graph/test/GraphBuilderAutoCompleteGTest.cpp
@@ -42,7 +42,7 @@ protected:
     Graph toGraph(GraphBuilder& b) const;
 };
 
-INSTANTIATE_TEST_CASE_P(InstantiationName, GraphBuilderAutoCompleteGTest, testing::Values(
+INSTANTIATE_TEST_SUITE_P(InstantiationName, GraphBuilderAutoCompleteGTest, testing::Values(
     std::make_tuple(false, false, false), // weighted, directed, parallel
     std::make_tuple(true, false, false),
     std::make_tuple(false, true, false),
@@ -52,7 +52,7 @@ INSTANTIATE_TEST_CASE_P(InstantiationName, GraphBuilderAutoCompleteGTest, testin
     std::make_tuple(true, false, true),
     std::make_tuple(false, true, true),
     std::make_tuple(true, true, true)
-), ); // comma required for variadic macro
+));
 
 bool GraphBuilderAutoCompleteGTest::isWeighted() const {
     return std::get<0>(GetParam());

--- a/networkit/cpp/graph/test/GraphBuilderDirectSwapGTest.cpp
+++ b/networkit/cpp/graph/test/GraphBuilderDirectSwapGTest.cpp
@@ -42,12 +42,12 @@ protected:
     Graph toGraph(GraphBuilder& b) const;
 };
 
-INSTANTIATE_TEST_CASE_P(InstantiationName, GraphBuilderDirectSwapGTest, testing::Values(
+INSTANTIATE_TEST_SUITE_P(InstantiationName, GraphBuilderDirectSwapGTest, testing::Values(
     std::make_tuple(false, false),
     std::make_tuple(true, false),
     std::make_tuple(false, true),
     std::make_tuple(false, false)
-), ); // comma required for variadic macro
+));
 
 bool GraphBuilderDirectSwapGTest::isWeighted() const {
     return std::get<0>(GetParam());

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -45,10 +45,10 @@ protected:
     count countSelfLoopsManually(const Graph &G);
 };
 
-INSTANTIATE_TEST_CASE_P(InstantiationName, GraphGTest, testing::Values(std::make_tuple(false, false),
+INSTANTIATE_TEST_SUITE_P(InstantiationName, GraphGTest, testing::Values(std::make_tuple(false, false),
                         std::make_tuple(true, false),
                         std::make_tuple(false, true),
-                        std::make_tuple(true, true)), ); // comma required for variadic macro
+                        std::make_tuple(true, true)));
 
 bool GraphGTest::isWeighted() const { return std::get<0>(GetParam()); }
 bool GraphGTest::isDirected() const { return std::get<1>(GetParam()); }

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -23,11 +23,9 @@ protected:
     bool directed() const noexcept;
 };
 
-INSTANTIATE_TEST_CASE_P(
-    InstantiationName, GraphToolsGTest,
-    testing::Values(std::make_pair(false, false), std::make_pair(true, false),
-                    std::make_pair(false, true),
-                    std::make_pair(true, true)), ); // comma required for variadic macro
+INSTANTIATE_TEST_SUITE_P(InstantiationName, GraphToolsGTest,
+                         testing::Values(std::make_pair(false, false), std::make_pair(true, false),
+                                         std::make_pair(false, true), std::make_pair(true, true)));
 
 Graph GraphToolsGTest::generateRandomWeights(const Graph &G) const {
     Graph Gw(G, true, G.isDirected());

--- a/networkit/cpp/graph/test/TraversalGTest.cpp
+++ b/networkit/cpp/graph/test/TraversalGTest.cpp
@@ -17,11 +17,9 @@ protected:
     bool directed() const noexcept;
 };
 
-INSTANTIATE_TEST_CASE_P(
-    InstantiationName, TraversalGTest,
-    testing::Values(std::make_pair(false, false), std::make_pair(true, false),
-                    std::make_pair(false, true),
-                    std::make_pair(true, true)), ); // comma required for variadic macro
+INSTANTIATE_TEST_SUITE_P(InstantiationName, TraversalGTest,
+                         testing::Values(std::make_pair(false, false), std::make_pair(true, false),
+                                         std::make_pair(false, true), std::make_pair(true, true)));
 
 Graph TraversalGTest::generateRandomWeights(const Graph &G) const {
     Graph Gw(G, true, G.isDirected());

--- a/networkit/cpp/io/test/MemoryMappedFileGTest.cpp
+++ b/networkit/cpp/io/test/MemoryMappedFileGTest.cpp
@@ -125,13 +125,13 @@ namespace NetworKit {
         tmpFile.verify_mapping(mmf);
     }
 
-    INSTANTIATE_TEST_CASE_P(MemoryMappedFileIOGTest, MemoryMappedFileIOGTest,
+    INSTANTIATE_TEST_SUITE_P(MemoryMappedFileIOGTest, MemoryMappedFileIOGTest,
         ::testing::Values(0, 1,
             (1 <<  2) - 1, (1 <<  2), (1 <<  2) + 1,
             (1 << 10) - 1, (1 << 10), (1 << 10) + 1,
             (1 << 16) - 1, (1 << 16), (1 << 16) + 1,
             (1 << 22) - 1, (1 << 22), (1 << 22) + 1
-        ), ); // comma required for variadic macro
+        ));
 
     TEST_F(MemoryMappedFileGTest, testMove) {
         const size_t bytes = 1000;

--- a/networkit/cpp/randomization/test/GlobalTradeSequenceGTest.cpp
+++ b/networkit/cpp/randomization/test/GlobalTradeSequenceGTest.cpp
@@ -20,7 +20,7 @@ class GlobalTradeSequenceGTest : public ::testing::Test {};
 
 using HashMapTypes = ::testing::Types<CurveballDetails::FixedLinearCongruentialMap<uint64_t>,
                                       CurveballDetails::LinearCongruentialMap<uint64_t>>;
-TYPED_TEST_CASE(GlobalTradeSequenceGTest, HashMapTypes, ); // comma required for variadic macro
+TYPED_TEST_SUITE(GlobalTradeSequenceGTest, HashMapTypes, );
 
 TYPED_TEST(GlobalTradeSequenceGTest, testInvert) {
     using Hash = TypeParam;

--- a/networkit/cpp/reachability/test/ReachabilityGTest.cpp
+++ b/networkit/cpp/reachability/test/ReachabilityGTest.cpp
@@ -16,11 +16,9 @@ protected:
     static void generateRandomWeights(Graph &G);
 };
 
-INSTANTIATE_TEST_CASE_P(
-    InstantiationName, ReachabilityGTest,
-    testing::Values(std::make_pair(false, false), std::make_pair(true, false),
-                    std::make_pair(false, true),
-                    std::make_pair(true, true)), ); // comma required for variadic macro
+INSTANTIATE_TEST_SUITE_P(InstantiationName, ReachabilityGTest,
+                         testing::Values(std::make_pair(false, false), std::make_pair(true, false),
+                                         std::make_pair(false, true), std::make_pair(true, true)));
 
 bool ReachabilityGTest::isWeighted() const noexcept {
     return GetParam().first;

--- a/networkit/cpp/sparsification/test/GlobalThresholdFilterGTest.cpp
+++ b/networkit/cpp/sparsification/test/GlobalThresholdFilterGTest.cpp
@@ -17,11 +17,9 @@ protected:
     bool isDirected() const noexcept { return GetParam().second; }
 };
 
-INSTANTIATE_TEST_CASE_P(
-    InstantiationName, GlobalThresholdFilterGTest,
-    testing::Values(std::make_pair(false, false), std::make_pair(true, false),
-                    std::make_pair(false, true),
-                    std::make_pair(true, true)), ); // comma required for variadic macro
+INSTANTIATE_TEST_SUITE_P(InstantiationName, GlobalThresholdFilterGTest,
+                         testing::Values(std::make_pair(false, false), std::make_pair(true, false),
+                                         std::make_pair(false, true), std::make_pair(true, true)));
 
 TEST_P(GlobalThresholdFilterGTest, testGlobalThresholdFilter) {
     static constexpr count n = 100;


### PR DESCRIPTION
CMake triggers some deprecation warnings in `extlibs/googletest/CMakeLists.txt`. This PR updates googletests and adapts the instantiation of test cases accordingly.