### PR TITLE
 Documentation: Fix missing/non-visible doc for Python modules beginning with 'c'

### DIFF
--- a/networkit/clique.pyx
+++ b/networkit/clique.pyx
@@ -16,7 +16,21 @@ cdef extern from "cython_helper.h":
 	void throw_runtime_error(string message)
 
 def stdstring(pystring):
-	""" convert a Python string to a bytes object which is automatically coerced to std::string"""
+	""" 
+	stdstring(pystring)
+
+	Convert a Python string to a bytes object which is automatically coerced to std::string
+	
+	Parameters
+	----------
+	pystring : str
+		Python string
+
+	Returns
+	-------
+	str 
+		Original string in utf-8 encoding
+	"""
 	pybytes = pystring.encode("utf-8")
 	return pybytes
 
@@ -47,6 +61,8 @@ cdef extern from "<networkit/clique/MaximalCliques.hpp>":
 
 cdef class MaximalCliques(Algorithm):
 	"""
+	MaximalCliques(G, maximumOnly = False, callback = None)
+
 	Algorithm for listing all maximal cliques.
 
 	The implementation is based on the "hybrid" algorithm described in
@@ -57,14 +73,14 @@ cdef class MaximalCliques(Algorithm):
 	Experimental Algorithms (pp. 364375). Springer Berlin Heidelberg.
 	Retrieved from http://link.springer.com/chapter/10.1007/978-3-642-20662-7_31
 
-	The running time of this algorithm should be in O(d^2 * n * 3^{d/3})
+	The running time of this algorithm should be in :math:`O(d^2 * n * 3^{d/3})`
 	where f is the degeneracy of the graph, i.e., the maximum core number.
 	The running time in practive depends on the structure of the graph. In
 	particular for complex networks it is usually quite fast, even graphs with
 	millions of edges can usually be processed in less than a minute.
 
-	Parameters:
-	-----------
+	Parameters
+	----------
 	G : networkit.Graph
 		The graph to list the cliques for
 	maximumOnly : bool
@@ -104,15 +120,18 @@ cdef class MaximalCliques(Algorithm):
 
 	def getCliques(self):
 		"""
+		getCliques()
+
 		Return all found cliques unless a callback was given.
 
 		This method will throw if a callback was given and thus the cliques were not stored.
 		If only the maximum clique was stored, it will return exactly one clique unless the graph
 		is empty.
 
-		Returns:
-		--------
-		A list of cliques, each being represented as a list of nodes.
+		Returns
+		-------
+		list
+			A list of cliques, each being represented as a list of nodes.
 		"""
 		return (<_MaximalCliques*>(self._this)).getCliques()
 

--- a/networkit/coarsening.pyx
+++ b/networkit/coarsening.pyx
@@ -22,6 +22,8 @@ cdef extern from "<networkit/coarsening/GraphCoarsening.hpp>":
 		map[node, vector[node]] getCoarseToFineNodeMapping() except +
 
 cdef class GraphCoarsening(Algorithm):
+	""" Abstract base class for coarsening measures"""
+
 	cdef Graph _G
 
 	def __init__(self, *args, **namedargs):
@@ -29,12 +31,42 @@ cdef class GraphCoarsening(Algorithm):
 			raise RuntimeError("Error, you may not use GraphCoarsening directly, use a sub-class instead")
 
 	def getCoarseGraph(self):
+		"""
+		getCoarseGraph()
+
+		Returns the coarse graph
+
+		Returns
+		-------
+		networkit.Graph
+			Coarse graph
+		"""
 		return Graph(0).setThis((<_GraphCoarsening*>(self._this)).getCoarseGraph())
 
 	def getFineToCoarseNodeMapping(self):
+		"""
+		getCoarseGraph()
+
+		Returns the coarse graph
+
+		Returns
+		-------
+		list
+			List containing mapping, whereas index represents node u from fine graph and value represents node v from coarse graph  
+		"""
 		return (<_GraphCoarsening*>(self._this)).getFineToCoarseNodeMapping()
 
 	def getCoarseToFineNodeMapping(self):
+		"""
+		getCoarseGraph()
+
+		Returns the coarse graph
+
+		Returns
+		-------
+		map[node, list]
+			Map containing node from coarse graph and all its mappings from finer graph
+		"""
 		return (<_GraphCoarsening*>(self._this)).getCoarseToFineNodeMapping()
 
 
@@ -45,6 +77,20 @@ cdef extern from "<networkit/coarsening/ParallelPartitionCoarsening.hpp>":
 
 
 cdef class ParallelPartitionCoarsening(GraphCoarsening):
+	"""
+	ParallelPartitionCoarsening(G, zeta, parallel = True)
+	
+	Coarsens graph according to a partition.
+ 	
+ 	Parameters
+ 	----------
+ 	G : networkit.Graph
+		The graph.
+	zeta : networkit.Partition
+		The partition, which is used for coarsening.
+ 	parallel : bool, optional
+		If true, algorithm runs in parallel
+	"""
 	def __cinit__(self, Graph G not None, Partition zeta not None, parallel = True):
 		self._this = new _ParallelPartitionCoarsening(G._this, zeta._this, parallel)
 
@@ -55,14 +101,19 @@ cdef extern from "<networkit/coarsening/MatchingCoarsening.hpp>":
 
 
 cdef class MatchingCoarsening(GraphCoarsening):
-	"""Coarsens graph according to a matching.
+	"""
+	MatchingCoarsening(G, M, noSelfLoops=False)
+	
+	Coarsens graph according to a matching.
  	
- 	Parameters:
- 	-----------
+ 	Parameters
+ 	----------
  	G : networkit.Graph
-	M : Matching
+		The graph.
+	M : networkit.matching.Matching
+		The matching, which is used for coarsening.
  	noSelfLoops : bool, optional
-		if true, self-loops are not produced
+		If true, self-loops are not produced
 	"""
 
 	def __cinit__(self, Graph G not None, Matching M not None, bool_t noSelfLoops=False):

