### PR TITLE
GHA: Fix windows-builds by passing Python-version from setup.py to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,10 +293,10 @@ endif()
 if(NETWORKIT_PYTHON)
 
 	if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
-		FIND_PACKAGE(FindPythonInterp REQUIRED)
-		FIND_PACKAGE(FindPythonLibs REQUIRED)
+		FIND_PACKAGE(FindPythonInterp ${NETWORKIT_PYTHON_VERSION} EXACT REQUIRED)
+		FIND_PACKAGE(FindPythonLibs ${NETWORKIT_PYTHON_VERSION} EXACT REQUIRED)
 	else()
-		FIND_PACKAGE(Python3 COMPONENTS Interpreter Development REQUIRED)
+		FIND_PACKAGE(Python3 ${NETWORKIT_PYTHON_VERSION} EXACT COMPONENTS Interpreter Development REQUIRED)
 	endif()
 
 	 foreach (EXT base centrality clique coarsening community components correlation

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ def buildNetworKit(install_prefix, externalCore=False, externalTlx=None, withTes
 	from sysconfig import get_paths, get_config_var
 	comp_cmd.append("-DNETWORKIT_PYTHON="+get_paths()['include']) #provide python.h files
 	comp_cmd.append("-DNETWORKIT_PYTHON_SOABI="+os_soabi) #provide lib env specification
+	comp_cmd.append("-DNETWORKIT_PYTHON_VERSION="+sysconfig.get_python_version())
 	if externalCore:
 		if sys.platform == "win32":
 			# Reasoning: only static builds are supported and libs+dlls must reside in the same folder


### PR DESCRIPTION
This change fixes the currently failing Windows-builds. For GHA-builds (could also apply for other setups), there are several Python-distributions installed by default. `FindPython` from CMake uses the most recent found by default. To override this, we either have to supply the Python-libraries by hand (needed for disabling `FindPython`) or pin the Python version. Since the former can be a challenging task on it's own - I decided to pin the Python version to the interpreter, which calls `setup.py`. 