### PR TITLE
Add cibuildwheel script to create wheel-artifacts on GHA

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -1,0 +1,154 @@
+name: Wheel builder
+
+on: [push, pull_request]
+
+jobs:
+  cpython-linux-x86_64:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        cibw_archs: ["x86_64"]
+        manylinux_image: ["manylinux2010"]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.1.1
+        env:
+          CIBW_BEFORE_BUILD: pip install cython
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs }}
+          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+          CIBW_SKIP: pp*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp36-${{ matrix.manylinux_image}}-${{ matrix.cibw_archs }}.whl
+          path: ./wheelhouse/*cp36*.whl
+          retention-days: 14
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp37-${{ matrix.manylinux_image}}-${{ matrix.cibw_archs }}.whl
+          path: ./wheelhouse/*cp37*.whl
+          retention-days: 14
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp38-${{ matrix.manylinux_image}}-${{ matrix.cibw_archs }}.whl
+          path: ./wheelhouse/*cp38*.whl
+          retention-days: 14
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp39-${{ matrix.manylinux_image}}-${{ matrix.cibw_archs }}.whl
+          path: ./wheelhouse/*cp39*.whl
+          retention-days: 14
+
+  cpython-linux-aarch64:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        cibw_archs: ["aarch64"]
+        manylinux_image: ["manylinux2014"]
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.1.1
+        env:
+          CIBW_BEFORE_BUILD: pip install cython
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs }}
+          CIBW_BUILD: "cp39-*"
+          CIBW_SKIP: pp*
+      
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp39-${{ matrix.manylinux_image}}-${{ matrix.cibw_archs }}.whl
+          path: ./wheelhouse/*cp39*.whl
+          retention-days: 14
+
+  cpython-macos-x86_64:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-10.15]
+        cibw_archs: ["x86_64"]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.1.1
+        env:
+          CIBW_BEFORE_BUILD: 
+            pip install cython &&
+            brew install libomp ninja
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs }}
+          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+          CIBW_SKIP: pp*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp36-macos-${{ matrix.cibw_archs }}.whl
+          path: ./wheelhouse/*cp36*.whl
+          retention-days: 14
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp37-macos-${{ matrix.cibw_archs }}.whl
+          path: ./wheelhouse/*cp37*.whl
+          retention-days: 14
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp38-macos-${{ matrix.cibw_archs }}.whl
+          path: ./wheelhouse/*cp38*.whl
+          retention-days: 14
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp39-macos-${{ matrix.cibw_archs }}.whl
+          path: ./wheelhouse/*cp39*.whl
+          retention-days: 14
+
+  cpython-windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup devCmd (vstools)
+        uses: ilammy/msvc-dev-cmd@v1
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.1.2
+        env:
+          CIBW_BEFORE_BUILD: pip install cython ipython
+          CIBW_ARCHS: "AMD64"
+          CIBW_BUILD: "cp39-*"
+          CIBW_SKIP: pp*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp39-win-amd64.whl
+          path: ./wheelhouse/*cp39*.whl
+          retention-days: 14

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,10 @@
-name: Wheel builder
+name: Build wheels
 
 on: [push, pull_request]
+
+# Default parameters for all builds
+env:
+  ARTIFACT_RETENTION: ${{ github.ref == 'refs/heads/master' && '30' || '7' }}
 
 jobs:
   cpython-linux-x86_64:
@@ -30,22 +34,22 @@ jobs:
         with:
           name: networkit-cp36-${{ matrix.manylinux_image}}-${{ matrix.cibw_archs }}.whl
           path: ./wheelhouse/*cp36*.whl
-          retention-days: 14
+          retention-days: ${{ env.ARTIFACT_RETENTION }}
       - uses: actions/upload-artifact@v2
         with:
           name: networkit-cp37-${{ matrix.manylinux_image}}-${{ matrix.cibw_archs }}.whl
           path: ./wheelhouse/*cp37*.whl
-          retention-days: 14
+          retention-days: ${{ env.ARTIFACT_RETENTION }}
       - uses: actions/upload-artifact@v2
         with:
           name: networkit-cp38-${{ matrix.manylinux_image}}-${{ matrix.cibw_archs }}.whl
           path: ./wheelhouse/*cp38*.whl
-          retention-days: 14
+          retention-days: ${{ env.ARTIFACT_RETENTION }}
       - uses: actions/upload-artifact@v2
         with:
           name: networkit-cp39-${{ matrix.manylinux_image}}-${{ matrix.cibw_archs }}.whl
           path: ./wheelhouse/*cp39*.whl
-          retention-days: 14
+          retention-days: ${{ env.ARTIFACT_RETENTION }}
 
   cpython-linux-aarch64:
     runs-on: ${{ matrix.os }}
@@ -79,7 +83,7 @@ jobs:
         with:
           name: networkit-cp39-${{ matrix.manylinux_image}}-${{ matrix.cibw_archs }}.whl
           path: ./wheelhouse/*cp39*.whl
-          retention-days: 14
+          retention-days: ${{ env.ARTIFACT_RETENTION }}
 
   cpython-macos-x86_64:
     runs-on: ${{ matrix.os }}
@@ -108,22 +112,22 @@ jobs:
         with:
           name: networkit-cp36-macos-${{ matrix.cibw_archs }}.whl
           path: ./wheelhouse/*cp36*.whl
-          retention-days: 14
+          retention-days: ${{ env.ARTIFACT_RETENTION }}
       - uses: actions/upload-artifact@v2
         with:
           name: networkit-cp37-macos-${{ matrix.cibw_archs }}.whl
           path: ./wheelhouse/*cp37*.whl
-          retention-days: 14
+          retention-days: ${{ env.ARTIFACT_RETENTION }}
       - uses: actions/upload-artifact@v2
         with:
           name: networkit-cp38-macos-${{ matrix.cibw_archs }}.whl
           path: ./wheelhouse/*cp38*.whl
-          retention-days: 14
+          retention-days: ${{ env.ARTIFACT_RETENTION }}
       - uses: actions/upload-artifact@v2
         with:
           name: networkit-cp39-macos-${{ matrix.cibw_archs }}.whl
           path: ./wheelhouse/*cp39*.whl
-          retention-days: 14
+          retention-days: ${{ env.ARTIFACT_RETENTION }}
 
   cpython-windows:
     runs-on: ${{ matrix.os }}
@@ -151,4 +155,4 @@ jobs:
         with:
           name: networkit-cp39-win-amd64.whl
           path: ./wheelhouse/*cp39*.whl
-          retention-days: 14
+          retention-days: ${{ env.ARTIFACT_RETENTION }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,14 +292,17 @@ endif()
 
 if(NETWORKIT_PYTHON)
 
-	if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
-		FIND_PACKAGE(FindPythonInterp ${NETWORKIT_PYTHON_VERSION} EXACT REQUIRED)
-		FIND_PACKAGE(FindPythonLibs ${NETWORKIT_PYTHON_VERSION} EXACT REQUIRED)
-	else()
-		FIND_PACKAGE(Python3 ${NETWORKIT_PYTHON_VERSION} EXACT COMPONENTS Interpreter Development REQUIRED)
+	if(WIN32)
+		# Linking against Python3_libs is only neccessary on Windows. On other OSes 
+		# this can lead to segmentation faults when importing NetworKit in Python.
+		if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
+			FIND_PACKAGE(FindPythonLibs ${NETWORKIT_PYTHON_VERSION} EXACT REQUIRED)
+		else()
+			FIND_PACKAGE(Python3 ${NETWORKIT_PYTHON_VERSION} EXACT COMPONENTS Interpreter Development REQUIRED)
+		endif()
 	endif()
 
-	 foreach (EXT base centrality clique coarsening community components correlation
+	foreach (EXT base centrality clique coarsening community components correlation
 			 distance dynamics embedding engineering flow generators globals graph graphio
 			 graphtools helpers independentset linkprediction matching
 			 randomization reachability scd simulation sparsification stats
@@ -333,8 +336,6 @@ if(NETWORKIT_PYTHON)
 					OUTPUT_NAME "${TARGET_LIB}.${NETWORKIT_PYTHON_SOABI}")
 		if(WIN32)
 			set_target_properties(${TARGET_LIB} PROPERTIES SUFFIX .pyd)
-			# Linking against Python3_libs is only neccessary on Windows. On other OSes 
-			# this can lead to segmentation faults when importing NetworKit in Python.
 			target_link_libraries(${TARGET_LIB} PRIVATE ${Python3_LIBRARIES})
 		endif()
 
@@ -702,7 +703,7 @@ install(DIRECTORY extlibs/ttmath/ttmath
 
 set(NETWORKIT_LIBNAME networkit)
 
-execute_process(COMMAND ${Python_EXECUTABLE} -c "from version import version; print(version, end='')"
+execute_process(COMMAND ${NETWORKIT_PYTHON_EXECUTABLE} -c "from version import version; print(version, end='')"
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 	OUTPUT_VARIABLE NETWORKIT_VERSION)
 configure_file(networkit.pc

--- a/setup.py
+++ b/setup.py
@@ -137,8 +137,11 @@ def buildNetworKit(install_prefix, externalCore=False, externalTlx=None, withTes
 	comp_cmd.append("-DCMAKE_CXX_COMPILER="+cmakeCompiler)
 	comp_cmd.append("-DNETWORKIT_FLATINSTALL=ON")
 	from sysconfig import get_paths, get_config_var
-	comp_cmd.append("-DNETWORKIT_PYTHON="+get_paths()['include']) #provide python.h files
-	comp_cmd.append("-DNETWORKIT_PYTHON_SOABI="+os_soabi) #provide lib env specification
+	# The following cmake parameters set Python-variables. This is done to avoid differences between the 
+	# python-toolchain calling setup.py and cmake-based find-mechanisms.
+	comp_cmd.append("-DNETWORKIT_PYTHON="+get_paths()['include']) # provide python.h files
+	comp_cmd.append("-DNETWORKIT_PYTHON_EXECUTABLE="+sys.executable) # provide cmake with Python interpreter
+	comp_cmd.append("-DNETWORKIT_PYTHON_SOABI="+os_soabi) # provide lib env specification
 	comp_cmd.append("-DNETWORKIT_PYTHON_VERSION="+sysconfig.get_python_version())
 	if externalCore:
 		if sys.platform == "win32":


### PR DESCRIPTION
This PR adds the following:

- Github actions based wheel-builder for Linux (x86_64 CPython 3.6-3.9, aarch64 CPython 3.9) based on Manylinux2010 for x86_64 and Manylinux2014 for aarach64, macOS (x86_64 CPython 3.6-3.9) based on toolchain 10.9 and Windows (amd64 CPython 3.9). 
- Upload as an artifact on the CI-pipeline. This makes the files available as download in the current CI-build. Downloads will be available for ~~14~~ 7 days on PR and 1 month on master.
- Pinning Python executable by providing it as a parameter from setuptools to cmake. This is necessary for Manylinux-images to work properly. Otherwise cmake and setuptools work on different Python-environments.

Remarks:
- Thanks to @nomanrz (see #451) for the initial work. I adapted the idea and especially the inside into Manylinux-images was helpful. 
- Manylinux2010 builds can be installed with pip from version 19.0, which is per default only available from Python 3.7 (ships with 20.0 for virtualenv). We still support Python 3.6, but this goes EOL in 2 months - so I didn't saw a point in still building on top of Manylinux1 (which is also EOL).
- I had to drop arm64_darwin builds for now. While AppleClang supports arm64/universal2 builds on GA virtual runners 10.15 and 11 (XCode versions >12.2), the problem remains, that OpenMP and arm-based AppleClang create segmentation faults. Tried several approaches to recreate a cross-compilation with the working miniforge/conda-forge environment based on custom build clang-compilers. However GA images do have issues when working with conda-environments. Couldn't get either the C++ or the Python-toolchain to properly compile the source. Solutions should only be a matter of time though (same for other data science packages like numpy). So this will be added in a future PR.