### PR TITLE
Deprecate Python modules: sampling, stopwatch, viztasks, workflows

### DIFF
--- a/networkit/sampling.py
+++ b/networkit/sampling.py
@@ -1,3 +1,7 @@
+from .graphtools import GraphTools
+
+from warnings import warn
+
 """ Sampling from graphs """
 
 __author__ = "Elisabetta Bergamini"
@@ -7,6 +11,8 @@ def bfsSample(G, source=None, k = 50):
 	bfsSample(G, source=None, k=50)    
 
 	Start a BFS from source node, return node-induced subgraph of the first k nodes discovered.
+
+	DEPRECATED. This function (and the networkit.sampling module) will be removed in future updates. 
 
 	Parameters
 	----------
@@ -22,8 +28,9 @@ def bfsSample(G, source=None, k = 50):
 	networkit.Graph
 		Subgraph based on bfsSample.
 	"""
+	warn("networkit.sampling.bfsSample is deprecated, will be removed in future updates.")
 	if not source:
-		source = nk.graphtools.randomNode(G)
+		source = GraphTools.randomNode(G)
 	n = G.numberOfNodes()
 	visited = [False]*n
 	Q = [source]
@@ -41,5 +48,5 @@ def bfsSample(G, source=None, k = 50):
 				closest.add(v)
 		G.forEdgesOf(u, enqueue)
 	print("found {0} nodes".format(len(closest)))
-	G1 = nk.graphtools.subgraphFromNodes(G, closest)
+	G1 = GraphTools.subgraphFromNodes(G, closest)
 	return G1

--- a/networkit/stopwatch.py
+++ b/networkit/stopwatch.py
@@ -8,6 +8,8 @@
 
 import time
 
+from warnings import warn
+
 """
 stopwatch is a very simple Python module for measuring time.
 Great for finding out how long code takes to execute.
@@ -40,8 +42,11 @@ __author__ = 'John Paulett <http://blog.7oars.com>'
 class Timer(object):
 	"""
 	Main stopwatch object, providing functionality to measure time.
+
+	DEPRECATED. This class (and the networkit.stopwatch module) will be removed in future updates.
 	"""
 	def __init__(self):
+		warn("networkit.Timer is deprecated, will be removed in future updates.")
 		self.__stopped = None
 		self.__start = self.__time()
 
@@ -130,6 +135,8 @@ def clockit(func):
 	Function decorator that times the evaluation of *func* and prints the
 	execution time.
 
+	DEPRECATED. This function (and the networkit.stopwatch module) will be removed in future updates.
+
 	Example
 	-------
 
@@ -142,6 +149,8 @@ def clockit(func):
 		>>> print mult(2, 6)
 		mult in 1.38282775879e-05 sec
 	"""
+	warn("networkit.stopwatch.clockit is deprecated, will be removed in future updates.")
+
 	def new(*args, **kw):
 		t = Timer()
 		retval = func(*args, **kw)

--- a/networkit/viztasks.py
+++ b/networkit/viztasks.py
@@ -5,6 +5,8 @@ from . import centrality
 from .coarsening import ParallelPartitionCoarsening
 from .support import MissingDependencyError
 
+from warnings import warn
+
 # external imports
 try:
 	import networkx
@@ -18,7 +20,9 @@ def save(name, dir="."):
 	save(name, dir=".")
 
 	Save a figure.
-	
+
+	DEPRECATED. This function (and the networkit.viztasks module) will be removed in future updates.
+
 	Parameters
 	----------
 	name : str
@@ -26,6 +30,7 @@ def save(name, dir="."):
 	dir : str
 		Output directory. Default: "."
 	"""
+	warn("networkit.viztasks.save is deprecated, will be removed in future updates.")
 	savefig(os.path.join(dir, "{0}.pdf".format(name)), bbox_inches="tight", transparent=True)
 
 
@@ -34,6 +39,8 @@ def coloringToColorList(G, coloring):
 	coloringToColorList(G, coloring)
 
 	Calculate node colors based on an input graph and color dict.
+
+	DEPRECATED. This function (and the networkit.viztasks module) will be removed in future updates.
 
 	Parameters
 	----------
