### PR TITLE
Github Actions documentation/opt. and AVX2-detection changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@
 # - Latest version (gcc/Python, clang/Python): core
 #
 # 3. Windows
-# - Latest version (msvc): core, core (release)
+# - Latest version (msvc): core, core (release), core (native)
 #
 #
 # Job naming
@@ -328,7 +328,7 @@ jobs:
       VS_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
     strategy:
       matrix:
-        build-configuration: ['core', 'core (release)']
+        build-configuration: ['core', 'core (release)', 'core (native)']
     steps:
       - name: Checkout networkit
         uses: actions/checkout@v2
@@ -339,7 +339,7 @@ jobs:
           cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\"
           ./vcvarsall.bat x64
           md ${{ github.workspace }}\build && cd ${{ github.workspace }}\build
-          cmake -G "Visual Studio 16 2019" -A x64 -DNETWORKIT_STATIC=ON -DNETWORKIT_BUILD_TESTS=ON ..
+          cmake -G "Visual Studio 16 2019" -A x64 -DNETWORKIT_STATIC=ON -DNETWORKIT_BUILD_TESTS=ON -DNETWORKIT_NATIVE=${{ matrix.build-configuration == 'core (native)' }} ..
           cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\"
           ./devenv.com $Env:GITHUB_WORKSPACE\build\networkit.sln /build ${{ matrix.build-configuration == 'core' && 'Debug' || 'Release' }}
           cd ${{ github.workspace }}\build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,94 @@
+########################################################################################################
+# Build configurations
+# ====================
+#
+# full
+# ----
+# Description: Basic build with all components (TLX, C++, Cython). Has to be tested on every fully 
+#              supported platform. Close to user-experience, except that warnings are also treated 
+#              as errors during build and TLX is provided as externally build library (normal 
+#              installation builds both NetworKit and TLX in one step).
+# Script:      scripts/full.sh
+# Build-type:  Release
+# Variants:    native = Build for native architecture
+# 
+#         
+# core
+# ----
+# Description: Builds the C++ code into one shared library. Has also sanity checks and debugging. 
+#              Since this only modifies the C++ building-process, Cython + Python-tests are removed in 
+#              order to increase speed.
+# Script:      scripts/core.sh
+# Build-type:  Debug
+# Variants:    release = Release-build (only used on Windows, since "full" is not supported)
+#              native = Build for native architecture (only used on Windows, since "full" is not supported)
+#              non-monolithic = Each C++ module is a library
+#              C++20 = Check for (latest) C++20 conformance
+#
+#
+# clang-tidy
+# ----------
+# Description: Uses clang-tidy for several static analysis checks. These involve bug prone programming
+#              errors, possible modernizations and performance optiomizations.
+# Script:      scripts/clang_tidy.sh
+# Config:      .clang-tidy
+# Build-type:  Debug
+#
+# 
+# coverage
+# --------
+# Description: Enables code-coverage, address- & leak-sanitizers and tests in order to create cpp-coveralls data.
+# Script:      scripts/core_sanitizers_coverage.sh
+# Build type:  Debug
+# 
+#
+# documentation:
+# --------------
+# Description: Builds documentation of both C++ and Python-code. The result is automatically deployed
+#              when a pull request is merged.
+# Script:      scripts/documentation.sh 
+# Build-type:  Debug
+#
+#
+# Jobs:
+# =====
+# 0. Rationale:
+# - Main platform is Linux, which is therefore used for most of the tests. 
+# - Basic user experience (full) should be tested on all supported platforms (Linux, macOS, Windows) 
+#   with the default compiler.
+# - For further user-centric tests, "full (native)" should be tested with default compiler for 
+#   vectorization support.
+# - At least one debug build, so either core or one of its variants, should be done on each platform 
+#   to check for problems like possible race conditions. 
+# - At least on one platform: code styling/static-analysis (clang-tidy, code-style), coverage,
+#   documentation and all core-variants, minimum supported version of compilers / Python
+# - Remark: Currently Windows does not support a full/native build, therefore core builds are used.
+# 
+# 1. Linux:
+# - Latest version (gcc/Python): full, full (native) 
+# - Latest version (clang/Python): core
+# - Minimum version (gcc/Python, clang/Python): full
+# - Additional: core (non-monolithic), core (C++20), clang-tidy, code-style, coverage, 
+#               documentation
+#
+# 2. macOS:
+# - Latest version (apple-clang): full, full (native)
+# - Latest version (gcc/Python, clang/Python): core
+#
+# 3. Windows
+# - Latest version (msvc): core, core (release)
+#
+#
+# Job naming
+# ==========
+# <OS> [opt.]<OS-VERSION> (<COMPILER>, [opt.]<PYTHON VERSION>): <BUILD CONFIGURATION>
+########################################################################################################
+
 name: build
 
 on: [push, pull_request]
 
