### PR TITLE
New Algorithm for Forest Closeness Centrality

### DIFF
--- a/include/networkit/centrality/ForestCentrality.hpp
+++ b/include/networkit/centrality/ForestCentrality.hpp
@@ -1,0 +1,112 @@
+/*
+ * ForestCentrality.hpp
+ *
+ *  Created on: 12.02.2020
+ *      Author: Eugenio Angriman <angrimae@hu-berlin.de>
+ */
+
+#ifndef NETWORKIT_CENTRALITY_FOREST_CENTRALITY_HPP_
+#define NETWORKIT_CENTRALITY_FOREST_CENTRALITY_HPP_
+
+#include <cmath>
+#include <functional>
+#include <omp.h>
+#include <random>
+#include <vector>
+
+#include <networkit/algebraic/Vector.hpp>
+#include <networkit/centrality/Centrality.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+// NOTE: Does not support multiple calls of run()
+class ForestCentrality final : public Centrality {
+
+public:
+    /**
+     * Approximates the forest closeness centrality of all the vertices of a graph by approximating
+     * the diagonal of the forest matrix of @a G. Every element of the diagonal is guaranteed to
+     * have a maximum absolute error of @a epsilon. Based on "New Approximation Algorithms for
+     * Forest Closeness Centrality - for Individual Vertices and Vertex Groups", van der Grinten et
+     * al, SDM 2021.
+     * The algorithm runs in two steps: solves a linear system and samples uniform spanning
+     * trees (USTs). The parameter @a kappa balances the tolerance of solver for the linear system
+     * and the number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver
+     * converges faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
+     * Note: the algorithm requires as input an augmented graph (see the reference paper for
+     * details). An augmented graphs can be generated with GraphTools::createAugmentedGraph.
+     *
+     * @param G The input graph. Must be an augmented graph (an augmented graph can be crated with
+     * GraphTools::createAugmentedGraph.
+     * @param root Root node of the augmented graph.
+     * @param epsilon Maximum absolute error of the elements in the diagonal.
+     * @param kappa Balances the tolerance of the solver for the linear system and the number of
+     * USTs to be sampled.
+     */
+    explicit ForestCentrality(const Graph &G, node root, double epsilon = 0.1, double kappa = 0.3);
+
+    /**
+     * Run the algorithm.
+     */
+    void run() override;
+
+    /**
+     * Return an epsilon-approximation of the diagonal of the forest matrix.
+     *
+     * @return Approximation of the diagonal of the forest matrix.
+     */
+    const std::vector<double> &getDiagonal() const {
+        assureFinished();
+        return diagonal;
+    }
+
+    /**
+     * Return the number of sampled USTs.
+     *
+     * @return Number of sampled USTs.
+     */
+    count getNumberOfSamples() const noexcept { return numberOfUSTs; }
+
+private:
+    node root;
+    const double epsilon, kappa, volG;
+    const count numberOfUSTs;
+
+    // Used to mark the status of each node, one vector per thread
+    std::vector<std::vector<uint8_t>> statusGlobal;
+
+    // Pointers to the parent of the UST, one vector per thread
+    std::vector<std::vector<node>> parentsGlobal;
+
+    // Nodes sorted by decreasing degree
+    std::vector<node> decDegree;
+
+    // Non-normalized approx effective resistance, one per thread.
+    std::vector<std::vector<count>> approxEffResistanceGlobal;
+
+    // Distributions for selecting random neighbors
+    std::vector<std::uniform_int_distribution<count>> uniformDistr;
+
+    // Solution of the linear system
+    Vector linearSysSol;
+
+    // Diagonal elements
+    std::vector<double> diagonal;
+
+    count computeNumberOfUSTs() const {
+        return count{4}
+               * static_cast<count>(std::ceil(
+                   std::log(2.0 * static_cast<double>(G.numberOfEdges()) * G.numberOfNodes())
+                   / (2.0 * epsilon * epsilon)));
+    }
+
+    void sampleUSTs();
+    void solveLinearSystem();
+    void computeDiagonal();
+    void computeScores();
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_CENTRALITY_FOREST_CENTRALITY_HPP_

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -384,6 +384,18 @@ std::vector<node> invertContinuousNodeIds(const std::unordered_map<node, node> &
 Graph restoreGraph(const std::vector<node> &invertedIdMap, const Graph &G);
 
 /**
+ * Augments the input graph in-place as required by ForestCentrality. With respect to the input
+ * graph G, the augmented graph has a new root node connected to all the other nodes in the graph.
+ */
+node augmentGraph(Graph &G);
+
+/**
+ * Constructs an augmented graph as required by ForestCentrality. With respect to the input graph G,
+ * the augmented graph has a new root node connected to all the other nodes in the graph.
+ */
+std::pair<Graph, node> createAugmentedGraph(const Graph &G);
+
+/**
  * Sorts the adjacency arrays by increasing or decreasing edge weight. Edge ids are used
  * to break ties.
  *

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -2640,6 +2640,58 @@ cdef class ApproxElectricalCloseness(Centrality):
 		return (<_ApproxElectricalCloseness*>self._this).computeExactDiagonal(tol)
 
 
+cdef extern from "<networkit/centrality/ForestCentrality.hpp>":
+	cdef cppclass _ForestCentrality "NetworKit::ForestCentrality"(_Centrality):
+		_ForestCentrality(_Graph G, node root, double eps, double kappa) except +
+		vector[double] &getDiagonal() except +
+
+cdef class ForestCentrality(Centrality):
+	"""
+	ForestCentrality(G, root, eps = 0.1, kappa = 0.3)
+	
+	Approximates the forest closeness centrality of all the vertices of a graph by approximating
+	the diagonal of the forest matrix of @a G. Every element of the diagonal is guaranteed to
+	have a maximum absolute error of @a epsilon. Based on "New Approximation Algorithms for
+	Forest Closeness Centrality - for Individual Vertices and Vertex Groups", van der Grinten et
+	al, SDM 2021.
+	The algorithm runs in two steps: solves a linear system and samples uniform spanning
+	trees (USTs). The parameter @a kappa balances the tolerance of solver for the linear system
+	and the number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver
+	converges faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
+	Note: the algorithm requires as input an augmented graph (see the reference paper for
+	details). An augmented graphs can be generated with graphtools.createAugmentedGraph.
+
+	Parameters
+	----------
+	G : networkit.Graph
+		The input graph. Must be an augmented graph (an augmented graph can be crated with
+		graphtools.createAugmentedGraph.
+	root : int
+		Root node of the augmented graph.
+	epsilon : float, optional
+		Maximum absolute error of the elements in the diagonal. Default: 0.1
+	kappa : float, option
+		Balances the tolerance of the solver for the linear system and the number of
+		USTs to be sampled. Default: 0.3
+	"""
+
+	def __cinit__(self, Graph G, node root, double eps = 0.1, double kappa = 0.3):
+		self._G = G
+		self._this = new _ForestCentrality(G._this, root, eps, kappa)
+
+	def getDiagonal(self):
+		"""
+		getDiagonal()
+
+		Return an epsilon-approximation of the diagonal of the forest matrix.
+
+		Returns
+		-------
+		list(float)
+			Approximation of the diagonal of the laplacian's pseudoinverse.
+		"""
+		return (<_ForestCentrality*>self._this).getDiagonal()
+
 cdef extern from "<networkit/centrality/ApproxSpanningEdge.hpp>":
 	cdef cppclass _ApproxSpanningEdge "NetworKit::ApproxSpanningEdge"(_Algorithm):
 		_ApproxSpanningEdge(_Graph G, double eps) except +

--- a/networkit/cpp/centrality/CMakeLists.txt
+++ b/networkit/cpp/centrality/CMakeLists.txt
@@ -16,6 +16,7 @@ networkit_add_module(centrality
     DynTopHarmonicCloseness.cpp
     EigenvectorCentrality.cpp
     EstimateBetweenness.cpp
+    ForestCentrality.cpp
     GedWalk.cpp
     GroupCloseness.cpp
     GroupClosenessLocalSearch.cpp

--- a/networkit/cpp/centrality/ForestCentrality.cpp
+++ b/networkit/cpp/centrality/ForestCentrality.cpp
@@ -1,0 +1,149 @@
+/*
+ * ForestCentrality.cpp
+ *
+ *  Created on: 17.10.2019
+ *      Author: Eugenio Angriman <angrimae@hu-berlin.de>
+ */
+
+#include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/auxiliary/Log.hpp>
+#include <networkit/auxiliary/Random.hpp>
+#include <networkit/centrality/ForestCentrality.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/numerics/ConjugateGradient.hpp>
+#include <networkit/numerics/Preconditioner/DiagonalPreconditioner.hpp>
+
+namespace NetworKit {
+
+ForestCentrality::ForestCentrality(const Graph &G, node root, double inputEpsilon, double kappa)
+    : Centrality(G), root(root), epsilon(inputEpsilon), kappa(kappa), volG(GraphTools::volume(G)),
+      numberOfUSTs(computeNumberOfUSTs()), decDegree(G.nodeRange().begin(), G.nodeRange().end()) {
+
+    if (G.isWeighted())
+        WARN("ForestCentrality ignores edge weights.");
+
+    if (G.isDirected())
+        throw std::runtime_error("The input graph must be undirected.");
+
+    if (G.numberOfNodes() != G.upperNodeIdBound())
+        throw std::runtime_error("The graph must be compact");
+
+    if (G.degree(root) != G.numberOfNodes() - 1)
+        throw std::runtime_error("The input graph is not an augmented graph. Create an augmented "
+                                 "graph with GraphTools::createAugmentedGraph.");
+
+    const auto n = G.upperNodeIdBound();
+    parentsGlobal.resize(omp_get_max_threads(), std::vector<node>(n));
+    statusGlobal.resize(omp_get_max_threads(), std::vector<uint8_t>(n));
+    std::sort(decDegree.begin(), decDegree.end(),
+              [&G](node n1, node n2) { return G.degree(n1) < G.degree(n2); });
+
+    diagonal.resize(n);
+
+    approxEffResistanceGlobal.resize(omp_get_max_threads(), std::vector<count>(n));
+    G.forNodes([&](node u) {
+        const auto degU = G.degree(u);
+        if (degU == 0)
+            uniformDistr.emplace_back();
+        else
+            uniformDistr.emplace_back(0, degU - 1);
+    });
+}
+
+void ForestCentrality::run() {
+    sampleUSTs();
+    computeDiagonal();
+    computeScores();
+    hasRun = true;
+}
+
+void ForestCentrality::sampleUSTs() {
+#pragma omp parallel
+    {
+        if (omp_get_thread_num() == 0)
+            solveLinearSystem(); // Thread 0 solves the linear system
+
+#pragma omp for schedule(dynamic)
+        for (omp_index i = 0; i < static_cast<omp_index>(numberOfUSTs); ++i) {
+            // Getting thread-local vectors
+            const omp_index thread = omp_get_thread_num();
+            auto &parent = parentsGlobal[thread];
+            auto &r = approxEffResistanceGlobal[thread];
+            auto &status = statusGlobal[thread];
+            auto &generator = Aux::Random::getURNG();
+            uint8_t rootStatus = ++status[root];
+
+            count nodesInUST = 1;
+
+            for (const node walkStart : decDegree) {
+                if (status[walkStart] == rootStatus)
+                    continue;
+
+                node currentNode = walkStart;
+                do {
+                    auto idx = uniformDistr[currentNode](generator);
+                    assert(idx < G.degree(currentNode));
+                    const node randomNeighbor = G.getIthNeighbor(currentNode, idx);
+                    parent[currentNode] = randomNeighbor;
+                    currentNode = randomNeighbor;
+                } while (status[currentNode] != rootStatus);
+
+                const node walkEnd = currentNode;
+                node next = parent[walkStart];
+                currentNode = walkStart;
+                do {
+                    status[currentNode] = rootStatus;
+                    r[currentNode] += static_cast<count>(next == root);
+                    currentNode = next;
+                    next = parent[next];
+                    ++nodesInUST;
+                } while (currentNode != walkEnd);
+
+                if (nodesInUST == G.numberOfNodes())
+                    break;
+            }
+        }
+    }
+}
+
+void ForestCentrality::solveLinearSystem() {
+    const count n = G.numberOfNodes();
+    const auto L = CSRMatrix::laplacianMatrix(G);
+    const double c = static_cast<double>(n) / volG;
+    const double eta = kappa * epsilon / (6. * (c + 2.) * volG);
+    ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg(eta);
+    cg.setupConnected(L);
+
+    Vector rhs(n);
+    linearSysSol = Vector(n);
+    G.parallelForNodes([&](node u) { rhs[u] = -1. / static_cast<double>(n); });
+    rhs[root] += 1.;
+    cg.solve(rhs, linearSysSol);
+
+    // Ensure that column sum is 0
+    const double columnSum = G.parallelSumForNodes([&](node u) { return linearSysSol[u]; });
+    linearSysSol -= columnSum / static_cast<double>(n);
+}
+
+void ForestCentrality::computeDiagonal() {
+    diagonal.resize(G.upperNodeIdBound());
+    G.parallelForNodes([&](node u) {
+        double aggr = 0;
+        for (const auto &approxEffResLocal : approxEffResistanceGlobal)
+            aggr += static_cast<double>(approxEffResLocal[u]);
+        diagonal[u] = std::max(0., aggr / static_cast<double>(numberOfUSTs) - linearSysSol[root]
+                                       + 2. * linearSysSol[u]);
+    });
+}
+
+void ForestCentrality::computeScores() {
+    const auto n = G.upperNodeIdBound();
+    scoreData.resize(n);
+    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.0);
+    G.parallelForNodes([&](node u) {
+        const double farness = static_cast<double>(n) * diagonal[u] + trace - 2.0;
+        scoreData[u] = static_cast<double>(n) / farness;
+    });
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -27,6 +27,7 @@
 #include <networkit/centrality/DynTopHarmonicCloseness.hpp>
 #include <networkit/centrality/EigenvectorCentrality.hpp>
 #include <networkit/centrality/EstimateBetweenness.hpp>
+#include <networkit/centrality/ForestCentrality.hpp>
 #include <networkit/centrality/GedWalk.hpp>
 #include <networkit/centrality/GroupCloseness.hpp>
 #include <networkit/centrality/GroupClosenessGrowShrink.hpp>
@@ -2195,6 +2196,42 @@ TEST_P(CentralityGTest, testGroupClosenessLocalSearch) {
     gcls2.run();
 
     EXPECT_EQ(gcls2.numberOfIterations(), 0);
+}
+
+TEST_F(CentralityGTest, testForestCentrality) {
+    {
+        // Directed graphs are not supported
+        Graph G(10, true, true);
+        G.addEdge(0, 1);
+        EXPECT_THROW(ForestCentrality(G, 0), std::runtime_error);
+
+        // Non-augmented graph
+        G = GraphTools::toUndirected(G);
+        G = GraphTools::toUnweighted(G);
+        EXPECT_THROW(ForestCentrality(G, 0), std::runtime_error);
+
+        // Augmented but non-compact graph
+        node root = GraphTools::augmentGraph(G);
+        G.removeNode(5);
+        EXPECT_THROW(ForestCentrality(G, root), std::runtime_error);
+    }
+
+    Aux::Random::setSeed(42, true);
+    auto G = HyperbolicGenerator(200).generate();
+    const node root = GraphTools::augmentGraph(G);
+
+    const double eps = 0.05;
+
+    ForestCentrality fc(G, root, eps);
+    fc.run();
+    EXPECT_GT(fc.getNumberOfSamples(), 0);
+    const auto apxDiag = fc.getDiagonal();
+
+    ApproxElectricalCloseness ele(G);
+    const auto diag = ele.computeExactDiagonal();
+    G.forNodes([&](node u) { EXPECT_NEAR(apxDiag[u], diag[u], eps); });
+
+    EXPECT_EQ(fc.scores().size(), G.upperNodeIdBound());
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -907,13 +907,10 @@ void Graph::setWeightAtIthNeighbor(Unsafe, node u, index i, edgeweight ew) {
 /** SUMS **/
 
 edgeweight Graph::totalEdgeWeight() const noexcept {
-    if (weighted) {
-        edgeweight sum = 0.0;
-        forEdges([&](node, node, edgeweight ew) { sum += ew; });
-        return sum;
-    } else {
+    if (weighted)
+        return parallelSumForEdges([](node, node, edgeweight ew) { return ew; });
+    else
         return numberOfEdges() * defaultEdgeWeight;
-    }
 }
 
 bool Graph::checkConsistency() const {

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -485,6 +485,21 @@ Graph restoreGraph(const std::vector<node> &invertedIdMap, const Graph &G) {
     return Goriginal;
 }
 
+node augmentGraph(Graph &G) {
+    const node root = G.addNode();
+    G.forNodes([&](node u) {
+        if (u != root)
+            G.addEdge(u, root);
+    });
+    return root;
+}
+
+std::pair<Graph, node> createAugmentedGraph(const Graph &G) {
+    Graph augmented(G);
+    node root = augmentGraph(augmented);
+    return {augmented, root};
+}
+
 void sortEdgesByWeight(Graph &G, bool decreasing) {
     if (decreasing)
         G.sortEdges([](auto e1, auto e2) {

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -548,6 +548,22 @@ TEST_F(GraphToolsGTest, testRestoreGraph) {
     EXPECT_EQ(Goriginal.isWeighted(), Gcompact.isWeighted());
 }
 
+TEST_F(GraphToolsGTest, testAugmentedGraph) {
+    Aux::Random::setSeed(42, false);
+    const count n = 500;
+    auto G = ErdosRenyiGenerator(n, 0.05).generate();
+    node root;
+    Graph augG;
+    std::tie(augG, root) = GraphTools::createAugmentedGraph(G);
+
+    EXPECT_TRUE(augG.hasNode(root));
+    EXPECT_EQ(n + 1, augG.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges() + n, augG.numberOfEdges());
+    EXPECT_EQ(n, augG.degree(root));
+
+    G.parallelForNodes([&](node u) { EXPECT_TRUE(augG.hasEdge(u, root)); });
+}
+
 TEST_P(GraphToolsGTest, testGetRemappedGraph) {
     const auto n = 4;
     Graph G(n, weighted(), directed());

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -433,7 +433,7 @@ TEST_F(GraphToolsGTest, testGetCompactedGraphUndirectedWeighted1) {
     auto nodeMap = GraphTools::getContinuousNodeIds(G);
     auto Gcompact = GraphTools::getCompactedGraph(G, nodeMap);
 
-    EXPECT_EQ(G.totalEdgeWeight(), Gcompact.totalEdgeWeight());
+    EXPECT_DOUBLE_EQ(G.totalEdgeWeight(), Gcompact.totalEdgeWeight());
     EXPECT_NE(G.upperNodeIdBound(), Gcompact.upperNodeIdBound());
     EXPECT_EQ(G.numberOfNodes(), Gcompact.numberOfNodes());
     EXPECT_EQ(G.numberOfEdges(), Gcompact.numberOfEdges());
@@ -460,7 +460,7 @@ TEST_F(GraphToolsGTest, testGetCompactedGraphDirectedWeighted1) {
     auto nodeMap = GraphTools::getContinuousNodeIds(G);
     auto Gcompact = GraphTools::getCompactedGraph(G, nodeMap);
 
-    EXPECT_EQ(G.totalEdgeWeight(), Gcompact.totalEdgeWeight());
+    EXPECT_DOUBLE_EQ(G.totalEdgeWeight(), Gcompact.totalEdgeWeight());
     EXPECT_NE(G.upperNodeIdBound(), Gcompact.upperNodeIdBound());
     EXPECT_EQ(G.numberOfNodes(), Gcompact.numberOfNodes());
     EXPECT_EQ(G.numberOfEdges(), Gcompact.numberOfEdges());
@@ -486,7 +486,7 @@ TEST_F(GraphToolsGTest, testGetCompactedGraphDirectedUnweighted1) {
     auto nodeMap = GraphTools::getContinuousNodeIds(G);
     auto Gcompact = GraphTools::getCompactedGraph(G, nodeMap);
 
-    EXPECT_EQ(G.totalEdgeWeight(), Gcompact.totalEdgeWeight());
+    EXPECT_DOUBLE_EQ(G.totalEdgeWeight(), Gcompact.totalEdgeWeight());
     EXPECT_NE(G.upperNodeIdBound(), Gcompact.upperNodeIdBound());
     EXPECT_EQ(G.numberOfNodes(), Gcompact.numberOfNodes());
     EXPECT_EQ(G.numberOfEdges(), Gcompact.numberOfEdges());
@@ -540,7 +540,7 @@ TEST_F(GraphToolsGTest, testRestoreGraph) {
     auto Gcompact = GraphTools::getCompactedGraph(G, nodeMap);
     Graph Goriginal = GraphTools::restoreGraph(invertedNodeMap, Gcompact);
 
-    EXPECT_EQ(Goriginal.totalEdgeWeight(), Gcompact.totalEdgeWeight());
+    EXPECT_DOUBLE_EQ(Goriginal.totalEdgeWeight(), Gcompact.totalEdgeWeight());
     EXPECT_NE(Goriginal.upperNodeIdBound(), Gcompact.upperNodeIdBound());
     EXPECT_EQ(Goriginal.numberOfNodes(), Gcompact.numberOfNodes());
     EXPECT_EQ(Goriginal.numberOfEdges(), Gcompact.numberOfEdges());
@@ -815,7 +815,7 @@ TEST_P(GraphToolsGTest, testTranspose) {
         EXPECT_EQ(G.upperNodeIdBound(), Gtrans.upperNodeIdBound());
         EXPECT_EQ(G.numberOfEdges(), Gtrans.numberOfEdges());
         EXPECT_EQ(G.upperEdgeIdBound(), Gtrans.upperEdgeIdBound());
-        EXPECT_EQ(G.totalEdgeWeight(), Gtrans.totalEdgeWeight());
+        EXPECT_DOUBLE_EQ(G.totalEdgeWeight(), Gtrans.totalEdgeWeight());
         EXPECT_EQ(G.numberOfSelfLoops(), Gtrans.numberOfSelfLoops());
 
         // test for regular edges

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -44,6 +44,8 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
 	void sortEdgesByWeight(_Graph G, bool_t) nogil except +
 	vector[node] topologicalSort(_Graph G) nogil except +
+	node augmentGraph(_Graph G) nogil except +
+	pair[_Graph, node] createAugmentedGraph(_Graph G) nogil except +
 
 cdef class GraphTools:
 
@@ -647,3 +649,42 @@ cdef class GraphTools:
 			The directed input graph.
 		"""
 		return topologicalSort(G._this)
+
+	@staticmethod
+	def augmentGraph(Graph G):
+		"""
+		Augments the input graph in-place as required by ForestCentrality. With respect to the input
+		graph G, the augmented graph has a new root node connected to all the other nodes in the graph.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph (undirected).
+
+		Returns
+		-------
+		int
+			Returns the node id of the new root node.
+		"""
+		return augmentGraph(G._this)
+
+	@staticmethod
+	def createAugmentedGraph(Graph G):
+		"""
+		Constructs an augmented graph as required by ForestCentrality. With respect to the input
+		graph G, the augmented graph has a new root node connected to all the other nodes in the
+		graph.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph (undirected).
+
+		Returns
+		-------
+		pair(networkit.Graph, int)
+			Returns a pair (G, root) where G is the augmented graph and root is the id of the root
+			node.
+		"""
+		result = createAugmentedGraph(G._this)
+		return Graph().setThis(result.first), result.second

--- a/networkit/test/test_centrality.py
+++ b/networkit/test/test_centrality.py
@@ -2,6 +2,8 @@
 import unittest
 import os
 import networkit as nk
+import numpy as np
+import scipy
 
 
 class Test_Centrality(unittest.TestCase):
@@ -27,6 +29,23 @@ class Test_Centrality(unittest.TestCase):
 		dc = nk.centrality.DegreeCentrality(g).run().scores()
 
 		self.assertListEqual(expected_result, dc)
+
+	def test_ForestCentralty(self):
+		nk.engineering.setSeed(42, False)
+		eps = 0.05
+		g = nk.generators.HyperbolicGenerator(200).generate()
+		root = nk.graphtools.augmentGraph(g)
+
+		fc = nk.centrality.ForestCentrality(g, root, eps)
+		fc.run()
+		apxDiag = fc.getDiagonal()
+
+		A = nk.algebraic.adjacencyMatrix(g, "dense")
+		Fmat = scipy.sparse.csgraph.laplacian(A)
+		diag = np.linalg.pinv(Fmat).diagonal()
+
+		for apx, exact in zip(apxDiag, diag):
+			self.assertLessEqual(abs(apx - exact), eps)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -523,5 +523,16 @@ class TestGraphTools(unittest.TestCase):
 				self.assertLess(indexNode2, indexNode1)
 				self.assertLess(indexNode1, indexNode3)
 
+	def testAugmentedGraph(self):
+		nk.engineering.setSeed(42, False)
+		n = 20
+		G = nk.generators.ErdosRenyiGenerator(n, 0.3).generate()
+		augG, root = nk.graphtools.createAugmentedGraph(G);
+
+		self.assertTrue(augG.hasNode(root));
+		self.assertEqual(n + 1, augG.numberOfNodes());
+		self.assertEqual(G.numberOfEdges() + n, augG.numberOfEdges());
+		self.assertEqual(n, augG.degree(root));
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This PR brings the algorithm for forest centrality approximation based on the paper "New Approximation Algorithms for Forest Closeness Centrality - for Individual Vertices and Vertex Groups". Due to some unresolved issues, the algorithm does not yet support weighted graphs. The algorithm for group forest maximization will be added in a later PR.

Additional changes:
- Graph: parallel computation of the sum of the edge weights of the graph (this is useful for the weighted version of the algorithm).
- New GraphTools functions `augmentGraph` and `createAugmentedGraph` to generate the augmented graph required by the algorithm. The first builds the augmented graph in-place, the latter constructs an augmented graph from a copy of the input graph.