### PR TITLE
Python documentation: unify modules algebraic to csbridge with rest

### DIFF
--- a/docs/python_api/centrality.rst
+++ b/docs/python_api/centrality.rst
@@ -3,5 +3,4 @@ networkit.centrality
 
 .. automodule:: networkit.centrality
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/networkit/algebraic.py
+++ b/networkit/algebraic.py
@@ -18,15 +18,15 @@ def column(matrix, i):
 
 	Parameters
 	----------
-	matrix : sparse matrix
-		The matrix to compute the eigenvectors of
+	matrix : :py:class:`scipy.sparse.csr_matrix`
+		The matrix to compute the eigenvectors of.
 	i : int
-		column index
+		Column index.
 
 	Returns
 	-------
-	list
-		column i of matrix
+	list(float)
+		Column i of matrix.
 	"""	
 	return [row[i] for row in matrix]
 
@@ -41,8 +41,8 @@ def adjacencyMatrix(G, matrixType="sparse"):
 	----------
 	G : networkit.Graph
 		The graph.
-	matrixType : string
-		either "sparse" or "dense"
+	matrixType : str, optional
+		Either "sparse" or "dense". Default: "sparse"
 
 	Returns
 	-------
@@ -87,15 +87,14 @@ def laplacianMatrix(G):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph.
+		The input graph.
 
 	Returns
 	-------
+	ndarray or :py:class:`scipy.sparse.csr_matrix`
+    	The N x N laplacian matrix of csgraph. It will be a NumPy array (dense) if the input was dense, or a sparse matrix otherwise.
 	ndarray
-		The N x N laplacian matrix of graph.
-	ndarray
-		The length-N diagonal of the laplacian matrix.
-		diag is returned only if return_diag is True.
+    	The length-N diagonal of the Laplacian matrix. For the normalized Laplacian, this is the array of square roots of vertex degrees or 1 if the degree is zero.
 	"""
 	A = adjacencyMatrix(G)
 	return scipy.sparse.csgraph.laplacian(A)
@@ -107,13 +106,12 @@ def PageRankMatrix(G, damp=0.85):
 	Builds the PageRank matrix of the undirected Graph `G`. This matrix corresponds with the
 	PageRank matrix used in the C++ backend.
 
-
 	Parameters
 	----------
 	G : networkit.Graph
 		The graph.
 	damp: float, optional
-		Damping factor of the PageRank algorithm (0.85 by default)
+		Damping factor of the PageRank algorithm. Default: 0.85
 
 	Returns
 	-------
@@ -148,19 +146,18 @@ def symmetricEigenvectors(matrix, cutoff=-1, reverse=False):
 
 	Parameters
 	----------
-	matrix : sparse matrix
-		The matrix to compute the eigenvectors of
+	matrix : :py:class:`scipy.sparse.csr_matrix`
+		The matrix to compute the eigenvectors of.
 	cutoff : int, optional
-		The maximum (or minimum) magnitude of the eigenvectors needed
+		The maximum (or minimum) magnitude of the eigenvectors needed. Default: -1
 	reverse : boolean, optional
-		If set to true, the smaller eigenvalues will be computed before the larger ones
+		If set to true, the smaller eigenvalues will be computed before the larger ones. Default: False
 
 	Returns
 	-------
-	( [ float ], [ ndarray ] )
+	tuple(list(float), list(ndarray))
 		A tuple of ordered lists, the first containing the eigenvalues in descending (ascending) magnitude, the
 		second one holding the corresponding eigenvectors.
-
 	"""
 	if cutoff == -1:
 		cutoff = matrix.shape[0] - 3
@@ -188,16 +185,16 @@ def eigenvectors(matrix, cutoff=-1, reverse=False):
 
 	Parameters
 	----------
-	matrix : sparse matrix
-		The matrix to compute the eigenvectors of
+	matrix : :py:class:`scipy.sparse.csr_matrix`
+		The matrix to compute the eigenvectors of.
 	cutoff : int, optional
-		The maximum (or minimum) number of eigenvectors needed
-	reverse : boolean, optional
-		If set to true, the smaller eigenvalues will be computed before the larger ones
+		The maximum (or minimum) number of eigenvectors needed. Default: -1
+	reverse : bool, optional
+		If set to true, the smaller eigenvalues will be computed before the larger ones. Default: False
 
 	Returns
 	-------
-	( [ float ], [ ndarray ] )
+	tuple(list(float), list(ndarray))
 		A tuple of ordered lists, the first containing the eigenvalues in descending (ascending) magnitude, the
 		second one holding the corresponding eigenvectors
 
@@ -229,15 +226,15 @@ def laplacianEigenvectors(G, cutoff=-1, reverse=False):
 	Parameters
 	----------
 	G : networkit.graph
-		The graph.
+		The input graph.
 	cutoff : int, optional
-		The maximum (or minimum) number of eigenvectors needed
-	reverse : boolean, optional
-		If set to true, the smaller eigenvalues will be computed before the larger ones
+		The maximum (or minimum) number of eigenvectors needed. Default: -1
+	reverse : bool, optional
+		If set to true, the smaller eigenvalues will be computed before the larger ones. Default: False
 
 	Returns
 	-------
-	( [ float ], [ ndarray ] )
+	tuple(list(float), list(ndarray))
 		 A tuple of ordered lists, the first containing the eigenvalues in descending (ascending) magnitude, the
 		 second one holding the corresponding eigenvectors
 
@@ -258,13 +255,13 @@ def adjacencyEigenvectors(G, cutoff=-1, reverse=False):
 	G : networkit.graph
 		The graph.
 	cutoff : int, optional
-		The maximum (or minimum) number of eigenvectors needed
-	reverse : boolean, optional
-		If set to true, the smaller eigenvalues will be computed before the larger ones
+		The maximum (or minimum) number of eigenvectors needed. Default: -1
+	reverse : bool, optional
+		If set to true, the smaller eigenvalues will be computed before the larger ones. Default: False
 
 	Returns
 	-------
-	( [ float ], [ ndarray ] )
+	tuple(list(float), list(ndarray))
 		A tuple of ordered lists, the first containing the eigenvalues in descending (ascending) magnitude, the
 		second one holding the corresponding eigenvectors
 
@@ -283,18 +280,17 @@ def laplacianEigenvector(G, i, reverse=False):
 	Parameters
 	----------
 	G : networkit.graph
-		The graph.
+		The input graph.
 	i : int
-		Computes the eigenvector and value of index i 
-	reverse : boolean, optional
-		If set to true, the smaller eigenvalues will be computed before the larger ones
+		Computes the eigenvector and value of index i.
+	reverse : bool, optional
+		If set to true, the smaller eigenvalues will be computed before the larger ones. Default: False
 
 	Returns
 	-------
-	( float, ndarray )
+	tuple(float, ndarray)
 		 A pair of values, the first containing the eigenvalue, the
 		 second one holding the corresponding eigenvector
-
 	"""
 	if G.isDirected():
 		spectrum = eigenvectors(laplacianMatrix(G), cutoff=i, reverse=reverse)
@@ -312,18 +308,17 @@ def adjacencyEigenvector(G, i, reverse=False):
 	Parameters
 	----------
 	G : networkit.graph
-		The graph.
+		The input graph.
 	i : int
-		Computes the eigenvector and value of index i 
-	reverse : boolean, optional
-		If set to true, the smaller eigenvalues will be computed before the larger ones
+		Computes the eigenvector and value of index i.
+	reverse : bool, optional
+		If set to true, the smaller eigenvalues will be computed before the larger ones. Default: False
 
 	Returns
 	-------
-	( float, ndarray )
+	tuple( float, ndarray )
 		 A pair of values, the first containing the eigenvalue, the
 		 second one holding the corresponding eigenvector
-
 	"""
 	if G.isDirected():
 		spectrum = eigenvectors(adjacencyMatrix(G), cutoff=i, reverse=reverse)

--- a/networkit/base.pyx
+++ b/networkit/base.pyx
@@ -22,7 +22,7 @@ cdef class Algorithm:
 
 		Returns
 		-------
-		Algorithm
+		networkit.base.Algorithm
 			self
 		"""
 		if self._this == NULL:

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -12,6 +12,7 @@ ctypedef index node
 ctypedef double edgeweight
 
 import math
+from enum import Enum
 
 from .base cimport _Algorithm, Algorithm
 from .dynamics cimport _GraphEvent, GraphEvent
@@ -48,12 +49,12 @@ cdef class Centrality(Algorithm):
 		"""
 		scores()
 
-		Returns the scores of all nodes for the centrality algorithm
+		Returns the scores of all nodes for the centrality algorithm.
 
 		Returns
 		-------
-		list
-			The list of all scores
+		list(float)
+			The list of all scores.
 		"""
 		if self._this == NULL:
 			raise RuntimeError("Error, object not properly initialized")
@@ -63,17 +64,17 @@ cdef class Centrality(Algorithm):
 		"""
 		score(v)
 		
-		Returns the score of node v for the centrality algorithm
+		Returns the score of node v for the centrality algorithm.
 
 		Parameters
 		----------
-		v : node
-			Node index
+		v : int
+			Node index.
 
 		Returns
 		-------
 		float
-			The score of node v
+			The score of node v.
 		"""
 		if self._this == NULL:
 			raise RuntimeError("Error, object not properly initialized")
@@ -87,7 +88,7 @@ cdef class Centrality(Algorithm):
 
 		Returns
 		-------
-		dictionary
+		dict(tuple(int, float))
 			A vector of pairs sorted into descending order. Each pair contains a node and the corresponding score
 		"""
 		if self._this == NULL:
@@ -98,12 +99,12 @@ cdef class Centrality(Algorithm):
 		"""
 		maximum()
 
-		Return the maximum theoretical centrality score
+		Return the maximum theoretical centrality score.
 
 		Returns
 		-------
 		float
-			The maximum theoretical centrality score for the given graph
+			The maximum theoretical centrality score for the given graph.
 		"""
 		if self._this == NULL:
 			raise RuntimeError("Error, object not properly initialized")
@@ -120,6 +121,11 @@ cdef class Centrality(Algorithm):
 		in centrality between the most central node in a network and all other nodes;
 		and (b) divide this quantity by the theoretically largest such sum of
 		differences in any network of the same size.
+
+		Returns
+		-------
+		float
+			Centralization value.
 		"""
 		if self._this == NULL:
 			raise RuntimeError("Error, object not properly initialized")
@@ -142,11 +148,11 @@ cdef class Betweenness(Centrality):
  	Parameters
  	----------
  	G : networkit.Graph
- 		The graph.
+ 		The input graph.
  	normalized : bool, optional
- 		Set this parameter to True if scores should be normalized in the interval [0,1].
+ 		Set this parameter to True if scores should be normalized in the interval [0,1]. Default: False
 	computeEdgeCentrality: bool, optional
-		Set this to true if edge betweenness scores should be computed as well.
+		Set this to true if edge betweenness scores should be computed as well. Default: False
 	"""
 
 	def __cinit__(self, Graph G, normalized=False, computeEdgeCentrality=False):
@@ -163,7 +169,7 @@ cdef class Betweenness(Centrality):
 
 		Returns
 		-------
-		vector
+		list(float)
 			The betweenness scores calculated by run().
 		"""
 		return (<_Betweenness*>(self._this)).edgeScores()
@@ -191,7 +197,7 @@ cdef class ApproxBetweenness(Centrality):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph
+		The input graph
 	epsilon : double, optional
 		Maximum additive error
 	delta : double, optional
@@ -290,19 +296,19 @@ cdef class KadabraBetweenness(Algorithm):
 	----------
 	G : networkit.Graph
 		The input graph.
-	err : double, optional
+	err : float, optional
 		Maximum additive error guaranteed when approximating the
-		betweenness centrality of all nodes.
-	delta : double, optional
+		betweenness centrality of all nodes. Default: 0.01
+	delta : float, optional
 		Probability that the values of the betweenness centrality are
-		within the error guarantee.
-	k : count, optional
+		within the error guarantee. Default: 0.1
+	k : int, optional
 		The number of top-k nodes to be computed. Set it to zero to
-		approximate the betweenness centrality of all the nodes.
-	unionSample : count, optional
-		Algorithm parameter # TODO: more details
-	startFactor : count, optional
-		Algorithm parameter # TODO: more details
+		approximate the betweenness centrality of all the nodes. Default: 0
+	unionSample : int, optional
+		Algorithm parameter. Default: 0
+	startFactor : int, optional
+		Algorithm parameter. Default: 100
 	"""
 
 	def __cinit__(self, Graph G, err = 0.01, delta = 0.1, k = 0,
@@ -319,7 +325,7 @@ cdef class KadabraBetweenness(Algorithm):
 
 		Returns
 		-------
-		list(int, double)
+		list(int, float)
 			A list of pairs (node, betweenness) representing the top-k ranking.
 		"""
 		return (<_KadabraBetweenness*>(self._this)).ranking()
@@ -347,7 +353,7 @@ cdef class KadabraBetweenness(Algorithm):
 
 		Returns
 		-------
-		list(double)
+		list(float)
 			A list with the top-k scores of the nodes with highest approximated
 			betweenness centrality.
 		"""
@@ -362,7 +368,7 @@ cdef class KadabraBetweenness(Algorithm):
 
 		Returns
 		-------
-		list(double)
+		list(float)
 			A list with the approximated betweenness centrality score of each node of
 			the graph.
 		"""
@@ -376,7 +382,7 @@ cdef class KadabraBetweenness(Algorithm):
 
 		Returns
 		-------
-		count
+		int
 			The total number of shortest paths sampled by the algorithm.
 		"""
 		return (<_KadabraBetweenness*>(self._this)).getNumberOfIterations()
@@ -389,7 +395,7 @@ cdef class KadabraBetweenness(Algorithm):
 
 		Returns
 		-------
-		count
+		int
 			Upper bound of the number of shortest paths to be sampled.
 		"""
 		return(<_KadabraBetweenness*>(self._this)).getOmega()
@@ -414,7 +420,7 @@ cdef class DynBetweenness(Algorithm):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph
+		The input graph.
 	"""
 	cdef Graph _G
 
@@ -459,7 +465,7 @@ cdef class DynBetweenness(Algorithm):
 
 		Returns
 		-------
-		vector
+		list(float)
 			The betweenness scores calculated by run().
 		"""
 		return (<_DynBetweenness*>(self._this)).scores()
@@ -472,12 +478,12 @@ cdef class DynBetweenness(Algorithm):
 
 		Parameters
 		----------
-		v : node
+		v : int
 			A node.
 
 		Returns
 		-------
-		double
+		float
 			The betweenness score of node `v`.
 		"""
 		return (<_DynBetweenness*>(self._this)).score(v)
@@ -491,8 +497,8 @@ cdef class DynBetweenness(Algorithm):
 
 		Returns
 		-------
-		vector
-			A vector of pairs.
+		list(tuple(int, float))
+			A list of pairs.
 		"""
 		return (<_DynBetweenness*>(self._this)).ranking()
 
@@ -523,16 +529,16 @@ cdef class DynApproxBetweenness(Algorithm):
 	----------
 	G : networkit.Graph
 		The graph
-	epsilon : double, optional
-		Maximum additive error
-	delta : double, optional
-		Probability that the values are within the error guarantee
+	epsilon : float, optional
+		Maximum additive error. Default: 0.01
+	delta : float, optional
+		Probability that the values are within the error guarantee. Default: 0.1
 	storePredecessors : bool, optional
-		Store lists of predecessors
-	universalConstant: double, optional
+		Store lists of predecessors. Default: True
+	universalConstant: float, optional
 		The universal constant to be used in computing the sample size.
 		It is 1 by default. Some references suggest using 0.5, but there
