### PR TITLE
Refactor: use STL algorithms

### DIFF
--- a/include/networkit/centrality/KadabraBetweenness.hpp
+++ b/include/networkit/centrality/KadabraBetweenness.hpp
@@ -175,11 +175,7 @@ class KadabraBetweenness : public Algorithm {
 
     count maxAllocatedFrames() const {
         assureFinished();
-        count maxNFrames = 0;
-        for (auto nFrames : maxFrames) {
-            maxNFrames = std::max(nFrames, maxNFrames);
-        }
-        return maxNFrames;
+        return *std::max_element(maxFrames.begin(), maxFrames.end());
     }
 
   protected:

--- a/include/networkit/generators/quadtree/QuadNode.hpp
+++ b/include/networkit/generators/quadtree/QuadNode.hpp
@@ -711,11 +711,9 @@ public:
      */
     count countLeaves() const {
         if (isLeaf) return 1;
-        count result = 0;
-        for (index i = 0; i < children.size(); i++) {
-            result += children[i].countLeaves();
-        }
-        return result;
+        return std::accumulate(
+            children.begin(), children.end(), count{0},
+            [](count result, const auto &child) -> count { return result + child.countLeaves(); });
     }
 
     double getLeftAngle() const {

--- a/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
@@ -311,9 +311,8 @@ public:
         else {
             assert(content.size() == 0);
             assert(positions.size() == 0);
-            for (index i = 0; i < children.size(); i++) {
-                children[i].getCoordinates(pointContainer);
-            }
+            for (auto &child : children)
+                child.getCoordinates(pointContainer);
         }
     }
 
@@ -465,9 +464,8 @@ public:
         content.shrink_to_fit();
         positions.shrink_to_fit();
         if (!isLeaf) {
-            for (index i = 0; i < children.size(); i++) {
-                children[i].trim();
-            }
+            for (auto &child : children)
+                child.trim();
         }
     }
 
@@ -491,7 +489,7 @@ public:
      */
     count height() const {
         count result = 1;//if leaf node, the children loop will not execute
-        for (auto child : children) result = std::max(result, child.height()+1);
+        for (const auto &child : children) result = std::max(result, child.height()+1);
         return result;
     }
 
@@ -514,9 +512,9 @@ public:
     index indexSubtree(index nextID) {
         index result = nextID;
         assert(children.size() == pow(2,dimension) || children.size() == 0);
-        for (int i = 0; i < children.size(); i++) {
-            result = children[i].indexSubtree(result);
-        }
+        for (auto &child : children)
+            result = child.indexSubtree(result);
+
         this->ID = result;
         return result+1;
     }
@@ -525,8 +523,8 @@ public:
         if (!responsible(pos)) return none;
         if (isLeaf) return getID();
         else {
-            for (int i = 0; i < children.size(); i++) {
-                index childresult = children[i].getCellID(pos);
+            for (const auto &child : children) {
+                index childresult = child.getCellID(pos);
                 if (childresult != none) return childresult;
             }
             throw std::runtime_error("No responsible child node found even though this node is responsible.");
@@ -555,9 +553,8 @@ public:
             }
             offset += size();
         } else {
-            for (int i = 0; i < children.size(); i++) {
-                offset = children[i].reindex(offset);
-            }
+            for (auto &child : children)
+                offset = child.reindex(offset);
         }
         return offset;
     }