+# Default parameters for all builds. 
 env:
   OMP_NUM_THREADS: 2
   CXX_STANDARD: 14
@@ -10,8 +97,8 @@ env:
   NATIVE: OFF
 
 jobs:
-  macos-build-apple-clang:
-    name: "macOS ${{ matrix.os }} (latest apple-clang, Python 3.9): ${{ matrix.variant }}"
+  macos-build-latest-version-apple-clang:
+    name: "macOS ${{ matrix.os }} (apple-clang, CPython 3.9): ${{ matrix.build-configuration }}"
     runs-on: macos-${{ matrix.os }}
     env:
       CC: cc
@@ -19,144 +106,13 @@ jobs:
     strategy:
       matrix:
         os: ['10.15'] # 11.0 temp. removed due to errors in preview image / git actions pipelines
-        variant: ['full build', 'non-monolithic']
+        build-configuration: ['full', 'full (native)']
     continue-on-error: ${{ matrix.os == '11.0' }}
     steps:
-      - name: Install prerequisites 📦
+      - name: Install prerequisites
         run: |
           brew install libomp
           brew install ninja
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Checkout networkit
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Checkout tlx
-        if: matrix.variant == 'full build'
-        uses: actions/checkout@v2
-        with:
-          repository: tlx/tlx
-          path: tlx
-      - name: Prepare environment and run checks (full build)
-        if: matrix.variant == 'full build'
-        run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
-        shell: bash
-        env:
-          TLX_PATH: /Users/runner/work/networkit/networkit/tlx
-          NATIVE: ON
-      - name: Prepare environment and run checks (non-monolithic)
-        if: matrix.variant == 'non-monolithic'
-        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
-        shell: bash
-        env:
-          MONOLITH: OFF
-
-  macos-build-misc-compiler:
-    name: "macOS ${{ matrix.os }} (latest ${{ matrix.variant }}, Python 3.9): core build"
-    runs-on: macos-${{ matrix.os }}
-    env:
-        NATIVE: ON
-    strategy:
-      matrix:
-        os: ['10.15']  # 11.0 temp. removed due to errors in preview image / git actions pipelines
-        variant: ['llvm-11', 'gcc-10']
-    continue-on-error: ${{ matrix.os == '11.0' }}
-    steps:
-      - name: Install prerequisites 📦
-        run: |
-          brew install libomp
-          brew install ninja
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Install compiler llvm
-        if: matrix.variant == 'llvm-11'
-        run: brew install llvm@11
-      - name: Install compiler gcc
-        if: matrix.variant == 'gcc-10'
-        run: |
-          brew install gcc@10
-          brew link gcc
-      - name: Checkout networkit
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Prepare environment and run checks (llvm)
-        if: matrix.variant == 'llvm-11'
-        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
-        shell: bash
-        env:
-          CC: /usr/local/opt/llvm/bin/clang
-          CXX: /usr/local/opt/llvm/bin/clang++
-      - name: Prepare environment and run checks (gcc)
-        if: matrix.variant == 'gcc-10'
-        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
-        shell: bash
-        env:
-          CC: gcc-10
-          CXX: g++-10
-
-  linux-build-latest-gcc:
-    name: "Linux (latest gcc-10, Python 3.9): ${{ matrix.variant }}"
-    runs-on: ubuntu-20.04
-    env:
-      CC: gcc-10
-      CXX: g++-10
-    strategy:
-      matrix:
-        variant: ['full build', 'core build', 'non-monolithic']
-    steps:
-      - name: Install prerequisites 📦
-        run:  |
-          sudo apt-get install ninja-build
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Checkout networkit
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Checkout tlx
-        if: matrix.variant == 'full build'
-        uses: actions/checkout@v2
-        with:
-          repository: tlx/tlx
-          path: tlx
-      - name: Prepare environment and run checks (full build)
-        if: matrix.variant == 'full build'
-        run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
-        shell: bash
-        env:
-          NATIVE: ON
-      - name: Prepare environment and run checks (core build)
-        if: matrix.variant == 'core build'
-        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
-        shell: bash
-      - name: Prepare environment and run checks (non-monolithic)
-        if: matrix.variant == 'non-monolithic'
-        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
-        shell: bash
-
-  linux-build-misc-compiler:
-    name: "Linux (latest ${{ matrix.variant }}, Python 3.9): full build"
-    runs-on: ubuntu-20.04
-    env:
-        NATIVE: ON
-    strategy:
-      matrix:
-        variant: ['llvm-11']
-    steps:
-      - name: Install prerequisites 📦
-        run:  |
-          curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-11 main" | sudo tee /etc/apt/sources.list.d/llvm11.list
-          sudo apt-get update
-          sudo apt-get install clang-11 libomp-11-dev ninja-build
       - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
