### PR TITLE
Refactor GroupCloseness

### DIFF
--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -62,9 +62,9 @@ public:
     double scoreOfGroup(const std::vector<node> &group) const;
 
 protected:
-    edgeweight computeImprovement(node u, count n, Graph &G, count h);
-    std::vector<count> newDistances(node u, count n, Graph &G, count h);
-    Graph G;
+    edgeweight computeImprovement(node u, count n, count h);
+    std::vector<count> newDistances(node u, count n, count h);
+    const Graph *G;
     count k = 1;
     std::vector<count> D;
     count iters;
@@ -83,7 +83,7 @@ inline std::vector<node> GroupCloseness::groupMaxCloseness() {
 }
 
 inline void GroupCloseness::checkGroup(const std::vector<node> &group) const {
-    const count z = G.upperNodeIdBound();
+    const count z = G->upperNodeIdBound();
     std::vector<bool> check(z, false);
 #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(group.size()); ++i) {

--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -68,7 +68,6 @@ protected:
     void updateDistances(node u);
     const Graph *G;
     count k = 1;
-    std::vector<count> D;
     count iters;
     std::vector<count> d;
     std::vector<node> S;

--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -22,7 +22,7 @@ namespace NetworKit {
 /**
  * @ingroup centrality
  */
-class GroupCloseness : public Algorithm {
+class GroupCloseness final : public Algorithm {
 public:
     /**
      * Finds the group of nodes with highest (group) closeness centrality.
@@ -63,7 +63,7 @@ public:
      */
     double scoreOfGroup(const std::vector<node> &group) const;
 
-protected:
+private:
     edgeweight computeImprovement(node u, count n, count h);
     void updateDistances(node u);
     const Graph *G;

--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -55,8 +55,8 @@ public:
      * Computes farness (i.e., inverse of the closeness) for a given group
      * (stopping after H iterations if H > 0).
      */
-    double computeFarness(std::vector<node> S,
-                          count H = std::numeric_limits<count>::max());
+    double computeFarness(const std::vector<node> &S,
+                          count H = std::numeric_limits<count>::max()) const;
 
     /**
      * Computes the score of a specific group.

--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -64,11 +64,12 @@ public:
     double scoreOfGroup(const std::vector<node> &group) const;
 
 private:
-    edgeweight computeImprovement(node u, count n, count h);
+    edgeweight computeImprovement(node u, count h);
     void updateDistances(node u);
     const Graph *G;
     count k = 1;
     std::vector<count> d;
+    std::vector<std::vector<count>> d1Global;
     std::vector<node> S;
     count H = 0;
 

--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -70,7 +70,6 @@ protected:
     count k = 1;
     std::vector<count> D;
     count iters;
-    count maxD;
     std::vector<count> d;
     std::vector<count> d1;
     std::vector<node> S;

--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -65,13 +65,12 @@ public:
 
 protected:
     edgeweight computeImprovement(node u, count n, count h);
-    std::vector<count> newDistances(node u, count n, count h);
+    void updateDistances(node u);
     const Graph *G;
     count k = 1;
     std::vector<count> D;
     count iters;
     std::vector<count> d;
-    std::vector<count> d1;
     std::vector<node> S;
     count H = 0;
 

--- a/include/networkit/centrality/GroupCloseness.hpp
+++ b/include/networkit/centrality/GroupCloseness.hpp
@@ -68,7 +68,6 @@ protected:
     void updateDistances(node u);
     const Graph *G;
     count k = 1;
-    count iters;
     std::vector<count> d;
     std::vector<node> S;
     count H = 0;

--- a/networkit/cpp/centrality/GroupCloseness.cpp
+++ b/networkit/cpp/centrality/GroupCloseness.cpp
@@ -117,18 +117,7 @@ void GroupCloseness::run() {
 
     G->parallelForNodes([&](node v) { d[v] = bfs.distance(v); });
 
-    // get max distance
-    maxD = 0;
-    count sumD = 0;
-    // TODO: actually, we could have more generic parallel reduction iterators in
-    // the Graph class
-    G->forNodes([&](node v) {
-        if (d[v] > maxD) {
-            maxD = d[v];
-        }
-        sumD += d[v];
-    });
-    INFO("maxD = ", maxD);
+    count sumD = G->parallelSumForNodes([&](node v) { return d[v]; });
 
     // init S
     S.clear();

--- a/networkit/cpp/centrality/GroupCloseness.cpp
+++ b/networkit/cpp/centrality/GroupCloseness.cpp
@@ -113,9 +113,7 @@ void GroupCloseness::run() {
         node maxNode = none;
 
         std::atomic<bool> toInterrupt{false};
-#pragma omp parallel // Shared variables:
-        // cc: synchronized write, read leads to a positive race condition;
-        // Q: fully synchronized;
+#pragma omp parallel
         {
             while (!toInterrupt.load(std::memory_order_relaxed)) {
                 omp_set_lock(&lock);

--- a/networkit/cpp/centrality/GroupCloseness.cpp
+++ b/networkit/cpp/centrality/GroupCloseness.cpp
@@ -156,7 +156,7 @@ void GroupCloseness::run() {
     hasRun = true;
 }
 
-double GroupCloseness::computeFarness(std::vector<node> S, count H) {
+double GroupCloseness::computeFarness(const std::vector<node> &S, count H) const {
     // we run a BFS from S up to distance H (if H > 0) and sum the distances
     double farness = 0;
     count k = S.size();

--- a/networkit/cpp/centrality/GroupCloseness.cpp
+++ b/networkit/cpp/centrality/GroupCloseness.cpp
@@ -9,7 +9,6 @@
 #include <networkit/centrality/GroupCloseness.hpp>
 #include <networkit/auxiliary/BucketPQ.hpp>
 #include <networkit/auxiliary/Log.hpp>
-#include <networkit/distance/BFS.hpp>
 #include <networkit/centrality/TopCloseness.hpp>
 
 #include <atomic>

--- a/networkit/cpp/centrality/GroupCloseness.cpp
+++ b/networkit/cpp/centrality/GroupCloseness.cpp
@@ -112,10 +112,8 @@ void GroupCloseness::run() {
     // first, we store the distances between each node and the top node
     d.clear();
     d.resize(n);
-    BFS bfs(*G, top);
-    bfs.run();
 
-    G->parallelForNodes([&](node v) { d[v] = bfs.distance(v); });
+    Traversal::BFSfrom(*G, top, [&d = d](node u, count distance) { d[u] = distance; });
 
     count sumD = G->parallelSumForNodes([&](node v) { return d[v]; });
 

--- a/networkit/cpp/centrality/GroupCloseness.cpp
+++ b/networkit/cpp/centrality/GroupCloseness.cpp
@@ -137,7 +137,10 @@ void GroupCloseness::run() {
         G->parallelForNodes([&](node v) { prios[v] = -prevBound[v]; });
         // Aux::BucketPQ Q(prios, currentImpr + 1);
         Aux::BucketPQ Q(n, -currentImpr - 1, 0);
-        G->forNodes([&](node v) { Q.insert(prios[v], v); });
+        G->forNodes([&](node v) {
+            if (d[v] > 0)
+                Q.insert(prios[v], v);
+        });
         currentImpr = 0;
         maxNode = 0;
         d1.resize(G->upperNodeIdBound());
@@ -166,7 +169,7 @@ void GroupCloseness::run() {
                     toInterrupt.store(true, std::memory_order_relaxed);
                     break;
                 }
-                if (D[v] > 1 && !(d[v] == 1 && D[v] == 2) && d[v] > 0 &&
+                if (D[v] > 1 && !(d[v] == 1 && D[v] == 2) &&
                     (i == 1 || prevBound[v] > static_cast<int64_t>(currentImpr))) {
                     count imp = computeImprovement(v, n, H);
                     omp_set_lock(&lock);

--- a/networkit/cpp/centrality/GroupCloseness.cpp
+++ b/networkit/cpp/centrality/GroupCloseness.cpp
@@ -69,11 +69,11 @@ void GroupCloseness::updateDistances(node u) {
 
 void GroupCloseness::run() {
     const count n = G->upperNodeIdBound();
-    node top = 0;
     iters = 0;
     std::vector<bool> visited(n, false);
     std::vector<node> pred(n);
     std::vector<count> distances(n);
+    node top;
 
     omp_lock_t lock;
     omp_init_lock(&lock);
@@ -101,7 +101,6 @@ void GroupCloseness::run() {
 
     std::vector<int64_t> prevBound(n, 0);
     count currentImpr = sumD + 1; // TODO change
-    count maxNode = 0;
 
     std::vector<count> S2(n, sumD);
     S2[top] = 0;
@@ -118,7 +117,7 @@ void GroupCloseness::run() {
                 Q.insert(prios[v], v);
         });
         currentImpr = 0;
-        maxNode = none;
+        node maxNode = none;
 
         std::atomic<bool> toInterrupt{false};
 #pragma omp parallel // Shared variables:

--- a/networkit/cpp/centrality/GroupCloseness.cpp
+++ b/networkit/cpp/centrality/GroupCloseness.cpp
@@ -80,7 +80,7 @@ bool pairCompare(const std::pair<node, count> &firstElem,
 }
 
 void GroupCloseness::run() {
-    count n = G->upperNodeIdBound();
+    const count n = G->upperNodeIdBound();
     node top = 0;
     iters = 0;
     std::vector<bool> visited(n, false);

--- a/networkit/cpp/centrality/GroupCloseness.cpp
+++ b/networkit/cpp/centrality/GroupCloseness.cpp
@@ -144,8 +144,7 @@ void GroupCloseness::run() {
                     toInterrupt.store(true, std::memory_order_relaxed);
                     break;
                 }
-                if (D[v] > 1 && !(d[v] == 1 && D[v] == 2) &&
-                    (i == 1 || prevBound[v] > static_cast<int64_t>(currentImpr))) {
+                if (i == 1 || prevBound[v] > static_cast<int64_t>(currentImpr)) {
                     count imp = computeImprovement(v, n, H);
                     omp_set_lock(&lock);
                     if (imp > currentImpr) {

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1602,12 +1602,6 @@ TEST_F(CentralityGTest, testGroupCloseness) {
     GroupCloseness gc(g, k);
     gc.run();
     auto apx = gc.groupMaxCloseness();
-    std::sort(apx.begin(), apx.end());
-    std::vector<node> solution = {0, 2, 5};
-    for (count i = 0; i < k; ++i) {
-        EXPECT_EQ(apx[i], solution[i]);
-    }
-
     EXPECT_NEAR(gc.scoreOfGroup(apx), 1.0, 1e-5);
 }
 


### PR DESCRIPTION
- Replace copy of `Graph` with `const Graph *`
- Remove unnecessary references to `G` since it is already a member variable
- Use algorithms implemented in `Traversal::` in `scoreOfGroup` instead of re-implementing them
- Bugfix: the algorithm discards low-degree nodes, which leads to incorrect results in small networks.
- Further performance improvements (mainly removing unnecessary variables)