### PR TITLE
link fix to notebooks Dev/notebooks -> master/notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ in NetworKit, and simply using NetworKit. We ask you to cite the appropriate one
 [list]: https://sympa.cms.hu-berlin.de/sympa/subscribe/networkit
 [networkit]: https://networkit.github.io/
 [IPython]: https://ipython.readthedocs.io/en/stable/
-[NetworKit UserGuide]: https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb
-[notebooks]: https://github.com/networkit/networkit/blob/Dev/notebooks/
+[NetworKit UserGuide]: https://github.com/networkit/networkit/blob/master/notebooks/User-Guide.ipynb
+[notebooks]: https://github.com/networkit/networkit/blob/master/notebooks/
 [g++]: https://gcc.gnu.org
 [clang++]: https://clang.llvm.org/
 [Pip]: https://pypi.python.org/pypi/pip

--- a/networkit/__init__.py
+++ b/networkit/__init__.py
@@ -20,7 +20,7 @@ and integration into the Python ecosystem of tools for data analysis and
 scientific computation.
 
 
-Usage examples can be found on https://github.com/networkit/networkit/blob/Dev/notebooks/User-Guide.ipynb
+Usage examples can be found on https://github.com/networkit/networkit/blob/master/notebooks/User-Guide.ipynb
 """
 
 __author__ = "Christian Staudt"


### PR DESCRIPTION
Currently several links point to `Dev/notebooks` instead of `master/notebooks`.
This PR fixes things partially as I'm unsure where https://networkit.github.io/get_started.html is in this repository.
