### PR TITLE
Update GHA: new images (windows-2022, macos-11), Python 3.10, Clang 4.0, MSVC 14.31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,25 +99,24 @@ env:
 
 jobs:
   macos-build-latest-version-apple-clang:
-    name: "macOS ${{ matrix.os }} (apple-clang, CPython 3.9): ${{ matrix.build-configuration }}"
+    name: "macOS ${{ matrix.os }} (apple-clang, CPython 3.10): ${{ matrix.build-configuration }}"
     runs-on: macos-${{ matrix.os }}
     env:
       CC: cc
       CXX: c++
     strategy:
       matrix:
-        os: ['10.15'] # 11.0 temp. removed due to errors in preview image / git actions pipelines
+        os: ['11']
         build-configuration: ['full', 'full (native)']
-    continue-on-error: ${{ matrix.os == '11.0' }}
     steps:
       - name: Install prerequisites
         run: |
           brew install libomp
           brew install ninja
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v2
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:
@@ -139,9 +138,8 @@ jobs:
     runs-on: macos-${{ matrix.os }}
     strategy:
       matrix:
-        os: ['10.15']  # 11.0 temp. removed due to errors in preview image / git actions pipelines
+        os: ['11']
         compiler: ['clang-13', 'gcc-11']
-    continue-on-error: ${{ matrix.os == '11.0' }}
     steps:
       - name: Install prerequisites
         run: |
@@ -169,7 +167,7 @@ jobs:
           CXX: ${{ matrix.compiler == 'clang-13' && '/usr/local/opt/llvm@13/bin/clang++' || 'g++-11' }}
 
   linux-build-latest:
-    name: "Linux (gcc-11${{ startsWith(matrix.build-configuration, 'full') && ', CPython 3.9' || '' }}): ${{ matrix.build-configuration }}"
+    name: "Linux (gcc-11${{ startsWith(matrix.build-configuration, 'full') && ', CPython 3.10' || '' }}): ${{ matrix.build-configuration }}"
     runs-on: ubuntu-20.04
     env:
       CC: gcc-11
@@ -180,13 +178,13 @@ jobs:
     steps:
       - name: Install prerequisites
         run:  |
-          sudo add-apt-repository 'deb http://mirrors.kernel.org/ubuntu hirsute main universe'
+          sudo add-apt-repository 'deb http://mirrors.kernel.org/ubuntu impish main universe'
           sudo apt-get update
           sudo apt-get install gcc-11 g++-11 ninja-build
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v2
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:
@@ -236,22 +234,22 @@ jobs:
           CXX: clang++-13
 
   linux-build-min-support:
-    name: "Linux (${{ matrix.compiler }}, CPython 3.6): full"
+    name: "Linux (${{ matrix.compiler }}, CPython 3.7): full"
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        compiler: ['gcc-6', 'clang-3.9']
+        compiler: ['gcc-6', 'clang-4.0']
     steps:
       - name: Install prerequisites
         run:  |
           sudo apt-get update
           sudo apt-get install ninja-build
-          sudo apt-get install libomp5 libomp-dev clang-3.9 clang++-3.9
+          sudo apt-get install libomp5 libomp-dev clang-4.0 clang++-4.0
           sudo apt-get install gcc-6 g++-6
-      - name: Setup Python 3.6
-        uses: actions/setup-python@v2
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: '3.7'
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:
@@ -265,8 +263,8 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/full.sh
         shell: bash
         env:
-          CC: ${{ matrix.compiler == 'gcc-6' && 'gcc-6' || 'clang-3.9' }}
-          CXX: ${{ matrix.compiler == 'gcc-6' && 'g++-6' || 'clang++-3.9' }}
+          CC: ${{ matrix.compiler == 'gcc-6' && 'gcc-6' || 'clang-4.0' }}
+          CXX: ${{ matrix.compiler == 'gcc-6' && 'g++-6' || 'clang++-4.0' }}
 
   linux-build-clang-tidy:
     name: "Linux (clang-13): clang-tidy"