-		is no guarantee in this case.
+		is no guarantee in this case. Default: 1.0
 	"""
 	cdef Graph _G
 
@@ -577,7 +583,7 @@ cdef class DynApproxBetweenness(Algorithm):
 
 		Returns
 		-------
-		vector
+		list(float)
 			The betweenness scores calculated by run().
 		"""
 		return (<_DynApproxBetweenness*>(self._this)).scores()
@@ -590,12 +596,12 @@ cdef class DynApproxBetweenness(Algorithm):
 
 		Parameters
 		----------
-		v : node
+		v : int
 			A node.
 
 		Returns
 		-------
-		double
+		float
 			The betweenness score of node `v`.
 		"""
 		return (<_DynApproxBetweenness*>(self._this)).score(v)
@@ -609,8 +615,8 @@ cdef class DynApproxBetweenness(Algorithm):
 
 		Returns
 		-------
-		vector
-			A vector of pairs.
+		list(tuple(int, float))
+			A list of pairs.
 		"""
 		return (<_DynApproxBetweenness*>(self._this)).ranking()
 
@@ -652,7 +658,7 @@ cdef class DynBetweennessOneNode:
 	----------
 	G : networkit.Graph
 		The graph
-	x : node
+	x : int
 		The node for which you want to update betweenness
 	"""
 	cdef _DynBetweennessOneNode* _this
@@ -744,7 +750,7 @@ cdef class DynBetweennessOneNode:
 		""" 
 		getbcx()
 		
-		Returns the betweenness centrality score of node x
+		Returns the betweenness centrality score of node x.
 
 		Returns
 		-------
@@ -755,11 +761,11 @@ cdef class DynBetweennessOneNode:
 
 cdef extern from "<networkit/centrality/Closeness.hpp>" namespace "NetworKit":
 
-	cdef enum _ClosenessVariant"NetworKit::ClosenessVariant":
-		standard = 0
+	cdef enum _ClosenessVariant  "NetworKit::ClosenessVariant":
+		standard = 0,
 		generalized = 1
 
-class ClosenessVariant(object):
+class ClosenessVariant:
 	Standard = standard
 	Generalized = generalized
 
@@ -771,12 +777,17 @@ cdef extern from "<networkit/centrality/Closeness.hpp>":
 
 cdef class Closeness(Centrality):
 	"""
-	Closeness(G, normalized, bool checkConnectdedness)
-	Closeness(G, normalized, networkit.centrality.ClosenessVariant variant)
+	Closeness(G, normalized, checkConnectdedness)
+	Closeness(G, normalized, variant)
 
 	Constructs the Closeness class for the given Graph `G`. If the Closeness scores should not be normalized,
 	set `normalized` to False. The run() method takes O(nm) time, where n is the number
 	of nodes and m is the number of edges of the graph.
+
+	Parameter :code:`variant` can be one of the following:
+
+	- networkit.centrality.ClosenessVariant.Standard
+	- networkit.centrality.ClosenessVariant.Generalized
 
 	Parameters
 	----------
@@ -807,12 +818,17 @@ cdef class Closeness(Centrality):
 		else:
 			raise Exception("Error: the third parameter must be either a bool or a ClosenessVariant")
 
-cdef extern from "<networkit/centrality/ApproxCloseness.hpp>":
+cdef extern from "<networkit/centrality/ApproxCloseness.hpp>" namespace "NetworKit::ApproxCloseness":
 
-	enum _ClosenessType "NetworKit::ApproxCloseness::CLOSENESS_TYPE":
+	cdef enum _ClosenessType "NetworKit::ApproxCloseness::CLOSENESS_TYPE":
 		INBOUND,
 		OUTBOUND,
 		SUM
+
+class ClosenessType(object):
+	Inbound = INBOUND
+	Outbound = OUTBOUND
+	Sum = SUM
 
 cdef extern from "<networkit/centrality/ApproxCloseness.hpp>":
 
@@ -823,7 +839,7 @@ cdef extern from "<networkit/centrality/ApproxCloseness.hpp>":
 
 cdef class ApproxCloseness(Centrality):
 	""" 
-	ApproxCloseness(G, nSamples, epsilon=0.1, normalized=False, type=OUTBOUND)
+	ApproxCloseness(G, nSamples, epsilon=0.1, normalized=False, type=networkit.centrality.ClosenessType.Outbound)
 
 	Approximation of closeness centrality according to algorithm described in
   	Cohen et al., Computing Classic Closeness Centrality, at Scale.
@@ -833,18 +849,25 @@ cdef class ApproxCloseness(Centrality):
 	remaining nodes is the closest sampled node to it. If a node lies very close to its pivot, a sampling approach is used.
 	Otherwise, a pivoting approach is used. Notice that the input graph has to be connected.
 
+	Parameter :code:`type` can be one of the following:
+
+	- networkit.centrality.ClosenessType.Inbound
+	- networkit.centrality.ClosenessType.Outbound
+	- networkit.centrality.ClosenessType.Sum
+
 	Parameters
 	----------
 	G : networkit.Graph
-		Input graph (undirected)
-	nSamples : count
-		User defined number of samples
-	epsilon : double, optional
-		Parameter used for the error guarantee; it is also used to control when to use sampling and when to use pivoting
+		Input graph (undirected).
+	nSamples : int
+		User defined number of samples.
+	epsilon : float, optional
+		Parameter used for the error guarantee; it is also used to control when to use sampling and when to use pivoting. Default: 0.1
 	normalized : bool, optional
-		Normalize centrality values in interval [0,1]
-	type : _ClosenessType, optional
-		Use in- or outbound centrality or the sum of both (see paper) for computing closeness on directed graph. If G is undirected, this can be ignored.
+		Normalize centrality values in interval [0,1]. Default: False
+	type : networkit.centrality.ClosenessType, optional
+		Use in- or outbound centrality or the sum of both (see paper) for computing closeness on directed graph. 
+		If G is undirected, this can be ignored. Default: networkit.centrality.ClosenessType.Outbound
 	"""
 
 	#cdef _ApproxCloseness _this
@@ -860,12 +883,12 @@ cdef class ApproxCloseness(Centrality):
 		""" 
 		getSquareErrorEstimates()
 		
-		Return a vector containing the square error estimates for all nodes.
+		Return a list containing the square error estimates for all nodes.
 
 		Returns
 		-------
-		vector
-			A vector of doubles.
+		list(float)
+			A list of square error estimate values.
 		"""
 		return (<_ApproxCloseness*>(self._this)).getSquareErrorEstimates()
 
@@ -888,13 +911,13 @@ cdef class DegreeCentrality(Centrality):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph.
+		The input graph.
 	normalized : bool, optional
-		Normalize centrality values in the interval [0,1].
-		outdeg : bool, optional
-		If set to true, computes the centrality based on out-degrees, otherwise based on the in-degrees.
-		ignoreSelfLoops : bool, optional
-		If set to true, self loops will not be taken into account.
+		Normalize centrality values in the interval [0,1]. Default: False
+	outdeg : bool, optional
+		If set to true, computes the centrality based on out-degrees, otherwise based on the in-degrees. Default: True
+	ignoreSelfLoops : bool, optional
+		If set to true, self loops will not be taken into account. Default: True
 	"""
 
 	def __cinit__(self, Graph G, bool_t normalized=False, bool_t outDeg = True, bool_t ignoreSelfLoops=True):
@@ -919,10 +942,10 @@ cdef class HarmonicCloseness(Centrality):
  	Parameters
  	----------
  	G : networkit.Graph
- 		The graph.
+ 		The input graph.
  	normalized : bool, optional
  		Set this parameter to False if scores should not be normalized 
-		into an interval of [0,1]. Normalization only for unweighted graphs.
+		into an interval of [0,1]. Normalization only for unweighted graphs. Default: True
 	"""
 
 	def __cinit__(self, Graph G, normalized=True):
@@ -965,9 +988,9 @@ cdef class TopCloseness(Algorithm):
 		For example, if k = 10, the top 10 nodes with highest closeness will be computed.
 	first_heu : bool, optional
 		If true, the neighborhood-based lower bound is computed and nodes are sorted according to it. 
-		If false, nodes are simply sorted by degree.
+		If false, nodes are simply sorted by degree. Default: True
 	sec_heu : bool, optional
-		If true, the BFSbound is re-computed at each iteration. If false, BFScut is used.
+		If true, the BFSbound is re-computed at each iteration. If false, BFScut is used. Default: True
 	"""
 	cdef Graph _G
 
@@ -988,11 +1011,11 @@ cdef class TopCloseness(Algorithm):
 		Parameters
 		----------
 		includeTrail : bool, optional
-			Whether or not to include trail nodes.
+			Whether or not to include trail nodes. Default: False
 
 		Returns
 		-------
-		vector
+		list(int)
 			The k nodes with highest closeness.
 		"""
 		return (<_TopCloseness*>(self._this)).topkNodesList(includeTrail)
@@ -1010,11 +1033,11 @@ cdef class TopCloseness(Algorithm):
 		Parameters
 		----------
 		includeTrail : bool, optional
-			Whether or not to include trail centrality value.
+			Whether or not to include trail centrality value. Default: False
 
 		Returns
 		-------
-		vector
+		list(int)
 			The k highest closeness scores.
 		"""
 		return (<_TopCloseness*>(self._this)).topkScoresList(includeTrail)
@@ -1045,20 +1068,17 @@ cdef class TopHarmonicCloseness(Algorithm):
 	number of nodes and m is the number of edges. However, for most real-world
 	networks the empirical running time is O(m).
 
-
-	
-
 	Parameters
 	----------
 	G : networkit.Graph
 		The graph. If useNBbound is set to 'True', edge weights will be ignored.
-	k : int
+	k : int, optional
 		Number of nodes with highest closeness that have to be found. For example, if k = 10, the
-		top 10 nodes with highest closeness will be computed. 
-	useNBbound : bool
+		top 10 nodes with highest closeness will be computed. Default: 1
+	useNBbound : bool, optional
 		If True, the NBbound is re-computed at each iteration. If False, NBcut is used. The worst case 
 		running time of the algorithm is :math:`O(nm)`, where n is the number of nodes and m is the number of edges.
-		However, for most networks the empirical running time is :math:`O(m)`.
+		However, for most networks the empirical running time is :math:`O(m)`. Default: True
 	"""
 	cdef Graph _G
 
@@ -1078,12 +1098,12 @@ cdef class TopHarmonicCloseness(Algorithm):
 
 		Parameters
 		----------
-		includeTrail : bool
-			Whether or not to include trail nodes.
+		includeTrail : bool, optional
+			Whether or not to include trail nodes. Default: False
 
 		Returns
 		-------
-		vector
+		list(int)
 			The k nodes with highest harmonic closeness.
 		"""
 		return (<_TopHarmonicCloseness*>(self._this)).topkNodesList(includeTrail)
@@ -1100,12 +1120,12 @@ cdef class TopHarmonicCloseness(Algorithm):
 
 		Parameters
 		----------
-		includeTrail : bool
-			Whether or not to include trail centrality value.
+		includeTrail : bool, optional
+			Whether or not to include trail centrality value. Default: False
 
 		Returns
 		-------
-		vector
+		list(int)
 			The k highest closeness harmonic scores.
 		"""
 		return (<_TopHarmonicCloseness*>(self._this)).topkScoresList(includeTrail)
@@ -1142,9 +1162,9 @@ cdef class DynTopHarmonicCloseness(Algorithm):
 		An unweighted graph.
 	k : int, optional
 		Number of nodes with highest closeness that have to be found. 
-		For example, if k = 10, the top 10 nodes with highest closeness will be computed.
+		For example, if k = 10, the top 10 nodes with highest closeness will be computed. Default: 1
 	useBFSbound : bool, optional
-		If true, the BFSbound is re-computed at each iteration. If false, BFScut is used.
+		If true, the BFSbound is re-computed at each iteration. If false, BFScut is used. Default: True
 	"""
 	cdef Graph _G
 
@@ -1165,11 +1185,11 @@ cdef class DynTopHarmonicCloseness(Algorithm):
 		Parameters
 		----------
 		includeTrail : bool, optional
-			Whether or not to include trail nodes.
+			Whether or not to include trail nodes. Default: False
 
 		Returns
 		-------
-		vector
+		int
 			The ranking.
 		"""
 		return (<_DynTopHarmonicCloseness*>(self._this)).ranking(includeTrail)
@@ -1187,11 +1207,11 @@ cdef class DynTopHarmonicCloseness(Algorithm):
 		Parameters
 		----------
 		includeTrail : bool, optional
-			Whether or not to include trail nodes.
+			Whether or not to include trail nodes. Default: False
 
 		Returns
 		-------
-		vector
+		list(int)
 			The k nodes with highest harmonic closeness.
 		"""
 		return (<_DynTopHarmonicCloseness*>(self._this)).topkNodesList(includeTrail)
@@ -1209,11 +1229,11 @@ cdef class DynTopHarmonicCloseness(Algorithm):
 		Parameters
 		----------
 		includeTrail : bool, optional
-			Whether or not to include trail centrality value.
+			Whether or not to include trail centrality value. Default: False
 
 		Returns
 		-------
-		vector
+		list(float)
 			The k highest closeness harmonic scores.
 		"""
 		return (<_DynTopHarmonicCloseness*>(self._this)).topkScoresList(includeTrail)
@@ -1266,7 +1286,7 @@ cdef class LocalPartitionCoverage(Centrality):
 	G : networkit.Graph
 		The graph.
 	P : networkit.Partition
-		The partition to use
+		The partition to use.
 	"""
 	cdef Partition _P
 
@@ -1300,11 +1320,11 @@ cdef class GroupDegree(Algorithm):
 	Parameters
 	----------
 		G : networkit.Graph
-			A graph.
-		k: int
-			Size of the group of nodes
+			The input graph.
+		k: int, optional
+			Size of the group of nodes. Default: 1
 		countGroupNodes: bool, optional
-			If nodes inside the group should be counted in the centrality score.
+			If nodes inside the group should be counted in the centrality score. Default: True
 	"""
 	cdef Graph _G
 
@@ -1320,7 +1340,7 @@ cdef class GroupDegree(Algorithm):
 
 		Returns
 		-------
-		vector
+		list(int)
 			The group of k nodes with highest degree centrality.
 		"""
 		return (<_GroupDegree*>(self._this)).groupMaxDegree()
@@ -1335,7 +1355,7 @@ cdef class GroupDegree(Algorithm):
 
 		Returns
 		-------
-		count
+		int
 			The number of nodes outside the group that can be reached in one hop
 			from at least one node in the group.
 		"""
@@ -1349,12 +1369,12 @@ cdef class GroupDegree(Algorithm):
 
 		Parameters
 		-----------
-		group : vector[node] 
-			Set of nodes
+		group : list(int)
+			List of nodes.
 
 		Returns
 		-------
-		count
+		int
 			The score of the given group.
 		"""
 		return (<_GroupDegree*>(self._this)).scoreOfGroup(group)
