### PR TITLE
Refactor: GraphEvent

### DIFF
--- a/include/networkit/dynamics/GraphEvent.hpp
+++ b/include/networkit/dynamics/GraphEvent.hpp
@@ -10,6 +10,8 @@
 
 #include <networkit/graph/Graph.hpp>
 
+#include <tlx/define/deprecated.hpp>
+
 namespace NetworKit {
 
 /**
@@ -38,8 +40,15 @@ public:
 
     GraphEvent(Type type, node u = none, node v = none, edgeweight w = 1.0);
 
-    static bool compare(GraphEvent a, GraphEvent b);
-    static bool equal(GraphEvent a, GraphEvent b);
+    static bool TLX_DEPRECATED(compare(GraphEvent a, GraphEvent b));
+    static bool TLX_DEPRECATED(equal(GraphEvent a, GraphEvent b));
+
+    bool operator==(const GraphEvent &rhs) const noexcept;
+    bool operator!=(const GraphEvent &rhs) const noexcept;
+    friend bool operator<(const GraphEvent &a, const GraphEvent &b) noexcept;
+    friend bool operator>(const GraphEvent &a, const GraphEvent &b) noexcept;
+    bool operator<=(const GraphEvent &rhs) const noexcept;
+    bool operator>=(const GraphEvent &rhs) const noexcept;
 
     /**
      * Return string representation.

--- a/networkit/cpp/dynamics/GraphEvent.cpp
+++ b/networkit/cpp/dynamics/GraphEvent.cpp
@@ -36,14 +36,39 @@ std::string GraphEvent::toString() const {
     return ss.str();
 }
 
+bool GraphEvent::operator==(const GraphEvent &rhs) const noexcept {
+    if (type == GraphEvent::TIME_STEP && rhs.type == GraphEvent::TIME_STEP) return true;
+    return (type == rhs.type && u == rhs.u && v == rhs.v && w == rhs.w);
+}
+
+bool GraphEvent::operator!=(const GraphEvent &rhs) const noexcept {
+    return !(*this == rhs);
+}
+
+bool operator<(const GraphEvent &a, const GraphEvent &b) noexcept {
+    return (a.type < b.type || (a.type == b.type && a.u < b.u)
+            || (a.type == b.type && a.u == b.u && a.v < b.v)
+            || (a.type == b.type && a.u == b.u && a.v == b.v && a.w < b.w));
+}
+
+bool operator>(const GraphEvent &a, const GraphEvent &b) noexcept {
+    return b < a;
+}
+
+bool GraphEvent::operator<=(const GraphEvent &rhs) const noexcept {
+    return !(*this > rhs);
+}
+
+bool GraphEvent::operator>=(const GraphEvent &rhs) const noexcept {
+    return !(*this < rhs);
+}
+
 bool GraphEvent::compare(GraphEvent a, GraphEvent b) {
-    if (a.type < b.type || (a.type == b.type && a.u < b.u) || (a.type == b.type && a.u == b.u && a.v < b.v) || (a.type == b.type && a.u == b.u && a.v == b.v && a.w < b.w)) return true;
-    else return false;
+    return a <= b;
 }
 
 bool GraphEvent::equal(GraphEvent a, GraphEvent b) {
-    if (a.type == GraphEvent::TIME_STEP && b.type == GraphEvent::TIME_STEP) return true;
-    return (a.type == b.type && a.u == b.u && a.v == b.v && a.w == b.w);
+    return a == b;
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
+++ b/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
@@ -338,8 +338,8 @@ void DynamicHyperbolicGenerator::getEventsFromNodeMovement(vector<GraphEvent> &r
     for (auto it = result.begin()+oldStreamMarker; it < result.end(); it++) {
         if (it->u > it->v) std::swap(it->u, it->v);
     }
-    Aux::Parallel::sort(result.begin()+oldStreamMarker, result.end(), GraphEvent::compare);
-    auto end = std::unique(result.begin()+oldStreamMarker, result.end(), GraphEvent::equal);
+    Aux::Parallel::sort(result.begin()+oldStreamMarker, result.end());
+    auto end = std::unique(result.begin()+oldStreamMarker, result.end());
     result.erase(end, result.end());
 
 }

--- a/networkit/dynamics.pxd
+++ b/networkit/dynamics.pxd
@@ -30,12 +30,12 @@ cdef extern from "<networkit/dynamics/GraphEvent.hpp>":
 		_GraphEvent() except +
 		_GraphEvent(_GraphEventType type, node u, node v, edgeweight w) except +
 		string toString() except +
+		bool_t operator==(_GraphEvent)
+		bool_t operator!=(_GraphEvent)
+		bool_t operator<(_GraphEvent, _GraphEvent)
+		bool_t operator>(_GraphEvent, _GraphEvent)
+		bool_t operator<=(_GraphEvent)
+		bool_t operator>=(_GraphEvent)
 
 cdef class GraphEvent:
 	cdef _GraphEvent _this
-
-cdef extern from "<networkit/dynamics/GraphEvent.hpp>" namespace "NetworKit::GraphEvent":
-
-	bool_t _GraphEvent_equal "NetworKit::GraphEvent::equal"(_GraphEvent a, _GraphEvent b) except +
-	bool_t _GraphEvent_compare "NetworKit::GraphEvent::compare"(_GraphEvent a, _GraphEvent b) except +
-

--- a/networkit/dynamics.pyx
+++ b/networkit/dynamics.pyx
@@ -53,7 +53,22 @@ cdef class GraphEvent:
 		return self.toString()
 
 	def __eq__(self, GraphEvent other not None):
-		return _GraphEvent_equal(self._this, other._this)
+		return self._this == other._this
+
+	def __ne__(self, GraphEvent other not None):
+		return self._this != other._this
+
+	def __lt__(self, GraphEvent other not None):
+		return self._this < other._this
+
+	def __gt__(self, GraphEvent other not None):
+		return self._this > other._this
+
+	def __le__(self, GraphEvent other not None):
+		return self._this <= other._this
+
+	def __ge__(self, GraphEvent other not None):
+		return self._this >= other._this
 
 cdef extern from "<networkit/dynamics/DGSStreamParser.hpp>":
 


### PR DESCRIPTION
Currently, `GraphEvent` implements two static functions `equal` and `compare`, which should be replaced with proper comparison operators. This PR
- implements comparison operators for `GraphEvent`
- deprecates `GraphEvent::equal` and `GraphEvent::compare`
- makes `GraphEvent` operators available in Python