### PR TITLE
Fixes pre- and post-increment of NeighborIterator + minor fixes/additions

### DIFF
--- a/networkit/graph.pxd
+++ b/networkit/graph.pxd
@@ -93,10 +93,12 @@ cdef extern from "<networkit/graph/Graph.hpp>":
 		_EdgeWeightRange edgeWeightRange() except +
 		_OutNeighborRange neighborRange(node u) except +
 		_InNeighborRange inNeighborRange(node u) except +
+		_OutNeighborWeightRange weightNeighborRange(node u) except +
+		_InNeighborWeightRange weightInNeighborRange(node u) except +
 
 cdef extern from "<networkit/graph/Graph.hpp>":
 	cdef cppclass _NodeIterator "NetworKit::Graph::NodeIterator":
-		_NodeIterator operator++() except +
+		_NodeIterator& operator++() except +
 		_NodeIterator operator++(int) except +
 		bool_t operator!=(const _NodeIterator) except +
 		node operator*() except +
@@ -108,7 +110,7 @@ cdef extern from "<networkit/graph/Graph.hpp>":
 
 cdef extern from "<networkit/graph/Graph.hpp>":
 	cdef cppclass _EdgeWeightIterator "NetworKit::Graph::EdgeWeightIterator":
-		_EdgeWeightIterator operator++() except +
+		_EdgeWeightIterator& operator++() except +
 		_EdgeWeightIterator operator++(int) except +
 		bool_t operator!=(const _EdgeWeightIterator) except +
 		WeightedEdge operator*() except +
@@ -120,7 +122,7 @@ cdef extern from "<networkit/graph/Graph.hpp>":
 
 cdef extern from "<networkit/graph/Graph.hpp>":
 	cdef cppclass _EdgeIterator "NetworKit::Graph::EdgeIterator":
-		_EdgeIterator operator++() except +
+		_EdgeIterator& operator++() except +
 		_EdgeIterator operator++(int) except +
 		bool_t operator!=(const _EdgeIterator) except +
 		Edge operator*() except +
@@ -132,7 +134,7 @@ cdef extern from "<networkit/graph/Graph.hpp>":
 
 cdef extern from "<networkit/graph/Graph.hpp>":
 	cdef cppclass _NeighborIterator "NetworKit::Graph::NeighborIterator":
-		_NeighborIterator operator++() except +
+		_NeighborIterator& operator++() except +
 		_NeighborIterator operator++(int) except +
 		bool_t operator!=(const _NeighborIterator) except +
 		node operator*() except +
@@ -146,6 +148,23 @@ cdef extern from "<networkit/graph/Graph.hpp>":
 	cdef cppclass _InNeighborRange "NetworKit::Graph::InNeighborRange":
 		_NeighborIterator begin() except +
 		_NeighborIterator end() except +
+
+cdef extern from "<networkit/graph/Graph.hpp>":
+	cdef cppclass _NeighborWeightIterator "NetworKit::Graph::NeighborWeightIterator":
+		_NeighborWeightIterator& operator++() except +
+		_NeighborWeightIterator operator++(int) except +
+		bool_t operator!=(const _NeighborWeightIterator) except +
+		pair[node, edgeweight] operator*() except +
+
+cdef extern from "<networkit/graph/Graph.hpp>":
+	cdef cppclass _OutNeighborWeightRange "NetworKit::Graph::OutNeighborWeightRange":
+		_NeighborWeightIterator begin() except +
+		_NeighborWeightIterator end() except +
+
+cdef extern from "<networkit/graph/Graph.hpp>":
+	cdef cppclass _InNeighborWeightRange "NetworKit::Graph::InNeighborWeightRange":
+		_NeighborWeightIterator begin() except +
+		_NeighborWeightIterator end() except +
 
 cdef class Graph:
 	cdef _Graph _this

--- a/networkit/graph.pyx
+++ b/networkit/graph.pyx
@@ -612,6 +612,42 @@ cdef class Graph:
 			yield dereference(it)
 			preincrement(it)
 
+	def iterNeighborsWeights(self, u):
+		"""
+		Iterates over a range of the neighbors of a node including the edge weights.
+		The iterator is not safe to use with unweighted graphs. To avoid unsafe behavior
+		a runtime error will be thrown.
+
+		Parameters:
+		-----------
+		u : Node
+		"""
+		if not self._this.isWeighted():
+			raise RuntimeError("iterNeighborsWeights: Use this iterator only on weighted graphs.")
+		
+		it = self._this.weightNeighborRange(u).begin()
+		while it != self._this.weightNeighborRange(u).end():
+			yield dereference(it)
+			preincrement(it)		
+
+	def iterInNeighborsWeights(self, u):
+		"""
+		Iterates over a range of the in-neighbors of a node including the edge weights.
+		The iterator is not safe to use with unweighted graphs. To avoid unsafe behavior
+		a runtime error will be thrown.
+
+		Parameters:
+		-----------
+		u : Node
+		"""
+		if not self._this.isWeighted():
+			raise RuntimeError("iterInNeighborsWeights: Use this iterator only on weighted graphs.")
+
+		it = self._this.weightInNeighborRange(u).begin()
+		while it != self._this.weightInNeighborRange(u).end():
+			yield dereference(it)
+			preincrement(it)
+
 cdef cppclass EdgeCallBackWrapper:
 	void* callback
 	__init__(object callback):


### PR DESCRIPTION
This PR includes the following:

- Fix pre- and post-increment of `NeighborIterator` (fixes error on CI with #734)
- Change to return-by-reference for pre-increment operator of all graph-iterator types
- Add missing Cython-extension for `NeighborWeightRange`