### PR TITLE
GHA: Adding arm64-wheels for macOS

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -129,6 +129,37 @@ jobs:
           path: ./wheelhouse/*cp39*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
 
+  cpython-macos-arm64:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        cibw_archs: ["arm64"]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.1.1
+        env:
+          CIBW_BEFORE_BUILD: 
+            pip install cython &&
+            brew install libomp ninja &&
+            pip install --pre -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
+          CIBW_ENVIRONMENT: CXX=c++ NETWORKIT_OSX_CROSSBUILD=ON
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs }}
+          CIBW_BUILD: "cp39-*"
+          CIBW_SKIP: pp*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: networkit-cp39-macos-${{ matrix.cibw_archs }}.whl
+          path: ./wheelhouse/*cp39*.whl
+          retention-days: ${{ env.ARTIFACT_RETENTION }}
+
   cpython-windows:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from Cython.Build import cythonize
 cmakeCompiler = None
 buildDirectory = "build/build_python"
 ninja_available = False
+enable_osx_crossbuild = False
 
 if sys.version_info.major < 3:
 	print("ERROR: NetworKit requires Python 3.")
@@ -19,6 +20,9 @@ if "CXX" in os.environ:
 
 if "NETWORKIT_OVERRIDE_CXX" in os.environ:
 	cmakeCompiler = os.environ["NETWORKIT_OVERRIDE_CXX"]
+
+if "NETWORKIT_OSX_CROSSBUILD" in os.environ:
+	enable_osx_crossbuild = True
 
 if shutil.which("cmake") is None:
 	print("ERROR: NetworKit compilation requires cmake.")
@@ -152,6 +156,8 @@ def buildNetworKit(install_prefix, externalCore=False, externalTlx=None, withTes
 	if sys.platform == "win32":
 		comp_cmd.append("-DNETWORKIT_STATIC=ON") # Windows only supports static core builds
 		comp_cmd.append("-DNETWORKIT_BUILDING_STATELIB=ON") # Adds dllexport
+	if enable_osx_crossbuild:
+		comp_cmd.append("-DCMAKE_OSX_ARCHITECTURES='arm64'")
 	if externalTlx:
 		comp_cmd.append("-DNETWORKIT_EXT_TLX="+externalTlx)
 	if ninja_available:


### PR DESCRIPTION
This PR adds arm64-wheels for macOS. Besides using a nightly-build scipy wheel for this (see #799), this also adds a crossbuild-variable for osx to pass to cmake (variable: `CMAKE_OSX_ARCHITECTURES`).