@@ -47,6 +54,7 @@ def coloringToColorList(G, coloring):
 	list(tuple(float, float, float))
 		List with color values for each node.
 	"""
+	warn("networkit.viztasks.coloringToColorList is deprecated, will be removed in future updates.")
 	clist = []
 
 	nColors = len(coloring.keys())
@@ -64,6 +72,9 @@ def drawGraph(G, **kwargs):
 	Draws a graph via networkX. Passes additional arguments beyond the graph to networkx.draw(...).
 	By default, node sizes are scaled between 30 and 300 by node degree.
 
+	DEPRECATED. This function (and the networkit.viztasks module) will be removed in future updates. Use networkit.vizbridges instead to draw 
+	graphs (needs additional plugins).
+
 	Parameters
 	----------
 	G : networkit.Graph
@@ -71,6 +82,7 @@ def drawGraph(G, **kwargs):
 	`**kwargs` : dict()
 		Additional arguments for networkx.draw function.
 	"""
+	warn("networkit.viztasks.drawGraph is deprecated, will be removed in future updates. Use networkit.vizbridges instead to draw graphs (needs additional plugins).")
 	if not have_nx:
 		raise MissingDependencyError("networkx")
 	if not G.checkConsistency():
@@ -88,6 +100,9 @@ def drawCommunityGraph(G, zeta, **kwargs):
 	Draws the community graph for a given graph and partition. Passes any additional arguments to networkx.draw(...).
 	By default, node sizes are scaled between 30 and 500 by community size.
 
+	DEPRECATED. This function (and the networkit.viztasks module) will be removed in future updates. Use networkit.vizbridges instead to draw 
+	graphs (needs additional plugins).
+
 	Parameters
 	----------
 	G : networkit.Graph
@@ -97,6 +112,7 @@ def drawCommunityGraph(G, zeta, **kwargs):
 	`**kwargs` : dict()
 		Additional arguments for networkx.draw function.	
 	"""
+	warn("networkit.viztasks.drawCommunityGraph is deprecated, will be removed in future updates. Use networkit.vizbridges instead to draw graphs (needs additional plugins).")
 	if not have_nx:
 		raise MissingDependencyError("networkx")
 	cg = ParallelPartitionCoarsening(G,zeta)

--- a/networkit/workflows.py
+++ b/networkit/workflows.py
@@ -2,6 +2,11 @@
 
 __author__ = "Christian Staudt"
 
+# internal imports
+from .graphio import readGraph
+from .components import ConnectedComponents
+from . import stopwatch 
+
 # external imports
 import operator
 import logging
@@ -10,13 +15,15 @@ import os
 import csv
 import fnmatch
 
-import networkit as nk
+from warnings import warn
 
 def extractLargestComponent(G):
 	"""
 	extractLargestComponent(G)
 
 	Extract the subgraph of the largest connected component.
+
+	DEPRECATED. This function (and the networkit.workflows module) will be removed in future updates. 
 
 	Parameters
 	----------
@@ -31,7 +38,7 @@ def extractLargestComponent(G):
 
 	from warnings import warn
 	warn("This function is deprecated, use extractLargestConnectedComponent in the ConnectedComponents module instead.")
-	return nk.components.extractLargestConnectedComponent(G)
+	return ConnectedComponents.extractLargestConnectedComponent(G)
 
 
 def batch(graphDir, match, format, function, outPath, header=None):
@@ -39,6 +46,8 @@ def batch(graphDir, match, format, function, outPath, header=None):
 	batch(graphDir, match, format, function, outPath, header=None)
 
 	Read graphs from a directory, apply a function and store result in CSV format.
+
+	DEPRECATED. This function (and the networkit.workflows module) will be removed in future updates. 
 
 	Parameters
 	----------
@@ -55,6 +64,7 @@ def batch(graphDir, match, format, function, outPath, header=None):
 	header : str, optional
 		CSV file header. Default: None
 	"""
+	warn("networkit.workflows.batch is deprecated, will be removed in future updates.")
 	with open(outPath, 'w') as outFile:
 		writer = csv.writer(outFile, delimiter='\t')
 		if header:
@@ -65,7 +75,7 @@ def batch(graphDir, match, format, function, outPath, header=None):
 					print("processing {0}".format(filename))
 					graphPath = os.path.join(root, filename)
 					timer = stopwatch.Timer()
-					G = nk.graphio.readGraph(graphPath)
+					G = readGraph(graphPath)
 					timer.stop()
 					result = function(G)
 					if type(result) is tuple:


### PR DESCRIPTION
This PR deprecates (and fixes) some older Python modules, which are not anymore relevant/needed. This includes: sampling, stopwatch, viztasks, workflows.