### PR TITLE
improved (parallel) coarsening implementation for clusterings

### DIFF
--- a/include/networkit/auxiliary/PrioQueue.hpp
+++ b/include/networkit/auxiliary/PrioQueue.hpp
@@ -10,6 +10,7 @@
 
 #include <set>
 #include <vector>
+#include <limits>
 
 #include <networkit/auxiliary/Log.hpp>
 

--- a/include/networkit/coarsening/ParallelPartitionCoarsening.hpp
+++ b/include/networkit/coarsening/ParallelPartitionCoarsening.hpp
@@ -5,6 +5,8 @@
  *      Author: cls
  */
 
+// networkit-format
+
 #ifndef NETWORKIT_COARSENING_PARALLEL_PARTITION_COARSENING_HPP_
 #define NETWORKIT_COARSENING_PARALLEL_PARTITION_COARSENING_HPP_
 
@@ -19,13 +21,13 @@ namespace NetworKit {
  */
 class ParallelPartitionCoarsening final : public GraphCoarsening {
 public:
-    ParallelPartitionCoarsening(const Graph& G, const Partition& zeta, bool useGraphBuilder = true);
+    ParallelPartitionCoarsening(const Graph &G, const Partition &zeta, bool parallel = true);
 
     void run() override;
 
 private:
-    const Partition& zeta;
-    bool useGraphBuilder;
+    const Partition &zeta;
+    bool parallel;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/structures/Partition.hpp
+++ b/include/networkit/structures/Partition.hpp
@@ -256,7 +256,7 @@ public:
      *
      * @return vector containing information about partitions.
      */
-    std::vector<index> getVector() const;
+    const std::vector<index> &getVector() const;
 
     /**
      * @return the subsets of the partition as a set of sets.

--- a/networkit/coarsening.pyx
+++ b/networkit/coarsening.pyx
@@ -45,8 +45,8 @@ cdef extern from "<networkit/coarsening/ParallelPartitionCoarsening.hpp>":
 
 
 cdef class ParallelPartitionCoarsening(GraphCoarsening):
-	def __cinit__(self, Graph G not None, Partition zeta not None, useGraphBuilder = True):
-		self._this = new _ParallelPartitionCoarsening(G._this, zeta._this, useGraphBuilder)
+	def __cinit__(self, Graph G not None, Partition zeta not None, parallel = True):
+		self._this = new _ParallelPartitionCoarsening(G._this, zeta._this, parallel)
 
 cdef extern from "<networkit/coarsening/MatchingCoarsening.hpp>":
 

--- a/networkit/cpp/algebraic/test/AlgebraicSpanningEdgeCentralityGTest.cpp
+++ b/networkit/cpp/algebraic/test/AlgebraicSpanningEdgeCentralityGTest.cpp
@@ -19,7 +19,7 @@ namespace NetworKit {
 class AlgebraicSpanningEdgeCentralityGTest : public testing::Test{};
 
 
-TEST(AlgebraicSpanningEdgeCentralityGTest, testOnToyGraph) {
+TEST_F(AlgebraicSpanningEdgeCentralityGTest, testOnToyGraph) {
     /* Graph:
             0    3
              \  / \

--- a/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
+++ b/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
@@ -15,8 +15,6 @@
 #include <networkit/coarsening/ParallelPartitionCoarsening.hpp>
 #include <networkit/graph/GraphBuilder.hpp>
 
-#include <iostream>
-
 namespace NetworKit {
 
 ParallelPartitionCoarsening::ParallelPartitionCoarsening(const Graph &G, const Partition &zeta,

--- a/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
+++ b/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
@@ -5,6 +5,8 @@
  *      Author: cls
  */
 
+// networkit-format
+
 #include <numeric>
 #include <omp.h>
 
@@ -13,124 +15,97 @@
 #include <networkit/coarsening/ParallelPartitionCoarsening.hpp>
 #include <networkit/graph/GraphBuilder.hpp>
 
+#include <iostream>
+
 namespace NetworKit {
 
-ParallelPartitionCoarsening::ParallelPartitionCoarsening(const Graph &G,
-                                                         const Partition &zeta,
-                                                         bool useGraphBuilder)
-    : GraphCoarsening(G), zeta(zeta), useGraphBuilder(useGraphBuilder) {}
+ParallelPartitionCoarsening::ParallelPartitionCoarsening(const Graph &G, const Partition &zeta,
+                                                         bool parallel)
+    : GraphCoarsening(G), zeta(zeta), parallel(parallel) {}
 
 void ParallelPartitionCoarsening::run() {
-    Aux::Timer timer;
-    timer.start();
-
     Partition nodeToSuperNode = zeta;
-    nodeToSuperNode.compact(
-        (zeta.upperBound() <=
-         G->upperNodeIdBound())); // use turbo if the upper id bound is <= number
-                                 // of nodes
-    count nextNodeId = nodeToSuperNode.upperBound();
+    nodeToSuperNode.compact((zeta.upperBound() <= G->upperNodeIdBound()));
+    index numParts = nodeToSuperNode.upperBound();
 
-    Graph Gcombined;
-    if (!useGraphBuilder) {
-        Graph Ginit(nextNodeId, true); // initial graph containing supernodes
+    // sort fine vertices by coarse vertices
+    std::vector<index> partBegin(numParts + 2, 0);
+    std::vector<node> nodesSortedByPart(G->numberOfNodes());
+    G->forNodes([&](const node u) { partBegin[nodeToSuperNode[u] + 2]++; });
+    std::partial_sum(partBegin.begin(), partBegin.end(), partBegin.begin());
+    G->forNodes([&](const node u) { nodesSortedByPart[partBegin[nodeToSuperNode[u] + 1]++] = u; });
 
-        // make copies of initial graph
-        count nThreads = omp_get_max_threads();
-        std::vector<Graph> localGraphs(nThreads, Ginit); // thread-local graphs
+    Gcoarsened = Graph(numParts, true, false);
 
-        // iterate over edges of G and create edges in coarse graph or update edge
-        // and node weights in Gcon
-        DEBUG("create edges in coarse graphs");
-        G->parallelForEdges([&](node u, node v, edgeweight ew) {
-            index t = omp_get_thread_num();
-
-            node su = nodeToSuperNode[u];
-            node sv = nodeToSuperNode[v];
-            localGraphs.at(t).increaseWeight(su, sv, ew);
-        });
-
-        Aux::Timer timer2;
-        timer2.start();
-        // combine local graphs in parallel
-        // Graph Gcombined(Ginit.numberOfNodes(), true); //
-        Gcombined = Graph(Ginit.numberOfNodes(), true);
-
-        std::vector<count> numEdges(nThreads);
-
-        // access internals of Graph to write adjacencies
-        auto threadSafeIncreaseWeight = [&](node u, node v, edgeweight ew) {
-            index vi = Gcombined.indexInOutEdgeArray(u, v);
-            if (vi == none) {
-                index t = omp_get_thread_num();
-                if (u == v) {
-                    numEdges[t] += 2;
-                } else {
-                    numEdges[t] += 1; // normal edges count half
-                }
-                Gcombined.outEdges[u].push_back(v);
-                Gcombined.outEdgeWeights[u].push_back(ew);
-            } else {
-                Gcombined.outEdgeWeights[u][vi] += ew;
-            }
-        };
-
-        DEBUG("combining graphs");
-        Gcombined.balancedParallelForNodes([&](node u) {
-            for (index l = 0; l < nThreads; ++l) {
-                localGraphs.at(l).forEdgesOf(u, [&](node u, node v, edgeweight w) {
-                    TRACE("increasing weight of (", u, v, ") to", w);
-                    threadSafeIncreaseWeight(u, v, w);
-                });
-            }
-        });
-
-        // ensure consistency of data structure
-        DEBUG("numEdges: ", numEdges);
-        count twiceM = std::accumulate(numEdges.begin(), numEdges.end(), count{0});
-        assert(twiceM % 2 == 0);
-        Gcombined.m = (twiceM / 2);
-
-        assert(Gcombined.checkConsistency());
-
-        // stop both timers before printing
-        timer2.stop();
-        INFO("combining coarse graphs took ", timer2.elapsedTag());
-    } else {
-        std::vector<std::vector<node>> nodesPerSuperNode(nextNodeId);
-        G->forNodes([&](node v) {
-            node sv = nodeToSuperNode[v];
-            nodesPerSuperNode[sv].push_back(v);
-        });
-
-        // iterate over edges of G and create edges in coarse graph or update edge
-        // and node weights in Gcon
-        DEBUG("create edges in coarse graphs");
-        GraphBuilder b(nextNodeId, true, false);
-#pragma omp parallel for schedule(guided)
-        for (omp_index su = 0; su < static_cast<omp_index>(nextNodeId); su++) {
-            std::map<index, edgeweight> outEdges;
-            for (node u : nodesPerSuperNode[su]) {
-                G->forNeighborsOf(u, [&](node v, edgeweight ew) {
-                    node sv = nodeToSuperNode[v];
-                    if (su != sv || u >= v) { // count edges inside uv only once (we
-                                                // iterate over them twice)
-                        outEdges[sv] += ew;
+    auto aggregateEdgeWeights = [&](node su, count &numEdges, count &numSelfLoops,
+                                    std::vector<edgeweight> &incidentPartWeights,
+                                    std::vector<node> &incidentParts) {
+        for (index i = partBegin[su]; i < partBegin[su + 1]; ++i) {
+            node u = nodesSortedByPart[i];
+            G->forNeighborsOf(u, [&](node v, edgeweight ew) {
+                const node sv = nodeToSuperNode[v];
+                if (sv != su || u >= v) {
+                    if (incidentPartWeights[sv] == 0.0) {
+                        incidentParts.push_back(sv);
                     }
-                });
-            }
-            for (auto it : outEdges) {
-                b.addHalfEdge(su, it.first, it.second);
-            }
+                    incidentPartWeights[sv] += ew;
+                }
+            });
         }
 
-        Gcombined = b.toGraph(false);
+        numEdges += incidentParts.size();
+        if (incidentPartWeights[su] != 0.0) {
+            numSelfLoops += 1;
+            numEdges -= 1;
+        }
+
+        Gcoarsened.preallocateUndirected(su, incidentParts.size());
+        for (node sv : incidentParts) {
+            Gcoarsened.addPartialEdge(unsafe, su, sv, incidentPartWeights[sv]);
+            incidentPartWeights[sv] = 0.0;
+        }
+        incidentParts.clear();
+    };
+
+    count numEdges = 0;
+    count numSelfLoops = 0;
+    if (!parallel) {
+        // The code has duplication because even the overhead of opening the parallel section was
+        // too much if used on lots of very small graphs, as in Ego-Splitting for example
+        std::vector<edgeweight> incidentPartWeights(numParts, 0.0);
+        std::vector<node> incidentParts;
+        incidentParts.reserve(numParts);
+        for (node su = 0; su < numParts; ++su) {
+            aggregateEdgeWeights(su, numEdges, numSelfLoops, incidentPartWeights, incidentParts);
+        }
+    } else {
+#pragma omp parallel
+        {
+            std::vector<edgeweight> incidentPartWeights(numParts, 0.0);
+            std::vector<node> incidentParts;
+            incidentParts.reserve(numParts);
+
+            count localEdges = 0;
+            count localSelfLoops = 0;
+
+#pragma omp for schedule(guided) nowait
+            for (omp_index su = 0; su < static_cast<omp_index>(numParts); ++su) {
+                aggregateEdgeWeights(su, localEdges, localSelfLoops, incidentPartWeights,
+                                     incidentParts);
+            }
+
+#pragma omp atomic
+            numEdges += localEdges;
+
+#pragma omp atomic
+            numSelfLoops += localSelfLoops;
+        }
     }
 
-    timer.stop();
-    INFO("parallel coarsening took ", timer.elapsedTag());
-    Gcoarsened = std::move(Gcombined);
-    nodeMapping = nodeToSuperNode.getVector();
+    Gcoarsened.storedNumberOfSelfLoops = numSelfLoops;
+    Gcoarsened.m = numEdges / 2 + numSelfLoops;
+
+    this->nodeMapping = nodeToSuperNode.getVector();
     hasRun = true;
 }
 

--- a/networkit/cpp/coarsening/test/CoarseningBenchmark.cpp
+++ b/networkit/cpp/coarsening/test/CoarseningBenchmark.cpp
@@ -35,16 +35,16 @@ TEST_F(CoarseningBenchmark, benchmarkCoarsening) {
     DEBUG("number of subsets: ", k);
 
     Aux::Timer timer;
-    INFO("parallel coarsening");
+    INFO("sequential coarsening");
     timer.start();
     ParallelPartitionCoarsening coarsening(G, zeta, false);
     coarsening.run();
     timer.stop();
     Graph Gc2 = coarsening.getCoarseGraph();
-    INFO("parallel coarsening: ", timer.elapsedTag());
+    INFO("sequential coarsening: ", timer.elapsedTag());
     EXPECT_EQ(k, Gc2.numberOfNodes());
 
-    INFO("parallel coarsening using GraphBuilder");
+    INFO("parallel coarsening");
     timer.start();
     ParallelPartitionCoarsening gbCoarsening(G, zeta, true);
     gbCoarsening.run();

--- a/networkit/cpp/coarsening/test/CoarseningGTest.cpp
+++ b/networkit/cpp/coarsening/test/CoarseningGTest.cpp
@@ -5,21 +5,23 @@
  *      Author: Christian Staudt (christian.staudt@kit.edu)
  */
 
+// networkit-format
+
 #include <gtest/gtest.h>
 
 #include <networkit/auxiliary/Log.hpp>
-#include <networkit/community/ClusteringGenerator.hpp>
 #include <networkit/coarsening/ClusteringProjector.hpp>
+#include <networkit/coarsening/MatchingCoarsening.hpp>
+#include <networkit/coarsening/ParallelPartitionCoarsening.hpp>
+#include <networkit/community/ClusteringGenerator.hpp>
 #include <networkit/community/GraphClusteringTools.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
-#include <networkit/coarsening/ParallelPartitionCoarsening.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/matching/LocalMaxMatcher.hpp>
-#include <networkit/coarsening/MatchingCoarsening.hpp>
 
 namespace NetworKit {
 
-class CoarseningGTest: public testing::Test{};
+class CoarseningGTest : public testing::Test {};
 
 TEST_F(CoarseningGTest, testClusteringProjectorWithOneClustering) {
     ErdosRenyiGenerator gen(100, 0.5);
@@ -30,9 +32,9 @@ TEST_F(CoarseningGTest, testClusteringProjectorWithOneClustering) {
     Partition zeta0 = clusteringGen.makeOneClustering(G0);
 
     // contract G0 according to 1-clusterings
-    ParallelPartitionCoarsening contract(G0,zeta0);
+    ParallelPartitionCoarsening contract(G0, zeta0);
     contract.run();
-    std::vector<std::vector<node> > maps;
+    std::vector<std::vector<node>> maps;
     Graph G1 = contract.getCoarseGraph();
     maps.push_back(contract.getFineToCoarseNodeMapping());
 
@@ -41,9 +43,9 @@ TEST_F(CoarseningGTest, testClusteringProjectorWithOneClustering) {
     ClusteringProjector project;
     Partition zetaBack = project.projectBackToFinest(zeta1, maps, G0);
 
-    EXPECT_TRUE(GraphClusteringTools::equalClusterings(zeta0, zetaBack, G0)) << "zeta^{1->0} and zeta^{0} should be identical";
+    EXPECT_TRUE(GraphClusteringTools::equalClusterings(zeta0, zetaBack, G0))
+        << "zeta^{1->0} and zeta^{0} should be identical";
 }
-
 
 TEST_F(CoarseningGTest, testClusteringProjectorWithSingletonClustering) {
     ErdosRenyiGenerator gen(100, 0.5);
@@ -56,7 +58,7 @@ TEST_F(CoarseningGTest, testClusteringProjectorWithSingletonClustering) {
     // contract G0 according to 1-clusterings
     ParallelPartitionCoarsening contract(G0, zeta0);
     contract.run();
-    std::vector<std::vector<node> > maps;
+    std::vector<std::vector<node>> maps;
     Graph G1 = contract.getCoarseGraph();
     maps.push_back(contract.getFineToCoarseNodeMapping());
 
@@ -65,9 +67,9 @@ TEST_F(CoarseningGTest, testClusteringProjectorWithSingletonClustering) {
     ClusteringProjector project;
     Partition zetaBack = project.projectBackToFinest(zeta1, maps, G0);
 
-    EXPECT_TRUE(GraphClusteringTools::equalClusterings(zeta0, zetaBack, G0)) << "zeta^{1->0} and zeta^{0} should be identical";
+    EXPECT_TRUE(GraphClusteringTools::equalClusterings(zeta0, zetaBack, G0))
+        << "zeta^{1->0} and zeta^{0} should be identical";
 }
-
 
 TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnErdosRenyi) {
     count n = 100;
@@ -78,19 +80,19 @@ TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnErdosRenyi) {
     ClusteringGenerator clusteringGen;
     Partition singleton = clusteringGen.makeSingletonClustering(G);
 
-
     DEBUG("coarsening on singleton partition");
     ParallelPartitionCoarsening coarsening(G, singleton);
     coarsening.run();
     Graph Gcon = coarsening.getCoarseGraph();
 
-    assert (Gcon.checkConsistency());
+    assert(Gcon.checkConsistency());
 
     EXPECT_EQ(G.numberOfNodes(), Gcon.numberOfNodes())
-            << "graph contracted according to singleton clustering should have the same number of nodes as original";
+        << "graph contracted according to singleton clustering should have the same number of "
+           "nodes as original";
     EXPECT_EQ(G.numberOfEdges(), Gcon.numberOfEdges())
-            << "graph contracted according to singletons clustering should have the same number of nodes as original";
-
+        << "graph contracted according to singletons clustering should have the same number of "
+           "nodes as original";
 
     DEBUG("coarsening on random partition");
     count k = 2; // number of clusters in random clustering
@@ -100,11 +102,13 @@ TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnErdosRenyi) {
     Graph GconRand = coarsening2.getCoarseGraph();
 
     EXPECT_EQ(k, GconRand.numberOfNodes())
-            << "graph contracted according to random clustering should have the same number of nodes as there are clusters.";
-    EXPECT_EQ(k + 1, GconRand.numberOfEdges()) << "graph contracted according to random clustering should have k+1 clusters";
+        << "graph contracted according to random clustering should have the same number of nodes "
+           "as there are clusters.";
+    EXPECT_EQ(k + 1, GconRand.numberOfEdges())
+        << "graph contracted according to random clustering should have k+1 clusters";
 }
 
-TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnErdosRenyiWithGraphBuilder) {
+TEST_F(CoarseningGTest, testSequentialPartitionCoarseningOnErdosRenyi) {
     count n = 100;
 
     ErdosRenyiGenerator ERGen(n, 0.5);
@@ -113,29 +117,82 @@ TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnErdosRenyiWithGraphBuil
     ClusteringGenerator clusteringGen;
     Partition singleton = clusteringGen.makeSingletonClustering(G);
 
-
     DEBUG("coarsening on singleton partition");
-    ParallelPartitionCoarsening coarsening(G, singleton); // uses graph builder by default
+    ParallelPartitionCoarsening coarsening(G, singleton, false); // parallel by default
     coarsening.run();
     Graph Gcon = coarsening.getCoarseGraph();
 
-    assert (Gcon.checkConsistency());
+    assert(Gcon.checkConsistency());
 
     EXPECT_EQ(G.numberOfNodes(), Gcon.numberOfNodes())
-            << "graph contracted according to singleton clustering should have the same number of nodes as original";
+        << "graph contracted according to singleton clustering should have the same number of "
+           "nodes as original";
     EXPECT_EQ(G.numberOfEdges(), Gcon.numberOfEdges())
-            << "graph contracted according to singletons clustering should have the same number of nodes as original";
+        << "graph contracted according to singletons clustering should have the same number of "
+           "nodes as original";
 
     DEBUG("coarsening on random partition");
     count k = 2; // number of clusters in random clustering
     Partition random = clusteringGen.makeRandomClustering(G, k);
-    ParallelPartitionCoarsening coarsening2(G, random);
+    ParallelPartitionCoarsening coarsening2(G, random, false);
     coarsening2.run();
     Graph GconRand = coarsening2.getCoarseGraph();
 
     EXPECT_EQ(k, GconRand.numberOfNodes())
-            << "graph contracted according to random clustering should have the same number of nodes as there are clusters.";
-    EXPECT_EQ(k + 1, GconRand.numberOfEdges()) << "graph contracted according to random clustering should have k+1 clusters";
+        << "graph contracted according to random clustering should have the same number of nodes "
+           "as there are clusters.";
+    EXPECT_EQ(k + 1, GconRand.numberOfEdges())
+        << "graph contracted according to random clustering should have k+1 clusters";
+}
+
+TEST_F(CoarseningGTest, testSequentialPartitionCoarseningEdgeWeights) {
+    METISGraphReader reader;
+    Graph G = reader.read("input/celegans_metabolic.graph");
+    G.addEdge(0, 0); // Add a self loop
+
+    ClusteringGenerator clusteringGen;
+    count k = 10; // number of clusters in random clustering
+    Partition random = clusteringGen.makeRandomClustering(G, k);
+
+    ParallelPartitionCoarsening coarsening(G, random, false);
+    coarsening.run();
+    Graph coarseGraph = coarsening.getCoarseGraph();
+
+    ASSERT_EQ(G.totalEdgeWeight(), coarseGraph.totalEdgeWeight());
+    std::vector<node> fineToCoarse = coarsening.getFineToCoarseNodeMapping();
+    for (const auto &cluster : random.getSubsets()) {
+        double degreeSum = 0.0;
+        for (node u : cluster) {
+            degreeSum += G.weightedDegree(u, true);
+        }
+        node coarseNode = fineToCoarse[*cluster.begin()];
+        ASSERT_EQ(degreeSum, coarseGraph.weightedDegree(coarseNode, true));
+    }
+}
+
+TEST_F(CoarseningGTest, testParallelPartitionCoarseningEdgeWeights) {
+    METISGraphReader reader;
+    Graph G = reader.read("input/celegans_metabolic.graph");
+    G.addEdge(0, 0); // Add a self loop
+
+    ClusteringGenerator clusteringGen;
+    count k = 10; // number of clusters in random clustering
+    Partition random = clusteringGen.makeRandomClustering(G, k);
+
+    ParallelPartitionCoarsening coarsening(G, random, false);
+    coarsening.run();
+    Graph coarseGraph = coarsening.getCoarseGraph();
+
+    ASSERT_EQ(G.totalEdgeWeight(), coarseGraph.totalEdgeWeight());
+    std::vector<node> fineToCoarse = coarsening.getFineToCoarseNodeMapping();
+    for (const auto &cluster : random.getSubsets()) {
+        double degreeSum = 0.0;
+        for (node u : cluster) {
+            degreeSum += G.weightedDegree(u, true);
+        }
+        node coarseNode = fineToCoarse[*cluster.begin()];
+        ASSERT_EQ(degreeSum, coarseGraph.weightedDegree(coarseNode, true));
+    }
 }
 
 TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnRealGraph) {
@@ -158,19 +215,20 @@ TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnRealGraph) {
     Graph Gseq = seqCoarsening.getCoarseGraph();
     EXPECT_EQ(k, Gseq.numberOfNodes());
 
-    EXPECT_EQ(Gseq.numberOfEdges(), Gpar.numberOfEdges()) << "sequential and parallel coarsening should produce the same number of edges";
+    EXPECT_EQ(Gseq.numberOfEdges(), Gpar.numberOfEdges())
+        << "sequential and parallel coarsening should produce the same number of edges";
 
     auto parMapping = parCoarsening.getFineToCoarseNodeMapping();
     auto seqMapping = seqCoarsening.getFineToCoarseNodeMapping();
     Gseq.forNodes([&](node u) {
         EXPECT_EQ(Gseq.degree(u), Gpar.degree(u)) << "node degrees should be equal for node " << u;
-        EXPECT_EQ(Gseq.weightedDegree(u), Gpar.weightedDegree(u)) << "Weighted degrees should be equald for node " << u;
+        EXPECT_EQ(Gseq.weightedDegree(u), Gpar.weightedDegree(u))
+            << "Weighted degrees should be equald for node " << u;
         EXPECT_EQ(parMapping[u], seqMapping[u]) << "mapping is equal";
     });
-
 }
 
-TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnRealGraphWithGraphBuilder) {
+TEST_F(CoarseningGTest, testPartitionCoarseningOnRealGraph) {
     METISGraphReader reader;
     Graph G = reader.read("input/celegans_metabolic.graph");
 
@@ -188,18 +246,20 @@ TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnRealGraphWithGraphBuild
     Graph Gseq = seqCoarsening.getCoarseGraph();
     EXPECT_EQ(random.numberOfSubsets(), Gseq.numberOfNodes());
 
-    EXPECT_EQ(Gseq.numberOfEdges(), Gpar.numberOfEdges()) << "sequential and parallel coarsening should produce the same number of edges";
+    EXPECT_EQ(Gseq.numberOfEdges(), Gpar.numberOfEdges())
+        << "sequential and parallel coarsening should produce the same number of edges";
 
     auto parMapping = parCoarsening.getFineToCoarseNodeMapping();
     auto seqMapping = seqCoarsening.getFineToCoarseNodeMapping();
     Gseq.forNodes([&](node u) {
         EXPECT_EQ(Gseq.degree(u), Gpar.degree(u)) << "node degrees should be equal for node " << u;
-        EXPECT_EQ(Gseq.weightedDegree(u), Gpar.weightedDegree(u)) << "Weighted degrees should be equal for node " << u;
+        EXPECT_EQ(Gseq.weightedDegree(u), Gpar.weightedDegree(u))
+            << "Weighted degrees should be equal for node " << u;
         EXPECT_EQ(parMapping[u], seqMapping[u]) << "mapping is equal";
     });
 }
 
-TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnRealGraphWithGraphBuilderAndLoops) {
+TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnRealGraphWithLoops) {
     METISGraphReader reader;
     Graph G = reader.read("input/celegans_metabolic.graph");
     G.addEdge(0, 0);
@@ -218,13 +278,15 @@ TEST_F(CoarseningGTest, testParallelPartitionCoarseningOnRealGraphWithGraphBuild
     Graph Gseq = seqCoarsening.getCoarseGraph();
     EXPECT_EQ(random.numberOfSubsets(), Gseq.numberOfNodes());
 
-    EXPECT_EQ(Gseq.numberOfEdges(), Gpar.numberOfEdges()) << "sequential and parallel coarsening should produce the same number of edges";
+    EXPECT_EQ(Gseq.numberOfEdges(), Gpar.numberOfEdges())
+        << "sequential and parallel coarsening should produce the same number of edges";
 
     auto parMapping = parCoarsening.getFineToCoarseNodeMapping();
     auto seqMapping = seqCoarsening.getFineToCoarseNodeMapping();
     Gseq.forNodes([&](node u) {
         EXPECT_EQ(Gseq.degree(u), Gpar.degree(u)) << "node degrees should be equal for node " << u;
-        EXPECT_EQ(Gseq.weightedDegree(u), Gpar.weightedDegree(u)) << "Weighted degrees should be equal for node " << u;
+        EXPECT_EQ(Gseq.weightedDegree(u), Gpar.weightedDegree(u))
+            << "Weighted degrees should be equal for node " << u;
         EXPECT_EQ(parMapping[u], seqMapping[u]) << "mapping is equal";
     });
 }
@@ -243,23 +305,23 @@ TEST_F(CoarseningGTest, testMatchingContractor) {
     Graph coarseG = coarsener.getCoarseGraph();
     std::vector<node> fineToCoarse = coarsener.getFineToCoarseNodeMapping();
 
-   EXPECT_GE(coarseG.numberOfNodes(), 0.5*G.numberOfNodes());
-   EXPECT_EQ(G.totalEdgeWeight(), coarseG.totalEdgeWeight());
-   if (G.numberOfEdges() > 0) {
-       EXPECT_LT(coarseG.numberOfNodes(), G.numberOfNodes());
-   }
+    EXPECT_GE(coarseG.numberOfNodes(), 0.5 * G.numberOfNodes());
+    EXPECT_EQ(G.totalEdgeWeight(), coarseG.totalEdgeWeight());
+    if (G.numberOfEdges() > 0) {
+        EXPECT_LT(coarseG.numberOfNodes(), G.numberOfNodes());
+    }
 }
 
 TEST_F(CoarseningGTest, testMatchingContractorWithSelfLoop) {
     Graph G(2, true);
-    G.addEdge(0,1,1);
-    G.addEdge(0,0,2);
+    G.addEdge(0, 1, 1);
+    G.addEdge(0, 0, 2);
 
     LocalMaxMatcher matcher(G);
     matcher.run();
     Matching matching = matcher.getMatching();
-    EXPECT_FALSE(matching.areMatched(0,0));
-    EXPECT_TRUE(matching.areMatched(1,0));
+    EXPECT_FALSE(matching.areMatched(0, 0));
+    EXPECT_TRUE(matching.areMatched(1, 0));
     ASSERT_TRUE(matching.isProper(G));
 
     MatchingCoarsening coarsener(G, matching);

--- a/networkit/cpp/components/ParallelConnectedComponents.cpp
+++ b/networkit/cpp/components/ParallelConnectedComponents.cpp
@@ -154,7 +154,7 @@ void ParallelConnectedComponents::runSequential() {
     }
     if (coarsening && numIterations == 8) { // TODO: externalize constant
         // coarsen and make recursive call
-        ParallelPartitionCoarsening con(*G, component, false);
+        ParallelPartitionCoarsening con(*G, component);
         con.run();
         auto Gcon = con.getCoarseGraph();
         ParallelConnectedComponents cc(Gcon);

--- a/networkit/cpp/structures/Partition.cpp
+++ b/networkit/cpp/structures/Partition.cpp
@@ -130,7 +130,7 @@ std::set<index> Partition::getMembers(index s) const {
     return subset;
 }
 
-std::vector<index> Partition::getVector() const {
+const std::vector<index> &Partition::getVector() const {
     return data;
 }
 


### PR DESCRIPTION
The algorithm generates all incident edges of a coarse vertex at the same time (on the same thread) and thus avoids linear searches in the neighbor lists.
This is the first in a potential series of pull-requests that contain the features from the 'huge' ego-splitting pull-request.

