### PR TITLE
Documentation fix for Python-modules: dynamic, dynamics, embedding, engineering, flow

### DIFF
--- a/docs/python_api/dynamics.rst
+++ b/docs/python_api/dynamics.rst
@@ -1,7 +1,6 @@
 networkit.dynamics
-=================
+==================
 
 .. automodule:: networkit.dynamics
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/python_api/embedding.rst
+++ b/docs/python_api/embedding.rst
@@ -1,5 +1,5 @@
 networkit.embedding
-==================
+===================
 
 .. automodule:: networkit.embedding
     :members:

--- a/docs/python_api/modules.rst
+++ b/docs/python_api/modules.rst
@@ -23,6 +23,8 @@ Modules
    csbridge
    distance
    dynamic
+   dynamics
+   embedding
    engineering
    flow
    generators

--- a/networkit/dynamic.py
+++ b/networkit/dynamic.py
@@ -1,21 +1,25 @@
 # extension imports
 from .graph import Graph
-from .dynamics import GraphEvent, DGSStreamParser, GraphUpdater, GraphDifference
-from .distance import APSP
+from .dynamics import graphFromStream as dynamicsGraphFromStream
 
 def graphFromStream(stream, weighted, directed):
-	""" Convenience function for creating a new graph from a stream of graph events
+	""" 
+	graphFromStream(stream, weighted, directed)
+	
+	DEPRECATED. Use networkit.dynamics.graphFromStream instead.
 
