### PR TITLE
Refactor CSRMatrix sort() and diagonal()

### DIFF
--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -429,25 +429,12 @@ public:
         if (sorted()) {
 #pragma omp parallel for
             for (omp_index i = 0; i < static_cast<omp_index>(diag.getDimension()); ++i) {
-                if (rowIdx[i] == rowIdx[i + 1])
-                    continue; // no entry in row i
-                index left = rowIdx[i];
-                index right = rowIdx[i + 1] - 1;
-                index mid = (left + right) / 2;
-                while (left <= right) {
-                    if (columnIdx[mid] == i) {
-                        diag[i] = nonZeros[mid];
-                        break;
-                    }
 
-                    if (columnIdx[mid] < i) {
-                        left = mid + 1;
-                    } else {
-                        right = mid - 1;
-                    }
+                const auto it = std::lower_bound(columnIdx.begin() + rowIdx[i],
+                                                 columnIdx.begin() + rowIdx[i + 1], i);
 
-                    mid = (left + right) / 2;
-                }
+                if (it != columnIdx.end() && *it == static_cast<index>(i))
+                    diag[i] = nonZeros[it - columnIdx.begin()];
             }
         } else {
 #pragma omp parallel for

--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -379,23 +379,14 @@ public:
                                                   nonZeros.begin() + endOfRow, permutation.begin());
             }
         }
-
-#ifndef NETWORKIT_SANITY_CHECKS
-        bool sorted = true;
-        tlx::unused(sorted);
-#pragma omp parallel for
-        for (omp_index i = 0; i < static_cast<omp_index>(nRows); ++i) {
-            for (index j = rowIdx[i] + 1; j < rowIdx[i + 1]; ++j) {
-                if (columnIdx[j - 1] > columnIdx[j]) {
-                    sorted = false;
-                    break;
-                }
-            }
-        }
-        assert(sorted);
-#endif // NETWORKIT_SANITY_CHECKS
-
         isSorted = true;
+
+#ifdef NETWORKIT_SANITY_CHECKS
+#pragma omp parallel for
+        for (omp_index i = 0; i < static_cast<omp_index>(nRows); ++i)
+            assert(
+                std::is_sorted(columnIdx.begin() + rowIdx[i], columnIdx.begin() + rowIdx[i + 1]));
+#endif // NETWORKIT_SANITY_CHECKS
     }
 
     /**

--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -42,47 +42,6 @@ class CSRGeneralMatrix {
     ValueType zero;
 
     /**
-     * Quicksort algorithm on columnIdx between [@a left, @a right].
-     * @param left
-     * @param right
-     */
-    void quicksort(index left, index right) {
-        if (left >= right)
-            return;
-        index pivotIdx = partition(left, right);
-        if (pivotIdx != 0) {
-            quicksort(left, pivotIdx - 1);
-        }
-        quicksort(pivotIdx + 1, right);
-    }
-
-    /**
-     * Partitions columnIdx between [@a left, @a right] after selecting the pivot
-     * in the middle.
-     * @param left
-     * @param right
-     * @return The pivot.
-     */
-    index partition(index left, index right) {
-        index mid = (left + right) / 2;
-        index pivot = columnIdx[mid];
-        std::swap(columnIdx[mid], columnIdx[right]);
-        std::swap(nonZeros[mid], nonZeros[right]);
-
-        index i = left;
-        for (index j = left; j < right; ++j) {
-            if (columnIdx[j] <= pivot) {
-                std::swap(columnIdx[i], columnIdx[j]);
-                std::swap(nonZeros[i], nonZeros[j]);
-                ++i;
-            }
-        }
-        std::swap(columnIdx[i], columnIdx[right]);
-        std::swap(nonZeros[i], nonZeros[right]);
-        return i;
-    }
-
-    /**
      * Binary search the sorted columnIdx vector between [@a left, @a right]
      * for column @a j.
      * If @a j is not present, the index that is immediately left of the place

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -1167,4 +1167,18 @@ TEST_F(MatricesGTest, testLaplacianMatrixOfGraph) {
     testLaplacianOfGraph<CSRMatrix>();
 }
 
+TEST_F(MatricesGTest, testCSRMatrixSort) {
+    /* 1 0 0 0
+     * 2 3 0 0
+     * 0 4 5 6
+     * 7 8 9 10
+     */
+    std::vector<Triplet> triplets{{0, 0, 1},
+                                  {1, 1, 3}, {1, 0, 2}, // Insert unsorted columns
+                                  {2, 2, 5}, {2, 1, 4}, {2, 3, 6},
+                                  {3, 1, 8}, {3, 3, 10}, {3, 0, 7}, {3, 2, 9}};
+
+    CSRGeneralMatrix<double> csr(4, 4, triplets);
+    csr.sort();
+}
 } /* namespace NetworKit */


### PR DESCRIPTION
Our CSRMatrix class uses simple quicksort and binary search implementations. This PR:
- In `sort()`: uses `std::sort` to compute a permutation of column indices and uses `ArrayTools::applyPermutation` to sort the values and column indices
- Simplifies the checks at the end of `sort()` with `std::is_sorted` and enables them only if NetworKit sanity checks are enabled, as originally intended
- Adds a simple test for `sort()`
- Uses `std::lower_bound` to search for diagonal elements in `diagonal()`