### PR TITLE
Refactor: use vector comparator in Aux

### DIFF
--- a/include/networkit/auxiliary/VectorComparator.hpp
+++ b/include/networkit/auxiliary/VectorComparator.hpp
@@ -3,6 +3,7 @@
 #ifndef NETWORKIT_AUXILIARY_VECTOR_COMPARATOR_HPP_
 #define NETWORKIT_AUXILIARY_VECTOR_COMPARATOR_HPP_
 
+#include <cstdint>
 #include <vector>
 
 namespace Aux {

--- a/include/networkit/centrality/TopCloseness.hpp
+++ b/include/networkit/centrality/TopCloseness.hpp
@@ -99,23 +99,6 @@ private:
     void BFSbound(node x, std::vector<double> &S, count &visEdges,
                   const std::vector<bool> &toAnalyze);
     void computeReachable();
-
-    // Returns the node with highest farness
-    struct LargerFarness {
-        LargerFarness(const std::vector<double> &v_) : v(v_) {}
-        bool operator()(node x, node y) const noexcept { return v[x] > v[y]; }
-
-    private:
-        const std::vector<double> &v;
-    };
-
-    struct SmallerFarness {
-        SmallerFarness(const std::vector<double> &v_) : v(v_) {}
-        bool operator()(node x, node y) const noexcept { return v[x] < v[y]; }
-
-    private:
-        const std::vector<double> &v;
-    };
 };
 
 inline std::vector<node> TopCloseness::topkNodesList(bool includeTrail) {

--- a/include/networkit/centrality/TopHarmonicCloseness.hpp
+++ b/include/networkit/centrality/TopHarmonicCloseness.hpp
@@ -12,6 +12,7 @@
 
 #include <memory>
 
+#include <networkit/auxiliary/VectorComparator.hpp>
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/components/WeaklyConnectedComponents.hpp>
 #include <networkit/graph/Graph.hpp>
@@ -106,26 +107,13 @@ private:
         }
     }
 
-    template <class Type>
-    struct Greater {
-        Greater(const std::vector<Type> &vec) : vec(&vec) {}
-        bool operator()(node u, node v) const noexcept { return (*vec)[u] > (*vec)[v]; }
-        const std::vector<Type> *vec;
-    };
-
-    template <class Type>
-    struct Less {
-        Less(const std::vector<Type> &vec) : vec(&vec) {}
-        bool operator()(node u, node v) const noexcept { return (*vec)[u] < (*vec)[v]; }
-        const std::vector<Type> *vec;
-    };
-
-    tlx::d_ary_addressable_int_heap<node, 2, Greater<double>> prioQ;
-    tlx::d_ary_addressable_int_heap<node, 2, Less<double>> topKNodesPQ;
+    tlx::d_ary_addressable_int_heap<node, 2, Aux::GreaterInVector<double>> prioQ;
+    tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<double>> topKNodesPQ;
     std::vector<node> trail;
 
     // For weighted graphs
-    std::vector<tlx::d_ary_addressable_int_heap<node, 2, Less<edgeweight>>> dijkstraHeaps;
+    std::vector<tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<edgeweight>>>
+        dijkstraHeaps;
     std::vector<std::vector<edgeweight>> distanceGlobal;
     edgeweight minEdgeWeight;
 

--- a/include/networkit/distance/BidirectionalDijkstra.hpp
+++ b/include/networkit/distance/BidirectionalDijkstra.hpp
@@ -10,6 +10,7 @@
 #ifndef NETWORKIT_DISTANCE_BIDIRECTIONAL_DIJKSTRA_HPP_
 #define NETWORKIT_DISTANCE_BIDIRECTIONAL_DIJKSTRA_HPP_
 
+#include <networkit/auxiliary/VectorComparator.hpp>
 #include <networkit/distance/STSP.hpp>
 
 #include <tlx/container/d_ary_addressable_int_heap.hpp>
@@ -53,15 +54,6 @@ private:
 
     void buildPaths(std::stack<std::deque<node>> &pathStack);
 
