### PR TITLE
Reduce desired number of Eigenvalues (scipy.linalg.eig), update Spectral Coloring

### DIFF
--- a/networkit/algebraic.py
+++ b/networkit/algebraic.py
@@ -7,6 +7,7 @@ __author__ = "Christian Staudt"
 
 # external imports
 import scipy.sparse
+from scipy.sparse import csgraph, linalg
 import numpy as np
 
 def column(matrix, i):
@@ -135,7 +136,7 @@ def symmetricEigenvectors(matrix, cutoff=-1, reverse=False):
 
 	"""
 	if cutoff == -1:
-		cutoff = matrix.shape[0] - 2
+		cutoff = matrix.shape[0] - 3
 
 	if reverse:
 		mode = "SA"
@@ -161,7 +162,7 @@ def eigenvectors(matrix, cutoff=-1, reverse=False):
 	matrix : sparse matrix
 			 The matrix to compute the eigenvectors of
 	cutoff : int
-			 The maximum (or minimum) magnitude of the eigenvectors needed
+			 The maximum (or minimum) number of eigenvectors needed
 	reverse : boolean
 			  If set to true, the smaller eigenvalues will be computed before the larger ones
 
@@ -173,7 +174,7 @@ def eigenvectors(matrix, cutoff=-1, reverse=False):
 
 	"""
 	if cutoff == -1:
-		cutoff = matrix.shape[0] - 2
+		cutoff = matrix.shape[0] - 3
 
 	if reverse:
 		mode = "SR"

--- a/networkit/coloring.py
+++ b/networkit/coloring.py
@@ -16,7 +16,7 @@ class SpectralColoring(object):
 
 	def valid(self, color):
 		for v in self.colors[color]:
-			for u in self.graph.neighbors(v):
+			for u in self.graph.iterNeighbors(v):
 				if u in self.colors[color]:
 					return False
 

--- a/networkit/test/test_coloring.py
+++ b/networkit/test/test_coloring.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+import unittest
+import os
+import networkit as nk
+
+class Test_Coloring(unittest.TestCase):
+
+	def test_SpectralColoring(self):
+		G = nk.readGraph("input/karate.graph", nk.Format.METIS)
+		spCol = nk.coloring.SpectralColoring(G)
+
+		spCol.run()
+
+		self.assertLessEqual(len(spCol.getColoring()), G.upperNodeIdBound())
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
This PR fixes problems with #796. Adds also an unit test for coloring-module.

Update: During tests with new arm-specific builds of scipy, I discovered that the submodule `linalg` is not anymore imported by default. Therefore changed includes in `algebraic.py` as a drive-by.

Closes #796 