### PR TITLE
Refactor PageRank: Add sink handling for directed graphs, fix norm-PageRank

### DIFF
--- a/include/networkit/centrality/PageRank.hpp
+++ b/include/networkit/centrality/PageRank.hpp
@@ -18,7 +18,19 @@ namespace NetworKit {
 
 /**
  * @ingroup centrality
- * Compute PageRank as node centrality measure.
+ * Compute PageRank as node centrality measure. In the default mode this computation is in line
+ * with the original paper "The PageRank citation ranking: Bringing order to the web." by L. Brin et
+ * al (1999). In later publications ("PageRank revisited." by M. Brinkmeyer et al. (2005) amongst
+ * others) sink-node handling was added for directed graphs in order to comply with the theoretical
+ * assumptions by the underlying Markov chain model. This can be activated by setting the matching
+ * parameter to true. By default this is disabled, since it is an addition to the original
+ * definition.
+ *
+ * Page-Rank values can also be normalized by post-processed according to "Comparing Apples and
+ * Oranges: Normalized PageRank for Evolving Graphs" by Berberich et al. (2007). This decouples
+ * the PageRank values from the size of the input graph. To enable this, set the matching parameter
+ * to true. Note that sink-node handling is automatically activated if normalization is used.
+ *
  * NOTE: There is an inconsistency in the definition in Newman's book (Ch. 7) regarding
  * directed graphs; we follow the verbal description, which requires to sum over the incoming
  * edges (as opposed to outgoing ones).
@@ -27,6 +39,7 @@ class PageRank final : public Centrality {
 
 public:
     enum Norm { L1Norm, L2Norm };
+    enum SinkHandling { NO_SINK_HANDLING, DISTRIBUTE_SINKS };
 
     /**
      * Constructs the PageRank class for the Graph @a G
@@ -34,8 +47,13 @@ public:
      * @param[in] G Graph to be processed.
      * @param[in] damp Damping factor of the PageRank algorithm.
      * @param[in] tol Error tolerance for PageRank iteration.
+     * @param[in] distributeSinks Set to distribute PageRank values for sink nodes. (default =
+     * false)
+     * @param[in] normalized Set to normalize Page-Rank values in order to decouple it from the
+     * network size. (default = false)
      */
-    PageRank(const Graph &G, double damp = 0.85, double tol = 1e-8, bool normalized = false);
+    PageRank(const Graph &G, double damp = 0.85, double tol = 1e-8, bool normalized = false,
+             SinkHandling distributeSinks = SinkHandling::NO_SINK_HANDLING);
 
     /**
      * Computes page rank on the graph passed in constructor.
@@ -43,8 +61,7 @@ public:
     void run() override;
 
     /**
-     * Returns upper bound on the page rank: 1.0. This could be tighter by assuming e.g. a star
-     * graph with n nodes.
+     * Returns the maximum PageRank score
      */
     double maximum() override;
 
@@ -69,6 +86,7 @@ private:
     double tol;
     count iterations;
     bool normalized;
+    SinkHandling distributeSinks;
     std::atomic<double> max;
 };
 

--- a/networkit/cpp/centrality/PageRank.cpp
+++ b/networkit/cpp/centrality/PageRank.cpp
@@ -2,7 +2,8 @@
  * PageRank.cpp
  *
  *  Created on: 19.03.2014
- *      Author: Henning
+ *      Authors: Henning Meyerhenke
+ *               Fabian Brandt-Tumescheit <brandtfa@hu-berlin.de>
  */
 
 #include <networkit/auxiliary/NumericTools.hpp>