@@ -1393,7 +1413,7 @@ cdef extern from "<networkit/centrality/GedWalk.hpp>":
 
 cdef class GedWalk(Algorithm):
 	"""
-	GedWalk(Graph G, k = 1, epsilon = 0.1, alpha = -1.0, bs = BoundStrategy.Geometric, gs = GreedyStrategy.Lazy, spectralDelta = 0.5)
+	GedWalk(Graph G, k = 1, epsilon = 0.1, alpha = -1.0, bs = networkit.centrality.BoundStrategy.Geometric, gs = GreedyStrategy.Lazy, spectralDelta = 0.5)
 
 	Finds a group of `k` vertices with at least ((1 - 1/e) * opt - epsilon) GedWalk centrality
 	score, where opt is the highest possible score. The algorithm is based on the paper "Group
@@ -1401,22 +1421,36 @@ cdef class GedWalk(Algorithm):
 	independent greedy strategies (lazy and stochastic). Furthermore, it allows to compute the
 	GedWalk score of a given set of nodes.
 
+	Parameter :code:`bs` can be one of the following:
+
+	- networkit.centrality.BoundStrategy.No
+	- networkit.centrality.BoundStrategy.Spectral
+	- networkit.centrality.BoundStrategy.Geometric
+	- networkit.centrality.BoundStrategy.AdaptiveGeometric
+
+	Parameter :code:`gs` can be one of the following:
+
+	- networkit.centrality.GreedyStrategy.Lazy
+	- networkit.centrality.GreedyStrategy.Stochastic
+
 	Parameters
 	----------
 	G : networkit.Graph
 		A (weakly) connected graph.
 	k : int, optional
-		The desired group size.
-	epsilon : double, optional
-		Precision of the algorithm.
-	alpha : double, optional
-		Exponent to compute the GedWalk score.
-	bs : BoundStrategy, optional
-		Bound strategy to compute the GedWalk bounds, default: BoundStrategy.geometric.
-	gs : GreedyStrategy, optional
-		Greedy strategy to be used (lazy or stochastic), default: GreedyStrategy.lazy.
-	spectralDelta : double
-		Delta to be used for the spectral bound.
+		The desired group size. Default: 1
+	epsilon : float, optional
+		Precision of the algorithm. Default: 0.1
+	alpha : float, optional
+		Exponent to compute the GedWalk score. Default: -1.0
+	bs : networkit.centrality.BoundStrategy, optional
+		Bound strategy to compute the GedWalk bounds.
+		Default: networkit.centrality.BoundStrategy.Geometric
+	gs : networkit.centrality.GreedyStrategy, optional
+		Greedy strategy to be used (lazy or stochastic). 
+		Default: networkit.centrality.GreedyStrategy.Lazy
+	spectralDelta : float, optional
+		Delta to be used for the spectral bound. Default: 0.5
 	"""
 	
 	cdef Graph _G
@@ -1440,7 +1474,7 @@ cdef class GedWalk(Algorithm):
 
 		Returns
 		-------
-		list
+		list(int)
 			The computed group.
 		"""
 		return (<_GedWalk*>(self._this)).groupMaxGedWalk()
@@ -1453,7 +1487,7 @@ cdef class GedWalk(Algorithm):
 
 		Returns
 		-------
-		double
+		float
 			The GedWalk score of the computed group.
 		"""
 		return (<_GedWalk*>(self._this)).getApproximateScore()
@@ -1466,14 +1500,14 @@ cdef class GedWalk(Algorithm):
 
 		Parameters
 		----------
-		group : list
+		group : list(int)
 			The input group.
-		epsilon : double, optional
-			The precision of the score to be computed.
+		epsilon : float, optional
+			The precision of the score to be computed. Default: 0.1
 
 		Returns
 		-------
-		double
+		float
 			An epsilon-approximation of the GedWalk score of the input group.
 		"""
 		cdef vector[node] groupVec
@@ -1502,10 +1536,10 @@ cdef class ApproxGroupBetweenness(Algorithm):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph.
-	groupSize : count
+		The input graph.
+	groupSize : int
 		The desired size of the group.
-	epsilon : double
+	epsilon : float
 		Determines the accuracy of the approximation.
 	"""
 	cdef Graph _G
@@ -1523,25 +1557,25 @@ cdef class ApproxGroupBetweenness(Algorithm):
 
 		Returns
 		-------
-		vector
+		list(int)
 			The group of nodes with highest approximated group betweenness.
 		"""
 		return (<_ApproxGroupBetweenness*>(self._this)).groupMaxBetweenness()
 
 	def scoreOfGroup(self, vector[node] group):
 		"""
-		scoreOfGroup(vector[node] group)
+		scoreOfGroup(group)
 		
 		Returns the score of the given group.
 
 		Parameters
 		----------
-		group : list
+		group : list(int)
 			Set of nodes.
 
 		Returns
 		-------
-		count
+		int
 			The score of the given group.
 		"""
 		return (<_ApproxGroupBetweenness*>(self._this)).scoreOfGroup(group)
@@ -1558,7 +1592,8 @@ cdef class GroupCloseness(Algorithm):
 	"""
 	GroupCloseness(G, k=1, H=0)
 	
-	Finds the group of nodes with highest (group) closeness centrality. The algorithm is the one proposed in Bergamini et al., ALENEX 2018 and finds a solution that is a (1-1/e)-approximation of the optimum.
+	Finds the group of nodes with highest (group) closeness centrality. The algorithm is the one 
+	proposed in Bergamini et al., ALENEX 2018 and finds a solution that is a (1-1/e)-approximation of the optimum.
 	The worst-case running time of this approach is quadratic, but usually much faster in practice.
 
 	Parameters
@@ -1566,10 +1601,10 @@ cdef class GroupCloseness(Algorithm):
 	G : networkit.Graph
 		An unweighted graph.
 	k : int, optional
-		Size of the group.
+		Size of the group. Default: 1
 	H : int, optional
 		If equal 0, simply runs the algorithm proposed in Bergamini et al.. 
-		If > 0, interrupts all BFSs after H iterations (suggested for very large networks).
+		If > 0, interrupts all BFSs after H iterations (suggested for very large networks). Default: 0
 	"""
 	cdef Graph _G
 
@@ -1585,7 +1620,7 @@ cdef class GroupCloseness(Algorithm):
 
 		Returns
 		-------
-		vector
+		list(int)
 			The group of k nodes with maximum closeness centrality.
 		"""
 		return (<_GroupCloseness*>(self._this)).groupMaxCloseness()
@@ -1598,13 +1633,16 @@ cdef class GroupCloseness(Algorithm):
 
 		Parameters
 		----------
-
-		S : vector[node]
+		S : list(int)
 			Group to compute farness on.
 		H : int, optional
 			If equal 0, simply runs the algorithm proposed in Bergamini et al.. 
-			If > 0, interrupts after H iterations (suggested for very large networks).
+			If > 0, interrupts after H iterations (suggested for very large networks). Default: 0
 
+		Returns
+		-------
+		float
+			Farness value for node group.
 		"""
 		return (<_GroupCloseness*>(self._this)).computeFarness(S, H)
 
@@ -1616,12 +1654,12 @@ cdef class GroupCloseness(Algorithm):
 
 		Parameters
 		----------
-		group : vector[node]
-			Vector of nodes.
+		group : list(int)
+			List of nodes.
 
 		Returns
 		-------
-		double
+		float
 			The group closeness score of the given group.
 		"""
 		return (<_GroupCloseness*>(self._this)).scoreOfGroup(group)
@@ -1648,14 +1686,14 @@ cdef class GroupClosenessGrowShrink(Algorithm):
 	----------
 	G : networkit.Graph
 		A connected, undirected, unweighted graph.
-	group : vector[node]
+	group : list(int)
 		The initial group of nodes.
 	extended : bool, optional
 		Set this parameter to true for the Extended Grow-Shrink algorithm (i.e.,
-		swaps are not restricted to only neighbors of the group).
+		swaps are not restricted to only neighbors of the group). Default: False
 	insertions : int, optional
 		Number of consecutive node insertions and removal per iteration. Let this
-		parameter to zero to use Diameter(G)/sqrt(k) nodes (where k is the size of the group).
+		parameter to zero to use Diameter(G)/sqrt(k) nodes (where k is the size of the group). Default: 0
 	"""
 	cdef Graph _G
 
@@ -1671,7 +1709,7 @@ cdef class GroupClosenessGrowShrink(Algorithm):
 
 		Returns
 		-------
-		list
+		list(int)
 			The computed group.
 		"""
 		return (<_GroupClosenessGrowShrink*>(self._this)).groupMaxCloseness()
@@ -1709,10 +1747,10 @@ cdef class GroupClosenessLocalSwaps(Algorithm):
 	----------
 	G : networkit.Graph
 		An undirected, unweighted graph.
-	group : vector[node]
+	group : list(int)
 		The initial group of nodes.
 	maxSwaps : int, optional
-		Maximum number of vertex exchanges allowed.
+		Maximum number of vertex exchanges allowed. Default: 0
 	"""
 	cdef Graph _G
 
@@ -1728,7 +1766,7 @@ cdef class GroupClosenessLocalSwaps(Algorithm):
 
 		Returns
 		-------
-		list
+		list(int)
 			The computed group.
 		"""
 		return (<_GroupClosenessLocalSwaps*>(self._this)).groupMaxCloseness()
@@ -1774,8 +1812,8 @@ cdef class GroupHarmonicCloseness(Algorithm):
 	----------
 	G : networkit.Graph
 		The input graph.
-	k : int
-		Size of the group of nodes.
+	k : int, optional
+		Size of the group of nodes. Default: 1
 	"""
 	cdef Graph _G
 
@@ -1791,7 +1829,7 @@ cdef class GroupHarmonicCloseness(Algorithm):
 
 		Returns
 		-------
-		vector
+		list(int)
 			The computed group.
 		"""
 		return (<_GroupHarmonicCloseness*>(self._this)).groupMaxHarmonicCloseness()
@@ -1807,12 +1845,12 @@ cdef class GroupHarmonicCloseness(Algorithm):
 		----------
 		graph : networkit.Graph
 			The input graph.
-		inputGroup : vector[node]
+		inputGroup : list(int)
 			The input group of nodes.
 
 		Returns
 		-------
-		double
+		float
 			The group-harmonic score of the input group.
 		"""
 		return _GroupHarmonicCloseness.scoreOfGroup[vector[node].iterator](
@@ -1846,7 +1884,7 @@ cdef class GroupClosenessLocalSearch(Algorithm):
 	----------
 	G : networkit.Graph
 		A connected, undirected, unweighted graph.
-	group : list
+	group : list(int)
 		The initial group of nodes.
 	useGrowShrink : bool
 		Whether or not to run the GrowShrink algorithm on the initial group.
@@ -1876,7 +1914,7 @@ cdef class GroupClosenessLocalSearch(Algorithm):
 
 		Returns
 		-------
-		list
+		list(int)
 			The computed group.
 		"""
 		return (<_GroupClosenessLocalSearch*>(self._this)).groupMaxCloseness()
@@ -1910,11 +1948,11 @@ cdef class KPathCentrality(Centrality):
  	----------
  	G : networkit.Graph
  		The graph.
- 	alpha : double, in interval [-0.5, 0.5], optional
+ 	alpha : float, optional
 		Tradeoff between runtime and precision with -0.5: maximum precision, maximum runtime
- 		and 0.5: lowest precision, lowest runtime
+ 		and 0.5: lowest precision, lowest runtime. Default: 0.2
 	k: int, optional
-		maximum length of paths
+		maximum length of paths. Default: 0
 	"""
 
 	def __cinit__(self, Graph G, alpha=0.2, k=0):
@@ -1949,14 +1987,14 @@ cdef class KatzCentrality(Centrality):
  	Parameters
  	----------
  	G : networkit.Graph
- 		The graph.
- 	alpha : double, optional
+ 		The input graph.
+ 	alpha : float, optional
 		Damping of the matrix vector product result, must be non negative.
-		Leave this parameter to 0 to use the default value :math:`1 / (max_degree + 1)`.
-	beta : double, optional
-		Constant value added to the centrality of each vertex
-	tol : double, optional
-		The tolerance for convergence.
+		Leave this parameter to 0 to use the default value :math:`1 / (max_degree + 1)`. Default: 0
+	beta : float, optional
+		Constant value added to the centrality of each vertex. Default: 0.1
+	tol : float, optional
+		The tolerance for convergence. Default: 1e-8
 	"""
 
 	def __cinit__(self, Graph G, alpha=0, beta=0.1, tol=1e-8):
@@ -1964,6 +2002,14 @@ cdef class KatzCentrality(Centrality):
 		self._this = new _KatzCentrality(G._this, alpha, beta, tol)
 
 	property edgeDirection:
+		"""
+		Property :code:`edgeDirection` can be one of the following:
+
+		- networkit.centrality.EdgeDirection.inEdges
+		- networkit.centrality.EdgeDirection.outEdges
+
+		Default: networkit.centrality.EdgeDirection.inEdges
+		"""
 		def __get__(self):
 			""" Get the used edge direction. """
 			return (<_KatzCentrality*>(self._this)).edgeDirection
@@ -1990,13 +2036,13 @@ cdef class DynKatzCentrality(Centrality):
  	Parameters
  	----------
  	G : networkit.Graph
- 		The graph.
- 	k : double
+ 		The input graph.
+ 	k : float
 		The number k for which we want to find the top-k nodes with highest Katz centrality.
 	groupOnly : bool, optional
-		Set whether the update will only update top-k nodes.
-	tolerance : double, optional
-		The tolerance for convergence.
+		Set whether the update will only update top-k nodes. Default: False
+	tolerance : float, optional
+		The tolerance for convergence. Default: 1e-9
 	"""
 
 	def __cinit__(self, Graph G, k, groupOnly=False, tolerance=1e-9):
@@ -2040,12 +2086,12 @@ cdef class DynKatzCentrality(Centrality):
 
 		Parameters
 		----------
-		n : count, optional
-			If set, retrieve n top-nodes. If not set, all nodes are retrieved.
+		n : int, optional
+			If set, retrieve n top-nodes. If not set, all nodes are retrieved. Default: 0
 
 		Returns
 		-------
-		list
+		list(int)
 			List of nodes with top-n centrality-scores.
 		"""
 		return (<_DynKatzCentrality*>(self._this)).top(n)
@@ -2054,17 +2100,17 @@ cdef class DynKatzCentrality(Centrality):
 		""" 
 		bound(v)
 		
-		Returns the (upper) bound of the centrality of node `v`
+		Returns the (upper) bound of the centrality of node `v`.
 
 		Parameters
 		----------
-		v : node
-			Node in the graph
+		v : int
+			Node in the graph.
 
 		Returns
 		-------
 		float
-			Upper bound of node `v`
+			Upper bound of node `v`.
 		"""		
 		return (<_DynKatzCentrality*>(self._this)).bound(v)
 
@@ -2076,15 +2122,15 @@ cdef class DynKatzCentrality(Centrality):
 
 		Parameters
 		----------
-		u : node
-			Node in the graph
-		v : node
-			Node in the graph
+		u : int
+			Node in the graph.
+		v : int
+			Node in the graph.
 
 		Returns
 		-------
 		bool
-			True if the bounds are sharp enough to rank two nodes against each other
+			True if the bounds are sharp enough to rank two nodes against each other.
 		"""	
 		return (<_DynKatzCentrality*>(self._this)).areDistinguished(u, v)
 
@@ -2110,9 +2156,9 @@ cdef class LocalClusteringCoefficient(Centrality):
  	Parameters
  	----------
  	G : networkit.Graph
- 		The graph.
-	turbo : bool
-		If the turbo mode shall be activated.
+ 		The input graph.
+	turbo : bool, optional
+		If the turbo mode shall be activated. Default: False
 	"""
 
 	def __cinit__(self, Graph G, bool_t turbo = False):
@@ -2135,7 +2181,7 @@ cdef class Sfigality(Centrality):
  	Parameters
  	----------
  	G : networkit.Graph
