### PR TITLE
Collection of small fixes / improvements for CMake and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,7 @@ jobs:
       - name: Prepare environment and run checks
         run:  ${{ github.workspace }}/.github/workflows/scripts/core_sanitizers_coverage.sh
         shell: bash
+        timeout-minutes: 60
       - name: Update Coveralls
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
     strategy:
       matrix:
         os: ['10.15']  # 11.0 temp. removed due to errors in preview image / git actions pipelines
-        compiler: ['clang-12', 'gcc-10']
+        compiler: ['clang-12', 'gcc-11']
     continue-on-error: ${{ matrix.os == '11.0' }}
     steps:
       - name: Install prerequisites
@@ -153,10 +153,10 @@ jobs:
           brew reinstall llvm@12
           brew link --overwrite llvm@12
       - name: Install compiler gcc
-        if: matrix.compiler == 'gcc-10'
+        if: matrix.compiler == 'gcc-11'
         run: |
-          brew reinstall gcc@10
-          brew link --overwrite gcc@10
+          brew reinstall gcc@11
+          brew link --overwrite gcc@11
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:
@@ -165,22 +165,24 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
         shell: bash
         env:
-          CC: ${{ matrix.compiler == 'clang-12' && '/usr/local/opt/llvm@12/bin/clang' || 'gcc-10' }}
-          CXX: ${{ matrix.compiler == 'clang-12' && '/usr/local/opt/llvm@12/bin/clang++' || 'g++-10' }}
+          CC: ${{ matrix.compiler == 'clang-12' && '/usr/local/opt/llvm@12/bin/clang' || 'gcc-11' }}
+          CXX: ${{ matrix.compiler == 'clang-12' && '/usr/local/opt/llvm@12/bin/clang++' || 'g++-11' }}
 
   linux-build-latest:
-    name: "Linux (gcc-10${{ startsWith(matrix.build-configuration, 'full') && ', CPython 3.9' || '' }}): ${{ matrix.build-configuration }}"
+    name: "Linux (gcc-11${{ startsWith(matrix.build-configuration, 'full') && ', CPython 3.9' || '' }}): ${{ matrix.build-configuration }}"
     runs-on: ubuntu-20.04
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc-11
+      CXX: g++-11
     strategy:
       matrix:
         build-configuration: ['full', 'full (native)', 'core (non-monolithic)', 'core (C++20)']
     steps:
       - name: Install prerequisites
         run:  |
-          sudo apt-get install ninja-build
+          sudo add-apt-repository 'deb http://mirrors.kernel.org/ubuntu hirsute main universe'
+          sudo apt-get update
+          sudo apt-get install gcc-11 g++-11 ninja-build
       - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,17 +237,17 @@ jobs:
 
   linux-build-min-support:
     name: "Linux (${{ matrix.compiler }}, CPython 3.6): full"
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
-        compiler: ['gcc-5', 'clang-3.9']
+        compiler: ['gcc-6', 'clang-3.9']
     steps:
       - name: Install prerequisites
         run:  |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install ninja-build
           sudo apt-get install libomp5 libomp-dev clang-3.9 clang++-3.9
+          sudo apt-get install gcc-6 g++-6
       - name: Setup Python 3.6
         uses: actions/setup-python@v2
         with:
@@ -265,8 +265,8 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
         shell: bash
         env:
-          CC: ${{ matrix.compiler == 'gcc-5' && 'gcc-5' || 'clang-3.9' }}
-          CXX: ${{ matrix.compiler == 'gcc-5' && 'g++-5' || 'clang++-3.9' }}
+          CC: ${{ matrix.compiler == 'gcc-6' && 'gcc-6' || 'clang-3.9' }}
+          CXX: ${{ matrix.compiler == 'gcc-6' && 'g++-6' || 'clang++-3.9' }}
 
   linux-build-clang-tidy:
     name: "Linux (clang-12): clang-tidy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,9 +298,8 @@ jobs:
     steps:
       - name: Install prerequisites
         run:  |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ninja-build gcc-10 g++-10
+          sudo apt-get install ninja-build
       - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
@@ -400,7 +399,6 @@ jobs:
     steps:
       - name: Install prerequisites
         run:  |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install doxygen pandoc
       - name: Checkout networkit

--- a/.github/workflows/scripts/documentation.sh
+++ b/.github/workflows/scripts/documentation.sh
@@ -9,7 +9,7 @@ pip3 install --upgrade pip
 pip3 install cython
 
 # Several modules are required to build the documentation.
-pip3 install sphinx sphinx_bootstrap_theme numpydoc exhale nbsphinx breathe
+pip3 install 'sphinx<4.1' sphinx_bootstrap_theme numpydoc exhale nbsphinx breathe
 pip3 install sphinx_copybutton sphinxcontrib.bibtex sphinx_gallery sphinx_last_updated_by_git 
 pip3 install ipykernel ipython matplotlib nbconvert jupyter-client networkx tabulate
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,9 @@ if(NETWORKIT_PYTHON)
 					OUTPUT_NAME "${TARGET_LIB}.${NETWORKIT_PYTHON_SOABI}")
 		if(WIN32)
 			set_target_properties(${TARGET_LIB} PROPERTIES SUFFIX .pyd)
+			# Linking against Python3_libs is only neccessary on Windows. On other OSes 
+			# this can lead to segmentation faults when importing NetworKit in Python.
+			target_link_libraries(${TARGET_LIB} PRIVATE ${Python3_LIBRARIES})
 		endif()
 
 		# If rpath-content is set explicitly, omit the dynamic binary path
@@ -351,7 +354,6 @@ if(NETWORKIT_PYTHON)
 		endif()
 
 		target_link_libraries(${TARGET_LIB} PRIVATE OpenMP::OpenMP_CXX PUBLIC tlx)
-		target_link_libraries(${TARGET_LIB} PRIVATE ${Python3_LIBRARIES})
 
 		install(TARGETS ${TARGET_LIB}
 			LIBRARY DESTINATION "${NETWORKIT_LIB_DEST}/networkit")


### PR DESCRIPTION
This PR includes the following:

- Fixing the documentation build by pinning sphinx to `<4.1` due to an incompatibility with breathe. This is currently worked on: https://github.com/michaeljones/breathe/pull/711 and https://github.com/sphinx-doc/sphinx/issues/9433
- Linking `Python3_libraries` for cython-extensions is only necessary for Windows. While there seems to be no problem with Linux, on macOS this can lead to segmentation faults on certain compiler/lib-combinations (e.g. `conda`) when importing NetworKit. Therefore it is removed for the other OSes.
- Github Actions: 
  - Raising minimum version of gcc to version 6. Also switching from Ubuntu 16.04 to 18.04, since packages are natively available in this distro (universe repo) and 16.04 will deprecate in September 2021.
  - Raising latest gcc to 11. For Ubuntu-images this is done by importing repos from Hirsute, since there is no PPA or gcc-11 in Github runners or base 20.04.
  - Removing unnecessary repos from Linux-builds
  - Adding a timeout to the googletest-step from the coverage-build. Occasionally single test-steps takes too long and get killed by CI (only for combination debug + coverage). Normally it takes 20-30 min, adding a timeout of 60 min should give enough space and seems to diminish this problem.