@@ -12,8 +13,10 @@
 
 namespace NetworKit {
 
-PageRank::PageRank(const Graph &G, double damp, double tol, bool normalized)
-    : Centrality(G, true), damp(damp), tol(tol), normalized(normalized) {}
+PageRank::PageRank(const Graph &G, double damp, double tol, bool normalized,
+                   SinkHandling distributeSinks)
+    : Centrality(G, true), damp(damp), tol(tol), normalized(normalized),
+      distributeSinks(distributeSinks) {}
 
 void PageRank::run() {
     Aux::SignalHandler handler;
@@ -21,11 +24,22 @@ void PageRank::run() {
     const auto z = G.upperNodeIdBound();
 
     const auto teleportProb = (1.0 - damp) / static_cast<double>(n);
+    const double factor = damp / static_cast<double>(n);
     scoreData.resize(z, 1.0 / static_cast<double>(n));
     std::vector<double> pr = scoreData;
 
     std::vector<double> deg(z, 0.0);
     G.parallelForNodes([&](const node u) { deg[u] = static_cast<double>(G.weightedDegree(u)); });
+
+    std::vector<node> sinks;
+    if (G.isDirected() && ((distributeSinks == SinkHandling::DISTRIBUTE_SINKS) || normalized)) {
+        G.forNodes([&](const node u) {
+            if (G.degree(u) == 0) {
+                sinks.push_back(u);
+            }
+        });
+    }
+    count nSinks = sinks.size();
 
     iterations = 0;
 
@@ -63,6 +77,19 @@ void PageRank::run() {
             pr[u] += teleportProb;
         });
 
+        // For directed graphs sink-handling is needed to fulfill |pr| == 1 in each step. Otherwise
+        // probability mass would be leaked, creating wrong results. For this, we add edges from
+        // sinks to all other nodes. This is described amongst others in "PageRank revisited."
+        // by M. Brinkmeyer et al. (2005).
+        if (G.isDirected() && ((distributeSinks == SinkHandling::DISTRIBUTE_SINKS) || normalized)) {
+            double totalSinkContrib = 0.0;
+#pragma omp parallel for reduction(+ : totalSinkContrib)
+            for (omp_index i = 0; i < static_cast<omp_index>(nSinks); i++) {
+                totalSinkContrib += factor * scoreData[sinks[i]];
+            }
+            G.balancedParallelForNodes([&](const node u) { pr[u] += totalSinkContrib; });
+        }
+
         ++iterations;
         isConverged = converged();
         std::swap(pr, scoreData);
@@ -70,34 +97,33 @@ void PageRank::run() {
 
     handler.assureRunning();
 
-    if (!normalized) {
-        const auto sum = G.parallelSumForNodes([&](const node u) { return scoreData[u]; });
-
-        // make sure scoreData sums up to 1
-        assert(!Aux::NumericTools::equal(sum, 0.0, 1e-15));
-        G.parallelForNodes([&](const node u) { scoreData[u] /= sum; });
-    } else {
-        // calculate sum of the Pagerank of dangling Nodes for normalization
-        const auto sum = G.parallelSumForNodes([&](const node u) {
-            if (G.degree(u) == 0.0)
-                return scoreData[u];
-            return 0.0;
-        });
-
-        const auto normFactor = (1.0 / n) * ((1 - damp) + (damp * sum));
-
+    // Post-processing for normalized PageRank
+    if (normalized) {
+        double normFactor;
+        if (G.isDirected()) {
+            // Calculate sum of dangling Nodes for normalization
+            double sum = 0.0;
+#pragma omp parallel for reduction(+ : sum)
+            for (omp_index i = 0; i < static_cast<omp_index>(nSinks); i++) {
+                sum += scoreData[sinks[i]];
+            }
+            normFactor = (1.0 / static_cast<double>(n)) * ((1.0 - damp) + (damp * sum));
+        } else {
+            normFactor = teleportProb;
+        }
         G.parallelForNodes([&](const node u) { scoreData[u] /= normFactor; });
-    }
 
-    // calculate the maxium
-    if (!normalized) {
-        max = 1.0; // upper bound, could be tighter by assuming e.g. a star graph with n nodes
+        // Post-processing for non-normalized PageRank
     } else {
-        max = scoreData[0]; // Unlike regular Page Rank there isn't a universal upper bound for
-                            // normalized page rank. So we need to iterate.
-        G.balancedParallelForNodes(
-            [&](const node u) { Aux::Parallel::atomic_max(max, scoreData[u]); });
+        if (G.isDirected() && distributeSinks == SinkHandling::NO_SINK_HANDLING) {
+            // In case no sink handling was done, make sure that |pr| == 1
+            const auto sum = G.parallelSumForNodes([&](const node u) { return scoreData[u]; });
+            G.parallelForNodes([&](const node u) { scoreData[u] /= sum; });
+        }
     }
+    // calculate the maxium
+    max = scoreData[0];
+    G.balancedParallelForNodes([&](const node u) { Aux::Parallel::atomic_max(max, scoreData[u]); });
     hasRun = true;
 }
 


### PR DESCRIPTION
This PR includes the following concerning PageRank:

- Adds sink-handling in order to properly fulfill the Markov chain model. See (among others): https://dl.acm.org/doi/pdf/10.1145/1151087.1151090
- Fixes an error with the normalized PageRank #720 (NPR). The result of NPR was wrong due to missing sink-handling - so this fix is more a drive-by.
- Adds documentation for new PageRank behavior and results
- Adjusting gtests accordingly