### PR TITLE
Refactor edgelistwriter

### DIFF
--- a/networkit/cpp/io/CoverWriter.cpp
+++ b/networkit/cpp/io/CoverWriter.cpp
@@ -20,7 +20,7 @@ void CoverWriter::write(Cover &zeta, const std::string &path) const {
         for (auto &v : nodes) {
             file << v << " ";
         }
-        file << std::endl;
+        file << '\n';
     }
 }
 

--- a/networkit/cpp/io/DGSReader.cpp
+++ b/networkit/cpp/io/DGSReader.cpp
@@ -119,7 +119,7 @@ void DGSReader::read(std::string path, GraphEventProxy& Gproxy) {
         std::cout << "nodeNames length " << nodeNames.size();
         std::map<std::string, node> ordered(nodeNames.begin(), nodeNames.end());
         for(auto it = ordered.begin(); it != ordered.end(); ++it)
-            std::cout << " contents " << it->second << std::endl;
+            std::cout << " contents " << it->second << '\n';
     }
 }
 

--- a/networkit/cpp/io/EdgeListWriter.cpp
+++ b/networkit/cpp/io/EdgeListWriter.cpp
@@ -5,15 +5,17 @@
  *      Author: cls
  */
 
+// networkit-format
+
 #include <fstream>
 
 #include <networkit/auxiliary/Enforce.hpp>
-#include <networkit/auxiliary/Log.hpp>
 #include <networkit/io/EdgeListWriter.hpp>
 
 namespace NetworKit {
 
-EdgeListWriter::EdgeListWriter(char separator, node firstNode, bool bothDirections) : separator(separator), firstNode(firstNode), bothDirections(bothDirections) {}
+EdgeListWriter::EdgeListWriter(char separator, node firstNode, bool bothDirections)
+    : separator(separator), firstNode(firstNode), bothDirections(bothDirections) {}
 
 void EdgeListWriter::write(const Graph &G, const std::string &path) {
     std::ofstream file(path);
@@ -23,30 +25,25 @@ void EdgeListWriter::write(const Graph &G, const std::string &path) {
         file << (u + firstNode) << separator << (v + firstNode) << separator << weight << std::endl;
     };
 
-    auto writeUnweightedEdge = [&](node u, node v){
+    auto writeUnweightedEdge = [&](node u, node v) {
         file << (u + firstNode) << separator << (v + firstNode) << std::endl;
     };
 
     if (G.isWeighted()) {
         if (bothDirections) {
-            G.forNodes([&](node u) {
-                G.forEdgesOf(u, writeWeightedEdge);
-            });
+            G.forNodes([&](node u) { G.forEdgesOf(u, writeWeightedEdge); });
         } else {
             G.forEdges(writeWeightedEdge);
         }
     } else {
         if (bothDirections) {
-            G.forNodes([&](node u) {
-                G.forEdgesOf(u, writeUnweightedEdge);
-            });
+            G.forNodes([&](node u) { G.forEdgesOf(u, writeUnweightedEdge); });
         } else {
             G.forEdges(writeUnweightedEdge);
         }
     }
 
     file.close();
-
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/io/EdgeListWriter.cpp
+++ b/networkit/cpp/io/EdgeListWriter.cpp
@@ -22,11 +22,11 @@ void EdgeListWriter::write(const Graph &G, const std::string &path) {
     Aux::enforceOpened(file);
 
     auto writeWeightedEdge = [&](node u, node v, edgeweight weight) {
-        file << (u + firstNode) << separator << (v + firstNode) << separator << weight << std::endl;
+        file << (u + firstNode) << separator << (v + firstNode) << separator << weight << '\n';
     };
 
     auto writeUnweightedEdge = [&](node u, node v) {
-        file << (u + firstNode) << separator << (v + firstNode) << std::endl;
+        file << (u + firstNode) << separator << (v + firstNode) << '\n';
     };
 
     if (G.isWeighted()) {

--- a/networkit/cpp/io/GraphIO.cpp
+++ b/networkit/cpp/io/GraphIO.cpp
@@ -17,10 +17,9 @@ void GraphIO::writeEdgeList(const Graph &G, const std::string &path) {
     std::ofstream file;
     file.open(path.c_str());
 
-    G.forEdges([&](const node v, const node w) { file << v << " " << w << std::endl; });
+    G.forEdges([&](const node v, const node w) { file << v << " " << w << '\n'; });
 
     file.close();
-    INFO("wrote graph to file: ", path);
 }
 
 void GraphIO::writeAdjacencyList(const Graph &G, const std::string &path) {
@@ -30,9 +29,8 @@ void GraphIO::writeAdjacencyList(const Graph &G, const std::string &path) {
     G.forNodes([&](const node v) {
         file << v;
         G.forNeighborsOf(v, [&](const node x) { file << " " << x; });
-        file << std::endl;
+        file << '\n';
     });
-    INFO("wrote graph to file: ", path);
 }
 
 } /* namespace NetworKit */


### PR DESCRIPTION
As suggested in #754, `std::endl` may degrade the performance of graph writers. This PR replaces `std::endl` with `\n` in the `io` module,
Closes #754 