--- a/networkit/coloring.py
+++ b/networkit/coloring.py
@@ -4,17 +4,49 @@ from . import graph
 from .algebraic import adjacencyEigenvectors
 
 class SpectralColoring(object):
+	"""
+	SpectralColoring(G)
+
+	Algorithm for computing a valid spectral coloring for a given graph.
+
+	Parameters
+	----------
+	G : networkit.Graph
+		The graph to compute the spectral coloring for
+	"""
 	def __init__(self, G):
 		super(SpectralColoring, self).__init__()
 
 		self.graph = G
 
 	def prepareSpectrum(self):
+		"""
+		prepareSpectrum()
+
+		Computes eigenvalues and eigenvector in order to prepare the spectral coloring. 
+		This function does not need to be called, it is sufficient to call run()
+		for the SpectralColoring-object.
+		"""
 		spectrum = adjacencyEigenvectors(self.graph)
 		self.eigenvalues = spectrum[0]
 		self.eigenvectors = spectrum[1]
 
 	def valid(self, color):
+		"""
+		valid(color)
+
+		Checks whether colorID is valid
+
+		Parameters
+		----------
+		color : int
+			colorID to check for
+
+		Returns
+		-------
+		bool
+			Returns True if valid, False if not.
+		"""
 		for v in self.colors[color]:
 			for u in self.graph.iterNeighbors(v):
 				if u in self.colors[color]:
@@ -23,6 +55,20 @@ class SpectralColoring(object):
 		return True
 
 	def split(self, color, depth=0):
+		"""
+		split(color, depth=0)
+
+		Helper method for computing spectral coloring. 
+		This function does not need to be called, it is sufficient to call run()
+		for the SpectralColoring-object.
+
+		Parameters
+		----------
+		color : colorID
+			colorID to split corresponding nodes into colorID and new color.
+		depth : int, optional
+			Sets index of eigenvector to compare to `depth` 
+		"""
 		otherColor = self.nextColor
 		self.nextColor += 1
 
@@ -38,6 +84,13 @@ class SpectralColoring(object):
 			self.split(otherColor, depth=depth+1)
 
 	def buildReverseDict(self):
+		"""
+		buildReverseDict()
+
+		Helper method for computing spectral coloring. 
+		This function does not need to be called, it is sufficient to call run()
+		for the SpectralColoring-object.
+		"""
 		self.coloring = {}
 
 		for color in self.colors:
@@ -46,6 +99,11 @@ class SpectralColoring(object):
 
 
 	def run(self):
+		"""
+		run()
+
+		Main method of SpectralColoring. This computes a valid coloring.
+		"""
 		self.prepareSpectrum()
 
 		self.colors = {0 : set(self.graph.iterNodes())}
