### PR TITLE
Perfemance improvement to Edge Indexing and The Edge List Reader.

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -150,8 +150,8 @@ class Graph final {
     index indexInOutEdgeArray(node u, node v) const;
 
     index indexSortedInInEdgeArray(node v, node u) const;
-	
-	index indexSortedInOutEdgeArray(node v, node u) const;
+
+    index indexSortedInOutEdgeArray(node v, node u) const;
 
     /**
      * Computes the weighted in/out degree of node @a u.

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -149,6 +149,10 @@ class Graph final {
      */
     index indexInOutEdgeArray(node u, node v) const;
 
+    index indexSortedInInEdgeArray(node v, node u) const;
+	
+	index indexSortedInOutEdgeArray(node v, node u) const;
+
     /**
      * Computes the weighted in/out degree of node @a u.
      *

--- a/include/networkit/io/EdgeListReader.hpp
+++ b/include/networkit/io/EdgeListReader.hpp
@@ -36,7 +36,7 @@ public:
      * @param[in]  directed  read graph as directed
      */
     EdgeListReader(char separator, node firstNode, const std::string &commentPrefix = "#",
-                   bool continuous = true, bool directed = false);
+                   bool continuous = true, bool directed = false, bool unique = false);
 
     /**
      * Given the path of an input file, read the graph contained.
@@ -57,6 +57,7 @@ private:
     bool continuous;
     std::map<std::string, node> mapNodeIds;
     bool directed;
+    bool unique; // confirmation that all edges are unique for faster reading
 };
 
 } /* namespace NetworKit */

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -207,22 +207,23 @@ index Graph::indexInOutEdgeArray(node u, node v) const {
     }
     return none;
 }
