### PR TITLE
Refactor: Untested Code

### DIFF
--- a/include/networkit/algebraic/DynamicMatrix.hpp
+++ b/include/networkit/algebraic/DynamicMatrix.hpp
@@ -69,21 +69,6 @@ public:
     DynamicMatrix(count nRows, count nCols, const std::vector<Triplet> &triplets,
                   double zero = 0.0);
 
-    /** Default copy constructor */
-    DynamicMatrix(const DynamicMatrix &other) = default;
-
-    /** Default move constructor */
-    DynamicMatrix(DynamicMatrix &&other) noexcept = default;
-
-    /** Default destructor */
-    ~DynamicMatrix() = default;
-
-    /** Default move assignment operator */
-    DynamicMatrix &operator=(DynamicMatrix &&other) noexcept = default;
-
-    /** Default copy assignment operator */
-    DynamicMatrix &operator=(const DynamicMatrix &other) = default;
-
     /**
      * Compares this matrix to @a other and returns true if the shape and zero element are the same
      * as well as all entries, otherwise returns false.

--- a/include/networkit/algebraic/Vector.hpp
+++ b/include/networkit/algebraic/Vector.hpp
@@ -58,21 +58,6 @@ public:
      */
     Vector(const std::initializer_list<double> &list);
 
-    /** Default copy constructor */
-    Vector(const Vector &other) = default;
-
-    /** Default move constructor */
-    Vector(Vector &&other) = default;
-
-    /** Default destructor */
-    ~Vector() = default;
-
-    /** Default copy assignment operator */
-    Vector &operator=(const Vector &other) = default;
-
-    /** Default move assignment operator */
-    Vector &operator=(Vector &&other) = default;
-
     /**
      * @return dimension of vector
      */

--- a/include/networkit/base/Algorithm.hpp
+++ b/include/networkit/base/Algorithm.hpp
@@ -12,8 +12,6 @@ protected:
     bool hasRun = false;
 
 public:
-    Algorithm() = default;
-
     virtual ~Algorithm() = default;
 
     /**

--- a/networkit/cpp/algebraic/test/AlgebraicSpanningEdgeCentralityGTest.cpp
+++ b/networkit/cpp/algebraic/test/AlgebraicSpanningEdgeCentralityGTest.cpp
@@ -51,7 +51,7 @@ TEST_F(AlgebraicSpanningEdgeCentralityGTest, testOnToyGraph) {
     EXPECT_NEAR(0.75, asp.score(5), 1e-5);
 }
 
-TEST_F(AlgebraicSpanningEdgeCentralityGTest, benchmarkSpanning) {
+TEST_F(AlgebraicSpanningEdgeCentralityGTest, testOnRealGraphs) {
     METISGraphReader reader;
 
     std::string graphFiles[2] = {"input/karate.graph", "input/tiny_01.graph"};

--- a/networkit/cpp/algebraic/test/VectorGTest.cpp
+++ b/networkit/cpp/algebraic/test/VectorGTest.cpp
@@ -36,6 +36,17 @@ TEST(VectorGTest, testVectorConstruction) {
     }
 }
 
+TEST(VectorGTest, testFill) {
+    const index n = 10;
+    Vector v(n);
+
+    const double val = 1;
+    v.fill(val);
+
+    for (index i = 0; i < n; ++i)
+        EXPECT_EQ(val, v[i]);
+}
+
 TEST(VectorGTest, testDimension) {
     Vector testVector = {1.0, 2.0, 3.0, 4.0, 5.0};
     ASSERT_EQ(5u, testVector.getDimension());
@@ -132,6 +143,16 @@ TEST(VectorGTest, testVectorScalarMultiplication) {
         EXPECT_EQ((i + 1) * 2.0, vectorScalar[i]);
         EXPECT_EQ((i + 1) * 2.0, scalarVector[i]);
     }
+}
+
+TEST(VectorGTest, testScalarVectorMultiplication) {
+    Vector vec(10, 1);
+    const double scalar = 2.;
+
+    auto vec2 = scalar * vec;
+
+    ASSERT_EQ(vec.getDimension(), vec2.getDimension());
+    vec2.forElements([&](double element) { ASSERT_EQ(element, scalar); });
 }
 
 TEST(VectorGTest, testVectorMatrixMultiplication) {


### PR DESCRIPTION
- Rename tests so that they are not filtered out by our GTest filter (see the `Unittests-X.cpp` file).
- Add missing tests for matrices iterators
- Add missing tests for Vector
- Removal of unused default constructor and assignment operators. I am not so sure about this; from the covered lines on coveralls, these functions seem to never be used. I would appreciate any feedback about this.