--- a/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
@@ -498,11 +498,9 @@ public:
      */
     count countLeaves() const {
         if (isLeaf) return 1;
-        count result = 0;
-        for (index i = 0; i < children.size(); i++) {
-            result += children[i].countLeaves();
-        }
-        return result;
+        return std::accumulate(
+            children.begin(), children.end(), count{0},
+            [](count result, const auto &child) { return result + child.countLeaves(); });
     }
 
     index getID() const {

--- a/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
@@ -541,11 +541,10 @@ public:
     index getMaxIDInSubtree() const {
         if (isLeaf) return getID();
         else {
-            index result = -1;
-            for (int i = 0; i < children.size(); i++) {
-                result = std::max(children[i].getMaxIDInSubtree(), result);
-            }
-            return std::max(result, getID());
+            const index maxID =
+                std::max_element(children.begin(), children.end(),
+                                 [](const auto &child) { return child.getMaxIDInSubtree(); });
+            return std::max(maxID, getID());
         }
     }
 

--- a/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
@@ -19,11 +19,6 @@
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/geometric/HyperbolicSpace.hpp>
 
-using std::vector;
-using std::min;
-using std::max;
-using std::cos;
-
 namespace NetworKit {
 
 template <class T>

--- a/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
@@ -532,10 +532,11 @@ public:
     index getMaxIDInSubtree() const {
         if (isLeaf) return getID();
         else {
-            const index maxID =
-                std::max_element(children.begin(), children.end(),
-                                 [](const auto &child) { return child.getMaxIDInSubtree(); });
-            return std::max(maxID, getID());
+            index result = 0;
+            for (int i = 0; i < children.size(); i++) {
+                result = std::max(children[i].getMaxIDInSubtree(), result);
+            }
+            return std::max(result, getID());
         }
     }
 

--- a/include/networkit/generators/quadtree/QuadNodePolarEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodePolarEuclid.hpp
@@ -158,12 +158,11 @@ public:
         }
         else {
             assert(children.size() > 0);
-            for (index i = 0; i < children.size(); i++) {
-                if (children[i].responsible(angle, R)) {
-                    children[i].addContent(input, angle, R);
+            for (auto &child : children)
+                if (child.responsible(angle, R)) {
+                    child.addContent(input, angle, R);
                     break;
                 }
-            }
             subTreeSize++;
         }
     }
@@ -398,8 +397,8 @@ public:
             assert(angles.size() == 0);
             assert(radii.size() == 0);
             vector<T> result;
-            for (index i = 0; i < children.size(); i++) {
-                std::vector<T> subresult = children[i].getElements();
+            for (const auto &child : children) {
+                std::vector<T> subresult = child.getElements();
                 result.insert(result.end(), subresult.begin(), subresult.end());
             }
             return result;
@@ -416,9 +415,8 @@ public:
             assert(content.size() == 0);
             assert(angles.size() == 0);
             assert(radii.size() == 0);
-            for (index i = 0; i < children.size(); i++) {
-                children[i].getCoordinates(anglesContainer, radiiContainer);
-            }
+            for (const auto &child : children)
+                child.getCoordinates(anglesContainer, radiiContainer);
         }
     }
 
@@ -458,9 +456,8 @@ public:
                 }
             }
         }	else {
-            for (index i = 0; i < children.size(); i++) {
-                children[i].getElementsInEuclideanCircle(center, radius, result, minAngle, maxAngle, lowR, highR);
-            }
+            for (const auto &child : children)
+                child.getElementsInEuclideanCircle(center, radius, result, minAngle, maxAngle, lowR, highR);
         }
     }
 
@@ -597,8 +594,8 @@ public:
      */
     count height() const {
         count result = 1;//if leaf node, the children loop will not execute
-        for (auto child : children) result = std::max(result, child.height()+1);
-        return result;
+        for (const auto &child : children) result = std::max(result, child.height()+1);
+        return std::max(count{1}, result);
     }
 
     /**
@@ -644,12 +641,12 @@ public:
     }
 
     index getCellID(double phi, double r) const {
-        if (!responsible(phi, r)) return NetworKit::none;
+        if (!responsible(phi, r)) return none;
         if (isLeaf) return getID();
         else {
-            for (int i = 0; i < children.size(); i++) {
-                index childresult = children[i].getCellID(phi, r);
-                if (childresult != NetworKit::none) return childresult;
+            for (const auto &child : children) {
+                index childresult = child.getCellID(phi, r);
+                if (childresult != none) return childresult;
             }
             throw std::runtime_error("No responsible child node found even though this node is responsible.");
         }

--- a/include/networkit/generators/quadtree/QuadNodePolarEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodePolarEuclid.hpp
@@ -652,7 +652,7 @@ public:
     index getMaxIDInSubtree() const {
         if (isLeaf) return getID();
         else {
-            index result = -1;
+            index result = 0;
             for (int i = 0; i < 4; i++) {
                 result = std::max(children[i].getMaxIDInSubtree(), result);
             }

--- a/include/networkit/generators/quadtree/QuadNodePolarEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodePolarEuclid.hpp
@@ -19,11 +19,6 @@
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/geometric/HyperbolicSpace.hpp>
 
-using std::vector;
-using std::min;
-using std::max;
-using std::cos;
-
 namespace NetworKit {
 
 template <class T>
@@ -262,13 +257,13 @@ public:
         double topDistance, bottomDistance, leftDistance, rightDistance;
 
         if (phi < leftAngle || phi > rightAngle) {
-            topDistance = min(c.distance(query), d.distance(query));
+            topDistance = std::min(c.distance(query), d.distance(query));
         } else {
             topDistance = abs(r - maxR);
         }
         if (topDistance <= radius) return false;
         if (phi < leftAngle || phi > rightAngle) {
-            bottomDistance = min(a.distance(query), b.distance(query));
+            bottomDistance = std::min(a.distance(query), b.distance(query));
         } else {
             bottomDistance = abs(r - minR);
         }
@@ -278,7 +273,7 @@ public:
         if (minDistanceR > minR && minDistanceR < maxR) {
             leftDistance = query.distance(HyperbolicSpace::polarToCartesian(phi, minDistanceR));
         } else {
-            leftDistance = min(a.distance(query), d.distance(query));
+            leftDistance = std::min(a.distance(query), d.distance(query));
         }
         if (leftDistance <= radius) return false;
 
@@ -286,7 +281,7 @@ public:
         if (minDistanceR > minR && minDistanceR < maxR) {
             rightDistance = query.distance(HyperbolicSpace::polarToCartesian(phi, minDistanceR));
         } else {
-            rightDistance = min(b.distance(query), c.distance(query));
+            rightDistance = std::min(b.distance(query), c.distance(query));
         }
         if (rightDistance <= radius) return false;
         return true;

--- a/include/networkit/generators/quadtree/QuadNodePolarEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodePolarEuclid.hpp
@@ -603,11 +603,8 @@ public:
      */
     count countLeaves() const {
         if (isLeaf) return 1;
-        count result = 0;
-        for (index i = 0; i < children.size(); i++) {
-            result += children[i].countLeaves();
-        }
-        return result;
+        return std::accumulate(children.begin(), children.end(), count{0},
+                               [](const auto &child) -> count { return child.countLeaves(); });
     }
 
     double getLeftAngle() const {

--- a/networkit/cpp/coarsening/ClusteringProjector.cpp
+++ b/networkit/cpp/coarsening/ClusteringProjector.cpp
@@ -44,11 +44,10 @@ Partition ClusteringProjector::projectBackToFinest(const Partition& zetaCoarse,
     });
 
     // find coarsest supernode for each node
