### PR TITLE
Small fixes: breath-update, workaround for clang-12 errors & adding includes for gcc-11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
     strategy:
       matrix:
         os: ['10.15']  # 11.0 temp. removed due to errors in preview image / git actions pipelines
-        compiler: ['clang-11', 'gcc-10']
+        compiler: ['clang-12', 'gcc-10']
     continue-on-error: ${{ matrix.os == '11.0' }}
     steps:
       - name: Install prerequisites
@@ -147,13 +147,15 @@ jobs:
           brew install libomp
           brew install ninja
       - name: Install compiler llvm
-        if: matrix.compiler == 'clang-11'
-        run: brew install llvm@11
+        if: matrix.compiler == 'clang-12'
+        run: |
+          brew reinstall llvm@12
+          brew link --overwrite llvm@12
       - name: Install compiler gcc
         if: matrix.compiler == 'gcc-10'
         run: |
-          brew install gcc@10
-          brew link gcc
+          brew reinstall gcc@10
+          brew link --overwrite gcc@10
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:
@@ -162,8 +164,8 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
         shell: bash
         env:
-          CC: ${{ matrix.compiler == 'clang-11' && '/usr/local/opt/llvm/bin/clang' || 'gcc-10' }}
-          CXX: ${{ matrix.compiler == 'clang-11' && '/usr/local/opt/llvm/bin/clang++' || 'g++-10' }}
+          CC: ${{ matrix.compiler == 'clang-12' && '/usr/local/opt/llvm@12/bin/clang' || 'gcc-10' }}
+          CXX: ${{ matrix.compiler == 'clang-12' && '/usr/local/opt/llvm@12/bin/clang++' || 'g++-10' }}
 
   linux-build-latest:
     name: "Linux (gcc-10${{ startsWith(matrix.build-configuration, 'full') && ', CPython 3.9' || '' }}): ${{ matrix.build-configuration }}"
@@ -206,14 +208,14 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        compiler: ['clang-11']
+        compiler: ['clang-12']
     steps:
       - name: Install prerequisites
         run:  |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-11 main" | sudo tee /etc/apt/sources.list.d/llvm11.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-12 main" | sudo tee /etc/apt/sources.list.d/llvm12.list
           sudo apt-get update
-          sudo apt-get install clang-11 libomp-11-dev ninja-build
+          sudo apt-get install clang-12 libomp-12-dev ninja-build
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:
@@ -227,8 +229,8 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
         shell: bash
         env:
-          CC: clang-11
-          CXX: clang++-11
+          CC: clang-12
+          CXX: clang++-12
 
   linux-build-min-support:
     name: "Linux (${{ matrix.compiler }}, CPython 3.6): full"
@@ -264,7 +266,7 @@ jobs:
           CXX: ${{ matrix.compiler == 'gcc-5' && 'g++-5' || 'clang++-3.9' }}
 
   linux-build-clang-tidy:
-    name: "Linux (clang-11): clang-tidy"
+    name: "Linux (clang-12): clang-tidy"
     runs-on: ubuntu-20.04
     env:
       CC: clang
@@ -273,9 +275,9 @@ jobs:
       - name: Install prerequisites
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-11 main" | sudo tee /etc/apt/sources.list.d/llvm11.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-12 main" | sudo tee /etc/apt/sources.list.d/llvm12.list
           sudo apt-get update
-          sudo apt-get install libomp-11-dev clang-11 clang-tidy-11 ninja-build
+          sudo apt-get install libomp-12-dev clang-12 clang-tidy-12 ninja-build
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/scripts/clang_tidy.sh
+++ b/.github/workflows/scripts/clang_tidy.sh
@@ -3,9 +3,9 @@ set -e
 set -o pipefail
 
 sudo rm -rf /usr/local/clang-*
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 9999
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 9999
-sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-11 9999
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 9999
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 9999
+sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 9999
 $CXX --version
 clang-tidy --version
 mkdir debug_test && cd "$_"

--- a/.github/workflows/scripts/documentation.sh
+++ b/.github/workflows/scripts/documentation.sh
@@ -9,8 +9,7 @@ pip3 install --upgrade pip
 pip3 install cython
 
 # Several modules are required to build the documentation.
-pip3 install sphinx sphinx_bootstrap_theme numpydoc exhale nbsphinx
-pip3 install "breathe<=4.29.0" # Temp. version pinning due to build errors. See: https://github.com/michaeljones/breathe/issues/683
+pip3 install sphinx sphinx_bootstrap_theme numpydoc exhale nbsphinx breathe
 pip3 install sphinx_copybutton sphinxcontrib.bibtex sphinx_gallery sphinx_last_updated_by_git 
 pip3 install ipykernel ipython matplotlib nbconvert jupyter-client networkx tabulate
 

--- a/include/networkit/centrality/GroupClosenessGrowShrink.hpp
+++ b/include/networkit/centrality/GroupClosenessGrowShrink.hpp
@@ -36,7 +36,8 @@ public:
      * nodes, and improves the group closeness of the given group by performing vertex exchanges.
      *
      * @param G A connected undirected graph.
-     * @param first, last A range that contains the initial group of nodes.
+     * @param first Iterator for first node of initial group of nodes.
+     * @param last Iterator for last node of initial group of nodes.
      * @param extended Set this parameter to true for the Extended Grow-Shrink algorithm (i.e.,
      * vertex exchanges are not restricted to only neighbors of the group).
      * @param insertions Number of consecutive node insertions and removal per iteration. Let this

--- a/networkit/cpp/centrality/DynTopHarmonicCloseness.cpp
+++ b/networkit/cpp/centrality/DynTopHarmonicCloseness.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cmath>
+#include <limits>
 #include <omp.h>
 
 #include <networkit/auxiliary/PrioQueue.hpp>