-    struct Compare {
-    public:
-        Compare(const std::vector<edgeweight> &dist) : dist(dist) {}
-        bool operator()(node u, node v) { return dist[u] < dist[v]; }
-
-    private:
-        const std::vector<edgeweight> &dist;
-    };
-
     struct CompareST {
     public:
         CompareST(const std::vector<edgeweight> &d1, const std::vector<edgeweight> &d2)
@@ -72,8 +64,8 @@ private:
         const std::vector<edgeweight> &d1, &d2;
     };
 
-    tlx::d_ary_addressable_int_heap<node, 2, Compare> h1{Compare(dist1)};
-    tlx::d_ary_addressable_int_heap<node, 2, Compare> h2{Compare(dist2)};
+    tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<edgeweight>> h1{dist1};
+    tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<edgeweight>> h2{dist2};
     tlx::d_ary_addressable_int_heap<node, 2, CompareST> stH{CompareST(dist1, dist2)};
 };
 } // namespace NetworKit

--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -12,6 +12,7 @@
 #include <stack>
 
 #include <networkit/auxiliary/Log.hpp>
+#include <networkit/auxiliary/VectorComparator.hpp>
 #include <networkit/centrality/TopCloseness.hpp>
 #include <networkit/graph/BFS.hpp>
 #include <networkit/reachability/ReachableNodes.hpp>
@@ -321,7 +322,7 @@ double TopCloseness::BFScut(node v, double x, std::vector<bool> &visited,
 
 void TopCloseness::run() {
     init();
-    tlx::d_ary_heap<node, 2, LargerFarness> top{farness};
+    tlx::d_ary_heap<node, 2, Aux::GreaterInVector<double>> top{farness};
     top.reserve(k);
     std::vector<bool> toAnalyze(n, true);
     omp_lock_t lock;
@@ -344,7 +345,7 @@ void TopCloseness::run() {
             farness[u] = -(static_cast<double>(G.degreeOut(u)));
         }
     });
-    tlx::d_ary_addressable_int_heap<node, 2, SmallerFarness> Q{farness};
+    tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<double>> Q{farness};
 
     std::vector<node> nodes;
     nodes.reserve(G.numberOfNodes());