-    for (auto iter = maps.begin(); iter != maps.end(); ++iter) {
+    for (const auto &map : maps)
         Gfinest.parallelForNodes([&](node v){
-            tempMap[v] = (* iter)[tempMap[v]];
+            tempMap[v] = map[tempMap[v]];
         });
-    }
 
 
     // set clusters for fine nodes
@@ -74,11 +73,10 @@ Partition ClusteringProjector::projectCoarseGraphToFinestClustering(const Graph&
 
 
     // find coarsest supernode for each node
-    for (auto iter = maps.begin(); iter != maps.end(); ++iter) {
+    for (const auto &map : maps)
         Gfinest.parallelForNodes([&](node v){
-            super[v] = (* iter)[super[v]];
+            super[v] = map[super[v]];
         });
-    }
 
     // assign super node id as cluster id
     Gfinest.parallelForNodes([&](node v) {

--- a/networkit/cpp/components/DynConnectedComponents.cpp
+++ b/networkit/cpp/components/DynConnectedComponents.cpp
@@ -121,8 +121,8 @@ namespace NetworKit {
 
         // If u and v are already in the same component, we
         // don't have to do anything
-        index maxComp = std::max(components[u], components[v]);
-        index minComp = std::min(components[u], components[v]);
+        index minComp, maxComp;
+        std::tie(minComp, maxComp) = std::minmax(components[u], components[v]);
 
         if (maxComp == minComp) {
             if (!updateResult.first) {

--- a/networkit/cpp/components/DynWeaklyConnectedComponents.cpp
+++ b/networkit/cpp/components/DynWeaklyConnectedComponents.cpp
@@ -152,8 +152,8 @@ namespace NetworKit {
 
         // If u and v are already in the same component, we
         // don't have to do anything. Same thing if edge (v, u) already exists.
-        index maxComp = std::max(components[u], components[v]);
-        index minComp = std::min(components[u], components[v]);
+        index minComp, maxComp;
+        std::tie(minComp, maxComp) = std::minmax(components[u], components[v]);
 
         if (maxComp == minComp || G->hasEdge(v, u)) {
             updateTreeAfterAddition(eid, false);

--- a/networkit/cpp/distance/Diameter.cpp
+++ b/networkit/cpp/distance/Diameter.cpp
@@ -268,11 +268,7 @@ edgeweight Diameter::estimatedVertexDiameter(const Graph& G, count samples) {
         edgeweight vd = estimateFrom(u);
         DEBUG("sampled vertex diameter from node ", u, ": ", vd);
         #pragma omp critical
-        {
-            if (vd > vdMax) {
-                vdMax = vd;
-            }
-        }
+        vdMax = std::max(vdMax, vd);
     }
 
     return vdMax;

--- a/networkit/cpp/distance/Diameter.cpp
+++ b/networkit/cpp/distance/Diameter.cpp
@@ -304,22 +304,21 @@ edgeweight Diameter::estimatedVertexDiameterPedantic(const Graph& G) {
         });
         vd ++; //we need the number of nodes, not the number of edges
     }
-    else {
+    else if (G.isEmpty()) {
+        vd = 0;
+    } else {
         ConnectedComponents cc(G);
         DEBUG("finding connected components");
         cc.run();
         INFO("Number of components ", cc.numberOfComponents());
         DEBUG("Estimating size of the largest component");
-        std::map<count, count> sizes = cc.getComponentSizes();
-        count largest_comp_size = 0;
-        for(auto it = sizes.cbegin(); it != sizes.cend(); ++it) {
-            DEBUG(it->second);
-            if (it->second > largest_comp_size) {
-                largest_comp_size = it->second;
-            }
-        }
-        INFO("Largest component size: ", largest_comp_size);
-        vd = largest_comp_size;
+        const auto compSizes = cc.getComponentSizes();
+        vd = std::max_element(
+                 compSizes.begin(), compSizes.end(),
+                 [](const auto &c1, const auto &c2) -> bool { return c1.second < c2.second; })
+                 ->second;
+
+        INFO("Largest component size: ", vd);
     }
     return vd;
 }

--- a/networkit/cpp/distance/Diameter.cpp
+++ b/networkit/cpp/distance/Diameter.cpp
@@ -101,11 +101,9 @@ std::pair<edgeweight, edgeweight> Diameter::estimatedDiameterRange(const Graph &
     std::vector<count> eccLowerBound(G.upperNodeIdBound()), eccUpperBound(G.upperNodeIdBound());
     std::vector<bool> finished(G.upperNodeIdBound());
 
-    for (node u = 0; u < G.upperNodeIdBound(); ++u) {
-        if (G.hasNode(u)) {
-            eccUpperBound[u] = G.numberOfNodes();
-        }
-    }
+    G.parallelForNodes([&](node u) {
+        eccUpperBound[u] = G.numberOfNodes();
+    });
 
     ConnectedComponents comp(G);
     comp.run();

--- a/networkit/cpp/io/test/IOBenchmark.cpp
+++ b/networkit/cpp/io/test/IOBenchmark.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <cmath>
 #include <vector>
 #include <string>
 #include <utility>
@@ -293,10 +294,10 @@ TEST_F(IOBenchmark, simulateDiseaseProgression) {
                 double minY = ycoords[newInfections[0]];
                 double maxY = ycoords[newInfections[0]];
                 for (index patient : newInfections) {
-                    minX = min(xcoords[patient], minX);
-                    maxX = max(xcoords[patient], maxX);
-                    minY = min(ycoords[patient], minY);
-                    maxY = max(ycoords[patient], maxY);
+                    minX = std::min(xcoords[patient], minX);
+                    maxX = std::max(xcoords[patient], maxX);
+                    minY = std::min(ycoords[patient], minY);
+                    maxY = std::max(ycoords[patient], maxY);
                 }
                 INFO("X coordinates of new infections range from ", minX, " to ", maxX, ".");
                 INFO("Y coordinates of new infections range from ", minY, " to ", maxY, ".");

--- a/networkit/cpp/viz/MaxentStress.cpp
+++ b/networkit/cpp/viz/MaxentStress.cpp
@@ -601,12 +601,8 @@ void MaxentStress::computeAlgebraicDistances(const Graph& graph, const count k) 
         }
     });
 
-    double minimumDist = minDist[0];
-    double maximumDist = maxDist[0];
-    for (node u = 1; u < G->numberOfNodes(); ++u) {
-        minimumDist = std::min(minimumDist, minDist[u]);
-        maximumDist = std::max(maximumDist, maxDist[u]);
-    }
+    const double minimumDist = *std::min_element(minDist.begin(), minDist.end()),
+                 maximumDist = *std::max_element(maxDist.begin(), maxDist.end());
 
     INFO("[min, max] = [", minimumDist, ",", maximumDist, "]");
 


### PR DESCRIPTION
I spotted several places of our codebase that can be simplified by using appropriate STL algorithms and range-based `for` loops. This PR fixes a few of them, in particular:
- uses `std::max/min_element` and `std::accumulate` where applicable
- uses `std::min/max` where applicable
- changes index-based for-loops with range-based for-loops
- fixes initialization bugs (i.e., `index i = -1` yields +inf, not -1)