### PR TITLE
Bug fix: group closeness local search

### DIFF
--- a/networkit/cpp/centrality/GroupClosenessGrowShrinkImpl.cpp
+++ b/networkit/cpp/centrality/GroupClosenessGrowShrinkImpl.cpp
@@ -401,8 +401,11 @@ node GroupClosenessGrowShrinkImpl<WeightType>::estimateHighestDecrement() {
             }
         });
 
-        if (distance[x] && (G->isWeighted() || (!leaf || distance[x] == WeightType{1})))
-            stack[stackSize++] = x;
+        if (distance[x] == 0)
+            continue; // Ignore vertices in the group
+
+        if (G->isWeighted() || extended || (!leaf || distance[x] == WeightType{1}))
+            stack[stackSize++] = x; // Avoid to consider DAG leaves if running non-extended GS
 
     } while (!(G->isWeighted() ? heap.empty() : q.empty()));
 

--- a/networkit/cpp/centrality/GroupClosenessLocalSearch.cpp
+++ b/networkit/cpp/centrality/GroupClosenessLocalSearch.cpp
@@ -466,16 +466,14 @@ void GroupClosenessLocalSearchImpl<count>::computeDAG() {
         const node x = q.front();
         q.pop();
 
-        bool isLeaf = true;
         G->forNeighborsOf(x, [&](node y) {
             if (!visited[y]) {
                 visited[y] = true;
-                isLeaf = false;
                 q.push(y);
             }
         });
 
-        if (distance[x] > 0 && (!isLeaf || distance[x] == 1))
+        if (distance[x] > 0)
             dagStack[stackSize++] = x;
 
     } while (!q.empty());

--- a/networkit/cpp/centrality/GroupClosenessLocalSearch.cpp
+++ b/networkit/cpp/centrality/GroupClosenessLocalSearch.cpp
@@ -989,7 +989,7 @@ bool GroupClosenessLocalSearchImpl<WeightType>::findAndSwap() {
 
         const int thread = threadToSelect.load(std::memory_order_relaxed);
 
-        if (thread != -1) { // There a convenient swap
+        if (thread != -1) { // There is a convenient swap
             node v;
             WeightType farnessDecrease;
             std::tie(v, farnessDecrease) = decreasePerThread[thread];


### PR DESCRIPTION
The local-search approximation algorithm should evaluate all swaps. However, the current implementation excludes leaves of the DAG, which leads to potentially incorrect results and random failures of `CentralityGTest.testGroupClosenessLocalSearch`.