### PR TITLE
Refactor: replace set with unordered set

### DIFF
--- a/include/networkit/generators/DynamicBarabasiAlbertGenerator.hpp
+++ b/include/networkit/generators/DynamicBarabasiAlbertGenerator.hpp
@@ -9,8 +9,6 @@
 #ifndef NETWORKIT_GENERATORS_DYNAMIC_BARABASI_ALBERT_GENERATOR_HPP_
 #define NETWORKIT_GENERATORS_DYNAMIC_BARABASI_ALBERT_GENERATOR_HPP_
 
-#include <set>
-
 #include <networkit/generators/DynamicGraphSource.hpp>
 
 namespace NetworKit {

--- a/include/networkit/sparsification/SimmelianScore.hpp
+++ b/include/networkit/sparsification/SimmelianScore.hpp
@@ -9,8 +9,12 @@
 #ifndef NETWORKIT_SPARSIFICATION_SIMMELIAN_SCORE_HPP_
 #define NETWORKIT_SPARSIFICATION_SIMMELIAN_SCORE_HPP_
 
-#include <networkit/edgescores/EdgeScore.hpp>
 #include <set>
+#include <unordered_set>
+
+#include <tlx/define/deprecated.hpp>
+
+#include <networkit/edgescores/EdgeScore.hpp>
 
 namespace NetworKit {
 
@@ -81,13 +85,19 @@ public:
             const std::vector<RankedNeighbors>& neighbors,
             const count& maxRank);
 
-    void matchNeighbors(node ego, node alter, bool reciprocityCheck,
+    void TLX_DEPRECATED(matchNeighbors(node ego, node alter, bool reciprocityCheck,
                         std::vector<RankedEdge>::const_iterator &egoIt,
                         const RankedNeighbors &egoNeighbors, std::set<node> &egoNeighborsUnmatched,
-                        std::set<node> &alterNeighborsUnmatched, count rank, count &overlap);
+                        std::set<node> &alterNeighborsUnmatched, count rank, count &overlap));
 
 protected:
     const std::vector<count>* triangles;
+
+    void matchNeighbors(node ego, node alter, bool reciprocityCheck,
+                        std::vector<RankedEdge>::const_iterator &egoIt,
+                        const RankedNeighbors &egoNeighbors, std::unordered_set<node> &egoNeighborsUnmatched,
+                        std::unordered_set<node> &alterNeighborsUnmatched, count rank, count &overlap);
+
 
 };
 

--- a/networkit/cpp/generators/DynamicBarabasiAlbertGenerator.cpp
+++ b/networkit/cpp/generators/DynamicBarabasiAlbertGenerator.cpp
@@ -6,6 +6,8 @@
  *      Author: cls
  */
 
+#include <unordered_set>
+
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/generators/DynamicBarabasiAlbertGenerator.hpp>
 
