### PR TITLE
Fix Unreachable ttmath Library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/tlx/tlx
 [submodule "extlibs/ttmath"]
 	path = extlibs/ttmath
-	url = https://gitea.ttmath.org/tomasz.sowa/ttmath
+	url = https://github.com/networkit/ttmath


### PR DESCRIPTION
The `ttmath` library [1] is unreachable at the moment. For better reliability, I updated the submodule to a fork of ttmath within the NetworKit organization.

[1] https://gitea.ttmath.org/tomasz.sowa/ttmath