### PR TITLE
Add support and documentation for arm64-apple-darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ While the most recent version is in general available for all package managers, 
 
     spack install py-networkit
 
+More system-specific information on how to install NetworKit on Linux, macOS (both Intel and M1) and Windows-systems can be found [here](https://networkit.github.io/get_started.html).
+
 ### Building the Python module from source
 
     git clone https://github.com/networkit/networkit networkit


### PR DESCRIPTION
This PR add support / documentation for arm64-apple-darwin when build from source.

Currently AppleClang + OpenMP (both `libomp` from brew and build from source) is not supported due to segmentation faults. This is also true for the clang-compiler package from brew. I suggest for now to officially support source build via conda environments (packages `compilers`+ `llvm-openmp` from miniforge), which is also what other data science Python packages recommend. 

Source:
https://github.com/numpy/numpy/issues/17807
https://github.com/scipy/scipy/issues/13364
https://scikit-learn.org/stable/install.html#installing-on-apple-silicon-m1-hardware

The build binary can still not be tested on CIs due to licensing problems. I can confirm however, that besides these building problems, all tests (gtests, Python unittests, Jupyter notebooks) succeed on a Macbook Pro M1.


