### PR TITLE
Debug_only Macro

### DIFF
--- a/include/networkit/Globals.hpp
+++ b/include/networkit/Globals.hpp
@@ -23,6 +23,14 @@ using omp_index = int64_t;
 using omp_index = index;
 #endif // _MSC_VER
 
+#ifdef NDEBUG
+#define DEBUG_ONLY(x)
+#else
+#define DEBUG_ONLY(x) = x;
+#endif
+
+
+
 using count = uint64_t;    ///< more expressive name for an integer quantity
 using node = index;        ///< node indices are 0-based
 using edgeweight = double; ///< edge weight type


### PR DESCRIPTION
As described in #811 this can be used to avoid bloating code with ifndef and endifs to maintain readability.

Where to put it, and how to name it is up for discussion.