-//TODO: binary search for the sorted version
+// TODO: binary search for the sorted version
 index Graph::indexSortedInInEdgeArray(node v, node u) const {
     if (!directed) {
         return indexInOutEdgeArray(v, u);
     }
-	
-	index l = 0;
-	index r = inEdges[u].size()-1;
-	
-    for (index i = (l + r)/2; l <= r; i = (l + r)/2) {
+
+    index l = 0;
+    index r = inEdges[u].size() - 1;
+
+    for (index i = (l + r) / 2; l <= r; i = (l + r) / 2) {
         node x = inEdges[v][i];
         if (x > u) {
-			l = i + 1;
-		} else (x < u) {
-			r = i - 1;
-		} else {
+            l = i + 1;
+        } else if (x < u) {
+            r = i - 1;
+        }
+        else {
             return i;
         }
     }
@@ -230,16 +231,17 @@ index Graph::indexSortedInInEdgeArray(node v, node u) const {
 }
 
 index Graph::indexSortedInOutEdgeArray(node u, node v) const {
-	index l = 0;
-	index r = outEdges[u].size()-1;
-	
-    for (index i = (l + r)/2; l <= r; i = (l + r)/2) {
+    index l = 0;
+    index r = outEdges[u].size() - 1;
+
+    for (index i = (l + r) / 2; l <= r; i = (l + r) / 2) {
         node x = outEdges[u][i];
-		if (x > v) {
-			l = i + 1;
-		} else (x < v) {
-			r = i - 1;
-		} else {
+        if (x > v) {
+            l = i + 1;
+        } else if (x < v) {
+            r = i - 1;
+        }
+        else {
             return i;
         }
     }
@@ -252,29 +254,26 @@ void Graph::indexEdges(bool force) {
     if (edgesIndexed && !force)
         return;
 
-    
-	
-	//TODO: Sort outedges and inedges
-	
-	std::vector<std::vector<node>> targetAdjacencies(upperNodeIdBound());
+    // TODO: Sort outedges and inedges
+
+    std::vector<std::vector<node>> targetAdjacencies(upperNodeIdBound());
     std::vector<std::vector<edgeweight>> targetWeight;
-	
-	if (isWeighted()) {
+
+    if (isWeighted()) {
         targetWeight.resize(upperNodeIdBound());
         forNodes([&](node u) { targetWeight[u].reserve(degree(u)); });
     }
-	
-	
-	forNodes([&](node u) { targetAdjacencies[u].reserve(degree(u)); });
-	
-	auto assignToTarget = [&](node u, node v, edgeweight w) {
+
+    forNodes([&](node u) { targetAdjacencies[u].reserve(degree(u)); });
+
+    auto assignToTarget = [&](node u, node v, edgeweight w) {
         targetAdjacencies[v].push_back(u);
         if (isWeighted()) {
             targetWeight[v].push_back(w);
         }
     };
-	
-	forNodes([&](node u) { forInEdgesOf(u, assignToTarget); });
+
+    forNodes([&](node u) { forInEdgesOf(u, assignToTarget); });
 
     outEdges.swap(targetAdjacencies);
     outEdgeWeights.swap(targetWeight);
@@ -299,11 +298,11 @@ void Graph::indexEdges(bool force) {
         inEdges.swap(targetAdjacencies);
         inEdgeWeights.swap(targetWeight);
     }
-	
-	//end TODO
-	
-	omega = 0; // reset edge ids (for re-indexing)
-	
+
+    // end TODO
+
+    omega = 0; // reset edge ids (for re-indexing)
+
     outEdgeIds.resize(outEdges.size());
     forNodes([&](node u) { outEdgeIds[u].resize(outEdges[u].size(), none); });
 
@@ -329,27 +328,27 @@ void Graph::indexEdges(bool force) {
     // makes sense.
     if (!directed) {
         balancedParallelForNodes([&](node u) {
-			//TODO: binary search
+            // TODO: binary search
             for (index i = 0; i < outEdges[u].size(); ++i) {
                 node v = outEdges[u][i];
                 if (v != none && outEdgeIds[u][i] == none) {
-                    index j = indexSortedInOutEdgeArray(v, u); //SLOW PART??
+                    index j = indexSortedInOutEdgeArray(v, u); // SLOW PART??
                     outEdgeIds[u][i] = outEdgeIds[v][j];
                 }
             }
-			//end TODO
+            // end TODO
         });
     } else {
         balancedParallelForNodes([&](node u) {
-			//TODO: binary search
+            // TODO: binary search
             for (index i = 0; i < inEdges[u].size(); ++i) {
                 node v = inEdges[u][i];
                 if (v != none) {
-                    index j = indexSortedInOutEdgeArray(v, u); //SLOW PART??
+                    index j = indexSortedInOutEdgeArray(v, u); // SLOW PART??
                     inEdgeIds[u][i] = outEdgeIds[v][j];
                 }
             }
-			//end TODO
+            // end TODO
         });
     }
 

--- a/networkit/cpp/io/EdgeListReader.cpp
+++ b/networkit/cpp/io/EdgeListReader.cpp
@@ -18,9 +18,9 @@
 namespace NetworKit {
 
 EdgeListReader::EdgeListReader(char separator, node firstNode, const std::string &commentPrefix,
-                               bool continuous, bool directed)
+                               bool continuous, bool directed, bool unique)
     : separator(separator), commentPrefix(commentPrefix), firstNode(firstNode),
-      continuous(continuous), mapNodeIds(), directed(directed) {}
+      continuous(continuous), mapNodeIds(), directed(directed), unique(unique) {}
 
 const std::map<std::string, node> &EdgeListReader::getNodeMap() const {
     if (this->continuous)
@@ -29,11 +29,20 @@ const std::map<std::string, node> &EdgeListReader::getNodeMap() const {
     return this->mapNodeIds;
 }
 
+struct pairhash {
+public:
+    template <typename T, typename U>
+    std::size_t operator()(const std::pair<T, U> &x) const {
+        return std::hash<T>()(x.first) ^ 13 * std::hash<U>()(x.second);
+    }
+};
+
 Graph EdgeListReader::read(const std::string &path) {
     this->mapNodeIds.clear();
     MemoryMappedFile mmfile(path);
     auto it = mmfile.cbegin();
     auto end = mmfile.cend();
+    std::unordered_map<std::pair<node, node>, edgeweight, pairhash> insertedEdges;
 
     bool weighted = false;
     bool checkedWeighted = false;
@@ -111,9 +120,13 @@ Graph EdgeListReader::read(const std::string &path) {
     };
 
     // This function modifies the graph on input.
-    auto handleEdge = [&graph](node source, node target, edgeweight weight) -> void {
-        if (!graph.hasEdge(source, target)) {
+    auto handleEdge = [&graph, this, &insertedEdges](node source, node target, edgeweight weight) -> void {
+        if (unique) {
             graph.addEdge(source, target, weight);
+        }
+        if (insertedEdges.find(std::pair<node, node>(source, target)) == insertedEdges.end()) {
+            graph.addEdge(source, target, weight);
+            insertedEdges.insert(std::make_pair(std::pair<node, node>(source, target), weight));
         }
     };
 

--- a/networkit/cpp/io/EdgeListReader.cpp
+++ b/networkit/cpp/io/EdgeListReader.cpp
@@ -31,9 +31,9 @@ const std::map<std::string, node> &EdgeListReader::getNodeMap() const {
 
 struct pairhash {
 public:
-    template <typename T, typename U>
-    std::size_t operator()(const std::pair<T, U> &x) const {
-        return std::hash<T>()(x.first) ^ 13 * std::hash<U>()(x.second);
+    template <typename T>
+    std::size_t operator()(const std::pair<T, T> &x) const {
+        return std::hash<T>()(x.first) ^ std::hash<T>()(313 * x.second);
     }
 };
 
@@ -42,7 +42,7 @@ Graph EdgeListReader::read(const std::string &path) {
     MemoryMappedFile mmfile(path);
     auto it = mmfile.cbegin();
     auto end = mmfile.cend();
-    std::unordered_map<std::pair<node, node>, edgeweight, pairhash> insertedEdges;
+    std::unordered_set<std::pair<node, node>, pairhash> insertedEdges;
 
     bool weighted = false;
     bool checkedWeighted = false;
@@ -120,13 +120,14 @@ Graph EdgeListReader::read(const std::string &path) {
     };
 
     // This function modifies the graph on input.
-    auto handleEdge = [&graph, this, &insertedEdges](node source, node target, edgeweight weight) -> void {
+    auto handleEdge = [&graph, this, &insertedEdges](node source, node target,
+                                                     edgeweight weight) -> void {
         if (unique) {
             graph.addEdge(source, target, weight);
         }
         if (insertedEdges.find(std::pair<node, node>(source, target)) == insertedEdges.end()) {
             graph.addEdge(source, target, weight);
-            insertedEdges.insert(std::make_pair(std::pair<node, node>(source, target), weight));
+            insertedEdges.insert(std::pair<node, node>(source, target));
         }
     };
 

--- a/networkit/graphio.pyx
+++ b/networkit/graphio.pyx
@@ -235,7 +235,7 @@ cdef extern from "<networkit/io/EdgeListReader.hpp>":
 
 	cdef cppclass _EdgeListReader "NetworKit::EdgeListReader"(_GraphReader):
 		_EdgeListReader() except +
-		_EdgeListReader(char separator, node firstNode, string commentPrefix, bool_t continuous, bool_t directed)
+		_EdgeListReader(char separator, node firstNode, string commentPrefix, bool_t continuous, bool_t directed, bool_t unique)
 		map[string,node] getNodeMap() except +
 
 cdef class EdgeListReader(GraphReader):
@@ -276,11 +276,11 @@ cdef class EdgeListReader(GraphReader):
 	directed : bool
 		Treat input file as a directed graph.
 	"""
-	def __cinit__(self, separator, firstNode, commentPrefix="#", continuous=True, directed=False):
+	def __cinit__(self, separator, firstNode, commentPrefix="#", continuous=True, directed=False, unique=False):
 		if len(separator) != 1 or ord(separator[0]) > 255:
 			raise RuntimeError("separator has to be exactly one ascii character");
 
-		self._this = new _EdgeListReader(stdstring(separator)[0], firstNode, stdstring(commentPrefix), continuous, directed)
+		self._this = new _EdgeListReader(stdstring(separator)[0], firstNode, stdstring(commentPrefix), continuous, directed, unique)
 
 	def getNodeMap(self):
 		""" Returns mapping of non-continuous files.


### PR DESCRIPTION
Addressing #735 and #736.

We now save the inserted edges in a Hash table to quickly check if the edge is already in the Graph. And now we have the option of passing the argument `unique` if we want to forego any checks to be even faster.

Edges are now sorted before being indexed so that we can binary search instead of linear searching the neighbors later.