### PR TITLE
Remove usage of functions from math.h

### DIFF
--- a/include/networkit/algebraic/MatrixTools.hpp
+++ b/include/networkit/algebraic/MatrixTools.hpp
@@ -25,7 +25,7 @@ bool isSymmetric(const Matrix &matrix) {
     bool output = true;
     matrix.forNonZeroElementsInRowOrder(
         [&](NetworKit::index i, NetworKit::index j, NetworKit::edgeweight w) {
-            if (fabs(matrix(j, i) - w) > NetworKit::FLOAT_EPSILON) {
+            if (std::fabs(matrix(j, i) - w) > NetworKit::FLOAT_EPSILON) {
                 output = false;
                 return;
             }
@@ -51,7 +51,7 @@ bool isSDD(const Matrix &matrix) {
             if (i == j) {
                 row_sum[i] += value;
             } else {
-                row_sum[i] -= fabs(value);
+                row_sum[i] -= std::fabs(value);
             }
         });
 
@@ -82,7 +82,7 @@ bool isLaplacian(const Matrix &matrix) {
         });
 
     return right_sign && std::all_of(row_sum.begin(), row_sum.end(), [](double val) {
-               return fabs(val) < NetworKit::FLOAT_EPSILON;
+               return std::fabs(val) < NetworKit::FLOAT_EPSILON;
            });
 }
 

--- a/include/networkit/algebraic/Vector.hpp
+++ b/include/networkit/algebraic/Vector.hpp
@@ -307,7 +307,7 @@ Matrix Vector::outerProduct(const Vector &v1, const Vector &v2) {
     for (index i = 0; i < v1.getDimension(); ++i) {
         for (index j = 0; j < v2.getDimension(); ++j) {
             double result = v1[i] * v2[j];
-            if (fabs(result) >= FLOAT_EPSILON) {
+            if (std::fabs(result) >= FLOAT_EPSILON) {
                 triplets.push_back({i, j, result});
             }
         }

--- a/include/networkit/algebraic/algorithms/AlgebraicSpanningEdgeCentrality.hpp
+++ b/include/networkit/algebraic/algorithms/AlgebraicSpanningEdgeCentrality.hpp
@@ -68,7 +68,7 @@ void AlgebraicSpanningEdgeCentrality<Matrix>::run() {
 
     this->G.parallelForEdges([&](node u, node v, edgeid e) {
         double diff = solutions[e][u] - solutions[e][v];
-        scoreData[e] = fabs(diff);
+        scoreData[e] = std::fabs(diff);
     });
 
     hasRun = true;
@@ -81,8 +81,8 @@ void AlgebraicSpanningEdgeCentrality<Matrix>::runApproximation() {
     scoreData.clear();
     scoreData.resize(m, 0.0);
     double epsilon2 = tol * tol;
-    const count k = ceil(log2(n)) / epsilon2;
-    double randTab[2] = {1.0 / sqrt(k), -1.0 / sqrt(k)};
+    const count k = std::ceil(std::log2(n)) / epsilon2;
+    double randTab[2] = {1.0 / std::sqrt(k), -1.0 / std::sqrt(k)};
 
     const auto rhsLoader = [&](count, Vector &yRow) -> Vector & {
         yRow.fill(0);

--- a/include/networkit/auxiliary/MissingMath.hpp
+++ b/include/networkit/auxiliary/MissingMath.hpp
@@ -38,8 +38,8 @@ inline double log_b(double x, double b) {
     if (x == 0) {
         throw std::domain_error("log(0) is undefined");
     }
-    assert(log(b) != 0);
-    return log(x) / log(b);
+    assert(std::log(b) != 0);
+    return std::log(x) / std::log(b);
 }
 
 } /* namespace MissingMath */

--- a/include/networkit/centrality/ApproxCloseness.hpp
+++ b/include/networkit/centrality/ApproxCloseness.hpp
@@ -84,7 +84,7 @@ private:
     std::vector<double> R;
 
     std::vector<double> SQErrEst;
-    const edgeweight infDist = floor(std::numeric_limits<edgeweight>::max() / 2.0); // divided by two s.t. infDist + infDist produces no overflow
+    const edgeweight infDist = std::floor(std::numeric_limits<edgeweight>::max() / 2.0); // divided by two s.t. infDist + infDist produces no overflow
 
     CLOSENESS_TYPE type;
 

--- a/include/networkit/centrality/GedWalk.hpp
+++ b/include/networkit/centrality/GedWalk.hpp
@@ -173,7 +173,8 @@ double GedWalk::scoreOfGroup(InputIt first, InputIt last, double scoreEpsilon) {
         groupScore = result.score;
         groupW = result.w;
         if (boundStrategy == BoundStrategy::spectral) {
-            const double gamma = sqrt(G->numberOfNodes()) * (sigmaMax / (1 - alpha * sigmaMax));
+            const double gamma =
+                std::sqrt(G->numberOfNodes()) * (sigmaMax / (1 - alpha * sigmaMax));
             groupBound = result.score + alphas[nLevels + 1] * gamma * graphW;
         } else if (boundStrategy == BoundStrategy::geometric) {
             const double gamma = (degInMax / (1 - alpha * degInMax));

--- a/include/networkit/generators/ErdosRenyiEnumerator.hpp
+++ b/include/networkit/generators/ErdosRenyiEnumerator.hpp
@@ -280,12 +280,12 @@ private:
          *  = 1 + floor((log2(X) - 64) * inv_log2_cp).
          */
         return 1 + static_cast<count>(
-            floor((log2(random_prob) - 8*sizeof(integral_t)) * inv_log2_cp)
+            std::floor((std::log2(random_prob) - 8*sizeof(integral_t)) * inv_log2_cp)
         );
     }
 
     count skip_distance(double random_prob, double inv_log2_cp) const {
-        return 1 + static_cast<count>(floor((log2(random_prob)) * inv_log2_cp));
+        return 1 + static_cast<count>(std::floor((std::log2(random_prob)) * inv_log2_cp));
     }
 
 // SFINAE to determine and construct the right uniform distribution

--- a/include/networkit/generators/HyperbolicGenerator.hpp
+++ b/include/networkit/generators/HyperbolicGenerator.hpp
@@ -108,11 +108,11 @@ private:
         */
         vector<double> bandRadius;
         bandRadius.push_back(0);
-        double a = R*(1-seriesRatio)/(1-pow(seriesRatio, log(n)));
-        const double logn = log(n);
+        double a = R*(1-seriesRatio)/(1-std::pow(seriesRatio, std::log(n)));
+        const double logn = std::log(n);
 
         for (int i = 1; i < logn; i++){
-            double c_i = a*((1-pow(seriesRatio, i))/(1-seriesRatio));
+            double c_i = a*((1-std::pow(seriesRatio, i))/(1-seriesRatio));
             bandRadius.push_back(c_i);
         }
         bandRadius.push_back(R);
@@ -136,13 +136,13 @@ private:
       if (cLow == 0)
       return std::make_tuple(0.0, 2* PI);
 
-      double a = (cosh(radius)*cosh(cLow) - cosh(thresholdDistance))/(sinh(radius)*sinh(cLow));
+      double a = (std::cosh(radius)*std::cosh(cLow) - std::cosh(thresholdDistance))/(std::sinh(radius)*std::sinh(cLow));
       //handle floating point error
       if(a < -1)
         a = -1;
       else if(a > 1)
         a = 1;
-      a = acos(a);
+      a = std::acos(a);
       maxTheta = angle + a;
       minTheta = angle - a;
       return std::make_tuple(minTheta, maxTheta);

--- a/include/networkit/generators/quadtree/QuadNode.hpp
+++ b/include/networkit/generators/quadtree/QuadNode.hpp
@@ -117,15 +117,15 @@ public:
             if (splitTheoretical) {
                 double hyperbolicOuter = HyperbolicSpace::EuclideanRadiusToHyperbolic(maxR);
                 double hyperbolicInner = HyperbolicSpace::EuclideanRadiusToHyperbolic(minR);
-                double hyperbolicMiddle = acosh((1-balance)*cosh(alpha*hyperbolicOuter) + balance*cosh(alpha*hyperbolicInner))/alpha;
+                double hyperbolicMiddle = std::acosh((1-balance)*std::cosh(alpha*hyperbolicOuter) + balance*std::cosh(alpha*hyperbolicInner))/alpha;
                 middleR = HyperbolicSpace::hyperbolicRadiusToEuclidean(hyperbolicMiddle);
             } else {
                 double nom = maxR - minR;
-                double denom = pow((1-maxR*maxR)/(1-minR*minR), 0.5)+1;
+                double denom = std::pow((1-maxR*maxR)/(1-minR*minR), 0.5)+1;
                 middleR = nom/denom + minR;
             }
         } else {
-            middleR = acosh((1-balance)*cosh(alpha*maxR) + balance*cosh(alpha*minR))/alpha;
+            middleR = std::acosh((1-balance)*std::cosh(alpha*maxR) + balance*std::cosh(alpha*minR))/alpha;
         }
 
         assert(middleR < maxR);
@@ -275,31 +275,31 @@ public:
         double topDistance, bottomDistance, leftDistance, rightDistance;
 
         if (phi < leftAngle || phi > rightAngle) {
-            topDistance = min(c.distance(query), d.distance(query));
+            topDistance = std::min(c.distance(query), d.distance(query));
         } else {
-            topDistance = abs(r - maxR);
+            topDistance = std::abs(r - maxR);
         }
         if (topDistance <= radius) return false;
         if (phi < leftAngle || phi > rightAngle) {
-            bottomDistance = min(a.distance(query), b.distance(query));
+            bottomDistance = std::min(a.distance(query), b.distance(query));
         } else {
-            bottomDistance = abs(r - minR);
+            bottomDistance = std::abs(r - minR);
         }
         if (bottomDistance <= radius) return false;
 
-        double minDistanceR = r*cos(abs(phi-leftAngle));
+        double minDistanceR = r*std::cos(std::abs(phi-leftAngle));
         if (minDistanceR > minR && minDistanceR < maxR) {
             leftDistance = query.distance(HyperbolicSpace::polarToCartesian(phi, minDistanceR));
         } else {
-            leftDistance = min(a.distance(query), d.distance(query));
+            leftDistance = std::min(a.distance(query), d.distance(query));
         }
         if (leftDistance <= radius) return false;
 
-        minDistanceR = r*cos(abs(phi-rightAngle));
+        minDistanceR = r*std::cos(std::abs(phi-rightAngle));
         if (minDistanceR > minR && minDistanceR < maxR) {
             rightDistance = query.distance(HyperbolicSpace::polarToCartesian(phi, minDistanceR));
         } else {
-            rightDistance = min(b.distance(query), c.distance(query));
+            rightDistance = std::min(b.distance(query), c.distance(query));
         }
         if (rightDistance <= radius) return false;
         return true;
@@ -337,14 +337,14 @@ public:
             r_h = r;
         }
 
-        double coshr = cosh(r_h);
-        double sinhr = sinh(r_h);
-        double coshMinR = cosh(minRHyper);
-        double coshMaxR = cosh(maxRHyper);
-        double sinhMinR = sinh(minRHyper);
-        double sinhMaxR = sinh(maxRHyper);
-        double cosDiffLeft = cos(phi - leftAngle);
-        double cosDiffRight = cos(phi - rightAngle);
+        double coshr = std::cosh(r_h);
+        double sinhr = std::sinh(r_h);
+        double coshMinR = std::cosh(minRHyper);
+        double coshMaxR = std::cosh(maxRHyper);
+        double sinhMinR = std::sinh(minRHyper);
+        double sinhMaxR = std::sinh(maxRHyper);
+        double cosDiffLeft = std::cos(phi - leftAngle);
+        double cosDiffRight = std::cos(phi - rightAngle);
 
         /**
          * If the query point is not within the quadnode, the distance minimum is on the border.
@@ -357,16 +357,16 @@ public:
         double lowerLeftDistance = coshMinR*coshr-sinhMinR*sinhr*cosDiffLeft;
         double upperLeftDistance = coshMaxR*coshr-sinhMaxR*sinhr*cosDiffLeft;
         if (responsible(phi, r)) coshMinDistance = 1; //strictly speaking, this is wrong
-        else coshMinDistance = min(lowerLeftDistance, upperLeftDistance);
+        else coshMinDistance = std::min(lowerLeftDistance, upperLeftDistance);
 
-        coshMaxDistance = max(lowerLeftDistance, upperLeftDistance);
-        //double a = cosh(r_h);
+        coshMaxDistance = std::max(lowerLeftDistance, upperLeftDistance);
+        //double a = std::cosh(r_h);
         double b = sinhr*cosDiffLeft;
-        double extremum = log((coshr+b)/(coshr-b))/2;
+        double extremum = std::log((coshr+b)/(coshr-b))/2;
         if (extremum < maxRHyper && extremum >= minRHyper) {
-            double extremeDistance = cosh(extremum)*coshr-sinh(extremum)*sinhr*cosDiffLeft;
-            coshMinDistance = min(coshMinDistance, extremeDistance);
-            coshMaxDistance = max(coshMaxDistance, extremeDistance);
+            double extremeDistance = std::cosh(extremum)*coshr-std::sinh(extremum)*sinhr*cosDiffLeft;
+            coshMinDistance = std::min(coshMinDistance, extremeDistance);
+            coshMaxDistance = std::max(coshMaxDistance, extremeDistance);
         }
         /**
          * cosh is a function from [0,\infty) to [1, \infty)
@@ -378,17 +378,17 @@ public:
         //Right border
         double lowerRightDistance = coshMinR*coshr-sinhMinR*sinhr*cosDiffRight;
         double upperRightDistance = coshMaxR*coshr-sinhMaxR*sinhr*cosDiffRight;
-        coshMinDistance = min(coshMinDistance, lowerRightDistance);
-        coshMinDistance = min(coshMinDistance, upperRightDistance);
-        coshMaxDistance = max(coshMaxDistance, lowerRightDistance);
-        coshMaxDistance = max(coshMaxDistance, upperRightDistance);
+        coshMinDistance = std::min(coshMinDistance, lowerRightDistance);
+        coshMinDistance = std::min(coshMinDistance, upperRightDistance);
+        coshMaxDistance = std::max(coshMaxDistance, lowerRightDistance);
+        coshMaxDistance = std::max(coshMaxDistance, upperRightDistance);
 
         b = sinhr*cosDiffRight;
-        extremum = log((coshr+b)/(coshr-b))/2;
+        extremum = std::log((coshr+b)/(coshr-b))/2;
         if (extremum < maxRHyper && extremum >= minRHyper) {
-            double extremeDistance = cosh(extremum)*coshr-sinh(extremum)*sinhr*cosDiffRight;
-            coshMinDistance = min(coshMinDistance, extremeDistance);
-            coshMaxDistance = max(coshMaxDistance, extremeDistance);
+            double extremeDistance = std::cosh(extremum)*coshr-std::sinh(extremum)*sinhr*cosDiffRight;
+            coshMinDistance = std::min(coshMinDistance, extremeDistance);
+            coshMaxDistance = std::max(coshMaxDistance, extremeDistance);
         }
 
         assert(coshMaxDistance >= 1);
@@ -396,12 +396,12 @@ public:
 
         //upper and lower borders
         if (phi >= leftAngle && phi < rightAngle) {
-            double lower = cosh(abs(r_h-minRHyper));
-            double upper = cosh(abs(r_h-maxRHyper));
-            coshMinDistance = min(coshMinDistance, lower);
-            coshMinDistance = min(coshMinDistance, upper);
-            coshMaxDistance = max(coshMaxDistance, upper);
-            coshMaxDistance = max(coshMaxDistance, lower);
+            double lower = std::cosh(std::abs(r_h-minRHyper));
+            double upper = std::cosh(std::abs(r_h-maxRHyper));
+            coshMinDistance = std::min(coshMinDistance, lower);
+            coshMinDistance = std::min(coshMinDistance, upper);
+            coshMaxDistance = std::max(coshMaxDistance, upper);
+            coshMaxDistance = std::max(coshMaxDistance, lower);
         }
 
         assert(coshMaxDistance >= 1);
@@ -414,18 +414,18 @@ public:
         if (mirrorphi >= leftAngle && mirrorphi < rightAngle) {
             double lower = coshMinR*coshr+sinhMinR*sinhr;
             double upper = coshMaxR*coshr+sinhMaxR*sinhr;
-            coshMinDistance = min(coshMinDistance, lower);
-            coshMinDistance = min(coshMinDistance, upper);
-            coshMaxDistance = max(coshMaxDistance, upper);
-            coshMaxDistance = max(coshMaxDistance, lower);
+            coshMinDistance = std::min(coshMinDistance, lower);
+            coshMinDistance = std::min(coshMinDistance, upper);
+            coshMaxDistance = std::max(coshMaxDistance, upper);
+            coshMaxDistance = std::max(coshMaxDistance, lower);
         }
 
         assert(coshMaxDistance >= 1);
         assert(coshMinDistance >= 1);
 
         double minDistance, maxDistance;
-        minDistance = acosh(coshMinDistance);
-        maxDistance = acosh(coshMaxDistance);
+        minDistance = std::acosh(coshMinDistance);
+        maxDistance = std::acosh(coshMaxDistance);
         assert(maxDistance >= 0);
         assert(minDistance >= 0);
         return std::pair<double, double>(minDistance, maxDistance);

--- a/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodeCartesianEuclid.hpp
@@ -90,7 +90,7 @@ public:
                 assert(middle[d] >= minPoint[d]);
             }
         }
-        count childCount = pow(2,dimension);
+        count childCount = std::pow(2,dimension);
         for (index i = 0; i < childCount; i++) {
             vector<double> lowerValues(dimension);
             vector<double> upperValues(dimension);
@@ -509,7 +509,7 @@ public:
 
     index indexSubtree(index nextID) {
         index result = nextID;
-        assert(children.size() == pow(2,dimension) || children.size() == 0);
+        assert(children.size() == std::pow(2,dimension) || children.size() == 0);
         for (auto &child : children)
             result = child.indexSubtree(result);
 

--- a/include/networkit/generators/quadtree/QuadNodePolarEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadNodePolarEuclid.hpp
@@ -102,7 +102,7 @@ public:
         if (splitTheoretical) {
             //Euclidean space is distributed equally
             middleAngle = (rightAngle - leftAngle) / 2 + leftAngle;
-            middleR = pow(maxR*maxR*(1-balance)+minR*minR*balance, 0.5);
+            middleR = std::pow(maxR*maxR*(1-balance)+minR*minR*balance, 0.5);
         } else {
             //median of points
             vector<double> sortedAngles = angles;
@@ -258,17 +258,17 @@ public:
         if (phi < leftAngle || phi > rightAngle) {
             topDistance = std::min(c.distance(query), d.distance(query));
         } else {
-            topDistance = abs(r - maxR);
+            topDistance = std::abs(r - maxR);
         }
         if (topDistance <= radius) return false;
         if (phi < leftAngle || phi > rightAngle) {
             bottomDistance = std::min(a.distance(query), b.distance(query));
         } else {
-            bottomDistance = abs(r - minR);
+            bottomDistance = std::abs(r - minR);
         }
         if (bottomDistance <= radius) return false;
 
-        double minDistanceR = r*cos(abs(phi-leftAngle));
+        double minDistanceR = r*std::cos(std::abs(phi-leftAngle));
         if (minDistanceR > minR && minDistanceR < maxR) {
             leftDistance = query.distance(HyperbolicSpace::polarToCartesian(phi, minDistanceR));
         } else {
@@ -276,7 +276,7 @@ public:
         }
         if (leftDistance <= radius) return false;
 
-        minDistanceR = r*cos(abs(phi-rightAngle));
+        minDistanceR = r*std::cos(std::abs(phi-rightAngle));
         if (minDistanceR > minR && minDistanceR < maxR) {
             rightDistance = query.distance(HyperbolicSpace::polarToCartesian(phi, minDistanceR));
         } else {
@@ -317,7 +317,7 @@ public:
         if (responsible(phi, r)) minDistance = 0;
 
         auto euclidDistancePolar = [](double phi_a, double r_a, double phi_b, double r_b){
-            return pow(r_a*r_a+r_b*r_b-2*r_a*r_b*cos(phi_a-phi_b), 0.5);
+            return std::pow(r_a*r_a+r_b*r_b-2*r_a*r_b*std::cos(phi_a-phi_b), 0.5);
         };
 
         auto updateMinMax = [&minDistance, &maxDistance, phi, r, euclidDistancePolar](double phi_b, double r_b){
@@ -331,13 +331,13 @@ public:
          * angular boundaries
          */
         //left
-        double extremum = r*cos(this->leftAngle - phi);
+        double extremum = r*std::cos(this->leftAngle - phi);
         if (extremum < maxR && extremum > minR) {
             updateMinMax(this->leftAngle, extremum);
         }
 
         //right
-        extremum = r*cos(this->rightAngle - phi);
+        extremum = r*std::cos(this->rightAngle - phi);
         if (extremum < maxR && extremum > minR) {
             updateMinMax(this->leftAngle, extremum);
         }

--- a/include/networkit/generators/quadtree/Quadtree.hpp
+++ b/include/networkit/generators/quadtree/Quadtree.hpp
@@ -110,12 +110,12 @@ public:
         double maxR = r_e + radius;
         if (maxR > 1) maxR = 1;
         if (minR < 0) {
-            maxR = std::max(abs(minR), maxR);
+            maxR = std::max(std::abs(minR), maxR);
             minR = 0;
             minPhi = 0;
             maxPhi = 2*PI;
         } else {
-            double spread = asin(radius / r_e);
+            double spread = std::asin(radius / r_e);
             minPhi = cc_phi - spread;
             maxPhi = cc_phi + spread;
             /**

--- a/include/networkit/geometric/HyperbolicSpace.hpp
+++ b/include/networkit/geometric/HyperbolicSpace.hpp
@@ -134,20 +134,22 @@ public:
      * @param area The area of the hyperbolic circle
      * @param return Radius of a hyperbolic circle with the given area
      */
-    static inline double hyperbolicAreaToRadius(double area) { return acosh(area / (2 * PI) + 1); }
+    static inline double hyperbolicAreaToRadius(double area) {
+        return std::acosh(area / (2 * PI) + 1);
+    }
 
     static inline double radiusToHyperbolicArea(double radius) {
-        return 2 * PI * (cosh(radius) - 1);
+        return 2 * PI * (std::cosh(radius) - 1);
     }
 
     static double getExpectedDegree(double n, double alpha, double R) {
         double gamma = 2 * alpha + 1;
         double xi = (gamma - 1) / (gamma - 2);
-        double firstSumTerm = exp(-R / 2);
+        double firstSumTerm = std::exp(-R / 2);
         double secondSumTerm =
-            exp(-alpha * R)
+            std::exp(-alpha * R)
             * (alpha * (R / 2)
-                   * ((PI / 4) * pow((1 / alpha), 2) - (PI - 1) * (1 / alpha) + (PI - 2))
+                   * ((PI / 4) * std::pow((1 / alpha), 2) - (PI - 1) * (1 / alpha) + (PI - 2))
                - 1);
         double expectedDegree = (2 / PI) * xi * xi * n * (firstSumTerm + secondSumTerm);
         return expectedDegree;
@@ -158,7 +160,7 @@ public:
         double gamma = 2 * alpha + 1;
         double xiInv = ((gamma - 2) / (gamma - 1));
         double v = k * (PI / 2) * xiInv * xiInv;
-        double currentR = 2 * log(n / v);
+        double currentR = 2 * std::log(n / v);
         double lowerBound = currentR / 2;
         double upperBound = currentR * 2;
         assert(getExpectedDegree(n, alpha, lowerBound) > k);
@@ -186,12 +188,12 @@ public:
         } else {
             double beta = 1 / T;
             if (T < 1) { // cold regime
-                double Iinv = ((beta / PI) * sin(PI / beta));
+                double Iinv = ((beta / PI) * std::sin(PI / beta));
                 double v = (targetAvgDegree * Iinv) * (PI / 2) * xiInv * xiInv;
-                result = 2 * log(n / v);
+                result = 2 * std::log(n / v);
             } else { // hot regime
-                double v = targetAvgDegree * (1 - beta) * pow((PI / 2), beta) * xiInv * xiInv;
-                result = 2 * log(n / v) / beta;
+                double v = targetAvgDegree * (1 - beta) * std::pow((PI / 2), beta) * xiInv * xiInv;
+                result = 2 * std::log(n / v) / beta;
             }
         }
         return result;

--- a/include/networkit/geometric/Point2DWithIndex.hpp
+++ b/include/networkit/geometric/Point2DWithIndex.hpp
@@ -69,7 +69,7 @@ public:
 
 template <class T>
 T Point2DWithIndex<T>::length() const {
-    return sqrt(x * x + y * y);
+    return std::sqrt(x * x + y * y);
 }
 
 template <class T>
@@ -86,7 +86,7 @@ T Point2DWithIndex<T>::squaredDistance(const Point2DWithIndex<T> &p) const {
 
 template <class T>
 T Point2DWithIndex<T>::distance(const Point2DWithIndex<T> &p) const {
-    return sqrt(squaredDistance(p));
+    return std::sqrt(squaredDistance(p));
 }
 
 template <class T>

--- a/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
+++ b/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
@@ -672,7 +672,7 @@ void MultiLevelSetup<Matrix>::computeStrongNeighbors(const Matrix& affinityMatri
         }
     }
 
-    double h = fabs(overallMax - overallMin) < 1e-15? 1.0 : (double) bins.size() / (overallMax - overallMin);
+    double h = std::fabs(overallMax - overallMin) < 1e-15? 1.0 : (double) bins.size() / (overallMax - overallMin);
     for (index i = 0; i < affinityMatrix.numberOfRows(); ++i) {
         if (undecided[i]) { // undecided nodes with strong neighbors
             index binIndex = (index) std::floor(h * (maxNeighbor[i] - overallMin));

--- a/include/networkit/viz/MaxentStress.hpp
+++ b/include/networkit/viz/MaxentStress.hpp
@@ -245,7 +245,7 @@ private:
      */
     inline double distance(const CoordinateVector &coordinates, const index i,
                            const index j) const {
-        return sqrt(squaredDistance(coordinates, i, j));
+        return std::sqrt(squaredDistance(coordinates, i, j));
     }
 
     /**
@@ -270,7 +270,7 @@ private:
     inline double distance(const CoordinateVector &coordinates1,
                            const CoordinateVector &coordinates2, const index i,
                            const index j) const {
-        return sqrt(squaredDistance(coordinates1, coordinates2, i, j));
+        return std::sqrt(squaredDistance(coordinates1, coordinates2, i, j));
     }
 
     /**
@@ -286,7 +286,7 @@ private:
      * @param i
      */
     inline double length(const CoordinateVector &coordinates, const index i) const {
-        return sqrt(squaredLength(coordinates, i));
+        return std::sqrt(squaredLength(coordinates, i));
     }
 
     /**

--- a/include/networkit/viz/Octree.hpp
+++ b/include/networkit/viz/Octree.hpp
@@ -313,7 +313,7 @@ private:
 template <typename T>
 Octree<T>::Octree(const std::vector<Vector> &points) {
     dimensions = points.size();
-    numChildrenPerNode = pow(2, dimensions);
+    numChildrenPerNode = std::pow(2, dimensions);
     batchInsert(points);
 }
 
@@ -337,7 +337,7 @@ void Octree<T>::batchInsert(const std::vector<Vector> &points) {
         }
 
         sideLength =
-            std::max(sideLength, fabs(maxVal - minVal) * 1.005); // add 0.5% to bounding box
+            std::max(sideLength, std::fabs(maxVal - minVal) * 1.005); // add 0.5% to bounding box
         center[d] = (minVal + maxVal) / 2.0;
     }
 

--- a/networkit/cpp/algebraic/DenseMatrix.cpp
+++ b/networkit/cpp/algebraic/DenseMatrix.cpp
@@ -37,7 +37,7 @@ DenseMatrix::DenseMatrix(const count nRows, const count nCols, const std::vector
 count DenseMatrix::nnzInRow(const index i) const {
     count nnz = 0;
     for (index offset = i*numberOfColumns(); offset < (i+1)*numberOfColumns(); ++offset) {
-        if (fabs(entries[offset] - zero) > FLOAT_EPSILON) nnz++;
+        if (std::fabs(entries[offset] - zero) > FLOAT_EPSILON) nnz++;
     }
     return nnz;
 }
@@ -45,7 +45,7 @@ count DenseMatrix::nnzInRow(const index i) const {
 count DenseMatrix::nnz() const {
     count nnz = 0;
     for (index k = 0; k < entries.size(); ++k) {
-        if (fabs(entries[k] - zero) > FLOAT_EPSILON) nnz++;
+        if (std::fabs(entries[k] - zero) > FLOAT_EPSILON) nnz++;
     }
     return nnz;
 }
@@ -180,7 +180,7 @@ DenseMatrix DenseMatrix::extract(const std::vector<index>& rowIndices, const std
     for (index i = 0; i < rowIndices.size(); ++i) {
         for (index j = 0; j < columnIndices.size(); ++j) {
             double value = (*this)(rowIndices[i], columnIndices[j]);
-            if (fabs(value - getZero()) > FLOAT_EPSILON) {
+            if (std::fabs(value - getZero()) > FLOAT_EPSILON) {
                 result.setValue(i,j,value);
             }
         }

--- a/networkit/cpp/algebraic/DynamicMatrix.cpp
+++ b/networkit/cpp/algebraic/DynamicMatrix.cpp
@@ -294,7 +294,7 @@ DynamicMatrix DynamicMatrix::incidenceMatrix(const Graph& graph, double zero) {
     if (graph.isDirected()) {
         graph.forEdges([&](node u, node v, edgeweight weight, edgeid edgeId) {
             if (u != v) {
-                edgeweight w = sqrt(weight);
+                edgeweight w = std::sqrt(weight);
                 I.setValue(u, edgeId, w);
                 I.setValue(v, edgeId, -w);
             }
@@ -302,7 +302,7 @@ DynamicMatrix DynamicMatrix::incidenceMatrix(const Graph& graph, double zero) {
     } else {
         graph.forEdges([&](node u, node v, edgeweight weight, edgeid edgeId){
             if (u != v) {
-                edgeweight w = sqrt(weight);
+                edgeweight w = std::sqrt(weight);
                 if (u < v) { // orientation: small node number -> great node number
                     I.setValue(u, edgeId, w);
                     I.setValue(v, edgeId, -w);
@@ -346,7 +346,7 @@ DynamicMatrix DynamicMatrix::normalizedLaplacianMatrix(const Graph& graph, doubl
     graph.forNodes([&](const node i){
         graph.forNeighborsOf(i, [&](const node j, double weight){
             if (i != j) {
-                nL.setValue(i, j, -weight/sqrt(weightedDegrees[i] * weightedDegrees[j]));
+                nL.setValue(i, j, -weight/std::sqrt(weightedDegrees[i] * weightedDegrees[j]));
             }
         });
 

--- a/networkit/cpp/algebraic/test/AlgebraicPageRankGTest.cpp
+++ b/networkit/cpp/algebraic/test/AlgebraicPageRankGTest.cpp
@@ -84,14 +84,14 @@ TEST(AlgebraicPageRankGTest, testPageRankCentrality) {
 
     // compare to Matlab results
     const double tol = 1e-4;
-    EXPECT_NEAR(0.0753, fabs(cen[0]), tol);
-    EXPECT_NEAR(0.0565, fabs(cen[1]), tol);
-    EXPECT_NEAR(0.2552, fabs(cen[2]), tol);
-    EXPECT_NEAR(0.1319, fabs(cen[3]), tol);
-    EXPECT_NEAR(0.0942, fabs(cen[4]), tol);
-    EXPECT_NEAR(0.2552, fabs(cen[5]), tol);
-    EXPECT_NEAR(0.0753, fabs(cen[6]), tol);
-    EXPECT_NEAR(0.0565, fabs(cen[7]), tol);
+    EXPECT_NEAR(0.0753, std::fabs(cen[0]), tol);
+    EXPECT_NEAR(0.0565, std::fabs(cen[1]), tol);
+    EXPECT_NEAR(0.2552, std::fabs(cen[2]), tol);
+    EXPECT_NEAR(0.1319, std::fabs(cen[3]), tol);
+    EXPECT_NEAR(0.0942, std::fabs(cen[4]), tol);
+    EXPECT_NEAR(0.2552, std::fabs(cen[5]), tol);
+    EXPECT_NEAR(0.0753, std::fabs(cen[6]), tol);
+    EXPECT_NEAR(0.0565, std::fabs(cen[7]), tol);
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/algebraic/test/AlgebraicSpanningEdgeCentralityGTest.cpp
+++ b/networkit/cpp/algebraic/test/AlgebraicSpanningEdgeCentralityGTest.cpp
@@ -76,8 +76,8 @@ TEST_F(AlgebraicSpanningEdgeCentralityGTest, benchmarkSpanning) {
 
         double error = 0.0;
         G.forEdges([&](node, node, edgeid e) {
-            double relError = fabs(asp.score(e) - exact.score(e));
-            if (fabs(exact.score(e)) > 1e-9) relError /= exact.score(e);
+            double relError = std::fabs(asp.score(e) - exact.score(e));
+            if (std::fabs(exact.score(e)) > 1e-9) relError /= exact.score(e);
             error += relError;
         });
         error /= G.numberOfEdges();
@@ -93,8 +93,8 @@ TEST_F(AlgebraicSpanningEdgeCentralityGTest, benchmarkSpanning) {
 
         error = 0.0;
         G.forEdges([&](node, node, edgeid e) {
-            double relError = fabs(sp.score(e) - exact.score(e));
-            if (fabs(exact.score(e)) > 1e-9) relError /= exact.score(e);
+            double relError = std::fabs(sp.score(e) - exact.score(e));
+            if (std::fabs(exact.score(e)) > 1e-9) relError /= exact.score(e);
             error += relError;
         });
         error /= G.numberOfEdges();

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -991,16 +991,16 @@ void MatricesGTest::testIncidenceMatrix() {
     ASSERT_EQ(G.numberOfNodes(), mat.numberOfRows());
     ASSERT_EQ(G.numberOfEdges(), mat.numberOfColumns());
 
-    EXPECT_EQ(sqrt(G.weight(0,1)), mat(0,0));
-    EXPECT_EQ(-sqrt(G.weight(0,1)), mat(1,0));
+    EXPECT_EQ(std::sqrt(G.weight(0,1)), mat(0,0));
+    EXPECT_EQ(-std::sqrt(G.weight(0,1)), mat(1,0));
     for (uint64_t i = 2; i < mat.numberOfRows(); ++i) {
         EXPECT_EQ(0.0, mat(i, 0));
     }
 
-    EXPECT_EQ(-sqrt(G.weight(0,2)), mat(2,1));
+    EXPECT_EQ(-std::sqrt(G.weight(0,2)), mat(2,1));
 
-    EXPECT_EQ(-sqrt(G.weight(0,3)), mat(3,2));
-    EXPECT_EQ(-sqrt(G.weight(2,3)), mat(3,3));
+    EXPECT_EQ(-std::sqrt(G.weight(0,3)), mat(3,2));
+    EXPECT_EQ(-std::sqrt(G.weight(2,3)), mat(3,3));
 
     for (uint64_t i = 0; i < mat.numberOfRows(); ++i) {
         EXPECT_EQ(0.0, mat(i, 5));
@@ -1009,9 +1009,9 @@ void MatricesGTest::testIncidenceMatrix() {
     Vector row0 = mat.row(0);
     ASSERT_EQ(row0.getDimension(), mat.numberOfColumns());
 
-    EXPECT_EQ(sqrt(G.weight(0,1)), row0[0]);
-    EXPECT_EQ(sqrt(G.weight(0,2)), row0[1]);
-    EXPECT_EQ(sqrt(G.weight(0,3)), row0[2]);
+    EXPECT_EQ(std::sqrt(G.weight(0,1)), row0[0]);
+    EXPECT_EQ(std::sqrt(G.weight(0,2)), row0[1]);
+    EXPECT_EQ(std::sqrt(G.weight(0,3)), row0[2]);
     for (uint64_t j = 3; j < row0.getDimension(); ++j) {
         EXPECT_EQ(0.0, row0[j]);
     }

--- a/networkit/cpp/centrality/ApproxCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxCloseness.cpp
@@ -52,7 +52,7 @@ void ApproxCloseness::run() {
         }
 
         G.parallelForNodes([&](node u) {
-            if (fabs(scoreData[u]) > 1e-9) {
+            if (std::fabs(scoreData[u]) > 1e-9) {
                 scoreData[u] = 1/scoreData[u];
             }
 
@@ -331,7 +331,7 @@ void ApproxCloseness::runOnPivot(index i, const std::vector<node> &pivot, const 
             }
 
             if (pivot[u] == i) {
-                if (epsilon == 0.0 || fabs(thresh[t] - d / epsilon) < 1e-9) {
+                if (epsilon == 0.0 || std::fabs(thresh[t] - d / epsilon) < 1e-9) {
                     nodes[t].push_back(u);
                 } else {
                     t++;

--- a/networkit/cpp/centrality/DynApproxBetweenness.cpp
+++ b/networkit/cpp/centrality/DynApproxBetweenness.cpp
@@ -43,7 +43,7 @@ void DynApproxBetweenness::run() {
     edgeweight vd = diam.getDiameter().first;
 
     INFO("estimated diameter: ", vd);
-    r = ceil((universalConstant / (epsilon * epsilon)) * (floor(log2(vd - 2)) + 1 - log(delta)));
+    r = std::ceil((universalConstant / (epsilon * epsilon)) * (std::floor(std::log2(vd - 2)) + 1 - std::log(delta)));
     INFO("taking ", r, " path samples");
     sssp.clear();
     sssp.resize(r);

--- a/networkit/cpp/centrality/DynKatzCentrality.cpp
+++ b/networkit/cpp/centrality/DynKatzCentrality.cpp
@@ -157,7 +157,7 @@ void DynKatzCentrality::updateBatch(const std::vector<GraphEvent> &events){
             newlySeen.clear();
 
             // Update the Katz centrality from nPaths.
-            auto alpha_pow = pow(alpha, i);
+            auto alpha_pow = std::pow(alpha, i);
             #pragma omp parallel for
             for (omp_index m = 0; m < static_cast<omp_index>(seenNodes.size()); ++m) {
                 node v = seenNodes[m];
@@ -166,7 +166,7 @@ void DynKatzCentrality::updateBatch(const std::vector<GraphEvent> &events){
             }
         }else{
             // In this case, we're basically applying the static algorithm.
-            auto alpha_pow = pow(alpha, i);
+            auto alpha_pow = std::pow(alpha, i);
             G.balancedParallelForNodes([&](node u) {
                 nPaths[i][u] = 0;
                 G.forInEdgesOf(u, [&](node v, edgeweight) {
@@ -198,7 +198,7 @@ void DynKatzCentrality::updateBatch(const std::vector<GraphEvent> &events){
     reactivation_threshold -= rankTolerance;
     DEBUG("DynKatz: Reactivation threshold: ", reactivation_threshold);
 
-    auto alpha_pow = pow(alpha, i); // See doIteration().
+    auto alpha_pow = std::pow(alpha, i); // See doIteration().
     auto next_alpha_pow = alpha * alpha_pow;
     auto bound_factor = next_alpha_pow * (1/(1 - alpha * maxdeg));
     G.forNodes([&](node u){
@@ -252,7 +252,7 @@ void DynKatzCentrality::doIteration() {
 
     // Next, compute the ranking of active nodes for the current iteration.
     // GCC 6 is not smart enough to move the 'pow' out of the loop automatically.
-    auto alpha_pow = pow(alpha, r);
+    auto alpha_pow = std::pow(alpha, r);
     auto next_alpha_pow = alpha * alpha_pow;
     auto bound_factor = next_alpha_pow * (1/(1 - alpha * maxdeg));
     G.balancedParallelForNodes([&](node u){
@@ -331,7 +331,7 @@ bool DynKatzCentrality::checkConvergence() {
 
         assert(!activeRanking.empty());
 /*
-        double length = sqrt(G.parallelSumForNodes([&](node u) {
+        double length = std::sqrt(G.parallelSumForNodes([&](node u) {
             return (scoreData[u] * scoreData[u]);
         }));
         DEBUG("DynKatz: Vector length: ", length);

--- a/networkit/cpp/centrality/KPathCentrality.cpp
+++ b/networkit/cpp/centrality/KPathCentrality.cpp
@@ -23,7 +23,7 @@ KPathCentrality::KPathCentrality(const Graph& G, double alpha, count k) : Centra
         throw std::runtime_error("alpha must lie in interval [-0.5, 0.5]");
     }
     if (k == 0) {
-        this->k = log(static_cast<double>(G.numberOfNodes() + G.numberOfEdges()));
+        this->k = std::log(static_cast<double>(G.numberOfNodes() + G.numberOfEdges()));
     } else if (k >0) {
         this->k = k;
     } else {
@@ -43,7 +43,7 @@ void KPathCentrality::run() {
     counter.assign(z, 0);
     explored.assign(z, false);
 
-    count t = 2.0 * k * k * pow(n, 1 - 2 * alpha) * log(n);
+    count t = 2.0 * k * k * std::pow(n, 1 - 2 * alpha) * std::log(n);
     std::stack<node> stack;
     node v = none;
 

--- a/networkit/cpp/centrality/SpanningEdgeCentrality.cpp
+++ b/networkit/cpp/centrality/SpanningEdgeCentrality.cpp
@@ -53,7 +53,7 @@ void SpanningEdgeCentrality::run() {
 
         lamg.solve(rhs, solution);
         double diff = solution[u] - solution[v];
-        scoreData[e] = fabs(diff); // TODO: check unweighted, fix weighted case, fix edge IDs!
+        scoreData[e] = std::fabs(diff); // TODO: check unweighted, fix weighted case, fix edge IDs!
         rhs[u] = 0.0;
         rhs[v] = 0.0;
     });
@@ -69,8 +69,8 @@ void SpanningEdgeCentrality::runApproximation() {
     const count n = G.numberOfNodes();
     const count m = G.numberOfEdges();
     double epsilon2 = tol * tol;
-    const count k = ceil(log2(n)) / epsilon2;
-    double randTab[3] = {1/sqrt(k), -1/sqrt(k)};
+    const count k = std::ceil(std::log2(n)) / epsilon2;
+    double randTab[3] = {1/std::sqrt(k), -1/std::sqrt(k)};
     Vector solution(n);
     scoreData.clear();
     scoreData.resize(m, 0.0);
@@ -108,8 +108,8 @@ void SpanningEdgeCentrality::runParallelApproximation() {
     const count n = G.numberOfNodes();
     const count m = G.numberOfEdges();
     double epsilon2 = tol * tol;
-    const count k = ceil(log2(n)) / epsilon2;
-    double randTab[3] = {1/sqrt(k), -1/sqrt(k)};
+    const count k = std::ceil(std::log2(n)) / epsilon2;
+    double randTab[3] = {1/std::sqrt(k), -1/std::sqrt(k)};
     std::vector<Vector> solutions(k, Vector(n));
     std::vector<Vector> rhs(k, Vector(n));
     scoreData.clear();
@@ -150,8 +150,8 @@ uint64_t SpanningEdgeCentrality::runApproximationAndWriteVectors(const std::stri
     const count n = G.numberOfNodes();
     const count m = G.numberOfEdges();
     const double epsilon2 = tol * tol;
-    const count k = ceil(log(n)) / epsilon2;
-    double randTab[3] = {1/sqrt(k), -1/sqrt(k)};
+    const count k = std::ceil(std::log(n)) / epsilon2;
+    double randTab[3] = {1/std::sqrt(k), -1/std::sqrt(k)};
     Vector solution(n);
     scoreData.clear();
     scoreData.resize(m, 0.0);
@@ -201,7 +201,7 @@ double SpanningEdgeCentrality::runForEdge(node u, node v) {
     TRACE("before solve for ", u, " and ", v);
 
     lamg.solve(rhs, solution);
-    return fabs(solution[u] - solution[v]); // TODO: fix weighted case, fix edge IDs!
+    return std::fabs(solution[u] - solution[v]); // TODO: fix weighted case, fix edge IDs!
 }
 
 

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -589,14 +589,14 @@ TEST_F(CentralityGTest, testEigenvectorCentrality) {
 
     // computed with Matlab
     const double tol = 1e-4;
-    EXPECT_NEAR(0.2254, fabs(cen[0]), tol);
-    EXPECT_NEAR(0.1503, fabs(cen[1]), tol);
-    EXPECT_NEAR(0.5290, fabs(cen[2]), tol);
-    EXPECT_NEAR(0.4508, fabs(cen[3]), tol);
-    EXPECT_NEAR(0.3006, fabs(cen[4]), tol);
-    EXPECT_NEAR(0.5290, fabs(cen[5]), tol);
-    EXPECT_NEAR(0.2254, fabs(cen[6]), tol);
-    EXPECT_NEAR(0.1503, fabs(cen[7]), tol);
+    EXPECT_NEAR(0.2254, std::fabs(cen[0]), tol);
+    EXPECT_NEAR(0.1503, std::fabs(cen[1]), tol);
+    EXPECT_NEAR(0.5290, std::fabs(cen[2]), tol);
+    EXPECT_NEAR(0.4508, std::fabs(cen[3]), tol);
+    EXPECT_NEAR(0.3006, std::fabs(cen[4]), tol);
+    EXPECT_NEAR(0.5290, std::fabs(cen[5]), tol);
+    EXPECT_NEAR(0.2254, std::fabs(cen[6]), tol);
+    EXPECT_NEAR(0.1503, std::fabs(cen[7]), tol);
 }
 
 TEST_F(CentralityGTest, testPageRankCentrality) {
@@ -631,14 +631,14 @@ TEST_F(CentralityGTest, testPageRankCentrality) {
 
     // compare to Matlab results
     const double tol = 1e-4;
-    EXPECT_NEAR(0.0753, fabs(cen[0]), tol);
-    EXPECT_NEAR(0.0565, fabs(cen[1]), tol);
-    EXPECT_NEAR(0.2552, fabs(cen[2]), tol);
-    EXPECT_NEAR(0.1319, fabs(cen[3]), tol);
-    EXPECT_NEAR(0.0942, fabs(cen[4]), tol);
-    EXPECT_NEAR(0.2552, fabs(cen[5]), tol);
-    EXPECT_NEAR(0.0753, fabs(cen[6]), tol);
-    EXPECT_NEAR(0.0565, fabs(cen[7]), tol);
+    EXPECT_NEAR(0.0753, std::fabs(cen[0]), tol);
+    EXPECT_NEAR(0.0565, std::fabs(cen[1]), tol);
+    EXPECT_NEAR(0.2552, std::fabs(cen[2]), tol);
+    EXPECT_NEAR(0.1319, std::fabs(cen[3]), tol);
+    EXPECT_NEAR(0.0942, std::fabs(cen[4]), tol);
+    EXPECT_NEAR(0.2552, std::fabs(cen[5]), tol);
+    EXPECT_NEAR(0.0753, std::fabs(cen[6]), tol);
+    EXPECT_NEAR(0.0565, std::fabs(cen[7]), tol);
 }
 
 TEST_F(CentralityGTest, benchSequentialBetweennessCentralityOnRealGraph) {

--- a/networkit/cpp/community/LouvainMapEquation.cpp
+++ b/networkit/cpp/community/LouvainMapEquation.cpp
@@ -502,7 +502,7 @@ void LouvainMapEquation::calculateInitialClusterCutAndVolume() {
 double LouvainMapEquation::plogpRel(double w) {
     if (w > 0) {
         double p = w / totalVolume;
-        return p * log(p);
+        return p * std::log(p);
     }
     return 0;
 }

--- a/networkit/cpp/correlation/Assortativity.cpp
+++ b/networkit/cpp/correlation/Assortativity.cpp
@@ -87,7 +87,7 @@ void Assortativity::run() {
             C += y * y;
         });
 
-        double r = A / sqrt(B * C);
+        double r = A / std::sqrt(B * C);
         coefficient = r;
     }
     hasRun = true;

--- a/networkit/cpp/distance/AdamicAdarDistance.cpp
+++ b/networkit/cpp/distance/AdamicAdarDistance.cpp
@@ -41,9 +41,9 @@ void AdamicAdarDistance::preprocess() {
 
                     edgeid eid_uw = G->edgeId(u, w);
 
-                    aaDistance[eid_uv] = aaDistance[eid_uv] + 1.0 / log(G->degree(w));
-                    aaDistance[eid_uw] = aaDistance[eid_uw] + 1.0 / log(G->degree(v));
-                    aaDistance[eid_vw] = aaDistance[eid_vw] + 1.0 / log(G->degree(u));
+                    aaDistance[eid_uv] = aaDistance[eid_uv] + 1.0 / std::log(G->degree(w));
+                    aaDistance[eid_uw] = aaDistance[eid_uw] + 1.0 / std::log(G->degree(v));
+                    aaDistance[eid_vw] = aaDistance[eid_vw] + 1.0 / std::log(G->degree(u));
                 }
             });
 

--- a/networkit/cpp/distance/AlgebraicDistance.cpp
+++ b/networkit/cpp/distance/AlgebraicDistance.cpp
@@ -122,17 +122,17 @@ double AlgebraicDistance::distance(node u, node v) {
 
     if (norm == MAX_NORM) {
         for (index sys = 0; sys < numSystems; ++sys) {
-            double absDiff = fabs(loads[u*numSystems + sys] - loads[v*numSystems + sys]);
+            double absDiff = std::fabs(loads[u*numSystems + sys] - loads[v*numSystems + sys]);
             if (absDiff > result) {
                 result = absDiff;
             }
         }
     } else {
         for (index sys = 0; sys < numSystems; ++sys) {
-            double absDiff = fabs(loads[u*numSystems + sys] - loads[v*numSystems + sys]);
-            result += pow(absDiff, norm);
+            double absDiff = std::fabs(loads[u*numSystems + sys] - loads[v*numSystems + sys]);
+            result += std::pow(absDiff, norm);
         }
-        result = pow(result, 1.0 / (double) norm);
+        result = std::pow(result, 1.0 / (double) norm);
     }
 
     return std::isnan(result) ? 0 : result;

--- a/networkit/cpp/distance/CommuteTimeDistance.cpp
+++ b/networkit/cpp/distance/CommuteTimeDistance.cpp
@@ -59,7 +59,7 @@ void CommuteTimeDistance::run() {
         solution = zeroVector;
 
         lamg.solve(rhs, solution);
-        double diff = fabs(solution[u] - solution[v]);
+        double diff = std::fabs(solution[u] - solution[v]);
         distances[u][v] = diff;
         distances[v][u] = diff;
         rhs[u] = 0.0;
@@ -78,10 +78,10 @@ void CommuteTimeDistance::runApproximation() {
 
     // init approximation parameters
     double epsilon2 = tol * tol;
-    k = ceil(log2(n)) / epsilon2;
+    k = std::ceil(std::log2(n)) / epsilon2;
 
     // entries of random projection matrix
-    double randTab[2] = {1/sqrt(k), -1/sqrt(k)};
+    double randTab[2] = {1/std::sqrt(k), -1/std::sqrt(k)};
 
     solutions.clear();
     solutions.resize(k, Vector(n));
@@ -118,10 +118,10 @@ void CommuteTimeDistance::runParallelApproximation() {
 
     // init approximation parameters
     double epsilon2 = tol * tol;
-    k = ceil(log2(n)) / epsilon2;
+    k = std::ceil(std::log2(n)) / epsilon2;
 
     // entries of random projection matrix
-    double randTab[3] = {1/sqrt(k), -1/sqrt(k)};
+    double randTab[3] = {1/std::sqrt(k), -1/std::sqrt(k)};
 
     solutions.clear();
     solutions.resize(k, Vector(n));
@@ -157,7 +157,7 @@ double CommuteTimeDistance::distance(node u, node v) {
     double volG = GraphTools::volume(*G);
 
     if (exactly) {
-        return sqrt(distances[u][v] * volG);
+        return std::sqrt(distances[u][v] * volG);
     }
     else {
         double dist = 0.0;
@@ -165,7 +165,7 @@ double CommuteTimeDistance::distance(node u, node v) {
             double diff = solutions[i][u] - solutions[i][v];
             dist += diff * diff;
         }
-        return sqrt(dist * volG);
+        return std::sqrt(dist * volG);
     }
 }
 
@@ -184,8 +184,8 @@ double CommuteTimeDistance::runSinglePair(node u, node v) {
     solution = zeroVector;
     lamg.solve(rhs, solution);
     double diff = solution[u] - solution[v];
-    dist = fabs(diff);
-    return sqrt(dist * GraphTools::volume(*G));
+    dist = std::fabs(diff);
+    return std::sqrt(dist * GraphTools::volume(*G));
 }
 
 double CommuteTimeDistance::runSingleSource(node u) {
@@ -215,7 +215,7 @@ double CommuteTimeDistance::runSingleSource(node u) {
             dist += diff * diff;
         }
     });
-    return sqrt(dist * GraphTools::volume(*G));
+    return std::sqrt(dist * GraphTools::volume(*G));
 }
 
 }

--- a/networkit/cpp/distance/EffectiveDiameterApproximation.cpp
+++ b/networkit/cpp/distance/EffectiveDiameterApproximation.cpp
@@ -20,7 +20,7 @@ EffectiveDiameterApproximation::EffectiveDiameterApproximation(const Graph& G, c
 void EffectiveDiameterApproximation::run() {
     count z = G->upperNodeIdBound();
     // the length of the bitmask where the number of connected nodes is saved
-    count lengthOfBitmask = (count) ceil(log2(G->numberOfNodes()));
+    count lengthOfBitmask = (count) std::ceil(std::log2(G->numberOfNodes()));
     // saves all k bitmasks for every node of the current iteration
     std::vector<std::vector<unsigned int>> mCurr(z);
     // saves all k bitmasks for every node of the previous iteration
@@ -28,7 +28,7 @@ void EffectiveDiameterApproximation::run() {
     // the maximum possible bitmask based on the random initialization of all k bitmasks
     std::vector<count> highestCount;
     // the amount of nodes that need to be connected to all others nodes
-    count threshold = (count) (ceil(ratio * G->numberOfNodes()));
+    count threshold = (count) (std::ceil(ratio * G->numberOfNodes()));
     // the current distance of the neighborhoods
     count h = 1;
     // sums over the number of edges needed to reach 90% of all other nodes
@@ -53,7 +53,7 @@ void EffectiveDiameterApproximation::run() {
         // set one bit in each bitmask with probability P(bit i=1) = 0.5^(i+1), i=0,..
         for (count j = 0; j < k; j++) {
             random = Aux::Random::real(0,1);
-            position = ceil(log(random)/log(0.5) - 1);
+            position = std::ceil(std::log(random)/std::log(0.5) - 1);
             // set the bit in the bitmask
             if (position < lengthOfBitmask+r) {
                 mPrev[v][j] |= 1 << position;
@@ -93,7 +93,7 @@ void EffectiveDiameterApproximation::run() {
             b = b / k;
 
             // calculate the estimated number of neighbors where 0.77351 is a correction factor and the result of a complex sum
-            estimatedConnectedNodes = (pow(2,b) / 0.77351);
+            estimatedConnectedNodes = (std::pow(2,b) / 0.77351);
 
             // check whether all k bitmask for this node have reached their highest possible value
             bool nodeFinished = true;

--- a/networkit/cpp/distance/HopPlotApproximation.cpp
+++ b/networkit/cpp/distance/HopPlotApproximation.cpp
@@ -25,7 +25,7 @@ HopPlotApproximation::HopPlotApproximation(const Graph& G, count maxDistance, co
 void HopPlotApproximation::run() {
     count z = G->upperNodeIdBound();
     // the length of the bitmask where the number of connected nodes is saved
-    count lengthOfBitmask = (count) ceil(log2(G->numberOfNodes()));
+    count lengthOfBitmask = (count) std::ceil(std::log2(G->numberOfNodes()));
     // saves all k bitmasks for every node of the current iteration
     std::vector<std::vector<unsigned int>> mCurr(z);
     // saves all k bitmasks for every node of the previous iteration
@@ -58,7 +58,7 @@ void HopPlotApproximation::run() {
         // set one bit in each bitmask with probability P(bit i=1) = 0.5^(i+1), i=0,..
         for (count j = 0; j < k; j++) {
             random = Aux::Random::real(0,1);
-            position = ceil(log(random)/log(0.5) - 1);
+            position = std::ceil(std::log(random)/std::log(0.5) - 1);
             // set the bit in the bitmask
             if (position < lengthOfBitmask+r) {
                 mPrev[v][j] |= 1 << position;
@@ -99,7 +99,7 @@ void HopPlotApproximation::run() {
 
             // calculate the estimated number of neighbors
             // For the origin of the factor 0.77351 see http://www.mathcs.emory.edu/~cheung/papers/StreamDB/Probab/1985-Flajolet-Probabilistic-counting.pdf Theorem 3.A (p. 193)
-            estimatedConnectedNodes = (pow(2,b) / 0.77351);
+            estimatedConnectedNodes = (std::pow(2,b) / 0.77351);
 
             // enforce monotonicity
             if (estimatedConnectedNodes > n) {

--- a/networkit/cpp/distance/NeighborhoodFunctionApproximation.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionApproximation.cpp
@@ -35,7 +35,7 @@ NeighborhoodFunctionApproximation::NeighborhoodFunctionApproximation(const Graph
 #endif // _MSC_VER
 void NeighborhoodFunctionApproximation::run() {
     // the length of the bitmask where the number of connected nodes is saved
-    const count lengthOfBitmask = (count) ceil(log2(G->numberOfNodes())) + r;
+    const count lengthOfBitmask = (count) std::ceil(std::log2(G->numberOfNodes())) + r;
     // saves all k bitmasks for every node of the current iteration
     std::vector<std::vector<unsigned int>> mCurr(G->upperNodeIdBound());
     // saves all k bitmasks for every node of the previous iteration
@@ -57,7 +57,7 @@ void NeighborhoodFunctionApproximation::run() {
         // set one bit in each bitmask with probability P(bit i=1) = 0.5^(i+1), i=0,..
         for (count j = 0; j < k; j++) {
             double random = Aux::Random::real(0,1);
-            count position = ceil(log(random)/log(0.5) - 1);
+            count position = std::ceil(std::log(random)/std::log(0.5) - 1);
             // set the bit in the bitmask
             if (position < lengthOfBitmask) {
                 mPrev[v][j] = 1 << position;
@@ -109,7 +109,7 @@ void NeighborhoodFunctionApproximation::run() {
             // calculate the average least bit number that has not been set over all parallel approximations
             b = b / k;
             // calculate the estimated number of neighbors where 0.77351 is a correction factor and the result of a complex sum
-            count estimatedConnectedNodes = (count)round(pow(2,b) / 0.77351);
+            count estimatedConnectedNodes = (count)std::round(std::pow(2,b) / 0.77351);
             localEstimatesSum[tid] += estimatedConnectedNodes;
             //std::cout << "(" << v << ", " << estimatedConnectedNodes << ")\t";
 

--- a/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
@@ -22,7 +22,7 @@ namespace NetworKit {
 NeighborhoodFunctionHeuristic::NeighborhoodFunctionHeuristic(const Graph& G, count nSamples, SelectionStrategy strategy) :
     Algorithm(),
     G(&G),
-    nSamples(!nSamples ? (count)ceil(std::max((double)0.15f * G.numberOfNodes(), sqrt(G.numberOfEdges()))) : nSamples),
+    nSamples(!nSamples ? (count)std::ceil(std::max((double)0.15f * G.numberOfNodes(), std::sqrt(G.numberOfEdges()))) : nSamples),
     strategy(strategy) {
 
     if (G.isDirected())
@@ -91,7 +91,7 @@ void NeighborhoodFunctionHeuristic::run() {
             tmp += nf[tid][dist];
         }
         // accumulate nf
-        result[dist-1] = round(tmp * norm_factor);
+        result[dist-1] = std::round(tmp * norm_factor);
         if (dist > 1) {
             result[dist-1] += result[dist-2];
         }

--- a/networkit/cpp/distance/Volume.cpp
+++ b/networkit/cpp/distance/Volume.cpp
@@ -29,7 +29,7 @@ std::unordered_map<node, double> Volume::nodesWithinDistance(const Graph &G, dou
                         msToCheckNew.push_back(m2);
                     }
                 } else {
-                    ms[m2] = fmin(ms[m2], r2);
+                    ms[m2] = std::fmin(ms[m2], r2);
                 }
             }
         }

--- a/networkit/cpp/distance/test/CommuteTimeDistanceGTest.cpp
+++ b/networkit/cpp/distance/test/CommuteTimeDistanceGTest.cpp
@@ -59,12 +59,12 @@ TEST_F(CommuteTimeDistanceGTest, testOnToyGraph) {
     CommuteTimeDistance ctd(G);
     ctd.run();
     double volG = 2.0 * G.numberOfEdges();
-    EXPECT_NEAR(sqrt(1.0 * volG), ctd.distance(0, 2), 1e-4);
-    EXPECT_NEAR(sqrt(1.0 * volG), ctd.distance(1, 2), 1e-4);
-    EXPECT_NEAR(sqrt(0.75 * volG), ctd.distance(2, 3), 1e-4);
-    EXPECT_NEAR(sqrt(0.75 * volG), ctd.distance(2, 4), 1e-4);
-    EXPECT_NEAR(sqrt(0.75 * volG), ctd.distance(3, 5), 1e-4);
-    EXPECT_NEAR(sqrt(0.75 * volG), ctd.distance(4, 5), 1e-4);
+    EXPECT_NEAR(std::sqrt(1.0 * volG), ctd.distance(0, 2), 1e-4);
+    EXPECT_NEAR(std::sqrt(1.0 * volG), ctd.distance(1, 2), 1e-4);
+    EXPECT_NEAR(std::sqrt(0.75 * volG), ctd.distance(2, 3), 1e-4);
+    EXPECT_NEAR(std::sqrt(0.75 * volG), ctd.distance(2, 4), 1e-4);
+    EXPECT_NEAR(std::sqrt(0.75 * volG), ctd.distance(3, 5), 1e-4);
+    EXPECT_NEAR(std::sqrt(0.75 * volG), ctd.distance(4, 5), 1e-4);
 }
 
 TEST_F(CommuteTimeDistanceGTest, testOnWeightedToyGraph) {
@@ -93,12 +93,12 @@ TEST_F(CommuteTimeDistanceGTest, testOnWeightedToyGraph) {
     ctd.run();
     double volG = 2.0 * G.totalEdgeWeight();
     DEBUG("volume : ", volG);
-    EXPECT_NEAR(sqrt(0.5 * volG), ctd.distance(0, 2), 1e-3);
-    EXPECT_NEAR(sqrt(0.3333 * volG), ctd.distance(1, 2), 1e-3);
-    EXPECT_NEAR(sqrt(0.1336 * volG), ctd.distance(2, 3), 1e-3);
-    EXPECT_NEAR(sqrt(0.1206 * volG), ctd.distance(2, 4), 1e-3);
-    EXPECT_NEAR(sqrt(0.0991 * volG), ctd.distance(3, 5), 1e-3);
-    EXPECT_NEAR(sqrt(0.0906 * volG), ctd.distance(4, 5), 1e-3);
+    EXPECT_NEAR(std::sqrt(0.5 * volG), ctd.distance(0, 2), 1e-3);
+    EXPECT_NEAR(std::sqrt(0.3333 * volG), ctd.distance(1, 2), 1e-3);
+    EXPECT_NEAR(std::sqrt(0.1336 * volG), ctd.distance(2, 3), 1e-3);
+    EXPECT_NEAR(std::sqrt(0.1206 * volG), ctd.distance(2, 4), 1e-3);
+    EXPECT_NEAR(std::sqrt(0.0991 * volG), ctd.distance(3, 5), 1e-3);
+    EXPECT_NEAR(std::sqrt(0.0906 * volG), ctd.distance(4, 5), 1e-3);
 }
 
 TEST_F(CommuteTimeDistanceGTest, runECTDOnSmallGraphs) {
@@ -126,9 +126,9 @@ TEST_F(CommuteTimeDistanceGTest, runECTDOnSmallGraphs) {
         double error = 0.0;
         G.forNodes([&](node u){
             G.forNodes([&](node v) {
-                double relError = fabs(cen.distance(u,v) - exact.distance(u,v));
+                double relError = std::fabs(cen.distance(u,v) - exact.distance(u,v));
             //	INFO("Approximated: ", cen.distance(u,v), ", exact: ", exact.distance(u,v));
-                if (fabs(exact.distance(u,v)) > 1e-9) {
+                if (std::fabs(exact.distance(u,v)) > 1e-9) {
                     relError /= exact.distance(u,v);
                 }
                 error += relError;
@@ -164,9 +164,9 @@ TEST_F(CommuteTimeDistanceGTest, runECTDParallelOnSmallGraphs) {
         double error = 0.0;
         G.forNodes([&](node u){
             G.forNodes([&](node v) {
-                double relError = fabs(cen.distance(u,v) - exact.distance(u,v));
+                double relError = std::fabs(cen.distance(u,v) - exact.distance(u,v));
             //	INFO("Approximated: ", cen.distance(u,v), ", exact: ", exact.distance(u,v));
-                if (fabs(exact.distance(u,v)) > 1e-9) {
+                if (std::fabs(exact.distance(u,v)) > 1e-9) {
                     relError /= exact.distance(u,v);
                 }
                 error += relError;

--- a/networkit/cpp/distance/test/DistanceGTest.cpp
+++ b/networkit/cpp/distance/test/DistanceGTest.cpp
@@ -82,7 +82,7 @@ TEST_F(DistanceGTest, testAStar) {
                        (colU > colT ? colU - colT : colT - colU));
                 double rowDiff = std::abs(static_cast<double>(u / cols) - static_cast<double>(rowT));
                 double colDiff = std::abs(static_cast<double>(u % cols) - static_cast<double>(rowT));
-                eucledianDist[u] = sqrt(std::pow(rowDiff, 2) + std::pow(colDiff, 2));
+                eucledianDist[u] = std::sqrt(std::pow(rowDiff, 2) + std::pow(colDiff, 2));
             };
             BFS bfs(G, source, true, false, target);
             bfs.run();

--- a/networkit/cpp/generators/ChungLuGenerator.cpp
+++ b/networkit/cpp/generators/ChungLuGenerator.cpp
@@ -38,7 +38,7 @@ ChungLuGenerator::ChungLuGenerator(const std::vector<count> &degreeSequence) :
                 if (p != 1.0) {
                     double randVal = Aux::Random::probability();
                     /* Calculate the distance to the next potential neighbour*/
-                    v = v + (node) std::floor(log(randVal)/log(1 - p));
+                    v = v + (node) std::floor(std::log(randVal)/std::log(1 - p));
                 }
                 if ((count) v < n) {
                     double q = std::min(((double) seq[u]) * ((double) seq[v]) / sum_deg, 1.0);

--- a/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
+++ b/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
@@ -170,9 +170,9 @@ void DynamicHyperbolicGenerator::moveNode(index toMove) {
     double hyperbolicRadius = radii[toMove];
 
     //angular movement
-    double maxcdf = cosh(alpha*R);
+    double maxcdf = std::cosh(alpha*R);
     double mincdf = 1;
-    double currcdf = cosh(alpha*hyperbolicRadius);
+    double currcdf = std::cosh(alpha*hyperbolicRadius);
 
     double newcosh = currcdf + alpha*radialMovement[toMove];
     double newphi = angles[toMove];
@@ -197,14 +197,14 @@ void DynamicHyperbolicGenerator::moveNode(index toMove) {
             newphi += PI;
         }
     }
-    double newradius = acosh(newcosh)/alpha;
+    double newradius = std::acosh(newcosh)/alpha;
     if (newradius >= R) newradius = std::nextafter(R, std::numeric_limits<double>::lowest());
     assert(newradius < R);
     assert(newradius >= 0);
 
     newphi += angularMovement[toMove]/newradius;
-    if (newphi < 0) newphi += (floor(-newphi/(2*PI))+1)*2*PI;
-    if (newphi > 2*PI) newphi -= floor(newphi/(2*PI))*2*PI;
+    if (newphi < 0) newphi += (std::floor(-newphi/(2*PI))+1)*2*PI;
+    if (newphi > 2*PI) newphi -= std::floor(newphi/(2*PI))*2*PI;
 
     angles[toMove] = newphi;
     radii[toMove] = newradius;
@@ -215,7 +215,7 @@ vector<index> DynamicHyperbolicGenerator::getNeighborsInBands(index i, bool both
     const double phi = angles[i];
     assert(bands.size() == bandAngles.size());
     assert(bands.size() == bandRadii.size() -1);
-    count expectedDegree = (4/PI)*nodeCount*exp(-(radii[i])/2);
+    count expectedDegree = (4/PI)*nodeCount*std::exp(-(radii[i])/2);
     vector<index> near;
     near.reserve(expectedDegree*1.1);
     for(index j = 0; j < bands.size(); j++){
@@ -254,7 +254,7 @@ void DynamicHyperbolicGenerator::getEventsFromNodeMovement(vector<GraphEvent> &r
         }
         assert(T == 0 || beta == beta);
 
-        edgeProb = [beta, tresholdDistance](double distance) -> double {return 1 / (exp(beta*(distance-tresholdDistance)/2)+1);};
+        edgeProb = [beta, tresholdDistance](double distance) -> double {return 1 / (std::exp(beta*(distance-tresholdDistance)/2)+1);};
     }
 
     count oldStreamMarker = result.size();

--- a/networkit/cpp/generators/HyperbolicGenerator.cpp
+++ b/networkit/cpp/generators/HyperbolicGenerator.cpp
@@ -126,7 +126,7 @@ Graph HyperbolicGenerator::generateCold(const vector<double> &angles, const vect
     }
 
     const count bandCount = bands.size();
-    const double coshR = cosh(R);
+    const double coshR = std::cosh(R);
     assert(radii.size() == n);
 
     Aux::Timer bandTimer;
@@ -160,9 +160,9 @@ Graph HyperbolicGenerator::generateCold(const vector<double> &angles, const vect
         threadtimers[id].start();
         #pragma omp for schedule(guided) nowait
         for (omp_index i = 0; i < static_cast<omp_index>(n); i++) {
-            const double coshr = cosh(radii[i]);
-            const double sinhr = sinh(radii[i]);
-            count expectedDegree = (4/PI)*n*exp(-(radii[i])/2);
+            const double coshr = std::cosh(radii[i]);
+            const double sinhr = std::sinh(radii[i]);
+            count expectedDegree = (4/PI)*n*std::exp(-(radii[i])/2);
             vector<index> near;
             near.reserve(expectedDegree*1.1);
             Point2DWithIndex<double> pointV(angles[i], radii[i], i);
@@ -174,8 +174,8 @@ Graph HyperbolicGenerator::generateCold(const vector<double> &angles, const vect
 
                     const count sSize = neighborCandidates.size();
                     for(index w = 0; w < sSize; w++){
-                        double deltaPhi = PI - abs(PI-abs(angles[i] - neighborCandidates[w].getX()));
-                        if (coshr*cosh(neighborCandidates[w].getY())-sinhr*sinh(neighborCandidates[w].getY())*cos(deltaPhi) <= coshR) {
+                        double deltaPhi = PI - std::abs(PI-std::abs(angles[i] - neighborCandidates[w].getX()));
+                        if (coshr*std::cosh(neighborCandidates[w].getY())-sinhr*std::sinh(neighborCandidates[w].getY())*std::cos(deltaPhi) <= coshR) {
                             if (neighborCandidates[w].getIndex() != i){
                                 near.push_back(neighborCandidates[w].getIndex());
                             }
@@ -228,7 +228,7 @@ Graph HyperbolicGenerator::generate(const vector<double> &angles, const vector<d
     //now define lambda
     double beta = 1/T;
     assert(beta == beta);
-    auto edgeProb = [beta, R](double distance) -> double {return 1 / (exp(beta*(distance-R)/2)+1);};
+    auto edgeProb = [beta, R](double distance) -> double {return 1 / (std::exp(beta*(distance-R)/2)+1);};
 
     //get Graph
     GraphBuilder result(n, false, false);//no direct swap with probabilistic graphs

--- a/networkit/cpp/generators/MocnikGenerator.cpp
+++ b/networkit/cpp/generators/MocnikGenerator.cpp
@@ -70,7 +70,7 @@ static inline double norm(std::vector<double> &v, double shift) {
     for (count j = 0; j < v.size(); j++) {
         x += (v[j] + shift) * (v[j] + shift);
     }
-    return sqrt(x);
+    return std::sqrt(x);
 }
 
 /**
@@ -81,7 +81,7 @@ static inline double dist(std::vector<double> &v, std::vector<double> &w) {
     for (count j = 0; j < v.size(); j++) {
         x += std::pow(v[j] - w[j], 2);
     }
-    x = sqrt(x);
+    x = std::sqrt(x);
     return x;
 }
 
@@ -106,7 +106,7 @@ void MocnikGenerator::addNode(MocnikGenerator::LayerState &s, int j) {
 int MocnikGenerator::toIndex(MocnikGenerator::LayerState &s, const std::vector<double> &v) {
     std::vector<int> w;
     for (count j = 0; j < v.size(); j++) {
-        w.push_back(fmin(floor(v[j] * s.aMax), s.aMax - 1));
+        w.push_back(std::min(static_cast<int>(std::floor(v[j] * s.aMax)), s.aMax - 1));
     }
     return toIndex(s, w);
 }
@@ -195,7 +195,7 @@ std::vector<int> MocnikGenerator::boxSurface(MocnikGenerator::LayerState &s, int
 }
 
 std::vector<int> MocnikGenerator::boxVolume(MocnikGenerator::LayerState &s, int i, double r) {
-    int r2 = ceil(r * s.aMax);
+    int r2 = std::ceil(r * s.aMax);
     std::vector<std::vector<int>> se;
     std::vector<int> tmp;
     se.push_back(tmp);
@@ -226,7 +226,7 @@ std::vector<int> MocnikGenerator::boxVolume(MocnikGenerator::LayerState &s, int 
 void MocnikGenerator::addEdgesToGraph(Graph &G, count n, double k, double relativeWeight, bool baseLayer) {
     // map vector containing the nodes resp. their positions
     MocnikGenerator::LayerState s;
-    initCellArray(s, ceil(std::pow(n / 2, 1./dim) / k));
+    initCellArray(s, std::ceil(std::pow(n / 2, 1./dim) / k));
 
     // add the nodes to the layer state
     for (count i = 0; i < n; i++) {

--- a/networkit/cpp/generators/MocnikGeneratorBasic.cpp
+++ b/networkit/cpp/generators/MocnikGeneratorBasic.cpp
@@ -23,7 +23,7 @@ static inline double norm(std::vector<double> &v, double shift) {
     for (count j = 0; j < v.size(); j++) {
         x += (v[j] + shift) * (v[j] + shift);
     }
-    return sqrt(x);
+    return std::sqrt(x);
 }
 
 /**
@@ -34,7 +34,7 @@ static inline double dist(std::vector<double> &v, std::vector<double> &w) {
     for (count j = 0; j < v.size(); j++) {
         x += std::pow(v[j] - w[j], 2);
     }
-    x = sqrt(x);
+    x = std::sqrt(x);
     return x;
 }
 

--- a/networkit/cpp/generators/PubWebGenerator.cpp
+++ b/networkit/cpp/generators/PubWebGenerator.cpp
@@ -114,13 +114,13 @@ void PubWebGenerator::chooseDenseAreaSizes() {
 // compute number of nodes per cluster, each cluster has approx. same density
 void PubWebGenerator::chooseClusterSizes() {
     auto f = std::accumulate(denseAreaXYR.begin(), denseAreaXYR.end(), 0.0,
-                             [](coordinate sum, circle c) { return sum + pow(c.rad, 1.5); });
+                             [](coordinate sum, circle c) { return sum + std::pow(c.rad, 1.5); });
 
     f = (n * (numDenseAreas / (numDenseAreas + 2.0))) / f;
 
     numPerArea.reserve(numDenseAreas);
     for (auto circle : denseAreaXYR) {
-        numPerArea.emplace_back(std::round(f * pow(circle.rad, 1.5)));
+        numPerArea.emplace_back(std::round(f * std::pow(circle.rad, 1.5)));
     }
 }
 

--- a/networkit/cpp/generators/StaticDegreeSequenceGenerator.cpp
+++ b/networkit/cpp/generators/StaticDegreeSequenceGenerator.cpp
@@ -44,12 +44,12 @@ bool StaticDegreeSequenceGenerator::isRealizable() {
     /**
      * Second inequality
      * We now check that for all 0 <= j < n the following inequality holds
-     *   sum(d[i] for 0 <= i <= j) <= sum( min(j+1, d[i]) for j < i < n),
+     *   sum(d[i] for 0 <= i <= j) <= sum( std::min(j+1, d[i]) for j < i < n),
      * where d is the sorted degree sequence.
      *
      * To avoid the quadratic runtime of the naive implementation above, we search for each
      * j the smallest index k with d[k] < j+1. Then the RHS becomes:
-     *     (j+1)*min(0, k-j-1)       // all cases where the min-term defaulted to (j+1)
+     *     (j+1)*std::min(0, k-j-1)       // all cases where the min-term defaulted to (j+1)
      *   + sum(d[i] for k <= i < n)  // "true" suffix sum.
      *
      * Observe that the suffix sum only depends on k and not j; so we can precompute it once

--- a/networkit/cpp/generators/quadtree/test/QuadTreeGTest.cpp
+++ b/networkit/cpp/generators/quadtree/test/QuadTreeGTest.cpp
@@ -288,12 +288,12 @@ TEST_F(QuadTreeGTest, testEuclideanCircle) {
         double maxR = query.length() + radius;
         double minPhi, maxPhi, phi_c, r_c, spread;
         if (minR < 0) {
-            maxR = std::max(abs(minR), maxR);
+            maxR = std::max(std::abs(minR), maxR);
             minR = 0;
             minPhi = 0;
             maxPhi = 2*PI;
         } else {
-            spread = asin(radius / query.length());
+            spread = std::asin(radius / query.length());
             HyperbolicSpace::cartesianToPolar(query, phi_c, r_c);
             minPhi = phi_c - spread;
             maxPhi = phi_c + spread;
@@ -451,7 +451,7 @@ TEST_F(QuadTreeGTest, testProbabilisticQuery) {
     count n = 5000;
     count m = n*3;
     count capacity = 20;
-    double R = 2*log(8*n / (PI*(m/n)*2));
+    double R = 2*std::log(8*n / (PI*(m/n)*2));
     double r = HyperbolicSpace::hyperbolicRadiusToEuclidean(R);
     double alpha = 1;
 
@@ -632,7 +632,7 @@ TEST_F(QuadTreeGTest, debugTreeExport) {
     double T = 0.5;
     double beta = 1/T;
 
-    auto edgeProb = [beta, targetR](double distance) -> double {return 1 / (exp(beta*(distance-targetR)/2)+1);};
+    auto edgeProb = [beta, targetR](double distance) -> double {return 1 / (std::exp(beta*(distance-targetR)/2)+1);};
 
     std::stack<std::tuple<QuadNode<index>, count, double, double, index > > quadnodestack;
     QuadNode<index> root = getRoot(quad);
@@ -668,7 +668,7 @@ TEST_F(QuadTreeGTest, debugTreeExport) {
             }
         }
 
-        double stepsize = pow(4, remainingHeight-1);
+        double stepsize = std::pow(4, remainingHeight-1);
         double newXOffset = xoffset-1.5*stepsize;
         double newYOffset = yoffset + 1;
         for (QuadNode<index> child : current.children) {

--- a/networkit/cpp/generators/test/ErdosRenyiEnumeratorGTest.cpp
+++ b/networkit/cpp/generators/test/ErdosRenyiEnumeratorGTest.cpp
@@ -95,7 +95,7 @@ static void testEre(const bool directed, const node n, const double prob) {
             auto count = edge_counts[edgeindex(u,v,n)];
             EXPECT_GE(count, 1u) << "edge(" << u << ", " << v << "), rounds=" << rounds;
             if (prob < 1.0) {
-                ASSERT_LE(count, log(rounds) * rounds * prob) << "edge(" << u << ", " << v << "), rounds=" << rounds;
+                ASSERT_LE(count, std::log(rounds) * rounds * prob) << "edge(" << u << ", " << v << "), rounds=" << rounds;
             }
         }
     }

--- a/networkit/cpp/generators/test/GeneratorsGTest.cpp
+++ b/networkit/cpp/generators/test/GeneratorsGTest.cpp
@@ -586,7 +586,7 @@ TEST_F(GeneratorsGTest, testDynamicPathGenerator) {
 
 TEST_F(GeneratorsGTest, testErdosRenyiGenerator) {
     count n = 2000;
-    double p = 1.5 * (log(n) / (double) n);
+    double p = 1.5 * (std::log(n) / (double) n);
 
     ErdosRenyiGenerator generator(n, p);
     Graph G = generator.generate();

--- a/networkit/cpp/geometric/HyperbolicSpace.cpp
+++ b/networkit/cpp/geometric/HyperbolicSpace.cpp
@@ -26,12 +26,12 @@ double HyperbolicSpace::nativeDistance(double firstangle, double firstR, double 
     assert(secondangle < 2*PI);
     double result;
     if (firstangle == secondangle) {
-        result = abs(firstR - secondR);
+        result = std::abs(firstR - secondR);
     }
     else {
-        double deltaPhi = PI - abs(PI-abs(firstangle - secondangle));
-        double coshDist = cosh(firstR)*cosh(secondR)-sinh(firstR)*sinh(secondR)*cos(deltaPhi);
-        if (coshDist >= 1) result = acosh(coshDist);
+        double deltaPhi = PI - std::abs(PI-std::abs(firstangle - secondangle));
+        double coshDist = std::cosh(firstR)*std::cosh(secondR)-std::sinh(firstR)*std::sinh(secondR)*std::cos(deltaPhi);
+        if (coshDist >= 1) result = std::acosh(coshDist);
         else result = 0;
     }
     assert(result >= 0);
@@ -50,7 +50,7 @@ double HyperbolicSpace::poincareMetric(double phi_a, double  r_a, double phi_b, 
 double HyperbolicSpace::poincareMetric(Point2DWithIndex<double> a, Point2DWithIndex<double> b) {
     assert(a.length() < 1);
     assert(b.length() < 1);
-    double result = acosh( 1 + 2*a.squaredDistance(b) / ((1 - a.squaredLength())*(1 - b.squaredLength())));
+    double result = std::acosh( 1 + 2*a.squaredDistance(b) / ((1 - a.squaredLength())*(1 - b.squaredLength())));
     assert(result >= 0);
     return result;
 }
@@ -63,8 +63,8 @@ void HyperbolicSpace::fillPoints(vector<double> &angles, vector<double> &radii, 
     uint64_t n = radii.size();
     assert(angles.size() == n);
 
-    double mincdf = cosh(alpha*minR);
-    double maxcdf = cosh(alpha*maxR);
+    double mincdf = std::cosh(alpha*minR);
+    double maxcdf = std::cosh(alpha*maxR);
     std::uniform_real_distribution<double> phidist{minPhi, maxPhi};
     std::uniform_real_distribution<double> rdist{mincdf, maxcdf};
 
@@ -76,7 +76,7 @@ void HyperbolicSpace::fillPoints(vector<double> &angles, vector<double> &radii, 
          * \int sinh = cosh+const
          */
         double random = rdist(Aux::Random::getURNG());
-        radii[i] = (acosh(random)/alpha);
+        radii[i] = (std::acosh(random)/alpha);
         assert(radii[i] <= maxR);
         assert(radii[i] >= minR);
         assert(angles[i] <= maxPhi);
@@ -87,7 +87,7 @@ void HyperbolicSpace::fillPoints(vector<double> &angles, vector<double> &radii, 
 }
 
 Point2DWithIndex<double> HyperbolicSpace::polarToCartesian(double phi, double r) {
-    return Point2DWithIndex<double>(r*cos(phi), r*sin(phi));
+    return Point2DWithIndex<double>(r*std::cos(phi), r*std::sin(phi));
 }
 
 std::map<index, Point<float> > HyperbolicSpace::polarToCartesian(const vector<double> &angles, const vector<double> &radii) {
@@ -104,9 +104,9 @@ void HyperbolicSpace::cartesianToPolar(Point2DWithIndex<double> a, double &phi, 
     r = a.length();
     if (r == 0) phi = 0;
     else if (a[1] >= 0){
-        phi = acos(a[0]/ r);
+        phi = std::acos(a[0]/ r);
     } else {
-        phi = -acos(a[0] / r);
+        phi = -std::acos(a[0] / r);
     }
     if (phi < 0) phi += 2*PI;
 }
@@ -120,30 +120,30 @@ void HyperbolicSpace::getEuclideanCircle(Point2DWithIndex<double> hyperbolicCent
 }
 
 void HyperbolicSpace::getEuclideanCircle(double r_h, double hyperbolicRadius, double &radialCoordOfEuclideanCenter, double &euclideanRadius) {
-    double a = cosh(hyperbolicRadius)-1;
+    double a = std::cosh(hyperbolicRadius)-1;
     double b = 1-(r_h*r_h);
     radialCoordOfEuclideanCenter = (2*r_h)/(b*a+2);
-    euclideanRadius = sqrt(radialCoordOfEuclideanCenter*radialCoordOfEuclideanCenter - (2*r_h*r_h - b*a)/(b*a+2));
+    euclideanRadius = std::sqrt(radialCoordOfEuclideanCenter*radialCoordOfEuclideanCenter - (2*r_h*r_h - b*a)/(b*a+2));
 }
 
 double HyperbolicSpace::hyperbolicRadiusToEuclidean(double hyperbolicRadius) {
-    double ch = cosh(hyperbolicRadius);
-    return sqrt((ch-1)/(ch+1));
+    double ch = std::cosh(hyperbolicRadius);
+    return std::sqrt((ch-1)/(ch+1));
 }
 
 double HyperbolicSpace::EuclideanRadiusToHyperbolic(double euclideanRadius) {
     double eusq = euclideanRadius*euclideanRadius;
-    double result = acosh( 1 + 2*eusq / ((1 - eusq)));
+    double result = std::acosh( 1 + 2*eusq / ((1 - eusq)));
     return result;
 }
 
 double HyperbolicSpace::maxRinSlice(double minPhi, double maxPhi, double phi_c, double r_c, double euRadius) {
-    double maxCos = max(cos(abs(minPhi - phi_c)), cos(abs(maxPhi - phi_c)));
+    double maxCos = std::max(std::cos(std::abs(minPhi - phi_c)), std::cos(std::abs(maxPhi - phi_c)));
 
     if (minPhi < phi_c && phi_c < maxPhi) maxCos = 1;
     //applying law of cosines here
     double p = r_c*maxCos;
-    double maxR = p + sqrt(p*p - r_c*r_c + euRadius*euRadius);
+    double maxR = p + std::sqrt(p*p - r_c*r_c + euRadius*euRadius);
     return maxR;
 }
 
@@ -161,11 +161,11 @@ double HyperbolicSpace::hyperbolicSpaceInEuclideanCircle(double r_c, double d_c,
 
         if (d_c - r_c < r_max) {
             //remaining query circle is smaller than the disk representation
-            result += 2*PI*(cosh(EuclideanRadiusToHyperbolic(d_c-r_c))-1);//adding small circle around origin
+            result += 2*PI*(std::cosh(EuclideanRadiusToHyperbolic(d_c-r_c))-1);//adding small circle around origin
         } else {
-            result += 2*PI*(cosh(EuclideanRadiusToHyperbolic(r_max))-1);//adding small circle around origin
+            result += 2*PI*(std::cosh(EuclideanRadiusToHyperbolic(r_max))-1);//adding small circle around origin
         }
-        assert(result <= 2*PI*(cosh(EuclideanRadiusToHyperbolic(r_max))-1));
+        assert(result <= 2*PI*(std::cosh(EuclideanRadiusToHyperbolic(r_max))-1));
         min = std::nextafter(d_c-r_c, std::numeric_limits<double>::max());//correcting integral start to exclude circle
     }
 
@@ -178,25 +178,25 @@ double HyperbolicSpace::hyperbolicSpaceInEuclideanCircle(double r_c, double d_c,
     if (max < min) return result;
 
     auto realpart = [](double r, double d, double c) {
-        double result = acos((c*c-d*d+r*r) / (2*c*r)) / (r*r-1);
+        double result = std::acos((c*c-d*d+r*r) / (2*c*r)) / (r*r-1);
         return result;
     };
 
     auto firstlogpart = [](double r, double d, double c) {
         double s = (c*c-d*d);
         double rsqs = r*r+s;
-        double real = -2*s*sqrt(4*c*c*r*r-rsqs*rsqs);
+        double real = -2*s*std::sqrt(4*c*c*r*r-rsqs*rsqs);
         double imag = -4*c*c*r*r+2*s*r*r+2*s*s;
-        return atan2(imag, real)/2;
+        return std::atan2(imag, real)/2;
     };
 
     auto secondlogpart = [](double r, double d, double c) {
         double s = (c*c-d*d);
         double rsqs = r*r+s;
-        double real = sqrt(4*c*c*r*r-rsqs*rsqs);
+        double real = std::sqrt(4*c*c*r*r-rsqs*rsqs);
         double imag = 2*c*c*(r*r+1)-(s+1)*rsqs;
-        imag = imag / sqrt((s+1)*(s+1)-(4*c*c));
-        return (s-1)*atan2(imag, real)/(2*sqrt((s+1)*(s+1)-(4*c*c)));
+        imag = imag / std::sqrt((s+1)*(s+1)-(4*c*c));
+        return (s-1)*std::atan2(imag, real)/(2*std::sqrt((s+1)*(s+1)-(4*c*c)));
     };
 
     double lower = -realpart(min, d_c, r_c) -firstlogpart(min, d_c, r_c) + secondlogpart(min, d_c, r_c);

--- a/networkit/cpp/geometric/test/GeometricGTest.cpp
+++ b/networkit/cpp/geometric/test/GeometricGTest.cpp
@@ -46,8 +46,8 @@ TEST_F(GeometricGTest, testConversion) {
         HyperbolicSpace::cartesianToPolar(point, phi,r);
         EXPECT_GE(phi, 0) << "Point (" << point[0] << "," << point[1] << ") was not converted correctly";
         EXPECT_GE(r, 0);
-        EXPECT_LE(abs(phi - angles[i]), epsilon);
-        EXPECT_LE(abs(r - radii[i]), epsilon);
+        EXPECT_LE(std::abs(phi - angles[i]), epsilon);
+        EXPECT_LE(std::abs(r - radii[i]), epsilon);
     }
 }
 
@@ -73,12 +73,12 @@ TEST_F(GeometricGTest, testEuclideanCircleConsistency) {
         double r_e, euRadius;
         HyperbolicSpace::getEuclideanCircle(radii[i], R, r_e, euRadius);
         double mirrorangle = fmod(angles[i] + PI, 2*PI);
-        double mirrorradiusInside = abs(r_e - euRadius)-epsilon;
+        double mirrorradiusInside = std::abs(r_e - euRadius)-epsilon;
         Point2DWithIndex<double> counterPointInside = HyperbolicSpace::polarToCartesian(mirrorangle, mirrorradiusInside);
         EXPECT_LE(HyperbolicSpace::poincareMetric(cartesianPoint, counterPointInside), R) << "(" << cartesianPoint.getX() << ", " << cartesianPoint.getY() << ")"
                 << " and (" << counterPointInside.getX() << ", " << counterPointInside.getY() << ")" << " are " << HyperbolicSpace::poincareMetric(cartesianPoint, counterPointInside) << " apart from each other, which is more than " << R << ".";
 
-        double mirrorradiusOutside = abs(r_e - euRadius)+epsilon;
+        double mirrorradiusOutside = std::abs(r_e - euRadius)+epsilon;
         Point2DWithIndex<double> counterPointOutside = HyperbolicSpace::polarToCartesian(mirrorangle, mirrorradiusOutside);
         EXPECT_GE(HyperbolicSpace::poincareMetric(cartesianPoint, counterPointOutside), R);
 

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -44,7 +44,7 @@ Graph::Graph(std::initializer_list<WeightedEdge> edges) : Graph(0, true) {
 
     /* Number of nodes = highest node index + 1 */
     for (const auto &edge : edges) {
-        node x = max(edge.u, edge.v);
+        node x = std::max(edge.u, edge.v);
         while (numberOfNodes() <= x) {
             addNode();
         }

--- a/networkit/cpp/io/test/IOBenchmark.cpp
+++ b/networkit/cpp/io/test/IOBenchmark.cpp
@@ -147,8 +147,8 @@ TEST_F(IOBenchmark, benchRasterReader) {
 
             INFO("Converted coordinates", runtime.elapsedTag());
             //define query function
-            auto edgeProb = [n](double distance) -> double {return (1/distance)*exp(5)/(double)n ;};
-            //auto edgeProb = [beta, thresholdDistance](double distance) -> double {return 1 / (exp(beta*(distance-thresholdDistance)/2)+1);};
+            auto edgeProb = [n](double distance) -> double {return (1/distance)*std::exp(5)/(double)n ;};
+            //auto edgeProb = [beta, thresholdDistance](double distance) -> double {return 1 / (std::exp(beta*(distance-thresholdDistance)/2)+1);};
 
             // construct quadtree
             runtime.start();
@@ -181,7 +181,7 @@ TEST_F(IOBenchmark, benchRasterReader) {
                 for (index i = 0; i < xcoords.size(); i++) {
                     double xdiff = xcoords[i] - x;
                     double ydiff = ycoords[i] - y;
-                    double prob = edgeProb(pow(xdiff*xdiff+ydiff*ydiff , 0.5));
+                    double prob = edgeProb(std::pow(xdiff*xdiff+ydiff*ydiff , 0.5));
                     double random = Aux::Random::real();
                     if (random < prob) result.push_back(i);
                 }
@@ -233,7 +233,7 @@ TEST_F(IOBenchmark, simulateDiseaseProgression) {
         }
 
         //set neighbor probability
-        auto edgeProb = [](double distance) -> double {return (1/distance)*exp(-11);};
+        auto edgeProb = [](double distance) -> double {return (1/distance)*std::exp(-11);};
 
         //convert coordinates
         runtime.start();

--- a/networkit/cpp/linkprediction/AlgebraicDistanceIndex.cpp
+++ b/networkit/cpp/linkprediction/AlgebraicDistanceIndex.cpp
@@ -53,7 +53,7 @@ double AlgebraicDistanceIndex::runImpl(node u, node v) {
 
     if (norm == MAX_NORM) { // maximum norm
         for (index sys = 0; sys < numSystems; ++sys) {
-            double absDiff = fabs(loads[sys][u] - loads[sys][v]);
+            double absDiff = std::fabs(loads[sys][u] - loads[sys][v]);
             if (absDiff > result) {
                 result = absDiff;
             }
@@ -61,10 +61,10 @@ double AlgebraicDistanceIndex::runImpl(node u, node v) {
     }
     else {
         for (index sys = 0; sys < numSystems; ++sys) {
-            double absDiff = fabs(loads[sys][u] - loads[sys][v]);
-            result += pow(absDiff, norm);
+            double absDiff = std::fabs(loads[sys][u] - loads[sys][v]);
+            result += std::pow(absDiff, norm);
         }
-        result = pow(result, 1.0 / (double) norm);
+        result = std::pow(result, 1.0 / (double) norm);
     }
 
     return std::isnan(result) ? 0 : result;

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -75,7 +75,7 @@ TEST_F(SelectiveCDGTest, testSCD) {
     std::set<node> seeds = {seed};
     double alpha = 0.1; // loop (or teleport) probability, changed due to DGleich from: // phi * phi
                         // / (225.0 * log(100.0 * sqrt(m)));
-    double epsilon = 1e-5; // changed due to DGleich from: pow(2, exponent) / (48.0 * B);
+    double epsilon = 1e-5; // changed due to DGleich from: std::pow(2, exponent) / (48.0 * B);
 
     std::vector<std::pair<std::string, std::unique_ptr<SelectiveCommunityDetector>>> algorithms;
     algorithms.emplace_back(std::make_pair(
@@ -216,7 +216,7 @@ TEST_F(SelectiveCDGTest, testSCDWeighted) {
     G.forNodes([&](node u) { seeds.insert(u); });
     double alpha = 0.1; // loop (or teleport) probability, changed due to DGleich from: // phi * phi
                         // / (225.0 * log(100.0 * sqrt(m)));
-    double epsilon = 1e-5; // changed due to DGleich from: pow(2, exponent) / (48.0 * B);
+    double epsilon = 1e-5; // changed due to DGleich from: std::pow(2, exponent) / (48.0 * B);
 
     std::vector<std::pair<std::string, std::unique_ptr<SelectiveCommunityDetector>>> algorithms;
     algorithms.emplace_back(std::make_pair(

--- a/networkit/cpp/sparsification/LocalDegreeScore.cpp
+++ b/networkit/cpp/sparsification/LocalDegreeScore.cpp
@@ -72,7 +72,7 @@ void LocalDegreeScore::run() {
 
             double e = 1.0; // If the node has only one neighbor, the edge should be kept anyway.
             if (d > 1)
-                e = 1.0 - (log(rank) / log(d));
+                e = 1.0 - (std::log(rank) / std::log(d));
 
             Aux::Parallel::atomic_max(exponents[eid], e);
         }

--- a/networkit/cpp/sparsification/LocalSimilarityScore.cpp
+++ b/networkit/cpp/sparsification/LocalSimilarityScore.cpp
@@ -59,7 +59,7 @@ void LocalSimilarityScore::run() {
 
             double e = 1.0; //If the node has only one neighbor, the edge will be kept anyway.
             if (d > 1)
-                e = 1 - (log(rank) / log(d));
+                e = 1 - (std::log(rank) / std::log(d));
 
             sparsificationExp[eid] = std::max(e, sparsificationExp[eid]);
             rank++;

--- a/networkit/cpp/sparsification/MultiscaleScore.cpp
+++ b/networkit/cpp/sparsification/MultiscaleScore.cpp
@@ -59,7 +59,7 @@ void MultiscaleScore::run() {
  * edges connected to a node of degree k are uniformly distributed.
  */
 double MultiscaleScore::getProbability(count degree, edgeweight normalizedWeight) {
-    return 1.0 - pow(1.0 - normalizedWeight, static_cast<double>(degree) - 1.0);
+    return 1.0 - std::pow(1.0 - normalizedWeight, static_cast<double>(degree) - 1.0);
 }
 
 double MultiscaleScore::score(node, node) {

--- a/networkit/cpp/sparsification/SimmelianScore.cpp
+++ b/networkit/cpp/sparsification/SimmelianScore.cpp
@@ -21,7 +21,7 @@ std::vector<RankedNeighbors> SimmelianScore::getRankedNeighborhood(const Graph& 
     g.forNodes([&](node u) {
         //Sort ego's alters from strongly to weakly tied.
         g.forNeighborsOf(u, [&](node, node v, edgeid eid) {
-            count triangleCount = round(triangles[eid]);
+            count triangleCount = std::round(triangles[eid]);
             neighbors[u].push_back(RankedEdge(u, v, triangleCount));
         });
         std::sort(neighbors[u].begin(), neighbors[u].end());

--- a/networkit/cpp/sparsification/test/LocalDegreeGTest.cpp
+++ b/networkit/cpp/sparsification/test/LocalDegreeGTest.cpp
@@ -70,7 +70,7 @@ double LocalDegreeGTest::getScore(const Graph& g, node x, node y, count rankX, c
     if (g.degree(x) == 1 || g.degree(y) == 1)
         return 1;
 
-    return 1 - log(rankX) / log(g.degree(y));
+    return 1 - std::log(rankX) / std::log(g.degree(y));
 }
 
 }

--- a/networkit/cpp/viz/MaxentStress.cpp
+++ b/networkit/cpp/viz/MaxentStress.cpp
@@ -106,7 +106,7 @@ void MaxentStress::run() {
             oldCoordinates = newCoordinates;
 
             t.start();
-            newLowerBound = floor(5 * std::log(numSolves));
+            newLowerBound = std::floor(5 * std::log(numSolves));
             if (newLowerBound != currentLowerBound) {
                 repulsiveForces = CoordinateVector(dim, Vector(G->numberOfNodes(), 0));
                 Octree<double> octree(oldCoordinates);
@@ -281,7 +281,7 @@ double MaxentStress::maxentMeasure() {
         augmentedGraph.forNodes([&](node v) {
             if (u == v) return;
             double dist = std::max(this->vertexCoordinates[u].distance(this->vertexCoordinates[v]), 1e-5);
-            entropy += (fabs(q) < 0.001)? log(dist) : pow(dist, -q);
+            entropy += (std::fabs(q) < 0.001)? std::log(dist) : std::pow(dist, -q);
         });
     }
 
@@ -291,11 +291,11 @@ double MaxentStress::maxentMeasure() {
         augmentedGraph.forNeighborsOf(u, [&](node v, edgeweight w) {
             double dist = std::max(this->vertexCoordinates[u].distance(this->vertexCoordinates[v]), 1e-5);
             energy += (dist - w)*(dist - w)/(w*w);
-            entropy -= (fabs(q) < 0.001)? log(dist) : pow(dist, -q);
+            entropy -= (std::fabs(q) < 0.001)? std::log(dist) : std::pow(dist, -q);
         });
     }
 
-    if(fabs(q) > 0.001) {
+    if(std::fabs(q) > 0.001) {
         entropy *= -sign(q);
     }
 
@@ -307,7 +307,7 @@ double MaxentStress::meanDistanceError() {
     double sum = 0.0;
     for (node u = 0; u < knownDistances.size(); ++u) {
         for (const ForwardEdge& edge : knownDistances[u]) {
-            sum += fabs(vertexCoordinates[u].distance(vertexCoordinates[edge.head]) - edge.weight) / edge.weight;
+            sum += std::fabs(vertexCoordinates[u].distance(vertexCoordinates[edge.head]) - edge.weight) / edge.weight;
         }
     }
 
@@ -324,7 +324,7 @@ double MaxentStress::ldme() {
     }
 
     sum /= knownDistancesCardinality;
-    return sqrt(sum);
+    return std::sqrt(sum);
 }
 
 bool MaxentStress::isConverged(const CoordinateVector& newCoords, const CoordinateVector& oldCoords) {
@@ -438,7 +438,7 @@ void MaxentStress::approxRepulsiveForces(const CoordinateVector& coordinates, co
         Point<double> pI = getPoint(coordinates, i);
         auto approximateNeighbor = [&](const count numNodes, const Point<double>& centerOfMass, const double sqDist) {
             if (sqDist < 1e-5) return;
-            double factor = qSign * numNodes * 1.0/pow(sqDist, q2);
+            double factor = qSign * numNodes * 1.0/std::pow(sqDist, q2);
             for (index d = 0; d < dim; ++d) {
                 b[d][i] += factor * (pI[d] - centerOfMass[d]);
             }
@@ -590,7 +590,7 @@ void MaxentStress::computeAlgebraicDistances(const Graph& graph, const count k) 
                         if (algebraicDist == 0.0) {
                             algebraicDist = 1e-5;
                         }
-                        algebraicDist /= sqrt(static_cast<double>(G->degree(u) * G->degree(w)));
+                        algebraicDist /= std::sqrt(static_cast<double>(G->degree(u) * G->degree(w)));
                         knownDistances[u].push_back({w, algebraicDist});
                         if (std::isnan(algebraicDist)) INFO("Warning: nan dist");
                         minDist[u] = std::min(minDist[u], algebraicDist);


### PR DESCRIPTION
Replace usage of math functions from the C standard library `math.h`  with C++ standard math functions from `cmath`.
I generated these changes automatically (of course I checked them before opening this PR); the only exception is:
https://github.com/networkit/networkit/compare/master...angriman:refactor/drop-math-h?expand=1#diff-d450828fc2762048c7b60b0267df545b4f96f5624e489fbc8293e87eb8f351a8R109
which does not compile without `static_cast<int>` because we are trying to call `std::min` with `double` and `int` parameters and template type deduction fails.