### PR TITLE
Fix: Spanning Forest and KruskalMSF

### DIFF
--- a/include/networkit/graph/KruskalMSF.hpp
+++ b/include/networkit/graph/KruskalMSF.hpp
@@ -21,7 +21,6 @@ namespace NetworKit {
 class KruskalMSF final : public SpanningForest {
 public:
     KruskalMSF(const Graph &G);
-    ~KruskalMSF() override = default;
 
     /**
      * Computes for each component a minimum weight spanning tree

--- a/include/networkit/graph/SpanningForest.hpp
+++ b/include/networkit/graph/SpanningForest.hpp
@@ -8,6 +8,7 @@
 #ifndef NETWORKIT_GRAPH_SPANNING_FOREST_HPP_
 #define NETWORKIT_GRAPH_SPANNING_FOREST_HPP_
 
+#include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
@@ -15,22 +16,24 @@ namespace NetworKit {
 /**
  * Base class for spanning forest/tree algorithms.
  */
-class SpanningForest {
+class SpanningForest : public Algorithm {
 protected:
     const Graph *G;
     Graph forest;
 
 public:
     SpanningForest(const Graph &G) : G(&G) {}
-    virtual ~SpanningForest() = default;
 
-    virtual void run();
+    void run() override;
 
     /**
      * @return Forest computed by run method.
      * Note: So far no explicit check if run method has been invoked before.
      */
-    Graph getForest() { return forest; }
+    const Graph &getForest() {
+        assureFinished();
+        return forest;
+    }
 };
 
 } /* namespace NetworKit */

--- a/networkit/cpp/graph/SpanningForest.cpp
+++ b/networkit/cpp/graph/SpanningForest.cpp
@@ -27,6 +27,7 @@ void SpanningForest::run() {
         }
     });
 
+    hasRun = true;
     INFO("tree edges in SpanningForest: ", forest.numberOfEdges());
 }
 

--- a/networkit/graph.pyx
+++ b/networkit/graph.pyx
@@ -725,7 +725,12 @@ cdef cppclass NodePairCallbackWrapper:
 		if (error):
 			throw_runtime_error(message)
 
-cdef class SpanningForest:
+cdef extern from "<networkit/graph/SpanningForest.hpp>" namespace "NetworKit::SpanningForest":
+	cdef cppclass _SpanningForest "NetworKit::SpanningForest"(_Algorithm):
+		_SpanningForest(_Graph G) except +
+		_Graph getForest() nogil except +
+
+cdef class SpanningForest(Algorithm):
 	""" Generates a spanning forest for a given graph
 
 		Parameters:
@@ -735,28 +740,11 @@ cdef class SpanningForest:
 		nodes : list
 			A subset of nodes of `G` which induce the subgraph.
 	"""
-	cdef _SpanningForest* _this
 	cdef Graph _G
 
 	def __cinit__(self, Graph G not None):
 		self._G = G
 		self._this = new _SpanningForest(G._this)
-
-
-	def __dealloc__(self):
-		del self._this
-
-	def run(self):
-		"""
-		Executes the algorithm.
-
-		Returns:
-		--------
-		Algorithm:
-			self
-		"""
-		self._this.run()
-		return self
 
 	def getForest(self):
 		"""
@@ -767,7 +755,7 @@ cdef class SpanningForest:
 		networkit.Graph
 			The computed spanning forest
 		"""
-		return Graph().setThis(self._this.getForest())
+		return Graph().setThis((<_SpanningForest*>(self._this)).getForest())
 
 cdef class RandomMaximumSpanningForest(Algorithm):
 	"""

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -263,7 +263,19 @@ class TestGraph(unittest.TestCase):
 		self.assertEqual(G.numberOfNodes(), G2.numberOfNodes())
 		self.assertEqual(G.numberOfEdges(), G2.numberOfEdges())
 		self.assertEqual(G.edgeId(0,1), G2.edgeId(0,1))
-		
+
+	def testSpanningForest(self):
+		G = self.getSmallGraph()
+		sf = nk.graph.SpanningForest(G)
+		sf.run()
+		F = sf.getForest()
+
+		self.assertEqual(G.numberOfNodes(), F.numberOfNodes())
+		for u in F.iterNodes():
+			self.assertTrue(F.degree(u) > 0 or G.degree(u) == 0)
+
+		for u, v in F.iterEdges():
+			self.assertTrue(G.hasEdge(u, v))
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
- `SpanningForest` inherits from `Algorithm`, which removes redundant code.
- `KruskalMSF` for unweighted graphs uses `SpanningForest` (and not the more expensive Kruskal algorithm).
- Add a simple Python test for `SpanningForest`.