### PR TITLE
Refactor CSRMatrix

### DIFF
--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -173,11 +173,8 @@ public:
             rowIdx[row]++;
         }
 
-        for (index i = 0, firstIdxOfRow = 0; i <= nRows; ++i) {
-            index newRow = rowIdx[i];
-            rowIdx[i] = firstIdxOfRow;
-            firstIdxOfRow = newRow;
-        }
+        rowIdx.back() = 0;
+        std::rotate(rowIdx.rbegin(), rowIdx.rbegin() + 1, rowIdx.rend());
     }
 
     /**


### PR DESCRIPTION
As the last step, the constructor of `CSRMatrix` restores the row indices to their correct values. However, this is equivalent to rotating the vector to the right by one and resetting its first value to zero, which can be implemented with just two lines of code instead of writing another loop.