### PR TITLE
OpenMP schedule dynamic for parallelForEdges

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -2008,7 +2008,7 @@ inline void Graph::forEdgeImpl(L handle) const {
 
 template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline void Graph::parallelForEdgesImpl(L handle) const {
-#pragma omp parallel for schedule(guided)
+#pragma omp parallel for schedule(dynamic)
     for (omp_index u = 0; u < static_cast<omp_index>(z); ++u) {
         forOutEdgesOfImpl<graphIsDirected, hasWeights, graphHasEdgeIds, L>(u, handle);
     }


### PR DESCRIPTION
I recently used `parallelForEdges` to generate random weights on large graphs (1-2 billion edges). On a 36-cores machine, the performance was very poor (it took >1h) due to bad load balancing (during the last 30 minutes only a few threads were running).
The loop iterates over the nodes in parallel and each thread iterates over the neighbors of the current node, so the workload of a thread depends on the degrees of the nodes it processes (which might vary a lot).

Changing the schedule from `guided` to `dynamic` improved the load balancing and the performance significantly (the time dropped to a few minutes), which makes sense because with `guided` some thread might end up processing many more edges than others. So I think we should use `dynamic` as the default scheduling strategy for this loop.