- 		The graph.
+ 		The input graph.
 	"""
 
 	def __cinit__(self, Graph G):
@@ -2161,9 +2207,9 @@ cdef class PermanenceCentrality(Algorithm):
  	Parameters
  	----------
  	G : networkit.Graph
- 		The graph.
+ 		The input graph.
 	P : networkit.Partition
-		Partition for graph G	
+		Partition for graph G.
 	"""
 	cdef Graph _G
 	cdef Partition _P
@@ -2181,8 +2227,8 @@ cdef class PermanenceCentrality(Algorithm):
 
 		Parameters
 		----------
-		u : node
-			Node in the graph
+		u : int
+			Node in the graph.
 
 		Returns
 		-------
@@ -2199,8 +2245,8 @@ cdef class PermanenceCentrality(Algorithm):
 
 		Parameters
 		----------
-		u : node
-			Node in the graph
+		u : int
+			Node in the graph.
 
 		Returns
 		-------
@@ -2231,9 +2277,9 @@ cdef class LaplacianCentrality(Centrality):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph.
+		The input graph.
 	normalized : bool, optional
-		Whether scores should be normalized by the energy of the full graph.
+		Whether scores should be normalized by the energy of the full graph. Default: False
 	"""
 
 	def __cinit__(self, Graph G, normalized = False):
@@ -2260,11 +2306,12 @@ cdef class CoreDecomposition(Centrality):
 	G : networkit.Graph
 		The graph.
 	normalized : bool, optional
-		Divide each core number by the maximum degree.
+		Divide each core number by the maximum degree. Default: False
 	enforceBucketQueueAlgorithm : bool, optional
-		enforce switch to sequential algorithm
+		Enforce switch to sequential algorithm. Default: False
 	storeNodeOrder : bool, optional
-		If set to True, the order of the nodes in ascending order of the cores is stored and can later be returned using getNodeOrder(). Enforces the sequential bucket priority queue algorithm.
+		If set to True, the order of the nodes in ascending order of the cores is stored and can later be returned using getNodeOrder(). 
+		Enforces the sequential bucket priority queue algorithm. Default: False
 
 	"""
 
@@ -2280,7 +2327,7 @@ cdef class CoreDecomposition(Centrality):
 
 		Returns
 		-------
-		index
+		int
 			The maximum core number.
 		"""
 		return (<_CoreDecomposition*>(self._this)).maxCoreNumber()
@@ -2293,7 +2340,7 @@ cdef class CoreDecomposition(Centrality):
 
 		Returns
 		-------
-		vector
+		list(int)
 			The k-cores as sets of nodes, indexed by k.
 		"""
 		return Cover().setThis((<_CoreDecomposition*>(self._this)).getCover())
@@ -2307,7 +2354,7 @@ cdef class CoreDecomposition(Centrality):
 		Returns
 		-------
 		networkit.Partition
-			The k-shells
+			The k-shells.
 		"""
 		return Partition().setThis((<_CoreDecomposition*>(self._this)).getPartition())
 
@@ -2319,7 +2366,7 @@ cdef class CoreDecomposition(Centrality):
 
 		Returns
 		-------
-		list
+		list(int)
 			The nodes sorted by increasing core number.
 		"""
 		return (<_CoreDecomposition*>(self._this)).getNodeOrder()
@@ -2341,8 +2388,8 @@ cdef class EigenvectorCentrality(Centrality):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph.
-	tol : double, optional
+		The input graph.
+	tol : float, optional
 		The tolerance for convergence.
 	"""
 
@@ -2394,18 +2441,24 @@ cdef class PageRank(Centrality):
  	the PageRank values from the size of the input graph. To enable this, set the matching parameter
  	to true. Note that, sink-node handling is automatically activated if normalization is used.
 
+	Parameter :code:`distributeSinks` can be one of the following:
+
+	- networkit.centrality.SinkHandling.NoSinkHandling
+	- networkit.centrality.SinkHandling.DistributeSinks
+
 	Parameters
 	----------
 	G : networkit.Graph
 		Graph to be processed.
-	damp : double
-		Damping factor of the PageRank algorithm.
-	tol : double, optional
-		Error tolerance for PageRank iteration.
+	damp : float, optional
+		Damping factor of the PageRank algorithm. Default: 0.85
+	tol : float, optional
+		Error tolerance for PageRank iteration. Default: 1e-8
 	distributeSinks: networkit.centrality.SinkHandling, optional
 		Set to distribute PageRank values for sink nodes. Default: SinkHandling.NoSinkHandling
 	normalized : bool, optional
-		If the results should be normalized by the lower bound of scores. This decouples the PageRank values from the size of the input graph. Default: False
+		If the results should be normalized by the lower bound of scores. 
+		This decouples the PageRank values from the size of the input graph. Default: False
 	"""
 
 	def __cinit__(self, Graph G, double damp=0.85, double tol=1e-8, bool_t normalized=False, distributeSinks=SinkHandling.NoSinkHandling):
@@ -2421,11 +2474,20 @@ cdef class PageRank(Centrality):
 		Returns
 		-------
 		int
-			Number of iterations performed by the algorithm.
+			Number of iterations performed by the algorithm. Default: unlimited
 		"""
 		return (<_PageRank*>(self._this)).numberOfIterations()
 
 	property norm:
+		"""
+		Property :code:`norm` can be one of the following:
+
+		- networkit.centrality.Norm.l1norm
+		- networkit.centrality.Norm.l2norm
+
+		Set this property before calling run() to change norm computation.
+		Default: networkit.centrality.Norm.l2norm
+		"""
 		def __get__(self):
 			""" Get the norm used as stopping criterion. """
 			return (<_PageRank*>(self._this)).norm
@@ -2434,6 +2496,10 @@ cdef class PageRank(Centrality):
 			(<_PageRank*>(self._this)).norm = norm
 
 	property maxIterations:
+		"""
+		Property :code:`maxIterations` sets a stopping criteria based on number
+		of runs. Default: unlimited
+		"""
 		def __get__(self):
 			""" Get the maximum number of iterations. """
 			return (<_PageRank*>(self._this)).maxIterations
@@ -2462,8 +2528,9 @@ cdef class SpanningEdgeCentrality(Algorithm):
 	----------
 	G : networkit.Graph
 		The graph.
-	tol: double, optional
-		Tolerance used for the approximation: with probability at least 1-1/n, the approximated scores are within a factor 1+tol from the exact scores.
+	tol: float, optional
+		Tolerance used for the approximation: with probability at least 1-1/n, the approximated 
+		scores are within a factor 1+tol from the exact scores. Default: 0.1
 	"""
 
 	cdef Graph _G
@@ -2500,7 +2567,7 @@ cdef class SpanningEdgeCentrality(Algorithm):
 
 		Returns
 		-------
-		vector
+		list(float)
 			The SEC scores.
 		"""
 		return (<_SpanningEdgeCentrality*>(self._this)).scores()
@@ -2528,9 +2595,9 @@ cdef class ApproxElectricalCloseness(Centrality):
 	----------
 	G : networkit.Graph
 		The input graph.
-	eps : double, optional
+	eps : float, optional
 		Maximum absolute error of the elements in the diagonal.
-	kappa : double, optional
+	kappa : float, optional
 		Balances the tolerance of the solver for the linear system and the
 		number of USTs to be sampled.
 	"""
@@ -2547,7 +2614,7 @@ cdef class ApproxElectricalCloseness(Centrality):
 
 		Returns
 		-------
-		vector[double]
+		list(float)
 			Approximation of the diagonal of the laplacian's pseudoinverse.
 		"""
 		return (<_ApproxElectricalCloseness*>self._this).getDiagonal()
@@ -2562,12 +2629,12 @@ cdef class ApproxElectricalCloseness(Centrality):
 
 		Parameters
 		----------
-		tol : double
+		tol : float
 			Tolerance for the LAMG solver.
 
 		Returns
 		-------
-		list
+		list(float)
 			Nearly-exact values of the diagonal of the laplacian's pseudoinverse.
 		"""
 		return (<_ApproxElectricalCloseness*>self._this).computeExactDiagonal(tol)
@@ -2589,9 +2656,9 @@ cdef class ApproxSpanningEdge(Algorithm):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph.
-	eps : double, optional
-		Maximum additive error.
+		The input graph.
+	eps : float, optional
+		Maximum additive error. Default: 0.1
 	"""
 
 	cdef Graph _G
@@ -2616,7 +2683,7 @@ cdef class ApproxSpanningEdge(Algorithm):
 
 def ranking(G, algorithm=Betweenness, normalized=False):
 	""" 
-	ranking(G, algorithm=Betweenness, normalized=False)
+	ranking(G, algorithm=networkit.centrality.Betweenness, normalized=False)
 
 	Return a ranking of nodes by the specified centrality type
 	
@@ -2624,14 +2691,14 @@ def ranking(G, algorithm=Betweenness, normalized=False):
 	----------
 	G : networkit.Graph
 		The input graph.
-	algorithm : networkit.centrality, optional
-		Instance of centrality algorithm to run. Default: Betweenness
+	algorithm : networkit.centrality.Centrality, optional
+		Instance of centrality algorithm to run. Default: networkit.centrality.Betweenness
 	normalized : bool, optional
-		Set whether the ranking values should be normalized
+		Set whether the ranking values should be normalized. Default: False
 
 	Returns
 	-------
-	list
+	list(int)
 		Ranking for nodes according to centrality algorithm.
 	"""
 	# FIXME: some centrality algorithms take more Parameters:
@@ -2649,14 +2716,14 @@ def scores(G, algorithm=Betweenness, normalized=False):
 	----------
 	G : networkit.Graph
 		The input graph.
-	algorithm : networkit.centrality, optional
-		Instance of centrality algorithm to run. Default: Betweenness
+	algorithm : networkit.centrality.Centrality, optional
+		Instance of centrality algorithm to run. Default: networkit.centrality.Betweenness
 	normalized : bool, optional
-		Set whether the ranking values should be normalized
+		Set whether the ranking values should be normalized. Default: False
 
 	Returns
 	-------
-	list
+	list(int)
 		Scores for nodes according to centrality algorithm.	
 	"""
 	centrality = algorithm(G, normalized)
@@ -2671,12 +2738,12 @@ def rankPerNode(ranking):
 
 	Parameters
 	----------
- 	ranking: tuple(node, score) 
-		Ordered list of tuples (node, score)
+ 	ranking: list(tuple(int, float))
+		Ordered list of tuples (node, score).
 
 	Returns
 	-------
-	list
+	list(int)
 		For each node (sorted by node ID), the ranking of the node
 	"""
 	n_nodes = len(ranking)
@@ -2701,15 +2768,15 @@ def relativeRankErrors(rx, ry):
 
 	Parameters
 	----------
-	rx : list
-		Ranking - ordered list of tuples (node, score)
+	rx : list(tuple(int, float))
+		Ranking - ordered list of tuples (node, score).
 
-	ry : list
-		Ranking - ordered list of tuples (node, score)
+	ry : list(tuple(int, float))
+		Ranking - ordered list of tuples (node, score).
 
 	Returns
 	-------
-	list 
+	list(int)
 		Rank errors ordered by node ID
 	"""
 	diff = []
@@ -2731,10 +2798,10 @@ class SpectralCentrality:
 
 	Parameters
 	----------
-	G : graph
-		The graph of which to compute the centrality
+	G : networkit.Graph
+		The graph of which to compute the centrality.
 	normalized : bool, optional
-		Whether to normalize the results or not
+		Whether to normalize the results or not. Default: False
 	"""
 	def __init__(self, G, normalized=False):
 		super(SpectralCentrality, self).__init__()
@@ -2791,7 +2858,7 @@ class SpectralCentrality:
 
 		Returns
 		-------
-		list
+		list(float)
 			The SpectralCentrality scores.
 		"""
 		if self.scoreList is None:
@@ -2807,7 +2874,7 @@ class SpectralCentrality:
 
 		Returns
 		-------
-		list
+		list(float)
 			Ranking for nodes according to SpectralCentrality.
 		"""
 		if self.rankList is None:
@@ -2823,10 +2890,10 @@ class SciPyEVZ(SpectralCentrality):
 
 	Parameters
 	----------
-	G : graph
-		The graph of which to compute the centrality
+	G : networkit.Graph
+		The graph of which to compute the centrality.
 	normalized : bool, optional
-		Whether to normalize the results or not
+		Whether to normalize the results or not. Default: False
 	"""
 	def __init__(self, G, normalized=False):
 		if G.isDirected():
@@ -2868,12 +2935,12 @@ class SciPyPageRank(SpectralCentrality):
 
 	Parameters
 	----------
-	G : graph
-		The graph of which to compute the centrality
+	G : networkit.Graph
+		The graph of which to compute the centrality.
 	damp : float, optional
-		Damping factor used for computation.
+		Damping factor used for computation. Default: 0.95
 	normalized : bool, optional
-		Whether to normalize the results or not
+		Whether to normalize the results or not. Default: False
 	"""
 	def __init__(self, G, damp=0.95, normalized=False):
 		super(SciPyPageRank, self).__init__(G, normalized=normalized)

--- a/networkit/clique.pyx
+++ b/networkit/clique.pyx
@@ -61,7 +61,7 @@ cdef extern from "<networkit/clique/MaximalCliques.hpp>":
 
 cdef class MaximalCliques(Algorithm):
 	"""
-	MaximalCliques(G, maximumOnly = False, callback = None)
+	MaximalCliques(G, maximumOnly=False, callback=None)
 
 	Algorithm for listing all maximal cliques.
 
@@ -83,14 +83,14 @@ cdef class MaximalCliques(Algorithm):
 	----------
 	G : networkit.Graph
 		The graph to list the cliques for
-	maximumOnly : bool
+	maximumOnly : bool, optional
 		A value of True denotes that only one maximum clique is desired. This enables
 		further optimizations of the algorithm to skip smaller cliques more
-		efficiently. This parameter is only considered when no callback is given.
-	callback : callable
+		efficiently. This parameter is only considered when no callback is given. Default: False
+	callback : callable, optional
 		If a callable Python object is given, it will be called once for each
 		maximal clique. Then no cliques will be stored. The callback must accept
-		one parameter which is a list of nodes.
+		one parameter which is a list of nodes. Default: None
 	"""
 	cdef NodeVectorCallbackWrapper* _callback
 	cdef Graph _G
@@ -130,7 +130,7 @@ cdef class MaximalCliques(Algorithm):
 
 		Returns
 		-------
-		list
+		list(list(int))
 			A list of cliques, each being represented as a list of nodes.
 		"""
 		return (<_MaximalCliques*>(self._this)).getCliques()

--- a/networkit/coarsening.pyx
+++ b/networkit/coarsening.pyx
@@ -39,7 +39,7 @@ cdef class GraphCoarsening(Algorithm):
 		Returns
 		-------
 		networkit.Graph
-			Coarse graph
+			Coarse graph.
 		"""
 		return Graph(0).setThis((<_GraphCoarsening*>(self._this)).getCoarseGraph())
 
@@ -51,7 +51,7 @@ cdef class GraphCoarsening(Algorithm):
 
 		Returns
 		-------
-		list
+		list(dict(int ``:`` int))
 			List containing mapping, whereas index represents node u from fine graph and value represents node v from coarse graph  
 		"""
 		return (<_GraphCoarsening*>(self._this)).getFineToCoarseNodeMapping()
@@ -64,7 +64,7 @@ cdef class GraphCoarsening(Algorithm):
 
 		Returns
 		-------
