### PR TITLE
Change the string argument for the NodeAttributeStorage constructor

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -215,7 +215,7 @@ private:
     template <typename T>
     class NodeAttributeStorage : public NodeAttributeStorageBase {
     public:
-        NodeAttributeStorage(const Graph *theGraph, std::string name)
+        NodeAttributeStorage(const Graph *theGraph, const std::string name)
             : NodeAttributeStorageBase{theGraph, std::move(name), typeid(T)} {}
 
         void resize(node i) {


### PR DESCRIPTION
The string argument NodeAttributeStorage is only read as a const reference. Changed it to avoid warnings.