@@ -47,7 +49,7 @@ void DynamicBarabasiAlbertGenerator::generate() {
 
     // 3) go through the items one at a time, subtracting their weight from your random number, until you get the item where the random number is less than that item's weight
     node u = this->Gproxy->addNode();
-    std::set<node> targets; // avoid duplicate edges by collecting target nodes in a set
+    std::unordered_set<node> targets; // avoid duplicate edges by collecting target nodes in a set
 
     count nAttempts = 0;
     while (targets.size() < k) {

--- a/networkit/cpp/generators/DynamicForestFireGenerator.cpp
+++ b/networkit/cpp/generators/DynamicForestFireGenerator.cpp
@@ -25,7 +25,6 @@ DynamicForestFireGenerator::DynamicForestFireGenerator(double p, bool directed, 
 std::vector<GraphEvent> DynamicForestFireGenerator::generate(count nSteps) {
 
     std::vector<GraphEvent> stream;
-    std::set<node> empty;
 
     /* this function creates a new node and connects it to
      * other nodes according to the forest fire model

--- a/networkit/cpp/io/DotPartitionWriter.cpp
+++ b/networkit/cpp/io/DotPartitionWriter.cpp
@@ -1,13 +1,13 @@
 // no-networkit-format
 #include <fstream>
-#include <set>
+#include <unordered_set>
 
 #include <networkit/io/DotPartitionWriter.hpp>
 
 namespace NetworKit {
 
 std::map<index, double> DotPartitionWriter::createHueMap(Graph &graph, Partition& zeta) const {
-    std::set<index> uniqueIds;
+    std::unordered_set<index> uniqueIds;
 
     graph.forNodes([&](node u){
         if (graph.degree(u) == 0) {

--- a/networkit/cpp/io/SNAPEdgeListPartitionReader.cpp
+++ b/networkit/cpp/io/SNAPEdgeListPartitionReader.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <fstream>
-#include <set>
+#include <unordered_set>
 #include <sstream>
 #include <unordered_map>
 #include <vector>
@@ -35,7 +35,9 @@ Cover SNAPEdgeListPartitionReader::read(const std::string &path,
 
     std::string commentPrefix = "#";
 
-    std::set<node> uniqueIDs;
+#ifndef NDEBUG
+    std::unordered_set<node> uniqueIDs;
+#endif
     count totalCounter = 0;
 
     Cover communities(G.upperNodeIdBound());

--- a/networkit/cpp/io/SNAPEdgeListPartitionReader.cpp
+++ b/networkit/cpp/io/SNAPEdgeListPartitionReader.cpp
@@ -53,7 +53,9 @@ Cover SNAPEdgeListPartitionReader::read(const std::string &path,
         } else {
             std::stringstream linestream(line);
             while (linestream >> current) {
+#ifndef NDEBUG
                 uniqueIDs.insert(current);
+#endif
                 totalCounter++;
                 if (mapNodeIds.find(current) != mapNodeIds.end()) {
                     communities.addToSubset(i,mapNodeIds[current]);
@@ -63,7 +65,9 @@ Cover SNAPEdgeListPartitionReader::read(const std::string &path,
             }
         }
     }
+#ifndef NDEBUG
     DEBUG("read ", uniqueIDs.size(), " unique node IDs with the total amount of occurrences: ",totalCounter);
+#endif
     count emptyElements = 0;
     count output = 0;
     std::stringstream outputString;

--- a/networkit/cpp/sparsification/SimmelianScore.cpp
+++ b/networkit/cpp/sparsification/SimmelianScore.cpp
@@ -56,8 +56,8 @@ Redundancy SimmelianScore::getOverlap(	const node& ego,
     std::vector<RankedEdge>::const_iterator egoIt = neighbors[ego].begin();
     std::vector<RankedEdge>::const_iterator alterIt = neighbors[alter].begin();
 
-    std::set<node> egoNeighborsUnmatched;
-    std::set<node> alterNeighborsUnmatched;
+    std::unordered_set<node> egoNeighborsUnmatched;
+    std::unordered_set<node> alterNeighborsUnmatched;
 
     for (count rank = 0; rank <= maxRank; rank++) {
         matchNeighbors(ego, alter, true, egoIt, neighbors[ego], egoNeighborsUnmatched, alterNeighborsUnmatched, rank, result.overlap);
@@ -71,6 +71,30 @@ Redundancy SimmelianScore::getOverlap(	const node& ego,
     }
 
     return result;
+}
+
+/**
+ * Helper function used in getOverlap. Adds the intersection of
+ * egoNeighbors and alterNeighborsUnmatched to overlap.
+ */
+void SimmelianScore::matchNeighbors(node, node alter, bool,
+                                    std::vector<RankedEdge>::const_iterator &,
+                                    const RankedNeighbors &egoNeighbors,
+                                    std::unordered_set<node> &egoNeighborsUnmatched,
+                                    std::unordered_set<node> &alterNeighborsUnmatched, count rank,
+                                    count &overlap) {
+
+    for (auto egoIt : egoNeighbors) {
+        node other = egoIt.alter;
+
+        if (other == alter || egoIt.rank != rank)
+            continue;
+
+        if (alterNeighborsUnmatched.erase(other))
+            overlap++;
+        else
+            egoNeighborsUnmatched.insert(other);
+    }
 }
 
 /**

--- a/networkit/cpp/structures/Cover.cpp
+++ b/networkit/cpp/structures/Cover.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <algorithm>
+#include <unordered_set>
 
 #include <networkit/structures/Cover.hpp>
 
@@ -32,7 +33,7 @@ bool Cover::inSameSubset(index e1, index e2) const {
     assert (e2 <= z);
     assert (! data[e1].empty());
     assert (! data[e2].empty()); // elements cannot be unassigned - it may be possible to change this behavior
-    std::set<index> intersect;
+    std::unordered_set<index> intersect;
     std::set_intersection(data[e1].begin(),data[e1].end(),data[e2].begin(), data[e2].end(), std::inserter(intersect,intersect.begin()));
     return (!intersect.empty());
 }


### PR DESCRIPTION
- Replace `std::set` with `std::unordered_set` in places where order is not important
- Remove unused instance of `std::unordered_set` from release mode