@@ -55,4 +113,14 @@ class SpectralColoring(object):
 		self.buildReverseDict()
 
 	def getColoring(self):
+		"""
+		getColoring()
+
+		Returns a valid coloring for a given graph. Each node has a color ID to be mapped onto a color palette.
+
+		Returns
+		-------
+		list
+			A list of nodes containing a valid color mapping. 
+		"""
 		return self.coloring

--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -1269,7 +1269,7 @@ cdef class LocalCommunityEvaluation(Algorithm):
 
 		Returns
 		-------
-		list[double]:
+		list(double):
 			The values of all clusters.
 		"""
 		if self._this == NULL:

--- a/networkit/components.pyx
+++ b/networkit/components.pyx
@@ -27,14 +27,14 @@ cdef extern from "<networkit/components/ConnectedComponents.hpp>":
 		_Graph extractLargestConnectedComponent(_Graph G, bool_t) nogil except +
 
 cdef class ConnectedComponents(Algorithm):
-	""" Determines the connected components and associated values for an undirected graph.
-
+	""" 
 	ConnectedComponents(G)
-
+	
+	Determines the connected components and associated values for an undirected graph. 
 	Create ConnectedComponents for Graph `G`.
 
-	Parameters:
-	-----------
+	Parameters
+	----------
 	G : networkit.Graph
 		The graph.
 	"""
@@ -45,49 +45,71 @@ cdef class ConnectedComponents(Algorithm):
 		self._this = new _ConnectedComponents(G._this)
 
 	def getPartition(self):
-		""" Get a Partition that represents the components.
+		""" 
+		getPartition()
 
-		Returns:
-		--------
+		Get a Partition that represents the components.
+
+		Returns
+		-------
 		networkit.Partition
 			A partition representing the found components.
 		"""
 		return Partition().setThis((<_ConnectedComponents*>(self._this)).getPartition())
 
 	def numberOfComponents(self):
-		""" Get the number of connected components.
+		""" 
+		numberOfComponents()
+		
+		Get the number of connected components.
 
-		Returns:
-		--------
-		count:
+		Returns
+		-------
+		int
 			The number of connected components.
 		"""
 		return (<_ConnectedComponents*>(self._this)).numberOfComponents()
 
 	def componentOfNode(self, v):
-		"""  Get the the component in which node `v` is situated.
+		"""  
+		componentOfNode(v)
+		
+		Get the the component in which node `v` is situated.
 
+		Parameters
+		----------
 		v : node
 			The node whose component is asked for.
+
+		Returns
+		-------
+		int
+			Component in which node `v` is situated
 		"""
 		return (<_ConnectedComponents*>(self._this)).componentOfNode(v)
 
 	def getComponentSizes(self):
-		""" Get the component sizes.
+		""" 
+		getComponentSizes()
+		
+		Get the component sizes.
 
-		Returns:
-		--------
-		map:
-			The map from component to size.
+		Returns
+		-------
+		dict(int : int)
+			A dict containing the component ids and their size.
 		"""
 		return (<_ConnectedComponents*>(self._this)).getComponentSizes()
 
 	def getComponents(self):
-		""" Get the connected components, each as a list of nodes.
+		""" 
+		getComponents()
+		
+		Get the connected components, each as a list of nodes.
 
-		Returns:
-		--------
-		list:
+		Returns
+		-------
+		list
 			The connected components.
 		"""
 		return (<_ConnectedComponents*>(self._this)).getComponents()
@@ -95,28 +117,27 @@ cdef class ConnectedComponents(Algorithm):
 	@staticmethod
 	def extractLargestConnectedComponent(Graph graph, bool_t compactGraph = False):
 		"""
-			Constructs a new graph that contains only the nodes inside the
-			largest connected component.
+		Constructs a new graph that contains only the nodes inside the
+		largest connected component.
 
-			Parameters:
-			-----------
-			graph: networkit.Graph
-				The input graph
-			compactGraph: bool
-				if true, the node ids of the output graph will be compacted
-				(i.e., re-numbered from 0 to n-1). If false, the node ids
-				will not be changed.
+		Notes
+		-----
+		Available for undirected graphs only.
 
-			Returns:
-			--------
-			networkit.Graph
-				A graph that contains only the nodes inside the largest
-				connected component.
+		Parameters
+		----------
+		graph : networkit.Graph
+			The input graph
+		compactGraph : bool, optional
+			if true, the node ids of the output graph will be compacted
+			(i.e., re-numbered from 0 to n-1). If false, the node ids
+			will not be changed.
 
