### PR TITLE
Remove networkit/build.sh

### DIFF
--- a/networkit/build.sh
+++ b/networkit/build.sh
@@ -1,4 +1,0 @@
-rm _NetworKit.cpp
-python3 setup.py clean
-python3 setup.py build_ext --inplace
-


### PR DESCRIPTION
The file still refers to the monolithic Cython-interface and is not referenced anywhere (both doc/codebase).