### PR TITLE
Fix EdgeListReader

### DIFF
--- a/networkit/cpp/io/EdgeListReader.cpp
+++ b/networkit/cpp/io/EdgeListReader.cpp
@@ -24,7 +24,7 @@ EdgeListReader::EdgeListReader(char separator, node firstNode, const std::string
     if (!continuous && firstNode != 0) {
         // firstNode not being 0 in the continuous = false case leads to a segmentation fault
         WARN("firstNode set to 0 since continuous is false");
-        firstNode = 0;
+        this->firstNode = 0;
     }
 }
 

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -84,6 +84,17 @@ TEST_F(IOGTest, testEdgeListWriter){
     EXPECT_EQ(G.numberOfEdges(),G2.numberOfEdges());
     EXPECT_EQ(G.isDirected(),G2.isDirected());
     EXPECT_EQ(G.isWeighted(),G2.isWeighted());
+
+    // If not continuous, firstNode should be set to 0 automatically
+    reader = EdgeListReader(' ', 1, "#", false, true);
+    Graph G3 = reader.read(path);
+    EXPECT_EQ(G.numberOfNodes(), G3.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), G3.numberOfEdges());
+    EXPECT_EQ(G.isDirected(), G3.isDirected());
+    EXPECT_EQ(G.isWeighted(), G3.isWeighted());
+    std::vector<node> nodes(G.nodeRange().begin(), G.nodeRange().end());
+    index i = 0;
+    G3.forNodes([&](node u) { EXPECT_EQ(u, nodes[i++]); });
 }
 
 TEST_F(IOGTest, testGraphIOEdgeList) {


### PR DESCRIPTION
In #727 we did not really fix the issue of `EdgeListReader` because https://github.com/networkit/networkit/blob/9128af222f2ddac8bfe079aa9697ed87026c39a9/networkit/cpp/io/EdgeListReader.cpp#L27 simply changes the input parameter of the constructor, not the actual class member. This PR:
- Performs the actual fix: `this->firstNode = 0;`
- Adds a test that triggers a segfault with the previous implementation