--- a/networkit/cpp/centrality/TopHarmonicCloseness.cpp
+++ b/networkit/cpp/centrality/TopHarmonicCloseness.cpp
@@ -20,8 +20,8 @@
 namespace NetworKit {
 
 TopHarmonicCloseness::TopHarmonicCloseness(const Graph &G, count k, bool useNBbound)
-    : G(&G), k(k), useNBbound(useNBbound), prioQ(Greater<double>{hCloseness}),
-      topKNodesPQ(Less<double>{hCloseness}) {
+    : G(&G), k(k), useNBbound(useNBbound), prioQ(Aux::GreaterInVector<double>{hCloseness}),
+      topKNodesPQ(Aux::LessInVector<double>{hCloseness}) {
 
     if (k == 0 || k > G.numberOfNodes())
         throw std::runtime_error("Error: k must be in [1,...,n].");
@@ -38,7 +38,7 @@ TopHarmonicCloseness::TopHarmonicCloseness(const Graph &G, count k, bool useNBbo
         distanceGlobal.resize(omp_get_max_threads(), std::vector<edgeweight>(n));
         dijkstraHeaps.reserve(omp_get_max_threads());
         for (int i = 0; i < omp_get_max_threads(); ++i)
-            dijkstraHeaps.emplace_back(Less<edgeweight>{distanceGlobal[i]});
+            dijkstraHeaps.emplace_back(Aux::LessInVector<edgeweight>{distanceGlobal[i]});
         minEdgeWeight = std::numeric_limits<edgeweight>::max();
         G.forEdges([&](node, node, edgeweight ew) { minEdgeWeight = std::min(minEdgeWeight, ew); });
     } else {

--- a/networkit/cpp/distance/BidirectionalDijkstra.cpp
+++ b/networkit/cpp/distance/BidirectionalDijkstra.cpp
@@ -60,7 +60,8 @@ void BidirectionalDijkstra::run() {
     std::stack<std::deque<node>> pathsToBuild;
 
     // Expands a ball; idx is the ball index (either 0 or 1<<7)
-    auto expand = [&](tlx::d_ary_addressable_int_heap<node, 2, Compare> &h, uint8_t idx) {
+    auto expand = [&](tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<edgeweight>> &h,
+                      uint8_t idx) {
         node u = h.extract_top();
         if (ts != (visited[u] & ~ballMask)) {
             // u not visited yet

--- a/networkit/cpp/graph/test/TraversalGTest.cpp
+++ b/networkit/cpp/graph/test/TraversalGTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <networkit/auxiliary/VectorComparator.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/graph/BFS.hpp>
 #include <networkit/graph/DFS.hpp>
@@ -151,20 +152,9 @@ TEST_P(TraversalGTest, testDijkstraFrom) {
     }
 
     auto dijkstra = [&](const Graph &G, const std::vector<node> &sources) {
-        struct CompareDistance {
-            CompareDistance(const std::vector<edgeweight> &distance) : distance(distance) {}
-
-            bool operator()(const node x, const node y) const noexcept {
-                return distance[x] < distance[y];
-            }
-
-        private:
-            const std::vector<edgeweight> &distance;
-        };
-
         std::vector<edgeweight> distance(G.upperNodeIdBound(),
                                          std::numeric_limits<edgeweight>::max());
-        tlx::d_ary_addressable_int_heap<node, 2, CompareDistance> heap{CompareDistance(distance)};
+        tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<edgeweight>> heap{distance};
         for (const auto u : sources) {
             distance[u] = 0;
             heap.push(u);

--- a/networkit/cpp/scd/LocalTightnessExpansion.cpp
+++ b/networkit/cpp/scd/LocalTightnessExpansion.cpp
@@ -6,6 +6,7 @@
 #include <tlx/container/d_ary_addressable_int_heap.hpp>
 #include <tlx/unused.hpp>
 
+#include <networkit/auxiliary/VectorComparator.hpp>
 #include <networkit/scd/LocalTightnessExpansion.hpp>
 
 #include "LocalDegreeDirectedGraph.hpp"
@@ -114,16 +115,8 @@ std::set<node> expandSeedSetInternal(const Graph &g, const std::set<node> &s, do
     std::vector<bool> inShell;
 
     // heap that contains the nodes of the shell that still need to be considered
-    class Compare {
-        const std::vector<double> &similarity;
-
-    public:
-        Compare(const std::vector<double> &similarity) : similarity(similarity) {}
-
-        bool operator()(node u, node v) { return similarity[u] > similarity[v]; }
-    };
-
-    tlx::d_ary_addressable_int_heap<node, 4, Compare> shell((Compare(nodeInternalSimilarity)));
+    tlx::d_ary_addressable_int_heap<node, 4, Aux::GreaterInVector<double>> shell{
+        nodeInternalSimilarity};
 
     double internalSimilarity = 0;
     double externalSimilarity = 0;

--- a/networkit/cpp/scd/TCE.cpp
+++ b/networkit/cpp/scd/TCE.cpp
@@ -6,6 +6,7 @@
 #include <tlx/container/d_ary_addressable_int_heap.hpp>
 #include <tlx/unused.hpp>
 
+#include <networkit/auxiliary/VectorComparator.hpp>
 #include <networkit/scd/TCE.hpp>
 
 #include "LocalDegreeDirectedGraph.hpp"
@@ -56,16 +57,7 @@ std::set<node> expandSeedSetInternal(const Graph &g, const std::set<node> &s, bo
     std::vector<bool> inResult;
 
     // heap that contains the nodes of the shell that still need to be considered
-    class Compare {
-        const std::vector<double> &similarity;
-
-    public:
-        Compare(const std::vector<double> &similarity) : similarity(similarity) {}
-
-        bool operator()(node u, node v) const { return similarity[u] > similarity[v]; }
-    };
-
-    tlx::d_ary_addressable_int_heap<node, 4, Compare> shell((Compare(nodeScore)));
+    tlx::d_ary_addressable_int_heap<node, 4, Aux::GreaterInVector<double>> shell{nodeScore};
 
     // data structures only for neighbors of a node
     std::vector<double> triangleSum;


### PR DESCRIPTION
This PR replaces custom vector-based comparators with the ones implemented in `Aux`.