--- a/networkit/cpp/graph/test/GraphBuilderAutoCompleteGTest.cpp
+++ b/networkit/cpp/graph/test/GraphBuilderAutoCompleteGTest.cpp
@@ -482,10 +482,9 @@ TEST_P(GraphBuilderAutoCompleteGTest, testForNodes) {
 }
 
 TEST_P(GraphBuilderAutoCompleteGTest, testParallelForNodes) {
-    std::vector<node> visited;
+    std::vector<node> visited(bHouse.upperNodeIdBound());
     this->bHouse.parallelForNodes([&](node u) {
-        #pragma omp critical
-        visited.push_back(u);
+        visited[u] = u;
     });
 
     Aux::Parallel::sort(visited.begin(), visited.end());

--- a/networkit/cpp/graph/test/GraphBuilderDirectSwapGTest.cpp
+++ b/networkit/cpp/graph/test/GraphBuilderDirectSwapGTest.cpp
@@ -527,10 +527,9 @@ TEST_P(GraphBuilderDirectSwapGTest, testForNodes) {
 }
 
 TEST_P(GraphBuilderDirectSwapGTest, testParallelForNodes) {
-    std::vector<node> visited;
+    std::vector<node> visited(bHouse.upperNodeIdBound());
     this->bHouse.parallelForNodes([&](node u) {
-        #pragma omp critical
-        visited.push_back(u);
+        visited[u] = u;
     });
 
     Aux::Parallel::sort(visited.begin(), visited.end());

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -1342,10 +1342,9 @@ TEST_P(GraphGTest, testForNodes) {
 }
 
 TEST_P(GraphGTest, testParallelForNodes) {
-    std::vector<node> visited;
+    std::vector<node> visited(Ghouse.upperNodeIdBound());
     this->Ghouse.parallelForNodes([&](node u) {
-#pragma omp critical
-        visited.push_back(u);
+        visited[u] = u;
     });
 
     Aux::Parallel::sort(visited.begin(), visited.end());

--- a/networkit/cpp/sparsification/LocalSimilarityScore.cpp
+++ b/networkit/cpp/sparsification/LocalSimilarityScore.cpp
@@ -26,7 +26,12 @@ void LocalSimilarityScore::run() {
 
     std::vector<double> sparsificationExp(G->upperEdgeIdBound(), 0.0);
 
-    G->balancedParallelForNodes([&](node i) {
+    // G->parallelForNodes is replaced here by it's code-logic due to bugs in clang 12.0.0 and 12.0.1
+    #pragma omp parallel for schedule(guided)
+    for (omp_index i = 0; i < static_cast<omp_index>(G->upperNodeIdBound()); ++i) {
+        if(!G->hasNode(i)) {
+            continue;
+        }
         count d = G->degree(i);
 
         /* The top d^e edges (sorted by similarity)
@@ -59,7 +64,7 @@ void LocalSimilarityScore::run() {
             rank++;
         }
 
-    });
+    };
 
     scoreData = std::move(sparsificationExp);
     hasRun = true;

--- a/networkit/cpp/viz/MaxentStress.cpp
+++ b/networkit/cpp/viz/MaxentStress.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cmath>
+#include <limits>
 #include <queue>
 
 #include <networkit/auxiliary/Log.hpp>

--- a/networkit/cpp/viz/PivotMDS.cpp
+++ b/networkit/cpp/viz/PivotMDS.cpp
@@ -5,6 +5,8 @@
  *      Author: Michael Wegner
  */
 
+#include <limits>
+
 #include <networkit/auxiliary/PrioQueue.hpp>
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/graph/GraphTools.hpp>


### PR DESCRIPTION
This PR introduces the following fixes:

- Introducing workarounds for clang-12 errors in `GraphGTest`, `GraphBuilderAutoCompleteGTest`and `GraphBuilderDirectSwapGTest` by rewriting the loops and removing `critical`-sections.
- Introducing workarounds for clang-12 error in `LocalSimilarityScore` by exchanging function call of `balancedParallelForNodes` by it's logic. 
- The pinning for breathe is removed, since the new release doesn't break anymore. 
- Slight changes to documentation code (see suggestions in https://github.com/michaeljones/breathe/releases/tag/v4.29.2). 
- Add explicit includes for `<limits>` due to changes in gcc-11 (errors already visible on CI for most recent Ubuntu-runners) (see #755)

Background to clang-12 errors:

The most recent version (12.0.0 & 12.0.1) crashes on IR generation for four occasions: [GraphGTest.cpp (line 1346)](https://github.com/networkit/networkit/blob/master/networkit/cpp/graph/test/GraphGTest.cpp#L1346), [GraphBuilderAutoCompleteGTest.cpp (line 486)](https://github.com/networkit/networkit/blob/master/networkit/cpp/graph/test/GraphBuilderAutoCompleteGTest.cpp#486), [GraphBuilderDirectSwapGTest.cpp (line 531)](https://github.com/networkit/networkit/blob/master/networkit/cpp/graph/test/GraphBuilderDirectSwapGTest.cpp#L531), [LocalSimilarityScore.cpp (line 51)](https://github.com/networkit/networkit/blob/master/networkit/cpp/sparsification/LocalSimilarityScore.cpp#L51). In all cases this happens during `parallelForNodes`, after `#pragma omp critical` is set. All other usages of `critical` don't involve `parrallelForNodes` (and don't cause crashes). If `critical` is removed (which we don't want of course), building the code completes without error. The errors are very likely bugs, the code itself seems ok.