-
-			Note:
-			-----
-			Available for undirected graphs only.
+		Returns
+		-------
+		networkit.Graph
+			A graph that contains only the nodes inside the largest
+			connected component.
 		"""
 		return Graph().setThis(_ConnectedComponents.extractLargestConnectedComponent(graph._this, compactGraph))
 
@@ -131,8 +152,21 @@ cdef extern from "<networkit/components/ParallelConnectedComponents.hpp>":
 
 
 cdef class ParallelConnectedComponents(Algorithm):
-	""" Determines the connected components and associated values for
-		an undirected graph.
+	""" 
+	ParallelConnectedComponents(G, coarsening=True)
+
+	Determines the connected components and associated values for
+	an undirected graph.
+
+	Parameters
+	----------
+	graph : networkit.Graph
+		The input graph
+	coarsening : bool, optional
+		Specifies whether the main algorithm based on label propagation (LP) 
+		shall work recursively (true) or not (false) by coarsening/contracting 
+		an LP-computed clustering. Defaults to true since we saw positive effects 
+		in terms of running time for many networks. Beware of possible memory implications.
 	"""
 	cdef Graph _G
 
@@ -141,39 +175,58 @@ cdef class ParallelConnectedComponents(Algorithm):
 		self._this = new _ParallelConnectedComponents(G._this, coarsening)
 
 	def getPartition(self):
-		""" Get a Partition that represents the components.
+		""" 
+		getPartition()
+		
+		Get a Partition that represents the components.
 
-		Returns:
-		--------
+		Returns
+		-------
 		networkit.Partition
 			A partition representing the found components.
 		"""
 		return Partition().setThis((<_ParallelConnectedComponents*>(self._this)).getPartition())
 
 	def numberOfComponents(self):
-		""" Get the number of connected components.
+		""" 
+		numberOfComponents()
+		
+		Get the number of connected components.
 
-		Returns:
-		--------
-		count:
+		Returns
+		-------
+		int
 			The number of connected components.
 		"""
 		return (<_ParallelConnectedComponents*>(self._this)).numberOfComponents()
 
 	def componentOfNode(self, v):
-		"""  Get the the component in which node `v` is situated.
+		"""  
+		componentOfNode(v)
+		
+		Get the the component in which node `v` is situated.
 
+		Parameters
+		----------
 		v : node
 			The node whose component is asked for.
+
+		Returns
+		-------
+		int
+			Component in which node `v` is situated
 		"""
 		return (<_ParallelConnectedComponents*>(self._this)).componentOfNode(v)
 
 	def getComponents(self):
-		""" Get the connected components, each as a list of nodes.
+		""" 
+		getComponents()
 
-		Returns:
-		--------
-		list:
+		Get the connected components, each as a list of nodes.
+
+		Returns
+		-------
+		list
 			The connected components.
 		"""
 		return (<_ParallelConnectedComponents*>(self._this)).getComponents()
@@ -192,17 +245,21 @@ cdef extern from "<networkit/components/StronglyConnectedComponents.hpp>":
 
 
 cdef class StronglyConnectedComponents:
+	""" 
+	StronglyConnectedComponents(G)
+
+	Computes the strongly connected components of a directed graph.
+
+	Parameters:
+	-----------
+	G : networkit.Graph
+		The graph.
+	"""
 	cdef _StronglyConnectedComponents* _this
 	cdef Graph _G
 
 	def __cinit__(self, Graph G):
-		""" Computes the strongly connected components of a directed graph.
 
-			Parameters:
-			-----------
-			G : networkit.Graph
-				The graph.
-		"""
 		self._G = G
 		self._this = new _StronglyConnectedComponents(G._this)
 
@@ -211,6 +268,8 @@ cdef class StronglyConnectedComponents:
 
 	def run(self):
 		"""
+		run()
+
 		Runs the algorithm.
 		"""
 		with nogil:
