### PR TITLE
Refactor: use vector comparator in Dijkstra

### DIFF
--- a/include/networkit/distance/Dijkstra.hpp
+++ b/include/networkit/distance/Dijkstra.hpp
@@ -11,6 +11,7 @@
 
 #include <tlx/container/d_ary_addressable_int_heap.hpp>
 
+#include <networkit/auxiliary/VectorComparator.hpp>
 #include <networkit/distance/SSSP.hpp>
 
 namespace NetworKit {
@@ -43,17 +44,7 @@ public:
     void run() override;
 
 private:
-    struct Compare {
-    public:
-        Compare(const std::vector<double> &dist_) : dist(dist_) {}
-
-        bool operator()(node x, node y) const { return dist[x] < dist[y]; }
-
-    private:
-        const std::vector<double> &dist;
-    };
-
-    tlx::d_ary_addressable_int_heap<node, 2, Compare> heap;
+    tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<double>> heap;
 };
 
 } /* namespace NetworKit */

--- a/networkit/cpp/distance/Dijkstra.cpp
+++ b/networkit/cpp/distance/Dijkstra.cpp
@@ -15,7 +15,7 @@ namespace NetworKit {
 Dijkstra::Dijkstra(const Graph &G, node source, bool storePaths,
                    bool storeNodesSortedByDistance, node target)
     : SSSP(G, source, storePaths, storeNodesSortedByDistance, target),
-      heap(Compare(distances)) {}
+      heap(Aux::LessInVector<double>{distances}) {}
 
 void Dijkstra::run() {
 


### PR DESCRIPTION
Replace custom vector-based comparator in `Dijkstra` with the one implemented in `Aux`.