### PR TITLE
[Fix] Binder, CI documentation-build by pinning older software-versions

### DIFF
--- a/.github/workflows/scripts/documentation.sh
+++ b/.github/workflows/scripts/documentation.sh
@@ -9,7 +9,8 @@ pip3 install --upgrade pip
 pip3 install cython
 
 # Several modules are required to build the documentation.
-pip3 install sphinx sphinx_bootstrap_theme numpydoc breathe exhale nbsphinx
+pip3 install sphinx sphinx_bootstrap_theme numpydoc exhale nbsphinx
+pip3 install "breathe<=4.29.0" # Temp. version pinning due to build errors. See: https://github.com/michaeljones/breathe/issues/683
 pip3 install sphinx_copybutton sphinxcontrib.bibtex sphinx_gallery sphinx_last_updated_by_git 
 pip3 install ipykernel ipython matplotlib nbconvert jupyter-client networkx tabulate
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM jupyter/base-notebook:latest
+# This version pinning of the image is temp. due to errors when using latest (kernel-version error triggered when calling conda)
+FROM jupyter/base-notebook:lab-3.0.11
 
 LABEL maintainer="Fabian Brandt-Tumescheit <brandtfa@hu-berlin.de>"
 


### PR DESCRIPTION
This PR fixes the following:

- Binder-image is broken when using base-image `jupyter/base-notebook:latest` (conda not supporting kernel-version). Using last release version lab-3.0.11 works. See also [broken](https://mybinder.org/v2/gh/networkit/networkit/master?urlpath=lab/tree/notebooks/User-Guide.ipynb) vs. [works](https://mybinder.org/v2/gh/fabratu/networkit/temp-version-pinning?urlpath=lab/tree/notebooks/User-Guide.ipynb).
- `documentation build` is broken, due to the most recent version of `breathe` (used for C++ doc-site generation). Pinning to the `<=4.29.0`(last release) works. See also https://github.com/michaeljones/breathe/issues/683