@@ -219,21 +278,25 @@ cdef class StronglyConnectedComponents:
 
 	def getPartition(self):
 		"""
+		getPartition()
+
 		Returns a Partition object representing the strongly connected components.
 
-		Returns:
-		--------
-		Partition
+		Returns
+		-------
+		networkit.Partition
 			The strongly connected components.
 		"""
 		return Partition().setThis(self._this.getPartition())
 
 	def numberOfComponents(self):
 		"""
+		numberOfComponents()
+		
 		Returns the number of strongly connected components of the graph.
 
-		Returns:
-		--------
+		Returns
+		-------
 		int
 			The number of strongly connected components.
 		"""
@@ -243,12 +306,13 @@ cdef class StronglyConnectedComponents:
 		"""
 		Returns the component of node `u`.
 
-		Parameters:
-		-----------
+		Parameters
+		----------
 		u : node
 			A node in the graph.
 
-		Returns:
+		Returns
+		-----------
 		int
 			The component of node `u`.
 		"""
@@ -256,22 +320,26 @@ cdef class StronglyConnectedComponents:
 
 	def getComponentSizes(self):
 		"""
-		Returns a map with the component indexes as keys, and their size as values.
+		getComponentSizes()
+		
+		Returns a map with the component indexes as keys and their size as values.
 
-		Returns:
-		--------
-		map[index, count]
-			Map with component indexes as keys, and their size as values.
+		Returns
+		-------
+		dict(int : int)
+			A dict with component indexes as keys and their size as values.
 		"""
 		return self._this.getComponentSizes()
 
 	def getComponents(self):
 		"""
+		getComponents()
+		
 		Returns a list of components.
 
-		Returns:
-		--------
-		list[list[node]]
+		Returns
+		-------
+		list(list(int))
 			A list of components.
 		"""
 		return self._this.getComponents()
@@ -287,12 +355,15 @@ cdef extern from "<networkit/components/WeaklyConnectedComponents.hpp>":
 		vector[vector[node]] getComponents() except +
 
 cdef class WeaklyConnectedComponents(Algorithm):
-	""" Determines the weakly connected components of a directed graph.
+	""" 
+	WeaklyConnectedComponents(G)
 
-		Parameters:
-		-----------
-		G : networkit.Graph
-			The graph.
+	Determines the weakly connected components of a directed graph.
+
+	Parameters
+	----------
+	G : networkit.Graph
+		The graph.
 	"""
 	cdef Graph _G
 
@@ -301,42 +372,59 @@ cdef class WeaklyConnectedComponents(Algorithm):
 		self._this = new _WeaklyConnectedComponents(G._this)
 
 	def numberOfComponents(self):
-		""" Returns the number of components.
+		""" 
+		numberOfComponents()
 
-			Returns:
-			--------
-			count
-				The number of components.
+		Returns the number of components.
+
+		Returns
+		-------
+		int
+			The number of components.
 		"""
 		return (<_WeaklyConnectedComponents*>(self._this)).numberOfComponents()
 
 	def componentOfNode(self, v):
-		""" Returns the the component in which node @a u is.
+		"""  
+		componentOfNode(v)
+		
+		Get the the component in which node `v` is situated.
 
-			Parameters:
-			-----------
-			v : node
-				The node.
+		Parameters
+		----------
+		v : node
+			The node whose component is asked for.
+
+		Returns
+		-------
+		int
+			Component in which node `v` is situated
 		"""
 		return (<_WeaklyConnectedComponents*>(self._this)).componentOfNode(v)
 
 	def getComponentSizes(self):
-		""" Returns the map from component to size.
+		""" 
+		getComponentSizes()
+		
+		Returns the map from component id to size.
 
-			Returns:
-			--------
-			map[index, count]
-			 	A map that maps each component to its size.
+		Returns
+		-------
+		dict(int : int)
+			A dict that maps each component id to its size.
 		"""
 		return (<_WeaklyConnectedComponents*>(self._this)).getComponentSizes()
 
 	def getComponents(self):
-		""" Returns all the components, each stored as (unordered) set of nodes.
+		""" 
+		getComponents()
+		
+		Returns all the components, each stored as (unordered) set of nodes.
 