@@ -174,19 +130,114 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
         shell: bash
         env:
+          TLX_PATH: /Users/runner/work/networkit/networkit/tlx
+          NATIVE: ${{ matrix.os == 'full (native)' }}
+
+  macos-build-latest-version-misc:
+    name: "macOS ${{ matrix.os }} (${{ matrix.compiler }}): core"
+    runs-on: macos-${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['10.15']  # 11.0 temp. removed due to errors in preview image / git actions pipelines
+        compiler: ['clang-11', 'gcc-10']
+    continue-on-error: ${{ matrix.os == '11.0' }}
+    steps:
+      - name: Install prerequisites
+        run: |
+          brew install libomp
+          brew install ninja
+      - name: Install compiler llvm
+        if: matrix.compiler == 'clang-11'
+        run: brew install llvm@11
+      - name: Install compiler gcc
+        if: matrix.compiler == 'gcc-10'
+        run: |
+          brew install gcc@10
+          brew link gcc
+      - name: Checkout networkit
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Prepare environment and run checks
+        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
+        shell: bash
+        env:
+          CC: ${{ matrix.compiler == 'clang-11' && '/usr/local/opt/llvm/bin/clang' || 'gcc-10' }}
+          CXX: ${{ matrix.compiler == 'clang-11' && '/usr/local/opt/llvm/bin/clang++' || 'g++-10' }}
+
+  linux-build-latest:
+    name: "Linux (gcc-10${{ startsWith(matrix.build-configuration, 'full') && ', CPython 3.9' || '' }}): ${{ matrix.build-configuration }}"
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc-10
+      CXX: g++-10
+    strategy:
+      matrix:
+        build-configuration: ['full', 'full (native)', 'core (non-monolithic)', 'core (C++20)']
+    steps:
+      - name: Install prerequisites
+        run:  |
+          sudo apt-get install ninja-build
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Checkout networkit
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Checkout tlx
+        if: ${{ startsWith(matrix.build-configuration, 'full') }}
+        uses: actions/checkout@v2
+        with:
+          repository: tlx/tlx
+          path: tlx
+      - name: Prepare environment and run checks
+        run:  ${{ github.workspace }}/.github/workflows/scripts/$SCRIPT
+        shell: bash
+        env:
+          NATIVE: ${{ matrix.build-configuration == 'full (native)' }}
+          MONOLITH: ${{ matrix.build-configuration != 'core (non-monolithic)' }}
+          SCRIPT: ${{ startsWith(matrix.build-configuration, 'core') && 'cpp_only.sh' || 'full.sh'}}
+          CXX_STANDARD: ${{ matrix.build-configuration == 'core (C++20)' && '20' || env.CXX_STANDARD }}
+
+  linux-build-misc:
+    name: "Linux (${{ matrix.compiler }}): core"
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        compiler: ['clang-11']
+    steps:
+      - name: Install prerequisites
+        run:  |
+          curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-11 main" | sudo tee /etc/apt/sources.list.d/llvm11.list
+          sudo apt-get update
+          sudo apt-get install clang-11 libomp-11-dev ninja-build
+      - name: Checkout networkit
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Checkout tlx
+        uses: actions/checkout@v2
+        with:
+          repository: tlx/tlx
+          path: tlx
+      - name: Prepare environment and run checks
+        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
+        shell: bash
+        env:
           CC: clang-11
           CXX: clang++-11
 
   linux-build-min-support:
-    name: "Linux (${{ matrix.variant }}, Python 3.6): full build"
+    name: "Linux (${{ matrix.compiler }}, CPython 3.6): full"
     runs-on: ubuntu-16.04
-    env:
-        NATIVE: ON
     strategy:
       matrix:
-        variant: ['gcc-5', 'clang-3.9']
+        compiler: ['gcc-5', 'clang-3.9']
     steps:
-      - name: Install prerequisites 📦
+      - name: Install prerequisites
         run:  |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
@@ -205,47 +256,15 @@ jobs:
         with:
           repository: tlx/tlx
           path: tlx
-      - name: Prepare environment and run checks (gcc-5)
-        if: matrix.variant == 'gcc-5'
+      - name: Prepare environment and run checks
         run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
         shell: bash
         env:
-          CC: gcc-5
-          CXX: g++-5
-      - name: Prepare environment and run checks (clang-3.9)
-        if: matrix.variant == 'clang-3.9'
-        run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
-        shell: bash
-        env:
-          CC: clang-3.9
-          CXX: clang++-3.9
-          NATIVE: ON
-
-  linux-build-conformance:
-    name: "Linux (latest gcc-10): C++${{ matrix.variant }} conformance"
-    runs-on: ubuntu-20.04
-    env:
-      CC: gcc-10
-      CXX: g++-10
-    strategy:
-      matrix:
-        variant: ['17', '20']
-    steps:
-      - name: Install prerequisites 📦
-        run:  |
-          sudo apt-get install ninja-build
-      - name: Checkout networkit
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Prepare environment and run checks (C++)
-        run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
-        shell: bash
-        env:
-          CXX_STANDARD: ${{ matrix.variant }}
+          CC: ${{ matrix.compiler == 'gcc-5' && 'gcc-5' || 'clang-3.9' }}
+          CXX: ${{ matrix.compiler == 'gcc-5' && 'g++-5' || 'clang++-3.9' }}
 
   linux-build-clang-tidy:
-    name: "Linux (clang-11): clang-tidy build"
+    name: "Linux (clang-11): clang-tidy"
     runs-on: ubuntu-20.04
     env:
       CC: clang
@@ -266,7 +285,7 @@ jobs:
         shell: bash
 
   linux-build-core-sanitizers-coverage:
-    name: "Linux (gcc-10, Python 3.9): core build, sanitizers, coverage"
+    name: "Linux (gcc-10, CPython 3.9): coverage"
     runs-on: ubuntu-20.04
     env:
       CC: gcc-10
@@ -288,7 +307,7 @@ jobs:
       - name: Prepare environment and run checks
         run:  ${{ github.workspace }}/.github/workflows/scripts/core_sanitizers_coverage.sh
         shell: bash
-      - name: Update Coveralls 🚀
+      - name: Update Coveralls
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           cd ${{ github.workspace }}
@@ -301,7 +320,7 @@ jobs:
           COVERALLS_SVC_NUM: ${{ github.run_number }}
 
   windows-build-msvc:
-    name: "Windows Server 2019 (msvc 14.28): ${{ matrix.type }} build, ${{ matrix.variant }}"
+    name: "Windows (msvc 14.28): ${{ matrix.build-configuration }}"
     runs-on: windows-2019
     env:
       MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\devenv.com
@@ -309,8 +328,7 @@ jobs:
       VS_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
     strategy:
       matrix:
-        type: ['Release', 'Debug']
-        variant: ['monolithic', 'non-monolithic']
+        build-configuration: ['core', 'core (release)']
     steps:
       - name: Checkout networkit
         uses: actions/checkout@v2
@@ -321,20 +339,20 @@ jobs:
           cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\"
           ./vcvarsall.bat x64
           md ${{ github.workspace }}\build && cd ${{ github.workspace }}\build
-          cmake -G "Visual Studio 16 2019" -A x64 -DNETWORKIT_STATIC=ON -DNETWORKIT_BUILD_TESTS=ON -DNETWORKIT_MONOLITH=${{ matrix.variant }} ..
+          cmake -G "Visual Studio 16 2019" -A x64 -DNETWORKIT_STATIC=ON -DNETWORKIT_BUILD_TESTS=ON ..
           cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\"
-          ./devenv.com $Env:GITHUB_WORKSPACE\build\networkit.sln /build ${{ matrix.type }}
+          ./devenv.com $Env:GITHUB_WORKSPACE\build\networkit.sln /build ${{ matrix.build-configuration == 'core' && 'Debug' || 'Release' }}
           cd ${{ github.workspace }}\build
-          ctest -V -C ${{ matrix.type }}
+          ctest -V -C ${{ matrix.build-configuration == 'core' && 'Debug' || 'Release' }}
 
   documentation-build:
-    name: "Documentation build"
+    name: "Linux (gcc-10, CPython 3.9): documentation"
     runs-on: ubuntu-20.04
     env:
       CC: gcc-10
       CXX: g++-10
     steps:
-      - name: Install prerequisites 📦
+      - name: Install prerequisites
         run:  |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
@@ -346,7 +364,7 @@ jobs:
       - name: Prepare environment and run checks
         run:  ${{ github.workspace }}/.github/workflows/scripts/documentation.sh
         shell: bash
-      - name: Deploy networkit.github.io 🚀
+      - name: Deploy networkit.github.io
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -359,10 +377,10 @@ jobs:
           user_email: 'github-actions[bot]@users.noreply.github.com'
 
   style-guide-compliance-build:
-    name: "Style guide compliance build"
+    name: "Linux (default): code-style"
     runs-on: ubuntu-20.04
     steps:
-      - name: Install prerequisites 📦
+      - name: Install prerequisites
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-11 main" | sudo tee /etc/apt/sources.list.d/llvm11.list

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,47 +94,12 @@ elseif (MSVC)
 	# TTMath requires running an ASM for MSVC which we disable here at the cost of worse performance
 	set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} /DTTMATH_NOASM=1")
 
