### PR TITLE
Fix to call subgraphFromNodes

### DIFF
--- a/networkit/sampling.py
+++ b/networkit/sampling.py
@@ -23,5 +23,5 @@ def bfsSample(G, source=None, k = 50):
                 closest.add(v)
         G.forEdgesOf(u, enqueue)
     print("found {0} nodes".format(len(closest)))
-    G1 = G.subgraphFromNodes(closest)
+    G1 = nk.graphtools.subgraphFromNodes(G, closest)
     return G1


### PR DESCRIPTION
`subgraphFromNodes()` function was moved from the `graph`-module to the `graphtools`-module [in NetworKit 8.0](https://github.com/networkit/networkit/blob/master/CHANGES.md#changes-in-python-interface). But there was one thing missing, so I fixed it.