-			Returns:
-			--------
-			vector[vector[node]]
-				A vector of vectors. Each inner vector contains all the nodes inside the component.
+		Returns
+		-------
+		vector[vector[node]]
+			A vector of vectors. Each inner vector contains all the nodes inside the component.
 		"""
 		return (<_WeaklyConnectedComponents*>(self._this)).getComponents()
 
@@ -350,15 +438,17 @@ cdef extern from "<networkit/components/BiconnectedComponents.hpp>":
 		vector[vector[node]] getComponents() except +
 
 cdef class BiconnectedComponents(Algorithm):
-	""" Determines the biconnected components of an undirected graph as defined in
-		Tarjan, Robert. Depth-First Search and Linear Graph Algorithms. SIAM J.
-		Comput. Vol 1, No. 2, June 1972.
+	""" 
+	BiconnectedComponents()
+	
+	Determines the biconnected components of an undirected graph as defined in
+	Tarjan, Robert. Depth-First Search and Linear Graph Algorithms. SIAM J.
+	Comput. Vol 1, No. 2, June 1972.
 
-
-		Parameters:
-		-----------
-		G : networkit.Graph
-			The graph.
+	Parameters
+	----------
+	G : networkit.Graph
+		The graph.
 	"""
 	cdef Graph _G
 
@@ -367,32 +457,41 @@ cdef class BiconnectedComponents(Algorithm):
 		self._this = new _BiconnectedComponents(G._this)
 
 	def numberOfComponents(self):
-		""" Returns the number of components.
+		"""
+		numberOfComponents()
+		
+		Returns the number of components.
 
-			Returns:
-			--------
-			count
-				The number of components.
+		Returns
+		-------
+		int
+			The number of components.
 		"""
 		return (<_BiconnectedComponents*>(self._this)).numberOfComponents()
 
 	def getComponentSizes(self):
-		""" Returns the map from component to size.
+		""" 
+		getComponentSizes()
+		
+		Returns the map from component id to size.
 
-			Returns:
-			--------
-			map[count, count]
-			A map that maps each component to its size.
+		Returns
+		-------
+		dict(int : int)
+			A dict that maps each component id to its size.
 		"""
 		return (<_BiconnectedComponents*>(self._this)).getComponentSizes()
 
 	def getComponents(self):
-		""" Returns all the components, each stored as (unordered) set of nodes.
+		""" 
+		getComponents()
+		
+		Returns all the components, each stored as (unordered) set of nodes.
 
-			Returns:
-			--------
-			vector[vector[node]]
-				A vector of vectors. Each inner vector contains all the nodes inside the component.
+		Returns
+		-------
+		vector[vector[node]]
+			A vector of vectors. Each inner vector contains all the nodes inside the component.
 		"""
 		return (<_BiconnectedComponents*>(self._this)).getComponents()
 
@@ -409,12 +508,15 @@ cdef extern from "<networkit/components/DynConnectedComponents.hpp>":
 		vector[vector[node]] getComponents() except +
 
 cdef class DynConnectedComponents(Algorithm):
-	""" Determines and updates the connected components of an undirected graph.
+	""" 
+	DynConnectedComponents(G)
+	
+	Determines and updates the connected components of an undirected graph.
 
-		Parameters:
-		-----------
-		G : networkit.Graph
-			The graph.
+	Parameters
+	----------
+	G : networkit.Graph
+		The graph.
 	"""
 	cdef Graph _G
 
@@ -423,64 +525,87 @@ cdef class DynConnectedComponents(Algorithm):
 		self._this = new _DynConnectedComponents(G._this)
 
 	def numberOfComponents(self):
-		""" Returns the number of components.
+		"""
+		numberOfComponents()
+		
+		Returns the number of components.
 
-			Returns:
-			--------
-			count
-				The number of components.
+		Returns
+		-------
+		int
+			The number of components.
 		"""
 		return (<_DynConnectedComponents*>(self._this)).numberOfComponents()
 
 	def componentOfNode(self, v):
-		""" Returns the the component in which node @a u is.
+		"""  
+		componentOfNode(v)
+		
+		Get the the component in which node `v` is situated.
 
-			Parameters:
-			-----------
-			v : node
-				The node.
+		Parameters
+		----------
+		v : node
+			The node whose component is asked for.
+
+		Returns
+		-------
+		int
+			Component in which node `v` is situated
 		"""
 		return (<_DynConnectedComponents*>(self._this)).componentOfNode(v)
 
 	def getComponentSizes(self):
-		""" Returns the map from component to size.
+		""" 
+		getComponentSizes()
+		
+		Returns the map from component id to size.
 