-		map[node, list]
+		dict(int ``:`` list(int))
 			Map containing node from coarse graph and all its mappings from finer graph
 		"""
 		return (<_GraphCoarsening*>(self._this)).getCoarseToFineNodeMapping()
@@ -85,11 +85,11 @@ cdef class ParallelPartitionCoarsening(GraphCoarsening):
  	Parameters
  	----------
  	G : networkit.Graph
-		The graph.
+		The input graph.
 	zeta : networkit.Partition
 		The partition, which is used for coarsening.
  	parallel : bool, optional
-		If true, algorithm runs in parallel
+		If true, algorithm runs in parallel. Default: True
 	"""
 	def __cinit__(self, Graph G not None, Partition zeta not None, parallel = True):
 		self._this = new _ParallelPartitionCoarsening(G._this, zeta._this, parallel)
@@ -109,11 +109,11 @@ cdef class MatchingCoarsening(GraphCoarsening):
  	Parameters
  	----------
  	G : networkit.Graph
-		The graph.
+		The input graph.
 	M : networkit.matching.Matching
 		The matching, which is used for coarsening.
  	noSelfLoops : bool, optional
-		If true, self-loops are not produced
+		If true, self-loops are not produced. Default: False
 	"""
 
 	def __cinit__(self, Graph G not None, Matching M not None, bool_t noSelfLoops=False):

--- a/networkit/coloring.py
+++ b/networkit/coloring.py
@@ -12,7 +12,7 @@ class SpectralColoring(object):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph to compute the spectral coloring for
+		The graph to compute the spectral coloring for.
 	"""
 	def __init__(self, G):
 		super(SpectralColoring, self).__init__()
@@ -40,7 +40,7 @@ class SpectralColoring(object):
 		Parameters
 		----------
 		color : int
-			colorID to check for
+			colorID to check for.
 
 		Returns
 		-------
@@ -64,10 +64,10 @@ class SpectralColoring(object):
 
 		Parameters
 		----------
-		color : colorID
+		color : int
 			colorID to split corresponding nodes into colorID and new color.
 		depth : int, optional
-			Sets index of eigenvector to compare to `depth` 
+			Sets index of eigenvector to compare to `depth`. Default: 0
 		"""
 		otherColor = self.nextColor
 		self.nextColor += 1
@@ -120,7 +120,7 @@ class SpectralColoring(object):
 
 		Returns
 		-------
-		list
+		list(int)
 			A list of nodes containing a valid color mapping. 
 		"""
 		return self.coloring

--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -62,9 +62,9 @@ cdef extern from "<networkit/community/CommunityDetectionAlgorithm.hpp>":
 
 cdef class CommunityDetector(Algorithm):
 	""" 
-	CommunityDetector(Algorithm)
+	CommunityDetector()
 
-	Abstract base class for static community detection algorithms 
+	Abstract base class for static community detection algorithms.
 	"""
 
 	cdef Graph _G
@@ -80,7 +80,7 @@ cdef class CommunityDetector(Algorithm):
 
 		Returns
 		-------
-		networkit.Partition:
+		networkit.Partition
 			A Partition of the clustering.
 		"""
 		if self._this == NULL:
@@ -95,9 +95,9 @@ cdef extern from "<networkit/community/OverlappingCommunityDetectionAlgorithm.hp
 
 cdef class OverlappingCommunityDetector(Algorithm):
 	""" 
-	OverlappingCommunityDetector(Algorithm)
+	OverlappingCommunityDetector()
 
-	Abstract base class for static overlapping community detection algorithms 
+	Abstract base class for static overlapping community detection algorithms.
 	"""
 
 	cdef Graph _G
@@ -140,79 +140,79 @@ cdef class ClusteringGenerator:
 	cdef _ClusteringGenerator _this
 	def makeSingletonClustering(self, Graph G):
 		"""  
-		makeSingletonClustering(Graph G)
+		makeSingletonClustering(G)
 
 		Generate a clustering where each node has its own cluster
 
 		Parameters
 		----------
 		G : networkit.Graph
-			The graph for which the clustering shall be generated
+			The graph for which the clustering shall be generated.
 
 		Returns
 		-------
 		networkit.Partition
-			The generated partition
+			The generated partition.
 		"""
 		return Partition().setThis(self._this.makeSingletonClustering(G._this))
 	def makeOneClustering(self, Graph G):
 		"""  
-		makeOneClustering(Graph G)
+		makeOneClustering(G)
 
-		Generate a clustering with one cluster consisting of all nodes
+		Generate a clustering with one cluster consisting of all nodes.
 
 		Parameters
 		----------
 		G : networkit.Graph
-			The graph for which the clustering shall be generated
+			The graph for which the clustering shall be generated.
 
 		Returns
 		-------
 		networkit.Partition
-			The generated partition
+			The generated partition.
 		"""
 		return Partition().setThis(self._this.makeOneClustering(G._this))
 	def makeRandomClustering(self, Graph G, count k):
 		"""  
-		makeRandomClustering(Graph G, count k)
+		makeRandomClustering(G, k)
 		
-		Generate a clustering with `k` clusters to which nodes are assigned randomly
+		Generate a clustering with `k` clusters to which nodes are assigned randomly.
 
 		Parameters
 		----------
 		G : networkit.Graph
-			The graph for which the clustering shall be generated
-		k: count
-			The number of clusters that shall be generated
+			The graph for which the clustering shall be generated.
+		k : int
+			The number of clusters that shall be generated.
 
 		Returns
 		-------
 		networkit.Partition
-			The generated partition
+			The generated partition.
 		"""
 		return Partition().setThis(self._this.makeRandomClustering(G._this, k))
 	def makeContinuousBalancedClustering(self, Graph G, count k):
 		"""  
-		makeContinuousBalancedClustering(Graph G, count k)
+		makeContinuousBalancedClustering(G, k)
 		
 		Generate a clustering with `k` clusters to which nodes are assigned in continuous blocks
 
 		Parameters
 		----------
 		G : networkit.Graph
-			The graph for which the clustering shall be generated
-		k: count
-			The number of clusters that shall be generated
+			The graph for which the clustering shall be generated.
+		k : int
+			The number of clusters that shall be generated.
 
 		Returns
 		-------
 		networkit.Partition
-			The generated partition
+			The generated partition.
 		"""
 		return Partition().setThis(self._this.makeContinuousBalancedClustering(G._this, k))
 	def makeNoncontinuousBalancedClustering(self, Graph G, count k):
 		"""  
-		makeNoncontinuousBalancedClustering(Graph G, count k)
+		makeNoncontinuousBalancedClustering(G, k)
 		
 		Generate a clustering with `k` clusters, the ith node is assigned to cluster i % k. This means that
 		for k**2 nodes, this clustering is complementary to the continuous clustering in the sense that no pair
@@ -221,14 +221,14 @@ cdef class ClusteringGenerator:
 		Parameters
 		----------
 		G : networkit.Graph
-			The graph for which the clustering shall be generated
-		k: count
-			The number of clusters that shall be generated
+			The graph for which the clustering shall be generated.
+		k : int
+			The number of clusters that shall be generated.
 
 		Returns
 		-------
 		networkit.Partition
-			The generated partition
+			The generated partition.
 		"""
 		return Partition().setThis(self._this.makeNoncontinuousBalancedClustering(G._this, k))
 
@@ -246,25 +246,25 @@ cdef class GraphClusteringTools:
 	@staticmethod
 	def getImbalance(Partition zeta):
 		"""  
-		getImbalance(Partition zeta)
+		getImbalance(zeta)
 
 		Get the imbalance of clusters in the given partition.
 
 		Parameters
 		----------
-		zeta: networkit.Partition
-			The first partition
+		zeta : networkit.Partition
+			The first partition.
 
 		Returns
 		-------
-		imbalance
-			Imbalance of the partition
+		int
+			Imbalance of the partition.
 		"""
 		return getImbalance(zeta._this)
 	@staticmethod
 	def communicationGraph(Graph graph, Partition zeta):
 		"""  
-		communicationGraph(Graph graph, Partition zeta)
+		communicationGraph(graph, zeta)
 
 		Get the communication graph for a given graph and its partition.
 		A communication graph consists of a number of nodes, which equal
@@ -276,120 +276,121 @@ cdef class GraphClusteringTools:
 
 		Parameters
 		----------
-		graph: networkit.Graph
-			The input graph
-		zeta: networkit.Partition
-			Partition, which contains information about clusters in the graph
+		graph : networkit.Graph
+			The input graph.
+		zeta : networkit.Partition
+			Partition, which contains information about clusters in the graph.
 
 		Returns
 		-------
-		communicationGraph
-			communication graph given by the input graph and its partition
+		networkit.Graph
+			Communication graph given by the input graph and its partition.
 		"""
 		return Graph().setThis(communicationGraph(graph._this, zeta._this))
 	@staticmethod
 	def weightedDegreeWithCluster(Graph graph, Partition zeta, node u, index cid):
 		"""  
-		weightedDegreeWithCluster(Graph graph, Partition zeta, node u, index cid)
+		weightedDegreeWithCluster(graph, zeta, u, cid)
 
 		Get weightedDegree of node u for a cluster (represented by a partition) of index cid.
 
 		Parameters
 		----------
-		graph: networkit.Graph
-			The input graph
-		zeta: networkit.Partition
-			Partition, which contains information about clusters in the graph
-		u : node
-		cid : index 
-			Index of cluster
+		graph : networkit.Graph
+			The input graph.
+		zeta : networkit.Partition
+			Partition, which contains information about clusters in the graph.
+		u : int
+			The input node.
+		cid : int
+			Index of cluster.
 
 		Returns
 		-------
-		weightedDegree
-			weighted degree of node u for cluster index cid
+		float
+			weighted degree of node u for cluster index cid.
 		"""
 		return weightedDegreeWithCluster(graph._this, zeta._this, u, cid)
 	@staticmethod
 	def isProperClustering(Graph G, Partition zeta):
 		"""  
-		isProperClustering(Graph G, Partition zeta)
+		isProperClustering(G, zeta)
 
-		Check whether a partition is a proper clustering for a given graph
+		Check whether a partition is a proper clustering for a given graph.
 
 		Parameters
 		----------
-		G: networkit.Graph
-			The input graph
-		zeta: networkit.Partition
-			The first partition
+		G : networkit.Graph
+			The input graph.
+		zeta : networkit.Partition
+			The first partition.
 
 		Returns
 		-------
 		bool
-			True if the partition is a proper clustering, False if not
+			True if the partition is a proper clustering, False if not.
 		"""
 		return isProperClustering(G._this, zeta._this)
 	@staticmethod
 	def isSingletonClustering(Graph G, Partition zeta):
 		"""  
-		isSingletonClustering(Graph G, Partition zeta)
+		isSingletonClustering(G, zeta)
 
-		Check whether a partition is a singleton clustering for a given graph
+		Check whether a partition is a singleton clustering for a given graph.
 
 		Parameters
 		----------
 		G: networkit.Graph
-			The input graph
+			The input graph.
 		zeta: networkit.Partition
-			The first partition
+			The first partition.
 
 		Returns
 		-------
 		bool
-			True if the partition is a singleton clustering, False if not
+			True if the partition is a singleton clustering, False if not.
 		"""
 		return isSingletonClustering(G._this, zeta._this)
 	@staticmethod
 	def isOneClustering(Graph G, Partition zeta):
 		"""  
-		isOneClusteringClustering(Graph G, Partition zeta)
+		isOneClusteringClustering(G, zeta)
 
-		Check whether a partition is a one clustering for a given graph
+		Check whether a partition is a one clustering for a given graph.
 
 		Parameters
 		----------
-		G: networkit.Graph
-			The input graph
-		zeta: networkit.Partition
-			The first partition
+		G : networkit.Graph
+			The input graph.
+		zeta : networkit.Partition
+			The first partition.
 
 		Returns
 		-------
 		bool
-			True if the partition is a one clustering, False if not
+			True if the partition is a one clustering, False if not.
 		"""
 		return isOneClustering(G._this, zeta._this)
 	@staticmethod
 	def equalClustering(Partition zeta, Partition eta, Graph G):
 		"""  
-		equalClusteringClustering(Partition zeta, Partition eta, Graph G)
+		equalClusteringClustering(zeta, eta, G)
 
-		Check whether two paritions are equal for a given graph
+		Check whether two paritions are equal for a given graph.
 
 		Parameters
 		----------
-		zeta: networkit.Partition
-			The first partition
-		eta: networkit.Partition
-			The second partition
-		G: networkit.Graph
-			The input graph
+		zeta : networkit.Partition
+			The first partition.
+		eta : networkit.Partition
+			The second partition.
+		G : networkit.Graph
+			The input graph.
 
 		Returns
 		-------
 		bool
-			True if both partitions are the same, False if not
+			True if both partitions are the same, False if not.
 		"""
 		return equalClusterings(zeta._this, eta._this, G._this)
 
@@ -412,15 +413,15 @@ cdef class PartitionIntersection:
 
 		Parameters
 		----------
-		zeta: networkit.Partition
-			The first partition
-		eta: networkit.Partition
-			The second partition
+		zeta : networkit.Partition
+			The first partition.
+		eta : networkit.Partition
+			The second partition.
 
 		Returns
 		-------
 		networkit.Partition
-			The intersection of zeta and eta
+			The intersection of zeta and eta.
 		"""
 		return Partition().setThis(self._this.calculate(zeta._this, eta._this))
 
@@ -447,14 +448,14 @@ cdef class Coverage:
 		Parameters
 		----------
 		zeta : networkit.Partition
-			The Partition for which the coverage shall be calculated
+			The Partition for which the coverage shall be calculated.
 		G : networkit.Graph
-			The Graph to which zeta belongs
+			The Graph to which zeta belongs.
 
 		Returns
 		-------
-		double
-			The coverage in the given Partition
+		float
+			The coverage in the given Partition.
 		"""
 		return self._this.getQuality(zeta._this, G._this)
 
@@ -474,7 +475,7 @@ cdef class EdgeCut:
 
 	def getQuality(self, Partition zeta, Graph G):
 		"""
-		getQuality(Partition zeta, Graph G)
+		getQuality(zeta, G)
 
 		Calculates the edgeCut in the given Partition of the given
 		Graph.
@@ -482,14 +483,14 @@ cdef class EdgeCut:
 		Parameters
 		----------
 		zeta : networkit.Partition
-			The Partition for which the edgeCut shall be calculated
+			The Partition for which the edgeCut shall be calculated.
 		G : networkit.Graph
-			The Graph to which zeta belongs
+			The Graph to which zeta belongs.
 
 		Returns
 		-------
-		double
-			The edgeCut in the given Partition
+		float
+			The edgeCut in the given Partition.
 		"""
 		return self._this.getQuality(zeta._this, G._this)
 
@@ -520,7 +521,7 @@ cdef class Modularity:
 
 	def getQuality(self, Partition zeta, Graph G):
 		"""
-		getQuality(Partition zeta, Graph G)
+		getQuality(zeta,  G)
 
 		Calculates the modularity in the given Partition of the given
 		Graph.
@@ -534,7 +535,7 @@ cdef class Modularity:
 
 		Returns
 		-------
-		double
+		float
 			The modularity in the given Partition
 		"""
 		cdef double ret
@@ -570,7 +571,7 @@ cdef class HubDominance:
 
 	def getQuality(self, PartitionCover zeta, Graph G):
 		"""
-		getQuality(PartitionCover zeta, Graph G)
+		getQuality(zeta, G)
 
 		Calculates the dominance of hubs in the given Partition or Cover of the given
 		Graph.
@@ -578,14 +579,14 @@ cdef class HubDominance:
 		Parameters
 		----------
 		zeta : networkit.Partition or networkit.Cover