-	Parameters:
-	-----------
-	stream : list of GraphEvent
-		event stream
-	weighted : produce a weighted or unweighted graph
-		boolean
-	directed : produce a directed or undirected graph
-		boolean
+	Convenience function for creating a new graph from a stream of graph events
+
+	Parameters
+	----------
+	stream : list(networkit.dynamics.GraphEvent)
+		Event stream
+	weighted : bool
+		Produce a weighted or unweighted graph
+	directed : bool
+		Produce a directed or undirected graph
 	"""
-	G = Graph(0, weighted, directed)
-	gu = GraphUpdater(G)
-	gu.update(stream)
+	from warnings import warn
+	warn("networkit.dynamic.graphFromStream is deprecated, use networkit.dynamics.graphFromStream")
+	G = dynamicsGraphFromStream(stream, weighted, directed)
 	return G

--- a/networkit/embedding.pyx
+++ b/networkit/embedding.pyx
@@ -12,59 +12,57 @@ ctypedef uint64_t count
 
 cdef extern from "<networkit/embedding/Node2Vec.hpp>":
 
-    cdef cppclass _Node2Vec "NetworKit::Node2Vec"(_Algorithm):
-        _Node2Vec(_Graph G, double P, double Q, count L, count N, count D) except +
-        vector[vector[float]] getFeatures() except +
+	cdef cppclass _Node2Vec "NetworKit::Node2Vec"(_Algorithm):
+		_Node2Vec(_Graph G, double P, double Q, count L, count N, count D) except +
+		vector[vector[float]] getFeatures() except +
 
 cdef class Node2Vec(Algorithm):
-    """ 
-    Algorithm to extract features from the graph with the node2vec(word2vec)
-    algorithm according to [https://arxiv.org/pdf/1607.00653v1.pdf].
-    CAUTION: 
-    This algorithm could take a lot of time on large networks (many nodes).
+	""" 
+	Node2Vec(G, P, Q, L, N, D)
 
-    Node2Vec(G, P, Q, L, N, D)
+	Algorithm to extract features from the graph with the node2vec(word2vec)
+	algorithm according to [https://arxiv.org/pdf/1607.00653v1.pdf].
 
-    Create a Node2Vec algorithm object for Graph `G` with these params 
+	Note
+	---- 
+	This algorithm could take a lot of time on large networks (many nodes).
  
-    Parameters
-    ----------
-    G : networkit.Graph
-        The graph.
-    P : double
-        The ratio for returning to the previous node on a walk.
-        P > max(Q,1) : less likely to sample an already-visited node in
-                       the following two steps
-        P < min(Q,1) : more likely to sample an already-visited node in
-                       the following two steps
-    Q : double
-        The ratio for the direction of the next step
-        Q > 1 : the random walk is biased towards nodes close to the
-                previous one.
-        Q < 1 : the random walk is biased towards nodes which are 
-                further away from the previous one. 
-    L : count
-        The walk length.
-    N : count
-        The number of walks per node.
-    D: count
-        The dimension of the calculated embedding. 
-    """
+	Parameters
+	----------
+	G : networkit.Graph
+		The graph.
+	P : float
+		The ratio for returning to the previous node on a walk.
+		For P > max(Q,1) it is less likely to sample an already-visited node in the following two steps.
+		For P < min(Q,1) it is more likely to sample an already-visited node in the following two steps.
+	Q : float
+		The ratio for the direction of the next step
+		For Q > 1 the random walk is biased towards nodes close to the previous one.
+		For Q < 1 the random walk is biased towards nodes which are further away from the previous one. 
+	L : int
+		The walk length.
+	N : int
+		The number of walks per node.
+	D: int
+		The dimension of the calculated embedding. 
+	"""
 
-    cdef Graph _G
+	cdef Graph _G
  
-    def __cinit__(self, Graph G, P=1, Q=1, L=80, N=10, D=128):
-        self._G = G
-        self._this = new _Node2Vec(G._this, P, Q, L, N, D)
+	def __cinit__(self, Graph G, P=1, Q=1, L=80, N=10, D=128):
+		self._G = G
+		self._this = new _Node2Vec(G._this, P, Q, L, N, D)
 
-    def getFeatures(self):
-        """
-        Returns all feature vectors
+	def getFeatures(self):
+		"""
+		getFeatures()
 
-        Returns
-        -------
-        A vector of vectors of floats.
-        A vector containing feature vectors of all nodes
-        """
-        return (<_Node2Vec*>(self._this)).getFeatures()
+		Returns all feature vectors
+
+		Returns
+		-------
+		list(list(float))
+			A vector containing feature vectors of all nodes
+		"""
+		return (<_Node2Vec*>(self._this)).getFeatures()
 

--- a/networkit/engineering.pyx
+++ b/networkit/engineering.pyx
@@ -18,11 +18,39 @@ import csv
 import warnings
 
 def pystring(stdstring):
-	""" convert a std::string (= python byte string) to a normal Python string"""
+	""" 
+	pystring(stdstring)
+
+	Convert a std::string (= python byte string) to a normal Python string
+
+	Parameters
+	----------
+	stdstring : str
+		Input python byte string.
+
+	Returns
+	-------
+	pystring
+		Python string.
+	"""
 	return stdstring.decode("utf-8")
 
 def stdstring(pystring):
-	""" convert a Python string to a bytes object which is automatically coerced to std::string"""
+	""" 
+	stdstring(pystring)
+
+	Convert a Python string to a bytes object which is automatically coerced to std::string
+
+	Parameters
+	----------
+	pystring : str
+		Input python string.
+
+	Returns
+	-------
+	stdstring
+		Python byte string.
+	"""
 	pybytes = pystring.encode("utf-8")
 	return pybytes
 
@@ -39,15 +67,38 @@ cdef extern from "<networkit/auxiliary/Parallelism.hpp>" namespace "Aux":
 	int _getMaxNumberOfThreads "Aux::getMaxNumberOfThreads" ()
 
 def setNumberOfThreads(nThreads):
-	""" Set the number of OpenMP threads """
+	""" 
+	setNumberOfThreads(nThreads)
+
+	Set the number of OpenMP threads
+	"""
 	_setNumberOfThreads(nThreads)
 
 def getCurrentNumberOfThreads():
-	""" Get the number of currently running threads"""
+	""" 
+	getCurrentNumberOfThreads()
+
+	Get the number of currently running threads.
+	
+	Returns
+	-------
+	int
+		Number of threads.
+	"""
 	return _getCurrentNumberOfThreads()
 
 def getMaxNumberOfThreads():
-	""" Get the maximum number of available threads"""
+	""" 
+	getMaxNumberOfThreads()
+
+	Get the maximum number of available threads
+	
+	
+	Returns
+	-------
+	int
+		Max number of threads.
+	"""
 	return _getMaxNumberOfThreads()
 
 cdef extern from "<networkit/auxiliary/Log.hpp>" namespace "Aux":
@@ -57,11 +108,29 @@ cdef extern from "<networkit/auxiliary/Log.hpp>" namespace "Aux":
 	void _setLogLevel "Aux::Log::setLogLevel" (string loglevel) except +
 
 def getLogLevel():
-	""" Get the current log level"""
+	""" 
+	getLogLevel()
+	
+	Get the current log level.
+	
+	Returns
+	-------
+	logLevel
+		The current loglevel.
+	"""
 	return pystring(_getLogLevel())
 
 def setLogLevel(loglevel):
-	""" Set the current loglevel"""
+	""" 
+	setLogLevel(loglevel)
+
+	Set the current loglevel
+	
+	Parameters
+	----------
+	loglevel : str
+		The new loglevel. Possible values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, QUIET
+	"""
 	_setLogLevel(stdstring(loglevel))
 
 cdef extern from "<networkit/GlobalState.hpp>" namespace "NetworKit":
@@ -69,7 +138,16 @@ cdef extern from "<networkit/GlobalState.hpp>" namespace "NetworKit":
 	void _setPrintLocation "NetworKit::GlobalState::setPrintLocation" (bool_t) except +
 
 def setPrintLocation(flag):
-	""" Switch locations in log statements on or off"""
+	""" 
+	setPrintLocation(flag)
+	
+	Switch locations in log statements on or off
+	
+	Parameters
+	----------
+	flag : bool
+		Sets whether to also log file, function and line of code. Default: False.
+	"""
 	_setPrintLocation(flag)
 
 cdef extern from "<networkit/auxiliary/Random.hpp>" namespace "Aux::Random":
@@ -77,13 +155,16 @@ cdef extern from "<networkit/auxiliary/Random.hpp>" namespace "Aux::Random":
 	void _setSeed "Aux::Random::setSeed" (uint64_t, bool_t)
 
 def setSeed(uint64_t seed, bool_t useThreadId):
-	""" Set the random seed that is used in NetworKit.
+	""" 
+	setSeed(seed, useThreadId)
+	
+	Set the random seed that is used in NetworKit.
 
 	Note that there is a separate random number generator per thread.
 
-	Parameters:
-	-----------
-	seed : uint64_t
+	Parameters
+	----------
+	seed : int
 		The seed
 	useThreadId : bool
 		If the thread id shall be added to the seed
@@ -91,8 +172,29 @@ def setSeed(uint64_t seed, bool_t useThreadId):
 	_setSeed(seed, useThreadId)
 
 def strongScaling(algorithmClass, threadSequence, inargs, inputTitle=None, repetitions=1, outPath=None):
-	""" Evaluate strong scaling, i.e. how the performance varies with the number of threads
-		for a fixed input size.
+	"""
+	strongScaling(algorithmClass, threadSequence, inargs, inputTitle=None, repetitions=1, outPath=None)
+	
+	Evaluate strong scaling, i.e. how the performance varies with the number of threads for a fixed input size.
+
+	Note
+	----
+	Algorithm is executed by calling :code:`algorithmClass(**inargs)`. See parameter for more details.
+
+	Parameters
+	----------
+	algorithmClass :
+		Algorithm, which should be tested.
+	threadSequence : list(int)
+		A list of thread numbers to run the :code:`algorithmClass` with.
+	inargs : **kwargs
+		Input arguments for algorithm. 
+	inputTitle : str, optional
+		Set a title for the output. Default: None
+	repetitions : int, optional
+		Number of repetitions. Default: 1
+	outPath : str, optional
+		File for writing the output to. Default: None
 	"""
 	data = []	# collects data about the experiments
 	threadsAvailable = getMaxNumberOfThreads()	# remember maximum number of threads and restore later
@@ -121,8 +223,31 @@ def strongScaling(algorithmClass, threadSequence, inargs, inputTitle=None, repet
 	return data
 
 def weakScaling(algorithmClass, inargs, threadSequence, inputSequence, inputTitles=None, repetitions=1, outPath=None):
-	""" Evaluate weak scaling, i.e. how the performance varies with the number of threads
-		for a fixed input size per processor.
+	"""
+	weakScaling(algorithmClass, inargs, threadSequence, inputSequence, inputTitles=None, repetitions=1, outPath=None)
+	
+	Evaluate weak scaling, i.e. how the performance varies with the number of threads for a fixed input size per processor.
+
+	Note
+	----
+	Algorithm is executed by calling :code:`algorithmClass(input, **inargs)`. See parameter for more details.
+
+	Parameters
+	----------
+	algorithmClass :
+		Algorithm, which should be tested.
+	inargs : **kwargs
+		Input arguments for algorithm.
+	threadSequence : list(int)
+		A list of thread numbers to run the :code:`algorithmClass` with.
+	inputSequence : list(networkit.Graph)
+		A list of graphs. The input algorithm is evaluated against every list-member.
+	inputTitles : str, optional
+		Set a title for the output. Default: None
+	repetitions : int, optional
+		Number of repetitions. Default: 1
+	outPath : str, optional
+		File for writing the output to. Default: None
 	"""
 	data = []	# collects data about the experiments
 	threadsAvailable = getMaxNumberOfThreads()	# remember maximum number of threads and restore later

--- a/networkit/flow.pyx
+++ b/networkit/flow.pyx
@@ -29,15 +29,17 @@ cdef extern from "<networkit/flow/EdmondsKarp.hpp>":
 
 cdef class EdmondsKarp(Algorithm):
 	"""
+	EdmondsKarp(graph, source, sink)
+
 	The EdmondsKarp class implements the maximum flow algorithm by Edmonds and Karp.
 
-	Parameters:
-	-----------
+	Parameters
+	----------
 	graph : networkit.Graph
 		The graph
-	source : node
+	source : int
 		The source node for the flow calculation
-	sink : node
+	sink : int
 		The sink node for the flow calculation
 	"""
 	cdef Graph _graph
@@ -48,42 +50,48 @@ cdef class EdmondsKarp(Algorithm):
 
 	def getMaxFlow(self):
 		"""
-		Returns: the value of the maximum flow from source to sink.
+		getMaxFlow()
 
-		Returns:
-		--------
-		edgeweight
+		Returns the value of the maximum flow from source to sink.
+
+		Returns
+		-------
+		float
 			The maximum flow value
 		"""
 		return (<_EdmondsKarp*>(self._this)).getMaxFlow()
 
 	def getSourceSet(self):
 		"""
-		Returns: the set of the nodes on the source side of the flow/minimum cut.
+		getSourceSet()
 
-		Returns:
-		--------
-		list
+		Returns the set of the nodes on the source side of the flow/minimum cut.
+
+		Returns
+		-------
+		list(int)
 			The set of nodes that form the (smallest) source side of the flow/minimum cut.
 		"""
 		return (<_EdmondsKarp*>(self._this)).getSourceSet()
 
 	def getFlow(self, node u, node v = none):
 		"""
+		getFlow(u, v = None)
+
 		Get the flow value between two nodes u and v or an edge identified by the edge id u.
 		Warning: The variant with two edge ids is linear in the degree of u.
 
-		Parameters:
-		-----------
-		u : node or edgeid
-			The first node incident to the edge or the edge id
-		v : node
-			The second node incident to the edge (optional if edge id is specified)
+		Parameters
+		----------
+		u : int
+			The first node incident to the edge or the edge id.
+		v : int, optional
+			The second node incident to the edge (optional if edge id is specified). Default: None
 
-		Returns:
-		--------
-		edgeweight
-			The flow on the specified edge
+		Returns
+		-------
+		float
+			The flow on the specified edge.
 		"""
 		if v == none: # Assume that node and edge ids are the same type
 			return (<_EdmondsKarp*>(self._this)).getFlow(u)
@@ -92,11 +100,13 @@ cdef class EdmondsKarp(Algorithm):
 
 	def getFlowVector(self):
 		"""
+		getFlowVector()
+
 		Return a copy of the flow values of all edges.
 
-		Returns:
-		--------
-		list
-			The flow values of all edges indexed by edge id
+		Returns
+		-------
+		list(float)
+			The flow values of all edges indexed by edge id.
 		"""
 		return (<_EdmondsKarp*>(self._this)).getFlowVector()


### PR DESCRIPTION
This PR fixes documentation for Python module `dynamic, dynamics, embedding, engineering, flow`. This also includes conversion of data types to Python native data types as discussed in https://github.com/networkit/networkit/pull/870.

I also introduced another change for enum-blocks. Until now all enum-definitions were also part of the doc, but only listed without additional context on how to correctly use them and how they are tied to other functions. Example from `centrality`:

![Bildschirmfoto 2022-02-16 um 10 02 17](https://user-images.githubusercontent.com/4864162/154231562-651558e0-4f28-4341-8044-155b8535f30d.png)

For `GraphEvent` this behavior is changed, so that the enum is listed as a parameter. In addition ` :undoc-members:` from automodule has to be removed, so that the original enum-blocks are gone. Example:

![Bildschirmfoto 2022-02-16 um 10 04 47](https://user-images.githubusercontent.com/4864162/154231536-1c7dd808-055f-41fd-807b-654c9330835b.png)