### PR TITLE
Added overloaded function that returns a reference instead of copying in Graphcoarsening

### DIFF
--- a/include/networkit/coarsening/GraphCoarsening.hpp
+++ b/include/networkit/coarsening/GraphCoarsening.hpp
@@ -31,12 +31,16 @@ public:
 
     void run() override = 0;
 
-    Graph getCoarseGraph() const;
+    const Graph& getCoarseGraph() const;
+
+    Graph& getCoarseGraph();
 
     /**
      * Get mapping from fine to coarse node.
      */
-    std::vector<node> getFineToCoarseNodeMapping() const;
+    const std::vector<node>& getFineToCoarseNodeMapping() const;
+
+    std::vector<node>& getFineToCoarseNodeMapping();
 
     /**
      * Get mapping from coarse node to collection of fine nodes.
@@ -47,7 +51,6 @@ protected:
     const Graph* G;
     Graph Gcoarsened;
     std::vector<node> nodeMapping;
-
 };
 
 } // namespace

--- a/networkit/cpp/coarsening/GraphCoarsening.cpp
+++ b/networkit/cpp/coarsening/GraphCoarsening.cpp
@@ -14,20 +14,25 @@ GraphCoarsening::GraphCoarsening(const Graph& G) : Algorithm(), G(&G) {
 
 }
 
-Graph GraphCoarsening::getCoarseGraph() const {
-    if(!hasRun) {
-        throw std::runtime_error("Call run()-method first.");
-    }
+const Graph& GraphCoarsening::getCoarseGraph() const {
+    assureFinished();
     return Gcoarsened;
 }
 
-std::vector<node> GraphCoarsening::getFineToCoarseNodeMapping() const {
-    if(!hasRun) {
-        throw std::runtime_error("Call run()-method first.");
-    }
+Graph& GraphCoarsening::getCoarseGraph() {
+    assureFinished();
+    return Gcoarsened;
+}
+
+const std::vector<node>& GraphCoarsening::getFineToCoarseNodeMapping() const {
+    assureFinished();
     return nodeMapping;
 }
 
+std::vector<node>& GraphCoarsening::getFineToCoarseNodeMapping() {
+    assureFinished();
+    return nodeMapping;
+}
 
 std::map<node, std::vector<node> > GraphCoarsening::getCoarseToFineNodeMapping() const {
     assureFinished();
@@ -37,7 +42,6 @@ std::map<node, std::vector<node> > GraphCoarsening::getCoarseToFineNodeMapping()
         std::vector<node> empty;
         reverseMap[v_] = empty;
     });
-
 
     G->forNodes([&](node v) {
         node v_ = nodeMapping[v];


### PR DESCRIPTION
As discussed in https://github.com/networkit/networkit/issues/801
Avoids copies, and allows the graph to be moved.

Perhaps there should be a check that makes sure the graph hasnt been moved or changed if a call to `getCoarseToFineNodeMapping` is made, but im not sure how that would work.