-			The Partition or Cover for which the hub dominance shall be calculated
+			The Partition or Cover for which the hub dominance shall be calculated.
 		G : networkit.Graph
-			The Graph to which zeta belongs
+			The Graph to which zeta belongs.
 
 		Returns
 		-------
-		double
-			The average hub dominance in the given Partition or Cover
+		float
+			The average hub dominance in the given Partition or Cover.
 		"""
 		return self._this.getQuality(zeta._this, G._this)
 
@@ -604,30 +605,28 @@ cdef extern from "<networkit/community/PLM.hpp>" namespace "NetworKit::PLM":
 
 cdef class PLM(CommunityDetector):
 	""" 
-	PLM(Graph G, refine=False, gamma=1.0, par="balanced", maxIter=32, turbo=True, recurse=True)
+	PLM(G, refine=False, gamma=1.0, par="balanced", maxIter=32, turbo=True, recurse=True)
 
 	Parallel Louvain Method - the Louvain method, optionally extended to
-	a full multi-level algorithm with refinement
+	a full multi-level algorithm with refinement.
 
 	Parameters
 	----------
 	G : networkit.Graph
-		A graph.
+		The input graph.
 	refine : bool, optional
-		Add a second move phase to refine the communities.
-	gamma : double
-		Multi-resolution modularity parameter:
-		1.0 -> standard modularity
-		0.0 -> one community
-		2m 	-> singleton communities
-	par : string
-		parallelization strategy
-	maxIter : count
-		maximum number of iterations for move phase
+		Add a second move phase to refine the communities. Default: False
+	gamma : float, optional
+		Multi-resolution modularity parameter: 1.0 (standard modularity), 0.0 (one community), 2m (singleton communities). Default: 1.0
+	par : str, optional
+		Parallelization strategy, possible values: "none", "simple", "balanced", "none randomized". Default "balanced"
+	maxIter : int, optional
+		Maximum number of iterations for move phase. Default: 32
 	turbo : bool, optional
-		faster but uses O(n) additional memory per thread
+		Faster but uses O(n) additional memory per thread. Default: True
 	recurse: bool, optional
-		use recursive coarsening, see http://journals.aps.org/pre/abstract/10.1103/PhysRevE.89.049902 for some explanations (default: true)
+		Use recursive coarsening, see http://journals.aps.org/pre/abstract/10.1103/PhysRevE.89.049902 for some explanations.
+		Default: True
 	"""
 
 	def __cinit__(self, Graph G not None, refine=False, gamma=1.0, par="balanced", maxIter=32, turbo=True, recurse=True):
@@ -642,15 +641,15 @@ cdef class PLM(CommunityDetector):
 
 		Returns
 		-------
-		double
-			Time for computing PLM
+		float
+			Time for computing PLM.
 		"""
 		return (<_PLM*>(self._this)).getTiming()
 
 	@staticmethod
 	def coarsen(Graph G, Partition zeta, bool_t parallel = False):
 		"""
-		coarsen(Graph G, Partition zeta, bool_t parallel = False)
+		coarsen(G, zeta, parallel=False)
 
 		Coarsens a graph based on a given partition and returns both the coarsened graph and a mapping 
 		for the nodes from fine to coarse.
@@ -660,14 +659,14 @@ cdef class PLM(CommunityDetector):
 		G : networkit.Graph
 			The input graph.
 		zeta : networkit.Partition
-			Partition of the graph, which represents the desired state of the coarsened graph
-		parallel : bool
-			Do the coarsening in parallel
+			Partition of the graph, which represents the desired state of the coarsened graph.
+		parallel : bool, optional
+			Do the coarsening in parallel. Default: False
 
 		Returns
 		-------
 		networkit.Graph
-			Pair of coarsened graph and node-mappings from fine to coarse graph
+			Pair of coarsened graph and node-mappings from fine to coarse graph.
 		"""
 		cdef pair[_Graph, vector[node]] result = move(PLM_coarsen(G._this, zeta._this))
 		return (Graph().setThis(result.first), result.second)
@@ -675,7 +674,7 @@ cdef class PLM(CommunityDetector):
 	@staticmethod
 	def prolong(Graph Gcoarse, Partition zetaCoarse, Graph Gfine, vector[node] nodeToMetaNode):
 		"""
-		prolong(Graph Gcoarse, Partition zetaCoarse, Graph Gfine, vector[node] nodeToMetaNode)
+		prolong(Gcoarse, zetaCoarse, Gfine, nodeToMetaNode)
 
 		Calculates a partition containing the mapping of node-id from a fine graph 
 		to a cluster-id from partition based on a coarse graph.
@@ -685,16 +684,16 @@ cdef class PLM(CommunityDetector):
 		Gcoarse : networkit.Graph
 			A coarse graph.
 		zetaCoarse : networkit.Partition
-			The first partition
+			The first partition.
 		Gfine : networkit.Graph
 			A fine graph.
-		nodeToMetaNode : vector[node]
-			Partition, which contains the cluster-id in the coarse graph for every node from the fine graph
+		nodeToMetaNode : list(int)
+			Partition, which contains the cluster-id in the coarse graph for every node from the fine graph.
 
 		Returns
 		-------
 		networkit.Partition
-			Partition
+			Output partition.
 		"""
 		return Partition().setThis(PLM_prolong(Gcoarse._this, zetaCoarse._this, Gfine._this, nodeToMetaNode))
 
@@ -705,21 +704,21 @@ cdef extern from "<networkit/community/ParallelLeiden.hpp>":
 		_ParallelLeiden(_Graph _G, int iterations, bool_t randomize, double gamma) except +
 
 cdef class ParallelLeiden(CommunityDetector):
-	""" Parallel Leiden Algorithm
+	""" 
+	ParallelLeiden(G, randomize=True, iterations=3, gamma=1)
 
-		Parameters
-		----------
-		G : networkit.Graph
-			A graph.
-		randomize : bool, optional
-			Whether to randomize the node order or not
-		iterations : count
-			Maximum count of Leiden runs
-		gamma : double
-			Multi-resolution modularity parameter:
-			1.0 -> standard modularity
-	 		0.0 -> one community
-	 		2m 	-> singleton communities
+	Parallel Leiden Algorithm.
+
+	Parameters
+	----------
+	G : networkit.Graph
+		A graph.
+	randomize : bool, optional
+		Whether to randomize the node order or not. Default: True
+	iterations : int, optional
+		Maximum count of Leiden runs. Default: 3
+	gamma : float, optional
+		Multi-resolution modularity parameter: 1.0 (standard modularity), 0.0 (one community), 2m (singleton communities). Default: 1.0
 	"""
 
 	def __cinit__(self, Graph G not None, int iterations = 3, bool_t randomize = True, double gamma = 1):
@@ -732,7 +731,7 @@ cdef extern from "<networkit/community/LouvainMapEquation.hpp>":
 
 cdef class LouvainMapEquation(CommunityDetector):
 	"""
-	LouvainMapEquation(Graph G, hierarchical = False, maxIterations = 32, parallelizationStrategy = "relaxmap")
+	LouvainMapEquation(G, hierarchical=False, maxIterations=32, parallelizationStrategy="relaxmap")
 	
 	Community detection algorithm based on the Louvain algorithm. Uses the Map Equation to find communities.
 
@@ -742,10 +741,10 @@ cdef class LouvainMapEquation(CommunityDetector):
 		The graph on which the algorithm has to run.
 	hierarchical: bool, optional
 		Iteratively create a graph of the locally optimal clusters and optimize locally on that graph.
-	maxIterations: count, optional
+	maxIterations: int, optional
 		The maximum number of local move iterations.
-	parallelizationStrategy: string, optional
-		relaxmap, synchronous, or none. default relaxmap.
+	parallelizationStrategy: str, optional
+		Parallelization strategy, possible values: "relaxmap", "synchronous", "none". Default: "relaxmap"
 	"""
 
 	def __cinit__(self, Graph G not None, hierarchical = False, maxIterations = 32, parallelizationStrategy = "relaxmap"):
@@ -763,7 +762,7 @@ cdef extern from "<networkit/community/PLP.hpp>":
 
 cdef class PLP(CommunityDetector):
 	""" 
-	PLP(Graph G, count updateThreshold=none, count maxIterations=none, Partition baseClustering=None)
+	PLP(G, updateThreshold=None, maxIterations=None, baseClustering=None)
 
 	Parallel label propagation for community detection:
 	Moderate solution quality, very short time to solution.
@@ -772,10 +771,11 @@ cdef class PLP(CommunityDetector):
 	----------
 	G : networkit.Graph
 		The graph on which the algorithm has to run.
-	updateThreshold : int
-		number of nodes that have to be changed in each iteration so that a new iteration starts.
-	baseClustering : networkit.Partition
-		PLP needs a base clustering to start from; if none is given the algorithm will run on a singleton clustering.
+	updateThreshold : int, optional
+		number of nodes that have to be changed in each iteration so that a new iteration starts. Default: None
+	baseClustering : networkit.Partition, optional
+		PLP needs a base clustering to start from; if none is given the algorithm will 
+		run on a singleton clustering. Default: None
 
 	Notes
 	-----
@@ -809,7 +809,7 @@ cdef class PLP(CommunityDetector):
 
 		Returns
 		-------
-		count
+		int
 			The number of iterations.
 		"""
 		return (<_PLP*>(self._this)).numberOfIterations()
@@ -822,7 +822,7 @@ cdef class PLP(CommunityDetector):
 
 		Returns
 		-------
-		count
+		int
 			The list of running times in milliseconds.
 		"""
 		return (<_PLP*>(self._this)).getTiming()
@@ -834,7 +834,7 @@ cdef extern from "<networkit/community/LFM.hpp>":
 
 cdef class LFM(OverlappingCommunityDetector):
 	""" 
-	LFM(Graph G , SelectiveCommunityDetector scd)
+	LFM(G, scd)
 	
 	Local community expansion algorithm:
  
@@ -874,7 +874,7 @@ cdef extern from "<networkit/community/LPDegreeOrdered.hpp>":
 
 cdef class LPDegreeOrdered(CommunityDetector):
 	""" 
-	LPDegreeOrdered(Graph G)
+	LPDegreeOrdered(G)
 	
 	Label propagation-based community detection algorithm which processes nodes in increasing order of node degree.	"""
 
@@ -890,7 +890,7 @@ cdef class LPDegreeOrdered(CommunityDetector):
 
 		Returns
 		-------
-		count
+		int
 			Number of iterations.
 		"""
 		return (<_LPDegreeOrdered*>(self._this)).numberOfIterations()
@@ -908,7 +908,7 @@ cdef extern from "<networkit/community/CutClustering.hpp>" namespace "NetworKit:
 
 cdef class CutClustering(CommunityDetector):
 	"""
-	CutClustering(Graph G, edgeweight alpha)
+	CutClustering(G, alpha)
 	
 	Cut clustering algorithm as defined in
 	Flake, Gary William; Tarjan, Robert E.; Tsioutsiouliklis, Kostas. Graph Clustering and Minimum Cut Trees.
@@ -917,8 +917,9 @@ cdef class CutClustering(CommunityDetector):
 	Parameters
 	----------
 	G : networkit.Graph
-	alpha : double
-		The parameter for the cut clustering algorithm
+		The input graph.
+	alpha : float
+		The parameter for the cut clustering algorithm.
 	"""
 	def __cinit__(self, Graph G not None,  edgeweight alpha):
 		self._G = G
@@ -927,7 +928,7 @@ cdef class CutClustering(CommunityDetector):
 	@staticmethod
 	def getClusterHierarchy(Graph G not None):
 		""" 
-		getClusterHierarchy(Graph G)
+		getClusterHierarchy(G)
 		
 		Get the complete hierarchy with all possible parameter values.
 
@@ -940,12 +941,12 @@ cdef class CutClustering(CommunityDetector):
 		Parameters
 		----------
 		G : networkit.Graph
-			The graph.
+			The input graph.
 
 		Returns
 		-------
-		dict
-			A dictionary with the parameter values as keys and the corresponding Partition instances as values
+		dict(str ``:`` networkit.Partition)
+			A dictionary with the parameter values as keys and the corresponding Partition instances as values.
 		"""
 		cdef map[double, _Partition] result
 		# FIXME: this probably copies the whole hierarchy because of exception handling, using move might fix this
@@ -979,23 +980,23 @@ cdef class NodeStructuralRandMeasure(DissimilarityMeasure):
 
 	def getDissimilarity(self, Graph G, Partition first, Partition second):
 		""" 
-		getDissimilarity(Graph G, Partition first, Partition second)
+		getDissimilarity(G, first, second)
 
 		Returns dissimilarity between two partitions.
 
 		Parameters
 		----------
 		G : networkit.Graph
-			The graph.
-		first: networkit.Partition
-			The first partition
-		second: networkit.Partition
-			The second partition
+			The input graph.
+		first : networkit.Partition
+			The first partition.
+		second : networkit.Partition
+			The second partition.
 
 		Returns
 		-------
-		double
-			Dissimilarity between partition first and second
+		float
+			Dissimilarity between partition first and second.
 		"""			
 		cdef double ret
 		with nogil:
@@ -1020,7 +1021,7 @@ cdef class GraphStructuralRandMeasure(DissimilarityMeasure):
 
 	def getDissimilarity(self, Graph G, Partition first, Partition second):
 		""" 
-		getDissimilarity(Graph G, Partition first, Partition second)
+		getDissimilarity(G, first, second)
 
 		Returns dissimilarity between two partitions.
 
@@ -1028,15 +1029,15 @@ cdef class GraphStructuralRandMeasure(DissimilarityMeasure):
 		----------
 		G : networkit.Graph
 			The graph.
-		first: networkit.Partition
-			The first partition
-		second: networkit.Partition
-			The second partition
+		first : networkit.Partition
+			The first partition.
+		second : networkit.Partition
+			The second partition.
 
 		Returns
 		-------
-		double
-			Dissimilarity between partition first and second
+		float
+			Dissimilarity between partition first and second.
 		"""		
 		cdef double ret
 		with nogil:
@@ -1058,23 +1059,23 @@ cdef class JaccardMeasure(DissimilarityMeasure):
 
 	def getDissimilarity(self, Graph G, Partition first, Partition second):
 		""" 
-		getDissimilarity(Graph G, Partition first, Partition second)
+		getDissimilarity(G, first, second)
 
 		Returns dissimilarity between two partitions.
 
 		Parameters
 		----------
 		G : networkit.Graph
-			The graph.
-		first: networkit.Partition
-			The first partition
-		second: networkit.Partition
-			The second partition
+			The input graph.
+		first : networkit.Partition
+			The first partition.
+		second : networkit.Partition
+			The second partition.
 
 		Returns
 		-------
-		double
-			Dissimilarity between partition first and second
+		float
+			Dissimilarity between partition first and second.
 		"""	
 		cdef double ret
 		with nogil:
@@ -1098,7 +1099,7 @@ cdef class NMIDistance(DissimilarityMeasure):
 
 	def getDissimilarity(self, Graph G, Partition first, Partition second):
 		""" 
-		getDissimilarity(Graph G, Partition first, Partition second)
+		getDissimilarity(G, first, second)
 
 		Returns dissimilarity between two partitions.
 
@@ -1106,15 +1107,15 @@ cdef class NMIDistance(DissimilarityMeasure):
 		----------
 		G : networkit.Graph
 			The graph.
-		first: networkit.Partition
-			The first partition
-		second: networkit.Partition
-			The second partition
+		first : networkit.Partition
+			The first partition.
+		second : networkit.Partition
+			The second partition.
 
 		Returns
 		-------
-		double
-			Dissimilarity between partition first and second
+		float
+			Dissimilarity between partition first and second.
 		"""			
 		cdef double ret
 		with nogil:
@@ -1136,23 +1137,23 @@ cdef class AdjustedRandMeasure(DissimilarityMeasure):
 
 	def getDissimilarity(self, Graph G not None, Partition first not None, Partition second not None):
 		""" 
-		getDissimilarity(Graph G, Partition first, Partition second)
+		getDissimilarity(G, first, second)
 
 		Returns dissimilarity between two partitions.
 
 		Parameters
 		----------
 		G : networkit.Graph
-			The graph.
+			The input graph.
 		first: networkit.Partition
-			The first partition
+			The first partition.
 		second: networkit.Partition
-			The second partition
+			The second partition.
 
 		Returns
 		-------
-		double
-			Dissimilarity between partition first and second
+		float
+			Dissimilarity between partition first and second.
 		"""	
 		cdef double ret
 		with nogil:
@@ -1189,7 +1190,7 @@ cdef class LocalCommunityEvaluation(Algorithm):
 
 		Returns
 		-------
-		double:
+		float
 			The weighted average value.
 		"""
 		if self._this == NULL:
@@ -1204,7 +1205,7 @@ cdef class LocalCommunityEvaluation(Algorithm):
 
 		Returns
 		-------
-		double:
+		float
 			The unweighted average value.
 		"""
 		if self._this == NULL:
@@ -1219,7 +1220,7 @@ cdef class LocalCommunityEvaluation(Algorithm):
 
 		Returns
 		-------
-		double:
+		float
 			The maximum value.
 		"""
 		if self._this == NULL:
@@ -1234,7 +1235,7 @@ cdef class LocalCommunityEvaluation(Algorithm):
 
 		Returns
 		-------
-		double:
+		float
 			The minimum value.
 		"""
 		if self._this == NULL:
@@ -1249,12 +1250,12 @@ cdef class LocalCommunityEvaluation(Algorithm):
 
 		Parameters
 		----------
-		i : index
+		i : int
 			The cluster to get the value for.
 
 		Returns
 		-------
-		double:
+		float
 			The value of cluster i.
 		"""
 		if self._this == NULL:
@@ -1269,7 +1270,7 @@ cdef class LocalCommunityEvaluation(Algorithm):
 
 		Returns
 		-------
-		list(double):
+		list(float)
 			The values of all clusters.
 		"""
 		if self._this == NULL:
@@ -1284,7 +1285,7 @@ cdef class LocalCommunityEvaluation(Algorithm):
 
 		Returns
 		-------
-		bool:
+		bool
 			If small values are better.
 		"""
 		if self._this == NULL:
@@ -1298,7 +1299,7 @@ cdef extern from "<networkit/community/LocalPartitionEvaluation.hpp>":
 
 cdef class LocalPartitionEvaluation(LocalCommunityEvaluation):
 	"""
-	LocalPartitionEvaluation(Graph G, Partition P)
+	LocalPartitionEvaluation(G, P)
 	
 	Virtual base class of all evaluation methods for a single clustering which is based on the evaluation of single clusters.
 	This is the base class for Partitions.
@@ -1328,7 +1329,7 @@ cdef extern from "<networkit/community/LocalCoverEvaluation.hpp>":
 
 cdef class LocalCoverEvaluation(LocalCommunityEvaluation):
 	"""
-	LocalCoverEvaluation(Graph G, Partition P)
+	LocalCoverEvaluation(G, P)
 
 	Virtual base class of all evaluation methods for a single clustering which is based on the evaluation of single clusters.
 	This is the base class for Covers.
@@ -1357,7 +1358,7 @@ cdef extern from "<networkit/community/IntrapartitionDensity.hpp>":
 
 cdef class IntrapartitionDensity(LocalPartitionEvaluation):
 	"""
-	IntrapartitionDensity(Graph G, Partition P)
+	IntrapartitionDensity(G, P)
 	
 	The intra-cluster density of a partition is defined as the number of existing edges divided by the number of possible edges.
 	The global value is the sum of all existing intra-cluster edges divided by the sum of all possible intra-cluster edges.
@@ -1365,9 +1366,9 @@ cdef class IntrapartitionDensity(LocalPartitionEvaluation):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph on which the measure shall be evaluated
+		The graph on which the measure shall be evaluated.
 	P : networkit.Partition
-		The partition that shall be evaluated
+		The partition that shall be evaluated.
 	"""
 	def __cinit__(self):
 		self._this = new _IntrapartitionDensity(self._G._this, self._P._this)
@@ -1380,7 +1381,7 @@ cdef class IntrapartitionDensity(LocalPartitionEvaluation):
 
 		Returns
 		-------
-		double:
+		float
 			The global intra-cluster density.
 		"""
 		if self._this == NULL:
@@ -1395,7 +1396,7 @@ cdef extern from "<networkit/community/IsolatedInterpartitionConductance.hpp>":
 
 cdef class IsolatedInterpartitionConductance(LocalPartitionEvaluation):
 	"""
-	IsolatedInterpartitionConductance(Graph G, Partition P)
+	IsolatedInterpartitionConductance(G, P)
 	
 	Isolated inter-partition conductance is a measure for how well a partition
 	(communtiy/cluster) is separated from the rest of the graph.
@@ -1414,9 +1415,9 @@ cdef class IsolatedInterpartitionConductance(LocalPartitionEvaluation):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph on which the measure shall be evaluated
+		The graph on which the measure shall be evaluated.
 	P : networkit.Partition
-		The partition that shall be evaluated
+		The partition that shall be evaluated.
 	"""
 	def __cinit__(self):
 		self._this = new _IsolatedInterpartitionConductance(self._G._this, self._P._this)
@@ -1428,7 +1429,7 @@ cdef extern from "<networkit/community/IsolatedInterpartitionExpansion.hpp>":
 
 cdef class IsolatedInterpartitionExpansion(LocalPartitionEvaluation):
 	"""
-	IsolatedInterpartitionExpansion(Graph G, Partition P)
+	IsolatedInterpartitionExpansion(G, P)
 	
 	Isolated inter-partition expansion is a measure for how well a partition
 	(communtiy/cluster) is separated from the rest of the graph.
@@ -1447,9 +1448,9 @@ cdef class IsolatedInterpartitionExpansion(LocalPartitionEvaluation):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph on which the measure shall be evaluated
+		The graph on which the measure shall be evaluated.
 	P : networkit.Partition
-		The partition that shall be evaluated
+		The partition that shall be evaluated.
 	"""
 	def __cinit__(self):
 		self._this = new _IsolatedInterpartitionExpansion(self._G._this, self._P._this)
@@ -1461,7 +1462,7 @@ cdef extern from "<networkit/community/CoverHubDominance.hpp>":
 
 cdef class CoverHubDominance(LocalCoverEvaluation):
 	"""
-	CoverHubDominance(Graph G, Cover C)
+	CoverHubDominance(G, C)
 	
 	A quality measure that measures the dominance of hubs in clusters. The hub dominance of a single
 	cluster is defined as the maximum cluster-internal degree of a node in that cluster divided by
@@ -1478,9 +1479,9 @@ cdef class CoverHubDominance(LocalCoverEvaluation):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph on which the measure shall be evaluated
+		The graph on which the measure shall be evaluated.
 	C : networkit.Cover
-		The cover that shall be evaluated
+		The cover that shall be evaluated.
 	"""
 	def __cinit__(self):
 		self._this = new _CoverHubDominance(self._G._this, self._C._this)
@@ -1492,7 +1493,7 @@ cdef extern from "<networkit/community/PartitionHubDominance.hpp>":
 
 cdef class PartitionHubDominance(LocalPartitionEvaluation):
 	"""
-	PartitionHubDominance(Graph G, Partition P)
+	PartitionHubDominance(G, P)
 	
 	A quality measure that measures the dominance of hubs in clusters. The hub dominance of a single
 	cluster is defined as the maximum cluster-internal degree of a node in that cluster divided by
@@ -1508,9 +1509,9 @@ cdef class PartitionHubDominance(LocalPartitionEvaluation):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph on which the measure shall be evaluated
+		The graph on which the measure shall be evaluated.
 	P : networkit.Partition
-		The partition that shall be evaluated
+		The partition that shall be evaluated.
 	"""
 	def __cinit__(self):
 		self._this = new _PartitionHubDominance(self._G._this, self._P._this)
@@ -1522,7 +1523,7 @@ cdef extern from "<networkit/community/PartitionFragmentation.hpp>":
 
 cdef class PartitionFragmentation(LocalPartitionEvaluation):
 	"""
-	PartitionFragmentation(Graph G, Partition P)
+	PartitionFragmentation(G, P)
 	
 	This measure evaluates how fragmented a partition is. The fragmentation of a single cluster is defined as one minus the
 	number of nodes in its maximum connected componented divided by its total number of nodes. Smaller values thus indicate a smaller fragmentation.
@@ -1530,9 +1531,9 @@ cdef class PartitionFragmentation(LocalPartitionEvaluation):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph on which the measure shall be evaluated
+		The graph on which the measure shall be evaluated.
 	P : networkit.Partition
-		The partition that shall be evaluated
+		The partition that shall be evaluated.
 	"""
 	def __cinit__(self):
 		self._this = new _PartitionFragmentation(self._G._this, self._P._this)
@@ -1545,7 +1546,7 @@ cdef extern from "<networkit/community/StablePartitionNodes.hpp>":
 
 cdef class StablePartitionNodes(LocalPartitionEvaluation):
 	"""
-	StablePartitionNodes(Graph G, Partition P)
+	StablePartitionNodes(G, P)
 	
 	Evaluates how stable a given partition is. A node is considered to be stable if it has strictly more connections
 	to its own partition than to other partitions. Isolated nodes are considered to be stable.
@@ -1555,9 +1556,9 @@ cdef class StablePartitionNodes(LocalPartitionEvaluation):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph on which the measure shall be evaluated
+		The graph on which the measure shall be evaluated.
 	P : networkit.Partition
-		The partition that shall be evaluated
+		The partition that shall be evaluated.
 	"""
 	def __cinit__(self):
 		self._this = new _StablePartitionNodes(self._G._this, self._P._this)
@@ -1565,14 +1566,14 @@ cdef class StablePartitionNodes(LocalPartitionEvaluation):
 
 	def isStable(self, node u):
 		"""
-		isStable(node u)
+		isStable(u)
 		
 		Check if a given node is stable, i.e. more connected to its own partition than to other partitions.
 
 		Parameters
 		----------
-		u : node
-			The node to check
+		u : int
+			The node to check.
 
 		Returns
 		-------
@@ -1591,7 +1592,7 @@ cdef extern from "<networkit/community/CoverF1Similarity.hpp>":
 
 cdef class CoverF1Similarity(LocalCoverEvaluation):
 	"""
-	CoverF1Similarity(Graph G, Cover C)
+	CoverF1Similarity(G, C, reference)
 	
 	Compare a given cover to a reference cover using the F1 measure.
 	This is a typical similarity measure used to compare the found
@@ -1611,12 +1612,12 @@ cdef class CoverF1Similarity(LocalCoverEvaluation):
 
 	Parameters
 	----------
-	G : Graph
+	G : networkit.Graph
 		The graph on which the evaluation is performed.
-	C : Cover
-		The cover that shall be evaluated
-        reference : Cover
-		The cover to which the similarity shall be computed
+	C : networkit.Cover
+		The cover that shall be evaluated.
+	reference : networkit.Cover
+		The cover to which the similarity shall be computed.
 	"""
 	cdef Cover _reference
 	def __cinit__(self, Graph G not None, Cover C not None, Cover reference not None):
@@ -1627,7 +1628,7 @@ cdef class CoverF1Similarity(LocalCoverEvaluation):
 
 def detectCommunities(G, algo=None, inspect=True):
 	""" 
-	detectCommunities(Graph G, algo=None, inspect=True)
+	detectCommunities(G, algo=None, inspect=True)
 
 	Perform high-performance community detection on the graph.
 	
@@ -1635,15 +1636,15 @@ def detectCommunities(G, algo=None, inspect=True):
 	----------
 	G : Graph
 		The graph on which the evaluation is performed.
-	algo :
-		Community detection algorithm instance
-	inspect: bool
-		Print properties of the found solution
+	algo : networkit.community.CommunityDetector
+		Community detection algorithm instance. Default: None
+	inspect: bool, optional
+		Print properties of the found solution. Default: True
 
 	Returns
 	-------
 	networkit.Partition
-		Return communities (as type Partition)
+		Return communities (as type Partition).
 	
 	"""
 	if algo is None:
@@ -1660,20 +1661,20 @@ def detectCommunities(G, algo=None, inspect=True):
 
 def inspectCommunities(zeta, G):
 	""" 
-	inspectCommunities(Partition zeta, Graph G)
+	inspectCommunities(zeta, G)
 	
-	Display information about communities
+	Display information about communities.
 
 	Parameters
 	----------
 	zeta : networkit.Partition
-		Partition
+		The input Partition.
 	G : networkit.Graph
 		The graph on which the evaluation is performed.
 
 	Returns
 	-------
-	visual
+	tabulate.tabulate
 		inspection of communities (needs external tabulate-module)
 	"""
 	if not have_tabulate:
@@ -1693,16 +1694,17 @@ def inspectCommunities(zeta, G):
 
 def communityGraph(G, zeta):
 	""" 
-	communityGraph(Graph G, Partition P)
+	communityGraph(G, P)
 	
-	Create a community graph, i.e. a graph in which one node represents a community and an edge represents the edges between communities, from a given graph and a community detection solution
+	Create a community graph, i.e. a graph in which one node represents a community and an edge represents the edges 
+	between communities, from a given graph and a community detection solution.
 	
 	Parameters
 	----------
 	G : networkit.Graph
 		The graph on which the evaluation is performed.	
 	P : networkit.Partition
-		Partition
+		The input Partition.
 	"""
 	cg = ParallelPartitionCoarsening(G, zeta)
 	cg.run()
@@ -1712,18 +1714,19 @@ def communityGraph(G, zeta):
 def evalCommunityDetection(algo, G):
 	""" 
 	evalCommunityDetection(algo, G)
+
 	Evaluate a community detection algorithm 
-	
+
 	Parameters
 	----------
-	algo :
+	algo : networkit.community.CommunityDetector
 		Community detection algorithm instance
-	G : Graph
+	G : networkit.Graph
 		The graph on which the evaluation is performed.
 
 	Returns
 	-------