@@ -290,20 +288,21 @@ jobs:
         shell: bash
 
   linux-build-core-sanitizers-coverage:
-    name: "Linux (gcc-10, CPython 3.9): coverage"
+    name: "Linux (gcc-11, CPython 3.10): coverage"
     runs-on: ubuntu-20.04
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc-11
+      CXX: g++-11
     steps:
       - name: Install prerequisites
         run:  |
+          sudo add-apt-repository 'deb http://mirrors.kernel.org/ubuntu impish main universe'
           sudo apt-get update
-          sudo apt-get install ninja-build
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v2
+          sudo apt-get install gcc-11 g++-11 ninja-build
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -325,8 +324,8 @@ jobs:
           COVERALLS_SVC_NUM: ${{ github.run_number }}
 
   windows-build-msvc:
-    name: "Windows (msvc 14.28): ${{ matrix.build-configuration }}"
-    runs-on: windows-2019
+    name: "Windows (msvc 14.31): ${{ matrix.build-configuration }}"
+    runs-on: windows-2022
     strategy:
       matrix:
         build-configuration: ['core']
@@ -346,16 +345,16 @@ jobs:
           ctest -V -C Debug
 
   windows-build-latest:
-    name: "Windows (msvc 14.28, CPython 3.9): ${{ matrix.build-configuration }}"
-    runs-on: windows-2019
+    name: "Windows (msvc 14.31, CPython 3.10): ${{ matrix.build-configuration }}"
+    runs-on: windows-2022
     strategy:
       matrix:
         build-configuration: ['full', 'full (native)']
     steps:
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v2
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:
@@ -393,16 +392,22 @@ jobs:
           NATIVE: ${{ matrix.os == 'full (native)' }}
 
   documentation-build:
-    name: "Linux (gcc-10, CPython 3.9): documentation"
+    name: "Linux (gcc-11, CPython 3.10): documentation"
     runs-on: ubuntu-20.04
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc-11
+      CXX: g++-11
     steps:
       - name: Install prerequisites
         run:  |
+          sudo add-apt-repository 'deb http://mirrors.kernel.org/ubuntu impish main universe'
           sudo apt-get update
+          sudo apt-get install gcc-11 g++-11 ninja-build
           sudo apt-get install doxygen pandoc
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:
@@ -429,9 +434,9 @@ jobs:
       - name: Install prerequisites
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-11 main" | sudo tee /etc/apt/sources.list.d/llvm11.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-13 main" | sudo tee /etc/apt/sources.list.d/llvm11.list
           sudo apt-get update
-          sudo apt-get install clang-format-11 python-yaml
+          sudo apt-get install clang-format-13 python-yaml
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/scripts/documentation.sh
+++ b/.github/workflows/scripts/documentation.sh
@@ -9,7 +9,7 @@ pip3 install --upgrade pip
 pip3 install cython
 
 # Several modules are required to build the documentation.
-pip3 install 'sphinx<4.1' sphinx_bootstrap_theme numpydoc exhale nbsphinx breathe
+pip3 install 'Jinja2<3.1.0' sphinx sphinx_bootstrap_theme numpydoc exhale nbsphinx breathe
 pip3 install sphinx_copybutton sphinxcontrib.bibtex sphinx_gallery sphinx_last_updated_by_git 
 pip3 install ipykernel ipython matplotlib nbconvert jupyter-client networkx tabulate
 pip3 install ipycytoscape plotly seaborn


### PR DESCRIPTION
This PR updates CI pipeline:

- Minimum versions: clang 3.9 -> 4.0, Python 3.6 -> 3.7
- Images: windows-2019 -> windows-2022, macos-10.15 -> macos-11
- Latest versions: Python 3.9 -> 3.10, gcc 11.1 -> 11.2, clang-format 11 -> 13