-			Returns:
-			--------
-			map[index, count]
-			 	A map that maps each component to its size.
+		Returns
+		-------
+		dict(int : int)
+			A dict that maps each component id to its size.
 		"""
 		return (<_DynConnectedComponents*>(self._this)).getComponentSizes()
 
 	def getComponents(self):
-		""" Returns all the components, each stored as (unordered) set of nodes.
+		"""
+		getComponents()
+		
+		Returns all the components, each stored as (unordered) set of nodes.
 
-			Returns:
-			--------
-			vector[vector[node]]
-				A vector of vectors. Each inner vector contains all the nodes inside the component.
+		Returns
+		-------
+		list[list[int]]
+			A list of lists. Each inner list contains all the nodes inside the component.
 		"""
 		return (<_DynConnectedComponents*>(self._this)).getComponents()
 
 	def update(self, event):
-		""" Updates the connected components after an edge insertion or
-			deletion.
+		""" 
+		update(event)
+		
+		Updates the connected components after an edge insertion or
+		deletion.
 
-			Parameters:
-			-----------
-			event : GraphEvent
-				The event that happened (edge deletion or insertion).
+		Parameters
+		----------
+		event : GraphEvent
+			The event that happened (edge deletion or insertion).
 		"""
 		(<_DynConnectedComponents*>(self._this)).update(_GraphEvent(event.type, event.u, event.v, event.w))
 
 	def updateBatch(self, batch):
-		""" Updates the connected components after a batch of edge insertions or
-			deletions.
+		""" 
+		updateBatch(batch)
+		
+		Updates the connected components after a batch of edge insertions or
+		deletions.
 
-			Parameters:
-			-----------
-			batch : vector[GraphEvent]
-				A vector that contains a batch of edge insertions or deletions.
+		Parameters
+		----------
+		batch : vector[GraphEvent]
+			A vector that contains a batch of edge insertions or deletions.
 		"""
 		cdef vector[_GraphEvent] _batch
 		for event in batch:
@@ -501,12 +626,15 @@ cdef extern from "<networkit/components/DynWeaklyConnectedComponents.hpp>":
 		vector[vector[node]] getComponents() except +
 
 cdef class DynWeaklyConnectedComponents(Algorithm):
-	""" Determines and updates the weakly connected components of a directed graph.
+	""" 
+	DynWeaklyConnectedComponents(G)
+	
+	Determines and updates the weakly connected components of a directed graph.
 
-		Parameters:
-		-----------
-		G : networkit.Graph
-			The graph.
+	Parameters
+	----------
+	G : networkit.Graph
+		The graph.
 	"""
 	cdef Graph _G
 
@@ -515,66 +643,88 @@ cdef class DynWeaklyConnectedComponents(Algorithm):
 		self._this = new _DynWeaklyConnectedComponents(G._this)
 
 	def numberOfComponents(self):
-		""" Returns the number of components.
+		""" 
+		numberOfComponents()
+		
+		Returns the number of components.
 
-			Returns:
-			--------
-			count
-				The number of components.
+		Returns
+		-------
+		int
+			The number of components.
 		"""
 		return (<_DynWeaklyConnectedComponents*>(self._this)).numberOfComponents()
 
 	def componentOfNode(self, v):
-		""" Returns the the component in which node @a u is.
+		"""  
+		componentOfNode(v)
+		
+		Get the the component in which node `v` is situated.
 
-			Parameters:
-			-----------
-			v : node
-				The node.
+		Parameters
+		----------
+		v : node
+			The node whose component is asked for.
+
+		Returns
+		-------
+		int
+			Component in which node `v` is situated
 		"""
 		return (<_DynWeaklyConnectedComponents*>(self._this)).componentOfNode(v)
 
 	def getComponentSizes(self):
-		""" Returns the map from component to size.
+		""" 
+		getComponentSizes()
+		
+		Returns the map from component id to size.
 
-			Returns:
-			--------
-			map[index, count]
-			 	A map that maps each component to its size.
+		Returns
+		-------
+		dict(int : int)
+			A dict that maps each component id to its size.
 		"""
 		return (<_DynWeaklyConnectedComponents*>(self._this)).getComponentSizes()
 
 	def getComponents(self):
-		""" Returns all the components, each stored as (unordered) set of nodes.
+		""" 
+		getComponents()
+		
+		Returns all the components, each stored as (unordered) set of nodes.
 
