### PR TITLE
Add topology sort for both C++ and Python interface

### DIFF
--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -421,6 +421,18 @@ Graph restoreGraph(const std::vector<node> &invertedIdMap, const Graph &G);
 void sortEdgesByWeight(Graph &G, bool decreasing = false);
 
 /**
+ * Given a directed graph G, the topology sort algorithm creates one valid topology order of nodes.
+ * Undirected graphs are not accepted as input, since a topology sort is a linear ordering of
+ * vertices such that for every edge u -> v, node u comes before v in the ordering.
+ *
+ * This is a helper function. Instead of calling it via GraphTools, it is also possible to create a
+ * TopologicalSort-object from the base-class.
+ * @param   G           Directed input graph
+ * @return              A vector of node-ids sorted according to their topology.
+ */
+std::vector<node> topologicalSort(const Graph &G);
+
+/**
  * Rename nodes in a graph using a callback which translates each old id to a new one.
  * For each node u in input graph, oldIdToNew(u) < numNodes.
  *

--- a/include/networkit/graph/TopologicalSort.hpp
+++ b/include/networkit/graph/TopologicalSort.hpp
@@ -1,0 +1,64 @@
+/*
+ * TopologicalSort.hpp
+ *
+ *  Created on: 22.11.2021
+ *      Author: Fabian Brandt-Tumescheit
+ */
+#ifndef NETWORKIT_GRAPH_TOPOLOGICAL_SORT_HPP_
+#define NETWORKIT_GRAPH_TOPOLOGICAL_SORT_HPP_
+
+#include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+/**
+ * Given a directed graph G, the topology sort algorithm creates one valid topology order of nodes.
+ * Undirected graphs are not accepted as input, since a topology sort is a linear ordering of
+ * vertices such that for every edge u -> v, node u comes before v in the ordering.
+ */
+class TopologicalSort final : public Algorithm {
+public:
+    /**
+     * Initialize the topological sort algorithm by passing an input graph. Note that topological
+     * sort is defined for directed graphs only.
+     *
+     * @param G The input graph.
+     */
+    TopologicalSort(const Graph &G);
+
+    /**
+     * Execute the algorithm. The algorithm is not parallel.
+     */
+    void run() override;
+
+    /**
+     * Return the topology
+     *
+     * @return One valid topology. Order in topology is from 0 to number of nodes.
+     */
+    std::vector<node> getResult() {
+        assureFinished();
+        return topology;
+    }
+
+private:
+    enum class NodeMark : unsigned char { NONE, TEMP, PERM };
+
+    const Graph *G;
+
+    // Used to mark the status of each node, one vector per thread
+    std::vector<NodeMark> topSortMark;
+
+    // Contains information about the computed topology
+    std::vector<node> topology;
+
+    // Helper structures
+    count current;
+
+    // Reset algorithm data structure
+    void reset();
+};
+} // namespace NetworKit
+
+#endif // NETWORKIT_GRAPH_TOPOLOGICAL_SORT_HPP_

--- a/networkit/cpp/graph/CMakeLists.txt
+++ b/networkit/cpp/graph/CMakeLists.txt
@@ -5,6 +5,7 @@ networkit_add_module(graph
     KruskalMSF.cpp
     RandomMaximumSpanningForest.cpp
     SpanningForest.cpp
+    TopologicalSort.cpp
     UnionMaximumSpanningForest.cpp
     )
 

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -5,6 +5,7 @@
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/graph/Graph.hpp>
 #include <networkit/graph/GraphTools.hpp>
+#include <networkit/graph/TopologicalSort.hpp>
 
 namespace NetworKit {
 
@@ -502,6 +503,13 @@ void sortEdgesByWeight(Graph &G, bool decreasing) {
                 return e1.v < e2.v;
             return e1.weight < e2.weight;
         });