+	if (NETWORKIT_NATIVE)
+		message(WARNING "Compiling NetworKit with native instructions (like AVX) is not yet supported on this OS.")
+	endif()
+
 else()
 	message(WARNING "Support only GCC, Clang, MSVC and AppleClang. Your compiler may or may not work.")
-endif()
-
-# Add flags for AVX instructions if available on the machine (and NETWORKIT_NATIVE is set to ON)
-if (NETWORKIT_NATIVE)
-
-	# Warning message to throw if AVX instructions are not available on host.
-	set(AVX_WARNING_MESSAGE "AVX instructions are not available on this machine")
-
-	# Check if avx2 is available on host. Store result in AVX2_TRUE
-	function(check_avx2 CPUINFO)
-		STRING(REGEX REPLACE "^.*(avx2).*$" "\\1" AVX_THERE ${CPUINFO})
-		STRING(COMPARE EQUAL "avx2" "${AVX_THERE}" AVX_FOUND)
-		set(AVX2_TRUE ${AVX_FOUND} PARENT_SCOPE)
-	endfunction(check_avx2)
-
-	# Check if AVX instructions are supported on host. If yes, enable the required AVX flags.
-	function(set_avx_flags CPUINFO)
-		check_avx2(${CPUINFO})
-
-		if (AVX2_TRUE)
-			set(NETWORKIT_CXX_FLAGS "-mavx -mavx2 -DAVX2_AVAILABLE ${NETWORKIT_CXX_FLAGS}" PARENT_SCOPE)
-		else()
-			message(WARNING ${AVX_WARNING_MESSAGE})
-		endif()
-	endfunction(set_avx_flags)
-
-	if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-		# Get cpu info
-		EXEC_PROGRAM(cat ARGS "/proc/cpuinfo" OUTPUT_VARIABLE CPUINFO)
-		set_avx_flags(${CPUINFO})
-
-	elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-		# Get cpu info
-		EXEC_PROGRAM("/usr/sbin/sysctl -n machdep.cpu.features" OUTPUT_VARIABLE CPUINFO)
-		set_avx_flags(${CPUINFO})
-	else()
-		# TODO check avx flags on Windows
-		message(WARNING "Compiling NetworKit with AVX instructions is not yet supported on this OS.")
-	endif()
 endif()
 
 # Checking sanitizer options; in both cases we include 'undefined'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,12 @@ elseif (MSVC)
 	set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} /DTTMATH_NOASM=1")
 
 	if (NETWORKIT_NATIVE)