-	visual
+	tabulate.tabulate
 		inspection of communities (needs external tabulate-module)
 	"""
 
@@ -1749,9 +1752,9 @@ def readCommunities(path, format="default"):
 	Parameters
 	----------
 	path : str
-		Path to file, which contains information about communities
-	format : str
-		Besides default, this can be set to "edgelist-t1", "edgelist-t0", "edgelist-s1", "edgelist-s0"
+		Path to file, which contains information about communities.
+	format : str, optional
+		Format from file, possible values: "default", "edgelist-t1", "edgelist-t0", "edgelist-s1", "edgelist-s0". Default: "default"
 	"""
 	readers =  {"default": PartitionReader(),
 		"edgelist-t1": EdgeListPartitionReader(1, '\t'),
@@ -1789,24 +1792,30 @@ def writeCommunities(communities, path):
 
 	Parameters
 	----------
+	communities : networkit.Partition
+		The input communities.
 	path : str
-		Path to file, which contains information about communities
-	format : str
-		Besides default, this can be set to "edgelist-t1", "edgelist-t0", "edgelist-s1", "edgelist-s0"
+		Path to write the file to.
 	"""
 	PartitionWriter().write(communities, path)
 	print("wrote communities to: {0}".format(path))
 
 
 def compareCommunities(G, zeta1, zeta2):
-	""" 
-	Compare the partitions with respect to several (dis)similarity measures. Note: Currently not implemented
+	"""
+	compareCommunities(G, zeta1, zeta2)
+
+	Compare the partitions with respect to several (dis)similarity measures. 
+	
+	Notes
+	-----
+	Currently not implemented.
 	"""
 	raise NotImplementedError("TODO:")
 
 def kCoreCommunityDetection(G, k, algo=None, inspect=True):
 	""" 
-	kCoreCommunityDetection(Graph G, double k, algo=None, inspect=True)
+	kCoreCommunityDetection(G, k, algo=None, inspect=True)
 	
 	Perform community detection on the k-core of the graph, which possibly
 
@@ -1814,15 +1823,16 @@ def kCoreCommunityDetection(G, k, algo=None, inspect=True):
 	----------
 	G : networkit.Graph
 		The graph on which the evaluation is performed.
-	k : double
-		set k as used in k-core
-	algo : networkit.Algorithm
-		Community detection algorithm instance
-
+	k : float
+		Set k as used in k-core.
+	algo : networkit.community.CommunityDetector, optional
+		Community detection algorithm instance. Default: None
+	inspect: bool, optional
+		Print properties of the found solution. Default: True
 	Returns
 	-------
 	networkit.Partition
-		Return communities (as type Partition)
+		Return communities (as type Partition).
 		"""
 	coreDec = CoreDecomposition(G)
 	coreDec.run()
@@ -1877,6 +1887,13 @@ cdef extern from "<networkit/community/OverlappingNMIDistance.hpp>" namespace "N
 		MAX,
 		JOINT_ENTROPY
 
+class Normalization:
+	Min = MIN
+	GeometricMean = GEOMETRIC_MEAN
+	ArithmeticMean = ARITHMETIC_MEAN
+	Max = MAX
+	JointEntropy = JOINT_ENTROPY
+
 cdef extern from "<networkit/community/OverlappingNMIDistance.hpp>":
 
 	cdef cppclass _OverlappingNMIDistance "NetworKit::OverlappingNMIDistance":
@@ -1888,18 +1905,26 @@ cdef extern from "<networkit/community/OverlappingNMIDistance.hpp>":
 
 cdef class OverlappingNMIDistance(DissimilarityMeasure):
 	"""
-	OverlappingNMIDistance(normalization = OverlappingNMIDistance.Max)
+	OverlappingNMIDistance(normalization = networkit.community.Normalization.Max)
 	
 	Compare two covers using the overlapping normalized mutual information measure. This is a dissimilarity measure with
 	a range of [0, 1]. A value of 0 indicates a perfect agreement while a 1 indicates complete disagreement.
 
-	For the `OverlappingNMIDistance.Max` normalization, this is the measure introduced in [NMI13]. Other normalization
+	For `networkit.community.Normalization.Max` normalization, this is the measure introduced in [NMI13]. Other normalization
 	methods result in similar measures.
+
+	Parameter :code:`normalization` can be one of the following:
+
+	- networkit.community.Normalization.Min
+	- networkit.community.Normalization.GeometricMean
+	- networkit.community.Normalization.ArithmeticMean
+	- networkit.community.Normalization.Max
+	- networkit.community.Normalization.JointEntropy
 
 	Parameters
 	----------
-	normalization : {Min, GeometricMean, ArithmeticMean, Max, JointEntropy}, optional
-		The default is OverlappingNMIDistance.Max.
+	normalization : networkit.community.Normalization, optional
+		Normalization strategy for OverlappingNMIDistance. Default: networkit.community.Normalization.Max
 
 	Raises
 	------
@@ -1930,9 +1955,18 @@ cdef class OverlappingNMIDistance(DissimilarityMeasure):
 		
 		Set the normalization method.
 
+		Parameter :code:`normalization` can be one of the following:
+
+		- networkit.community.Normalization.Min
+		- networkit.community.Normalization.GeometricMean
+		- networkit.community.Normalization.ArithmeticMean
+		- networkit.community.Normalization.Max
+		- networkit.community.Normalization.JointEntropy
+
 		Parameters
 		----------
-		normalization : {Min, GeometricMean, ArithmeticMean, Max, JointEntropy}
+		normalization : networkit.community.Normalization
+			Normalization strategy for OverlappingNMIDistance.
 
 		Raises
 		------
@@ -1944,16 +1978,18 @@ cdef class OverlappingNMIDistance(DissimilarityMeasure):
 
 	def getDissimilarity(self, Graph G, PartitionCover first, PartitionCover second):
 		"""
-		getDissimilarity(Graph G, PartitionCover first, PartitionCover second)
+		getDissimilarity(G, first, second)
 		
 		Calculate the dissimilarity.
 
 		Parameters
 		----------
 		G : networkit.Graph
+			The input graph.
 		first : networkit.Partition or networkit.Cover
+			The first input partition/cover.
 		second : networkit.Partition or networkit.Cover
-			Must be the same type as `first`.
+			The second input partition/cover. Must be the same type as `first`.
 
 		Raises
 		------
@@ -1965,7 +2001,7 @@ cdef class OverlappingNMIDistance(DissimilarityMeasure):
 		Returns
 		-------
 		float
-			distance
+			Resulting overlapping NMI distance.
 		"""
 		cdef double ret
 		if isinstance(first, Partition) and isinstance(second, Partition):

--- a/networkit/components.pyx
+++ b/networkit/components.pyx
@@ -36,7 +36,7 @@ cdef class ConnectedComponents(Algorithm):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph.
+		The input graph.
 	"""
 	cdef Graph _G
 
@@ -78,13 +78,13 @@ cdef class ConnectedComponents(Algorithm):
 
 		Parameters
 		----------
-		v : node
+		v : int
 			The node whose component is asked for.
 
 		Returns
 		-------
 		int
-			Component in which node `v` is situated
+			Component in which node `v` is situated.
 		"""
 		return (<_ConnectedComponents*>(self._this)).componentOfNode(v)
 
@@ -96,7 +96,7 @@ cdef class ConnectedComponents(Algorithm):
 
 		Returns
 		-------
-		dict(int : int)
+		dict(int ``:`` int)
 			A dict containing the component ids and their size.
 		"""
 		return (<_ConnectedComponents*>(self._this)).getComponentSizes()
@@ -109,7 +109,7 @@ cdef class ConnectedComponents(Algorithm):
 
 		Returns
 		-------
-		list
+		list(int)
 			The connected components.
 		"""
 		return (<_ConnectedComponents*>(self._this)).getComponents()
@@ -117,6 +117,8 @@ cdef class ConnectedComponents(Algorithm):
 	@staticmethod
 	def extractLargestConnectedComponent(Graph graph, bool_t compactGraph = False):
 		"""
+		extractLargestConnectedComponent(graph, compactGraph=False)
+
 		Constructs a new graph that contains only the nodes inside the
 		largest connected component.
 
@@ -127,11 +129,11 @@ cdef class ConnectedComponents(Algorithm):
 		Parameters
 		----------
 		graph : networkit.Graph
-			The input graph
+			The input graph.
 		compactGraph : bool, optional
-			if true, the node ids of the output graph will be compacted
+			If true, the node ids of the output graph will be compacted
 			(i.e., re-numbered from 0 to n-1). If false, the node ids
-			will not be changed.
+			will not be changed. Default: False
 
 		Returns
 		-------
@@ -208,7 +210,7 @@ cdef class ParallelConnectedComponents(Algorithm):
 
 		Parameters
 		----------
-		v : node
+		v : int
 			The node whose component is asked for.
 
 		Returns
@@ -226,7 +228,7 @@ cdef class ParallelConnectedComponents(Algorithm):
 
 		Returns
 		-------
-		list
+		list(int)
 			The connected components.
 		"""
 		return (<_ParallelConnectedComponents*>(self._this)).getComponents()
@@ -253,7 +255,7 @@ cdef class StronglyConnectedComponents:
 	Parameters:
 	-----------
 	G : networkit.Graph
-		The graph.
+		The input graph.
 	"""
 	cdef _StronglyConnectedComponents* _this
 	cdef Graph _G
@@ -308,11 +310,11 @@ cdef class StronglyConnectedComponents:
 
 		Parameters
 		----------
-		u : node
+		u : int
 			A node in the graph.
 
 		Returns
-		-----------
+		-------
 		int
 			The component of node `u`.
 		"""
@@ -326,7 +328,7 @@ cdef class StronglyConnectedComponents:
 
 		Returns
 		-------
-		dict(int : int)
+		dict(int ``:`` int)
 			A dict with component indexes as keys and their size as values.
 		"""
 		return self._this.getComponentSizes()
@@ -392,7 +394,7 @@ cdef class WeaklyConnectedComponents(Algorithm):
 
 		Parameters
 		----------
-		v : node
+		v : int
 			The node whose component is asked for.
 
 		Returns
@@ -410,7 +412,7 @@ cdef class WeaklyConnectedComponents(Algorithm):
 
 		Returns
 		-------
-		dict(int : int)
+		dict(int ``:`` int)
 			A dict that maps each component id to its size.
 		"""
 		return (<_WeaklyConnectedComponents*>(self._this)).getComponentSizes()
@@ -423,8 +425,8 @@ cdef class WeaklyConnectedComponents(Algorithm):
 
 		Returns
 		-------
-		vector[vector[node]]
-			A vector of vectors. Each inner vector contains all the nodes inside the component.
+		list(list(int))
+			A list of lists. Each inner vector contains all the nodes inside the component.
 		"""
 		return (<_WeaklyConnectedComponents*>(self._this)).getComponents()
 
@@ -439,7 +441,7 @@ cdef extern from "<networkit/components/BiconnectedComponents.hpp>":
 
 cdef class BiconnectedComponents(Algorithm):
 	""" 
-	BiconnectedComponents()
+	BiconnectedComponents(G)
 	
 	Determines the biconnected components of an undirected graph as defined in
 	Tarjan, Robert. Depth-First Search and Linear Graph Algorithms. SIAM J.
@@ -448,7 +450,7 @@ cdef class BiconnectedComponents(Algorithm):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph.
+		The input graph.
 	"""
 	cdef Graph _G
 
@@ -477,7 +479,7 @@ cdef class BiconnectedComponents(Algorithm):
 
 		Returns
 		-------
-		dict(int : int)
+		dict(int ``:`` int)
 			A dict that maps each component id to its size.
 		"""
 		return (<_BiconnectedComponents*>(self._this)).getComponentSizes()
@@ -490,8 +492,8 @@ cdef class BiconnectedComponents(Algorithm):
 
 		Returns
 		-------
-		vector[vector[node]]
-			A vector of vectors. Each inner vector contains all the nodes inside the component.
+		list(list(int))
+			A list of lists. Each inner vector contains all the nodes inside the component.
 		"""
 		return (<_BiconnectedComponents*>(self._this)).getComponents()
 
@@ -516,7 +518,7 @@ cdef class DynConnectedComponents(Algorithm):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph.
+		The input graph.
 	"""
 	cdef Graph _G
 
@@ -545,13 +547,13 @@ cdef class DynConnectedComponents(Algorithm):
 
 		Parameters
 		----------
-		v : node
+		v : int
 			The node whose component is asked for.
 
 		Returns
 		-------
 		int
-			Component in which node `v` is situated
+			Component in which node `v` is situated.
 		"""
 		return (<_DynConnectedComponents*>(self._this)).componentOfNode(v)
 
@@ -563,7 +565,7 @@ cdef class DynConnectedComponents(Algorithm):
 
 		Returns
 		-------
-		dict(int : int)
+		dict(int ``:`` int)
 			A dict that maps each component id to its size.
 		"""
 		return (<_DynConnectedComponents*>(self._this)).getComponentSizes()
@@ -576,7 +578,7 @@ cdef class DynConnectedComponents(Algorithm):
 
 		Returns
 		-------
-		list[list[int]]
+		list(list(int))
 			A list of lists. Each inner list contains all the nodes inside the component.
 		"""
 		return (<_DynConnectedComponents*>(self._this)).getComponents()
@@ -590,7 +592,7 @@ cdef class DynConnectedComponents(Algorithm):
 
 		Parameters
 		----------
-		event : GraphEvent
+		event : networkit.dynamics.GraphEvent
 			The event that happened (edge deletion or insertion).
 		"""
 		(<_DynConnectedComponents*>(self._this)).update(_GraphEvent(event.type, event.u, event.v, event.w))
@@ -604,8 +606,8 @@ cdef class DynConnectedComponents(Algorithm):
 
 		Parameters
 		----------
-		batch : vector[GraphEvent]
-			A vector that contains a batch of edge insertions or deletions.
+		batch : list(networkit.dynamics.GraphEvent)
+			A list that contains a batch of edge insertions or deletions.
 		"""
 		cdef vector[_GraphEvent] _batch
 		for event in batch:
@@ -634,7 +636,7 @@ cdef class DynWeaklyConnectedComponents(Algorithm):
 	Parameters
 	----------
 	G : networkit.Graph
-		The graph.
+		The input graph.
 	"""
 	cdef Graph _G
 
@@ -663,7 +665,7 @@ cdef class DynWeaklyConnectedComponents(Algorithm):
 
 		Parameters
 		----------
-		v : node
+		v : int
 			The node whose component is asked for.
 
 		Returns
@@ -681,7 +683,7 @@ cdef class DynWeaklyConnectedComponents(Algorithm):
 
 		Returns
 		-------
-		dict(int : int)
+		dict(int ``:`` int)
 			A dict that maps each component id to its size.
 		"""
 		return (<_DynWeaklyConnectedComponents*>(self._this)).getComponentSizes()
@@ -694,8 +696,8 @@ cdef class DynWeaklyConnectedComponents(Algorithm):
 
 		Returns
 		-------
-		vector[vector[node]]
-			A vector of vectors. Each inner vector contains all the nodes
+		list(list(int))
+			A list of lists. Each inner vector contains all the nodes
 			inside the component.
 		"""
 		return (<_DynWeaklyConnectedComponents*>(self._this)).getComponents()
@@ -709,7 +711,7 @@ cdef class DynWeaklyConnectedComponents(Algorithm):
 
 		Parameters
 		----------
-		event : GraphEvent
+		event : networkit.dynamics.GraphEvent
 			The event that happened (edge deletion or insertion).
 		"""
 		(<_DynWeaklyConnectedComponents*>(self._this)).update(_GraphEvent(event.type, event.u, event.v, event.w))
@@ -723,7 +725,7 @@ cdef class DynWeaklyConnectedComponents(Algorithm):
 
 		Parameters
 		----------
-		batch : vector[GraphEvent]
+		batch : list(networkit.dynamics.GraphEvent)
 			A vector that contains a batch of edge insertions or deletions.
 		"""
 		cdef vector[_GraphEvent] _batch

--- a/networkit/correlation.pyx
+++ b/networkit/correlation.pyx
@@ -23,9 +23,9 @@ cdef class Assortativity(Algorithm):
 	Parameters
 	----------
 	G : networkit.graph
-		The graph.
+		The input graph.
 	data : list(float)
-			Numerical node value array
+		Numerical node value array.
 	"""
 	cdef Graph G
 	cdef vector[double] attribute


### PR DESCRIPTION
This unifies documentation for Python modules beginning with `a` to `c` with the rest (Python types, enums, properties). For modules beginning with `d` to `z` these fixes have already been merged. Also some method-docs are fixed, which were not handled properly in previous doc-fix PRs.