+}
+
+std::vector<node> topologicalSort(const Graph &G) {
+    TopologicalSort topSort(G);
+    topSort.run();
+
+    return topSort.getResult();
 }
 
 } // namespace GraphTools

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -1,0 +1,66 @@
+/*
+ * TopologicalSort.cpp
+ *
+ *  Created on: 22.11.2021
+ *      Author: Fabian Brandt-Tumescheit
+ */
+#include <networkit/graph/TopologicalSort.hpp>
+
+namespace NetworKit {
+
+TopologicalSort::TopologicalSort(const Graph &G) : G(&G) {
+    if (!G.isDirected())
+        throw std::runtime_error("Topological sort is defined for directed graphs only.");
+}
+
+void TopologicalSort::run() {
+    reset();
+
+    std::stack<node> nodeStack;
+
+    G->forNodes([&](node u) {
+        if (topSortMark[u] == NodeMark::PERM)
+            return;
+
+        nodeStack.push(u);
+        do {
+            node v = nodeStack.top();
+            if (topSortMark[v] != NodeMark::NONE) {
+                nodeStack.pop();
+                if (topSortMark[v] == NodeMark::TEMP) {
+                    topSortMark[v] = NodeMark::PERM;
+                    topology[current] = v;
+                    current--;
+                }
+            } else {
+                topSortMark[v] = NodeMark::TEMP;
+                G->forNeighborsOf(v, [&](node w) {
+                    if (topSortMark[w] == NodeMark::NONE)
+                        nodeStack.push(w);
+                    else if (topSortMark[w] == NodeMark::TEMP)
+                        throw std::runtime_error("Error: the input graph has cycles.");
+                });
+            }
+        } while (!nodeStack.empty());
+    });
+
+    hasRun = true;
+}
+
+void TopologicalSort::reset() {
+    // Reset node marks
+    count n = G->numberOfNodes();
+    if (n == 0)
+        throw std::runtime_error("Graph should contain at least one node.");
+
+    if (n != static_cast<count>(topSortMark.size())) {
+        topSortMark.resize(n);
+        topology.resize(n);
+    }
+    std::fill(topSortMark.begin(), topSortMark.end(), NodeMark::NONE);
+    std::fill(topology.begin(), topology.end(), 0);
+    // Reset current
+    current = n - 1;
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/graph/test/CMakeLists.txt
+++ b/networkit/cpp/graph/test/CMakeLists.txt
@@ -4,6 +4,7 @@ networkit_add_test(graph GraphGTest
 networkit_add_test(graph GraphToolsGTest generators io)
 networkit_add_test(graph TraversalGTest generators)
 networkit_add_test(graph SpanningGTest io)
+networkit_add_test(graph TopologicalSortGTest)
 
 networkit_add_benchmark(graph Graph2Benchmark)
 networkit_add_benchmark(graph GraphBenchmark auxiliary)

--- a/networkit/cpp/graph/test/TopologicalSortGTest.cpp
+++ b/networkit/cpp/graph/test/TopologicalSortGTest.cpp
@@ -1,0 +1,76 @@
+/*
+ * TopologicalSort.hpp
+ *
+ *  Created on: 22.11.2021
+ *      Author: Fabian Brandt-Tumescheit
+ */
+
+#include <networkit/graph/TopologicalSort.hpp>
+
+#include <iostream>
+#include <gtest/gtest.h>
+
+namespace NetworKit {
+
+class TopologicalSortGTest : public testing::TestWithParam<bool> {
+protected:
+    bool directed() const noexcept;
+};
+
+INSTANTIATE_TEST_SUITE_P(InstantiationName, TopologicalSortGTest, testing::Values(false, true));
+
+bool TopologicalSortGTest::directed() const noexcept {
+    return GetParam();
+}
+
+TEST_P(TopologicalSortGTest, testTopologicalSort) {
+    auto G = Graph(5, false, directed());
+
+    /**
+     * /--> 1 --> 3
+     * |    ^
+     * 0    |
+     * |    |
+     * \--> 2 <-- 4
+     */
+
+    G.addEdge(0, 1);
+    G.addEdge(0, 2);
+    G.addEdge(2, 1);
+    G.addEdge(1, 3);
+    G.addEdge(4, 2);
+
+    if (directed()) {
+        TopologicalSort topSort = TopologicalSort(G);
+        topSort.run();
+        std::vector<node> res = topSort.getResult();
+
+        // Test for valid topology
+        auto indexNode0 = std::distance(res.begin(), std::find(res.begin(), res.end(), 0));
+        auto indexNode1 = std::distance(res.begin(), std::find(res.begin(), res.end(), 1));
+        auto indexNode2 = std::distance(res.begin(), std::find(res.begin(), res.end(), 2));
+        auto indexNode3 = std::distance(res.begin(), std::find(res.begin(), res.end(), 3));
+        auto indexNode4 = std::distance(res.begin(), std::find(res.begin(), res.end(), 4));
+        // node 2 is depending on node 0
+        EXPECT_TRUE(indexNode2 > indexNode0);
+        // node 2 is depending on node 4
+        EXPECT_TRUE(indexNode2 > indexNode4);
+        // node 1 is depending on node 2
+        EXPECT_TRUE(indexNode1 > indexNode2);
+        // node 3 is depending on node 1
+        EXPECT_TRUE(indexNode3 > indexNode1);
+
+        // Test for repeated runs
+        topSort.run();
+        std::vector<node> res2 = topSort.getResult();
+        EXPECT_TRUE(res == res2);
+
+        // Test cycle detection
+        G.addEdge(3, 4);
+        topSort = TopologicalSort(G);
+        EXPECT_ANY_THROW(topSort.run());
+    } else {
+        EXPECT_ANY_THROW(new TopologicalSort(G));
+    }
+}
+} // namespace NetworKit

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -43,6 +43,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	unordered_map[node,node] getContinuousNodeIds(_Graph G) nogil except +
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
 	void sortEdgesByWeight(_Graph G, bool_t) nogil except +
+	vector[node] topologicalSort(_Graph G) nogil except +
 
 cdef class GraphTools:
 
@@ -567,3 +568,17 @@ cdef class GraphTools:
 			by using node ids.
 		"""
 		sortEdgesByWeight(G._this, decreasing)
+
+	@staticmethod
+	def topologicalSort(Graph G):
+		"""
+		Given a directed graph G, the topology sort algorithm creates one valid topology order of nodes.
+		Undirected graphs are not accepted as input, since a topology sort is a linear ordering of vertices 
+		such that for every edge u -> v, node u comes before v in the ordering.
+
+		Parameters:
+		----------
+		G : networkit.Graph
+			The directed input graph.
+		"""
+		return topologicalSort(G._this)

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -496,5 +496,32 @@ class TestGraphTools(unittest.TestCase):
 		# Test weighted
 		doTest(g)
 
+	def testTopologicalSort(self):
+		def generateGraph(directed):
+			G = nk.Graph(5, False, directed)
+			G.addEdge(0, 1)
+			G.addEdge(0, 2)
+			G.addEdge(2, 1)
+			G.addEdge(1, 3)
+			G.addEdge(4, 2)
+			return G
+		
+		for directed in [True, False]:
+			G = generateGraph(directed)
+			if(directed == False):
+				with self.assertRaises(Exception):
+					nk.graphtools.topologicalSort(G)
+			else:
+				res = nk.graphtools.topologicalSort(G)
+				indexNode0 = res.index(0)
+				indexNode1 = res.index(1)
+				indexNode2 = res.index(2)
+				indexNode3 = res.index(3)
+				indexNode4 = res.index(4)
+				self.assertLess(indexNode0, indexNode2)
+				self.assertLess(indexNode4, indexNode2)
+				self.assertLess(indexNode2, indexNode1)
+				self.assertLess(indexNode1, indexNode3)		
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This PR adds a sequential Topology Sort algorithm as requested/discussed here: https://github.com/networkit/networkit/discussions/829