-		message(WARNING "Compiling NetworKit with native instructions (like AVX) is not yet supported on this OS.")
+		message(WARNING "Compiling NetworKit with native instructions is not yet supported by MSVC. Activating AVX2-support if possible.")
+		include(CheckCXXCompilerFlag)
+		CHECK_CXX_COMPILER_FLAG("/arch:AVX2" COMPILER_OPT_ARCH_AVX_SUPPORTED)
+		if(COMPILER_OPT_ARCH_AVX_SUPPORTED)
+			set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} /arch:AVX2")
+		endif()
 	endif()
 
 else()

--- a/networkit/cpp/centrality/GroupClosenessGrowShrinkImpl.cpp
+++ b/networkit/cpp/centrality/GroupClosenessGrowShrinkImpl.cpp
@@ -8,6 +8,7 @@
 // networkit-format
 
 #include <omp.h>
+#include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
 
 #include "GroupClosenessGrowShrinkImpl.hpp"
@@ -27,6 +28,10 @@ GroupClosenessGrowShrinkImpl<WeightType>::GroupClosenessGrowShrinkImpl(const Gra
 
     if (G.isDirected())
         std::runtime_error("Error, this algorithm does not support directed graphs.");
+
+#if __AVX2__
+    INFO("AVX2 is available.");
+#endif
 }
 
 template <class WeightType>

