### PR TITLE
Move to C++17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ on: [push, pull_request]
 # Default parameters for all builds.
 env:
   OMP_NUM_THREADS: 2
-  CXX_STANDARD: 14
+  CXX_STANDARD: 17
   MONOLITH: ON
   TLX_PATH: /home/runner/work/networkit/networkit/tlx
   TLX_PATH_WIN: /d/a/networkit/networkit/tlx
@@ -238,16 +238,16 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        compiler: ['gcc-6', 'clang-4.0']
+        compiler: ['gcc-7', 'clang-5']
     steps:
       - name: Install prerequisites
         run:  |
           sudo apt-get update
           sudo apt-get install ninja-build
-          sudo apt-get install libomp5 libomp-dev clang-4.0 clang++-4.0
-          sudo apt-get install gcc-6 g++-6
+          sudo apt-get install libomp5 libomp-dev clang-5.0 clang++-5.0
+          sudo apt-get install gcc-7 g++-7
       - name: Setup Python 3.7
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v2
         with:
           python-version: '3.7'
       - name: Checkout networkit
@@ -263,8 +263,8 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
         shell: bash
         env:
-          CC: ${{ matrix.compiler == 'gcc-6' && 'gcc-6' || 'clang-4.0' }}
-          CXX: ${{ matrix.compiler == 'gcc-6' && 'g++-6' || 'clang++-4.0' }}
+          CC: ${{ matrix.compiler == 'gcc-7' && 'gcc-7' || 'clang-5.0' }}
+          CXX: ${{ matrix.compiler == 'gcc-7' && 'g++-7' || 'clang++-5.0' }}
 
   linux-build-clang-tidy:
     name: "Linux (clang-13): clang-tidy"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(NETWORKIT_RELEASE_LOGGING "AUTO" CACHE STRING "Do not compile log messages a
 set(NETWORKIT_PYTHON_RPATH "" CACHE STRING "Build specific rpath references.")
 set(NETWORKIT_EXT_TLX "" CACHE STRING "Absolute path for external tlx-library. If not set, extlibs/tlx is used")
 
-set (NETWORKIT_CXX_STANDARD "14" CACHE STRING "CXX Version to compile with. Currently fixed to 14")
+set (NETWORKIT_CXX_STANDARD "17" CACHE STRING "CXX Version to compile with. Currently fixed to 17")
 
 # Allow user to set installation paths relative to CMAKE_INSTALL_PREFIX
 

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ if cmakeCompiler is None:
 		try:
 			proc = subprocess.run(['brew','--prefix'], stdout=subprocess.PIPE)
 			brewPrefix = proc.stdout.decode('utf-8').strip()
-			cmakeCompiler = determineCompiler(["c++"], "c++14", ["-Xpreprocessor", "-fopenmp", "-I" + str(brewPrefix) + "/include", "-L" + str(brewPrefix) + "/lib", "-lomp"])
+			cmakeCompiler = determineCompiler(["c++"], "c++17", ["-Xpreprocessor", "-fopenmp", "-I" + str(brewPrefix) + "/include", "-L" + str(brewPrefix) + "/lib", "-lomp"])
 		except:
 			pass
 	if sys.platform == "win32":
@@ -131,7 +131,7 @@ if cmakeCompiler is None:
 		cmakeCompiler = "cl"
 		print("The default for Windows is to use cl.exe (MSVC), be sure to install and activate Visual Studio command line tools.")
 	if cmakeCompiler is None:
-		cmakeCompiler = determineCompiler(candidates, "c++14", ["-fopenmp"])
+		cmakeCompiler = determineCompiler(candidates, "c++17", ["-fopenmp"])
 	if cmakeCompiler is None:
 		print("ERROR: No suitable compiler found. Install any of these: ", candidates)
 		print("       If you have a suitable compiler installed, which is not a standard path, you can override detection by setting 'export NETWORKIT_OVERRIDE_CXX=<compiler-path>'")


### PR DESCRIPTION
This PR raises the NetworKit C++ standard to 17. The oldest clang version that supports C++17 is 5.0 and it was released on 7.9.17, so I guess that this PR should not be merged before 7.9.22.