-			Returns:
-			--------
-			vector[vector[node]]
-				A vector of vectors. Each inner vector contains all the nodes
-				inside the component.
-
+		Returns
+		-------
+		vector[vector[node]]
+			A vector of vectors. Each inner vector contains all the nodes
+			inside the component.
 		"""
 		return (<_DynWeaklyConnectedComponents*>(self._this)).getComponents()
 
 	def update(self, event):
-		""" Updates the connected components after an edge insertion or
-			deletion.
+		""" 
+		update(event)
+		
+		Updates the connected components after an edge insertion or
+		deletion.
 
-			Parameters:
-			-----------
-			event : GraphEvent
-				The event that happened (edge deletion or insertion).
+		Parameters
+		----------
+		event : GraphEvent
+			The event that happened (edge deletion or insertion).
 		"""
 		(<_DynWeaklyConnectedComponents*>(self._this)).update(_GraphEvent(event.type, event.u, event.v, event.w))
 
 	def updateBatch(self, batch):
-		""" Updates the connected components after a batch of edge insertions or
-			deletions.
+		"""
+		updateBatch(batch)
+		
+		Updates the connected components after a batch of edge insertions or
+		deletions.
 
-			Parameters:
-			-----------
-			batch : vector[GraphEvent]
-				A vector that contains a batch of edge insertions or deletions.
+		Parameters
+		----------
+		batch : vector[GraphEvent]
+			A vector that contains a batch of edge insertions or deletions.
 		"""
 		cdef vector[_GraphEvent] _batch
 		for event in batch:

--- a/networkit/correlation.pyx
+++ b/networkit/correlation.pyx
@@ -14,7 +14,19 @@ cdef extern from "<networkit/correlation/Assortativity.hpp>":
 		double getCoefficient() except +
 
 cdef class Assortativity(Algorithm):
-	""" """
+	""" 
+	Assortativity(G, data)
+	
+	Assortativity computes a coefficient that expresses the correlation of a
+	node attribute among connected pairs of nodes.
+	
+	Parameters
+	----------
+	G : networkit.graph
+		The graph.
+	data : list(float)
+			Numerical node value array
+	"""
 	cdef Graph G
 	cdef vector[double] attribute
 	cdef Partition partition
@@ -29,5 +41,15 @@ cdef class Assortativity(Algorithm):
 		self.G = G
 
 	def getCoefficient(self):
+		"""
+		getCoefficient()
+
+		Return the assortativity coefficient.
+
+		Returns
+		-------
+		float
+			The assortativity coefficient.
+		"""
 		return (<_Assortativity*>(self._this)).getCoefficient()
 

--- a/networkit/csbridge.py
+++ b/networkit/csbridge.py
@@ -19,26 +19,28 @@ else:
 
 def widget_from_graph(G, node_scores = None, node_partition = None, node_palette = None, show_ids = True):
 	""" 
+	widget_from_graph(G, node_scores = None, node_partition = None, node_palette = None, show_ids = True)
+
 	Creates a ipycytoscape-widget from a given graph. The returned widget already contains
 	all nodes and edges from the graph. The graph is colored using an array of norm. rgb-values
 	based on seaborn perceptually uniform color map (rocket) or a user given custom color array. 
 	See matplotlib color maps for the correct formatting: 
 	https://matplotlib.org/api/_as_gen/matplotlib.colors.Colormap.html#matplotlib.colors.Colormap 
 
-	Parameters:
-	-----------
+	Parameters
+	----------
 	G : networkit.graph.Graph
 		Graph (nodes, edges), which should be visualized
-	node_scores : list of numbers
+	node_scores : list of numbers, optional
 		List of scores for each nodes, for example scores from a centrality measure. This is 
 		used for color-calculation of the nodes (continuous distribution). Provide either 
 		node_scores or node_partition - not both.
-	node_partition : networkit.structures.Partition
+	node_partition : networkit.structures.Partition, optional
 		Partition object. This is used for color-calculation of the nodes (discrete distribution). 
 		Provide either node_scores or node_partition - not both. 	
-	node_palette : list of tuples
+	node_palette : list of tuples, optional
 		Array consisting of normalized rgb-values. If none is given, seaborn.color_palette.colors is used
-	show_ids : 	boolean	
+	show_ids : 	boolean, optional
 		Set whether node ids should be visible in plot-widget. Is set to True by default. 
 	"""
 	# Sanity checks


### PR DESCRIPTION
This PR is a follow-up and fixes missing/non-visible doc for modules: clique, coarsening, coloring, components, correlation, csbridge (remaining modules beginning with letter 'c').