--- a/networkit/cpp/centrality/GroupClosenessGrowShrinkImpl.hpp
+++ b/networkit/cpp/centrality/GroupClosenessGrowShrinkImpl.hpp
@@ -10,10 +10,10 @@
 #ifndef NETWORKIT_CENTRALITY_GROUP_CLOSENESS_GROW_SHRINK_IMPL_HPP_
 #define NETWORKIT_CENTRALITY_GROUP_CLOSENESS_GROW_SHRINK_IMPL_HPP_
 
-#ifdef AVX2_AVAILABLE
+#ifdef __AVX2__
 #include <immintrin.h>
 #include <networkit/auxiliary/AlignedAllocator.hpp>
-#endif // AVX2_AVAILABLE
+#endif // __AVX2__
 
 #include <cmath>
 #include <functional>
@@ -75,7 +75,7 @@ private:
 
     void init();
 
-#ifdef AVX2_AVAILABLE
+#ifdef __AVX2__
     union RandItem {
         uint16_t items[K];
         __m256i vec;
@@ -83,7 +83,7 @@ private:
     std::vector<RandItem, AlignedAllocator<RandItem, sizeof(RandItem)>> randVec;
 #else
     std::vector<uint16_t> randVec;
-#endif // AVX2_AVAILABLE
+#endif // __AVX2__
 
     std::vector<std::uniform_int_distribution<uint32_t>> intDistributions;
     void initRandomVec();


### PR DESCRIPTION
As discussed in #674 (and in preperation for the distribution of a wheel-package) this PR reduces the total number of tests slightly. This also changes:

- Remaining tests are renamed according to a certain scheme, which is now documented at the beginning of the `ci.yml` file. This also gives a rationale, why each test is done.
- ~~Shortening the name of each test, so that the full name is visible in the Actions-overview for a run. Hopefully the emojis are not to fancy~~
- Remove duplicating lines of code in `ci.myl` by using a "[fake ternary operator](https://github.community/t/do-expressions-support-ternary-operators-to-change-their-returned-value/18114)"
- Removing custom tests in main `CMakeLists.txt` for AVX2. `-march=native` already should enable all hardware-specific features like AVX2.
- Added custom-test for Windows/MSVC in order to detect AVX2-support. `-march=native` or similar is not available in MSVC.

Any input is appreciated :) Choosing the "right" test-cases is always depending on ones point of view.