### PR TITLE
Add option to return distances as numpy arrays.

### DIFF
--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -6,18 +6,13 @@ from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 from libcpp cimport bool as bool_t
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-ctypedef double edgeweight
-
 import math
 from enum import Enum
 
 from .base cimport _Algorithm, Algorithm
 from .dynamics cimport _GraphEvent, GraphEvent
 from .graph cimport _Graph, Graph
-from .structures cimport _Cover, Cover, _Partition, Partition
+from .structures cimport _Cover, Cover, _Partition, Partition, count, index, node, edgeweight
 from networkit.algebraic import adjacencyEigenvector, PageRankMatrix, symmetricEigenvectors
 
 cdef extern from "limits.h":

--- a/networkit/clique.pyx
+++ b/networkit/clique.pyx
@@ -1,16 +1,13 @@
 # distutils: language=c++
 
 from cython.operator import dereference, preincrement
-from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
 from libcpp cimport bool as bool_t
 from libcpp.string cimport string
 
-ctypedef uint64_t index
-ctypedef index node
-
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
+from .structures cimport index, node
 
 cdef extern from "cython_helper.h":
 	void throw_runtime_error(string message)
@@ -134,5 +131,3 @@ cdef class MaximalCliques(Algorithm):
 			A list of cliques, each being represented as a list of nodes.
 		"""
 		return (<_MaximalCliques*>(self._this)).getCliques()
-
-

--- a/networkit/coarsening.pyx
+++ b/networkit/coarsening.pyx
@@ -1,17 +1,13 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libcpp cimport bool as bool_t
 from libcpp.map cimport map
 from libcpp.vector cimport vector
 
-ctypedef uint64_t index
-ctypedef index node
-
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
 from .matching cimport _Matching, Matching
-from .structures cimport _Cover, Cover, _Partition, Partition
+from .structures cimport _Cover, Cover, _Partition, Partition, index, node
 
 cdef extern from "<networkit/coarsening/GraphCoarsening.hpp>":
 
@@ -118,4 +114,3 @@ cdef class MatchingCoarsening(GraphCoarsening):
 
 	def __cinit__(self, Graph G not None, Matching M not None, bool_t noSelfLoops=False):
 		self._this = new _MatchingCoarsening(G._this, M._this, noSelfLoops)
-

--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -1,7 +1,5 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
-
 from libcpp.string cimport string
 from libcpp cimport bool as bool_t
 from libcpp.vector cimport vector
@@ -21,14 +19,9 @@ else:
 import tempfile
 import subprocess
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-ctypedef double edgeweight
-
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
-from .structures cimport _Partition, Partition, _Cover, Cover
+from .structures cimport _Partition, Partition, _Cover, Cover, count, index, node, edgeweight
 from .graphio import PartitionReader, PartitionWriter, EdgeListPartitionReader, BinaryPartitionReader, BinaryPartitionWriter, BinaryEdgeListPartitionReader, BinaryEdgeListPartitionWriter
 from .scd cimport _SelectiveCommunityDetector, SelectiveCommunityDetector
 

--- a/networkit/components.pyx
+++ b/networkit/components.pyx
@@ -1,18 +1,13 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libcpp cimport bool as bool_t
 from libcpp.vector cimport vector
 from libcpp.map cimport map
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-
 from .base cimport _Algorithm, Algorithm
 from .dynamics cimport _GraphEvent, GraphEvent
 from .graph cimport _Graph, Graph
-from .structures cimport _Partition, Partition
+from .structures cimport _Partition, Partition, count, index, node
 
 cdef extern from "<networkit/components/ConnectedComponents.hpp>":
 
@@ -732,5 +727,3 @@ cdef class DynWeaklyConnectedComponents(Algorithm):
 		for event in batch:
 			_batch.push_back(_GraphEvent(event.type, event.u, event.v, event.w))
 		(<_DynWeaklyConnectedComponents*>(self._this)).updateBatch(_batch)
-
-

--- a/networkit/distance.pyx
+++ b/networkit/distance.pyx
@@ -178,17 +178,17 @@ cdef class SSSP(Algorithm):
 		if type(self) == SSSP:
 			raise RuntimeError("Error, you may not use SSSP directly, use a sub-class instead")
 
-	def getDistances(self, bint asarray=False):
+	def getDistances(self, asarray=None):
 		"""
-		getDistances(asarray=False)
+		getDistances(asarray=None)
 
 		Returns a list of weighted distances from the source node, i.e. the
  	 	length of the shortest path from the source node to any other node.
 
 		Parameters
 		----------
-		asarray : bool, optional
-			Return the result as a numpy array.
+		asarray : optional
+			Return the result as a numpy array. Default: Falsy.
 
  	 	Returns
  	 	-------
@@ -1182,16 +1182,16 @@ cdef class APSP(Algorithm):
 	def __dealloc__(self):
 		self._G = None
 
-	def getDistances(self, bint asarray=False):
+	def getDistances(self, asarray=None):
 		"""
-		getDistances(asarray=False)
+		getDistances(asarray=None)
 
 		Returns a vector of vectors of distances between each node pair.
 
 		Parameters
 		----------
-		asarray : bool, optional
-			Return the result as a numpy array.
+		asarray : optional
+			Return the result as a numpy array. Default: Falsy.
 
 		Returns
 		-------
@@ -1259,21 +1259,21 @@ cdef class SPSP(Algorithm):
 	def __dealloc__(self):
 		self._G = None
 
-	def getDistances(self, bint asarray=False):
+	def getDistances(self, asarray=None):
 		"""
-		getDistances(asarray=False)
+		getDistances(asarray=None)
 
 		Returns a list of lists of distances between each source node
 		and either all the other nodes (if no targets have been specified) or all target nodes.
 
 		Parameters
 		----------
-		asarray : bool, optional
-			Return the result as a numpy array.
+		asarray : optional
+			Return the result as a numpy array. Default: Falsy.
 
 		Returns
 		-------
-		list(list(float))
+		list(list(float)) or np.ndarray
 			The shortest-path distances from each source node to the target nodes (if target nodes
 			have been specified), or any other node in the graph.
 

--- a/networkit/distance.pyx
+++ b/networkit/distance.pyx
@@ -2,7 +2,6 @@
 
 from cython.operator import dereference, preincrement
 
-from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 from libcpp.map cimport map
@@ -11,15 +10,12 @@ from libcpp.string cimport string
 from libcpp.set cimport set
 from libcpp.unordered_map cimport unordered_map
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-ctypedef double edgeweight
-
 from .base cimport _Algorithm, Algorithm
 from .dynamics cimport _GraphEvent
 from .graph cimport _Graph, Graph
 from .helpers import stdstring
+from .helpers cimport maybe_asarray_1d, maybe_asarray_2d
+from .structures cimport count, index, node, edgeweight
 
 cdef extern from "<networkit/Globals.hpp>" namespace "NetworKit":
 
@@ -182,19 +178,24 @@ cdef class SSSP(Algorithm):
 		if type(self) == SSSP:
 			raise RuntimeError("Error, you may not use SSSP directly, use a sub-class instead")
 
-	def getDistances(self):
+	def getDistances(self, bint asarray=False):
 		"""
-		getDistances()
+		getDistances(asarray=False)
 
 		Returns a list of weighted distances from the source node, i.e. the
  	 	length of the shortest path from the source node to any other node.
 
+		Parameters
+		----------
+		asarray : bool, optional
+			Return the result as a numpy array.
+
  	 	Returns
  	 	-------
- 	 	list
+		list or np.ndarray
  	 		The weighted distances from the source node to any other node in the graph.
 		"""
-		return (<_SSSP*>(self._this)).getDistances()
+		return maybe_asarray_1d(&(<_SSSP*>(self._this)).getDistances(), asarray)
 
 	def distance(self, t):
 		"""
@@ -1181,21 +1182,26 @@ cdef class APSP(Algorithm):
 	def __dealloc__(self):
 		self._G = None
 
-	def getDistances(self):
-		""" 
-		getDistances()
+	def getDistances(self, bint asarray=False):
+		"""
+		getDistances(asarray=False)
 
 		Returns a vector of vectors of distances between each node pair.
 
- 	 	Returns
- 	 	-------
- 	 	list(list(float))
- 	 		The shortest-path distances from each node to any other node in the graph.
+		Parameters
+		----------
+		asarray : bool, optional
+			Return the result as a numpy array.
+
+		Returns
+		-------
+		list(list(float)) or np.ndarray
+			The shortest-path distances from each node to any other node in the graph.
 		"""
-		return (<_APSP*>(self._this)).getDistances()
+		return maybe_asarray_2d(&(<_APSP*>(self._this)).getDistances(), asarray)
 
 	def getDistance(self, node u, node v):
-		""" 
+		"""
 		getDistance(u, v)
 		
 		Returns the length of the shortest path from source u to target v.
@@ -1253,23 +1259,34 @@ cdef class SPSP(Algorithm):
 	def __dealloc__(self):
 		self._G = None
 
-	def getDistances(self):
-		""" 
-		getDistances()
-		
+	def getDistances(self, bint asarray=False):
+		"""
+		getDistances(asarray=False)
+
 		Returns a list of lists of distances between each source node
 		and either all the other nodes (if no targets have been specified) or all target nodes.
 
- 	 	Returns
- 	 	-------
- 	 	list(list(float))
+		Parameters
+		----------
+		asarray : bool, optional
+			Return the result as a numpy array.
+
+		Returns
+		-------
+		list(list(float))
 			The shortest-path distances from each source node to the target nodes (if target nodes
 			have been specified), or any other node in the graph.
+
+		Returns
+		-------
+		list(list(float)) or np.ndarray
+			The shortest-path distances from each source node to any other node
+			in the graph.
 		"""
-		return (<_SPSP*>self._this).getDistances()
+		return maybe_asarray_2d(&(<_SPSP*>self._this).getDistances(), asarray)
 
 	def getDistance(self, node u, node v):
-		""" 
+		"""
 		getDistance(u, v)
 
 		Returns the length of the shortest path from source u to target v.
@@ -1755,4 +1772,3 @@ cdef class ReverseBFS(SSSP):
 	def __cinit__(self, Graph G, source, storePaths=True, storeNodesSortedByDistance=False, target=none):
 		self._G = G
 		self._this = new _ReverseBFS(G._this, source, storePaths, storeNodesSortedByDistance, target)
-

--- a/networkit/dynamics.pxd
+++ b/networkit/dynamics.pxd
@@ -1,13 +1,9 @@
-from libc.stdint cimport uint64_t
 from libcpp cimport bool as bool_t
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-ctypedef double edgeweight
+from .structures cimport node, index, count, edgeweight
 
 cdef extern from "<networkit/dynamics/GraphEvent.hpp>" namespace "NetworKit::GraphEvent::Type":
 

--- a/networkit/embedding.pyx
+++ b/networkit/embedding.pyx
@@ -1,14 +1,11 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
-
-ctypedef uint64_t count
+from .structures cimport count
 
 cdef extern from "<networkit/embedding/Node2Vec.hpp>":
 
@@ -65,4 +62,3 @@ cdef class Node2Vec(Algorithm):
 			A vector containing feature vectors of all nodes
 		"""
 		return (<_Node2Vec*>(self._this)).getFeatures()
-

--- a/networkit/engineering.pyx
+++ b/networkit/engineering.pyx
@@ -7,8 +7,7 @@ from libc.stdint cimport uint64_t
 from libcpp.string cimport string
 from libcpp cimport bool as bool_t
 
-ctypedef uint64_t index
-ctypedef index node
+from .structures cimport index, node
 
 # local imports
 from . import stopwatch

--- a/networkit/flow.pyx
+++ b/networkit/flow.pyx
@@ -1,15 +1,10 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
-
-ctypedef uint64_t index
-ctypedef uint64_t edgeid
-ctypedef index node
-ctypedef double edgeweight
 
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
+from .structures cimport index, edgeid, node, edgeweight
 
 cdef extern from "<networkit/Globals.hpp>" namespace "NetworKit":
 

--- a/networkit/generators.pyx
+++ b/networkit/generators.pyx
@@ -6,15 +6,9 @@ import os
 import tempfile
 import scipy
 
-from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
 from libcpp cimport bool as bool_t
 from libcpp.utility cimport pair
-
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-ctypedef double coordinate
 
 from .base cimport _Algorithm, Algorithm
 from .centrality import DegreeCentrality, LocalPartitionCoverage
@@ -22,7 +16,7 @@ from .community import PLM
 from .dynamics cimport _GraphEvent, GraphEvent
 from .graph cimport _Graph, Graph
 from .graphtools import GraphTools
-from .structures cimport _Partition, Partition
+from .structures cimport _Partition, Partition, count, index, node, coordinate
 
 cdef extern from "<networkit/viz/Point.hpp>" namespace "NetworKit" nogil:
 
@@ -1862,4 +1856,3 @@ class BTERReplicator:
 			A new scaled graph.
 		"""
 		return cls(G, scale)
-

--- a/networkit/globals.pyx
+++ b/networkit/globals.pyx
@@ -1,11 +1,9 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libcpp cimport bool as bool_t
 
-ctypedef uint64_t count
-
 from .graph cimport _Graph, Graph
+from .structures cimport count
 
 
 cdef extern from "<networkit/global/ClusteringCoefficient.hpp>" namespace "NetworKit::ClusteringCoefficient":

--- a/networkit/graph.pxd
+++ b/networkit/graph.pxd
@@ -2,22 +2,14 @@
 
 from cython.operator import dereference, preincrement
 
-from libc.stdint cimport uint64_t
-
 from libcpp cimport bool as bool_t
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 from libcpp.string cimport string
 from libcpp.unordered_set cimport unordered_set
 
-ctypedef uint64_t edgeid
-ctypedef uint64_t index
-ctypedef uint64_t count
-ctypedef index node
-ctypedef double edgeweight
-
-from .base cimport _Algorithm
-from .base cimport Algorithm
+from .base cimport _Algorithm, Algorithm
+from .structures cimport edgeid, index, count, node, edgeweight
 
 cdef extern from "<algorithm>" namespace "std":
 	void swap[T](T &a,  T &b)
@@ -276,4 +268,3 @@ cdef extern from "<networkit/graph/UnionMaximumSpanningForest.hpp>":
 
 cdef class UnionMaximumSpanningForest(Algorithm):
 	cdef Graph _G
-

--- a/networkit/graphio.pyx
+++ b/networkit/graphio.pyx
@@ -1,6 +1,5 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libc.stdint cimport uint8_t
 
 from libcpp.vector cimport vector
@@ -16,14 +15,10 @@ import scipy.io
 import fnmatch
 from enum import Enum
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-
 from .dynamics import DGSWriter, DGSStreamParser
 from .graph cimport _Graph, Graph
 from .graph import Graph as __Graph
-from .structures cimport _Cover, Cover, _Partition, Partition
+from .structures cimport _Cover, Cover, _Partition, Partition, count, index, node
 from .GraphMLIO import GraphMLReader, GraphMLWriter
 from .GEXFIO import GEXFReader, GEXFWriter
 from . import algebraic

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -1,18 +1,13 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libcpp cimport bool as bool_t
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 from libcpp.unordered_map cimport unordered_map
 from libcpp.unordered_set cimport unordered_set
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-ctypedef double edgeweight
-
 from .graph cimport _Graph, Graph
+from .structures cimport count, index, node, edgeweight
 
 cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphTools":
 

--- a/networkit/helpers.pxd
+++ b/networkit/helpers.pxd
@@ -1,16 +1,14 @@
+from cython.operator cimport dereference
+
 from libcpp.string cimport string
-from libc.stdint cimport uint64_t
 from libcpp cimport bool as bool_t
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-
 from .graph cimport _Graph
 from .structures cimport _Partition, _Cover
 from .matching cimport _Matching
+from .structures cimport count, index, node, edgeweight
 
 cdef extern from "cython_helper.h":
 	void throw_runtime_error(string message)
@@ -28,3 +26,16 @@ cdef extern from "<algorithm>" namespace "std":
 	vector[pair[pair[node, node], double]] move(vector[pair[pair[node, node], double]]) nogil
 	vector[pair[node, node]] move(vector[pair[node, node]]) nogil
 
+ctypedef fused element_t:
+	edgeweight
+	node
+	double
+
+cdef asarray_1d(vector[element_t]* vec)
+cdef asarray_2d(vector[vector[element_t]]* nested)
+
+cdef inline maybe_asarray_1d(vector[element_t]* vec, bint asarray):
+	return asarray_1d[element_t](vec) if asarray else dereference(vec)
+
+cdef inline maybe_asarray_2d(vector[vector[element_t]]* nested, bint asarray):
+	return asarray_2d[element_t](nested) if asarray else dereference(nested)

--- a/networkit/helpers.pxd
+++ b/networkit/helpers.pxd
@@ -34,8 +34,8 @@ ctypedef fused element_t:
 cdef asarray_1d(vector[element_t]* vec)
 cdef asarray_2d(vector[vector[element_t]]* nested)
 
-cdef inline maybe_asarray_1d(vector[element_t]* vec, bint asarray):
+cdef inline maybe_asarray_1d(vector[element_t]* vec, asarray):
 	return asarray_1d[element_t](vec) if asarray else dereference(vec)
 
-cdef inline maybe_asarray_2d(vector[vector[element_t]]* nested, bint asarray):
+cdef inline maybe_asarray_2d(vector[vector[element_t]]* nested, asarray):
 	return asarray_2d[element_t](nested) if asarray else dereference(nested)

--- a/networkit/linkprediction.pyx
+++ b/networkit/linkprediction.pyx
@@ -1,15 +1,12 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-
 from .graph cimport _Graph, Graph
 from .support import MissingDependencyError
+from .structures cimport count, index, node
+
 import numpy as np
 import warnings
 try:

--- a/networkit/matching.pxd
+++ b/networkit/matching.pxd
@@ -1,16 +1,10 @@
-from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
 from libcpp cimport bool as bool_t
 from libcpp.string cimport string
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-ctypedef double edgeweight
-
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
-from .structures cimport _Partition, Partition
+from .structures cimport _Partition, Partition, count, index, node, edgeweight
 
 cdef extern from "cython_helper.h":
 	void throw_runtime_error(string message)

--- a/networkit/randomization.pyx
+++ b/networkit/randomization.pyx
@@ -1,16 +1,12 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libcpp cimport bool as bool_t
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
+from .structures cimport count, index, node
 
 cdef extern from "<networkit/randomization/EdgeSwitching.hpp>":
 	cdef cppclass _EdgeSwitching "NetworKit::EdgeSwitching"(_Algorithm):

--- a/networkit/reachability.pyx
+++ b/networkit/reachability.pyx
@@ -2,18 +2,14 @@
 
 from cython.operator import dereference, preincrement
 
-from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
 from libcpp cimport bool as bool_t
 from libcpp.string cimport string
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
 from .helpers import stdstring
+from .structures cimport count, index, node
 
 cdef extern from "<networkit/Globals.hpp>" namespace "NetworKit":
 

--- a/networkit/scd.pxd
+++ b/networkit/scd.pxd
@@ -1,11 +1,8 @@
-from libc.stdint cimport uint64_t
 from libcpp.map cimport map
 from libcpp.set cimport set
 
-ctypedef uint64_t index
-ctypedef index node
-
 from .graph cimport _Graph, Graph
+from .structures cimport index, node
 
 cdef extern from "<networkit/scd/SelectiveCommunityDetector.hpp>":
 

--- a/networkit/simulation.pyx
+++ b/networkit/simulation.pyx
@@ -1,15 +1,11 @@
 # distutils: language=c++
 
 from networkit.exceptions import ReducedFunctionalityWarning
-from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
-
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
 
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
+from .structures cimport count, index, node
 
 import warnings
 try:
@@ -67,6 +63,3 @@ cdef class EpidemicSimulationSEIR(Algorithm):
 			The simulation data.
 		"""
 		return pandas.DataFrame((<_EpidemicSimulationSEIR*>(self._this)).getData(), columns=["zero", "time", "state", "count"])
-
-
-

--- a/networkit/sparsification.pyx
+++ b/networkit/sparsification.pyx
@@ -1,18 +1,12 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libcpp cimport bool as bool_t
 from libcpp.vector cimport vector
-
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef uint64_t edgeid
-ctypedef index node
-ctypedef double edgeweight
 
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
 from .distance import AdamicAdarDistance, JaccardSimilarityAttributizer
+from .structures cimport count, node, index, edgeid, edgeweight
 from . import community
 from . import distance
 
@@ -1630,4 +1624,3 @@ class ConstantScore():
 			The input graph.
 		"""
 		return self.constValue
-

--- a/networkit/stats.pyx
+++ b/networkit/stats.pyx
@@ -1,10 +1,9 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 
-ctypedef uint64_t count
+from .structures cimport count
 
 cdef extern from "<networkit/auxiliary/Parallel.hpp>" namespace "Aux::Parallel":
 
@@ -37,6 +36,3 @@ def gini(values):
 		area += height - value / 2.
 	fair_area = height * len(values) / 2
 	return (fair_area - area) / fair_area
-
-
-

--- a/networkit/structures.pxd
+++ b/networkit/structures.pxd
@@ -7,6 +7,10 @@ from libcpp.string cimport string
 
 ctypedef uint64_t count
 ctypedef uint64_t index
+ctypedef uint64_t edgeid
+ctypedef index node
+ctypedef double coordinate
+ctypedef double edgeweight
 
 cdef extern from "cython_helper.h":
 	void throw_runtime_error(string message)

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -631,5 +631,22 @@ class TestSelfLoops(unittest.TestCase):
 		g.removeNode(0)
 		nk.distance.APSP(g).run()
 
+	def testDistancesAsArrayAPSP(self):
+		nk.engineering.setSeed(1, True)
+		random.seed(1)
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				g = nk.generators.ErdosRenyiGenerator(100, 0.15, directed).generate()
+				if weighted:
+					g = nk.graphtools.toWeighted(g)
+					g.forEdges(lambda u, v, ew, eid: g.setWeight(u, v, random.random()))
+				apsp = nk.distance.APSP(g)
+				apsp.run()
+				listDistances = apsp.getDistances()
+				arrayDistances = apsp.getDistances(asarray=True)
+				self.assertIsInstance(listDistances, list)
+				self.assertIsInstance(arrayDistances, np.ndarray)
+				np.testing.assert_allclose(listDistances, arrayDistances)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/traversal.pyx
+++ b/networkit/traversal.pyx
@@ -1,20 +1,14 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from cython.operator import dereference, preincrement
 
 from libcpp cimport bool as bool_t
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-ctypedef uint64_t edgeid
-ctypedef double edgeweight
-
 from .graph cimport _Graph, Graph
 from .helpers import stdstring
+from .structures cimport count, index, node, edgeid, edgeweight
 
 cdef extern from "cython_helper.h":
 	void throw_runtime_error(string message)

--- a/networkit/viz.pyx
+++ b/networkit/viz.pyx
@@ -1,17 +1,12 @@
 # distutils: language=c++
 
-from libc.stdint cimport uint64_t
 from libcpp.string cimport string
 from libcpp cimport bool as bool_t
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 
-ctypedef uint64_t count
-ctypedef uint64_t index
-ctypedef index node
-ctypedef double coordinate
-
 from .graph cimport _Graph, Graph
+from .structures cimport count, index, node, coordinate
 
 cdef extern from "<networkit/viz/Point.hpp>" namespace "NetworKit" nogil:
 
@@ -301,4 +296,3 @@ cdef class PivotMDS (GraphLayoutAlgorithm):
 		"""Constructs a PivotMDS object for the given @a graph. The algorithm should embed the graph in @a dim dimensions using @a numberOfPivots pivots."""
 		(<_PivotMDS*>(self._this)).run()
 		return self
-


### PR DESCRIPTION
Returning distances (or other lists of values) from `cython` can be a significant part of the computational cost in `networkit`. For example, consider the following snippet that gets all pairs shortest paths.


```python
def target(graph):
    apsp = nk.distance.APSP(graph).run()
    apsp.getDistances()
    
%lprun -f target [target(nk.generators.ErdosRenyiGenerator(500, 0.1).generate()) for _ in range(1000)]
```

About a third of the time is spent on *getting* distances rather than *evaluating* the distances.

```
Timer unit: 1e-06 s

Total time: 11.8565 s

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
     1                                           def target(graph):
     2      1000    7833515.0   7833.5     66.1      apsp = nk.distance.APSP(graph).run()
     3      1000    4022974.0   4023.0     33.9      apsp.getDistances()
```

This PR adds an optional argument `asarray` to the `getDistances` such that a numpy array is returned if `asarray=True`.

```python
def target(graph):
    apsp = nk.distance.APSP(graph).run()
    apsp.getDistances(asarray=True)
    
%lprun -f target [target(nk.generators.ErdosRenyiGenerator(500, 0.1).generate()) for _ in range(1000)]
```

This speeds up returning values by a factor of 11 and the `target` function by a factor of about 1.4 (in this particular example).

```
Timer unit: 1e-06 s

Total time: 8.38477 s

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
     1                                           def target(graph):
     2      1000    8041571.0   8041.6     95.9      apsp = nk.distance.APSP(graph).run()
     3      1000     343195.0    343.2      4.1      apsp.getDistances(asarray=True)
```

This PR ended up touching many more files than I anticipated because, for the fused types to work properly, all types had to "originate from the same source", i.e. we couldn't have multiple definitions of `ctypedef uint64_t index` throughout the code base but needed one `ctypedef` that was imported into other modules. This change should also help with maintainability, however.

Running more careful benchmarks (rather than just using the line profiler) indicates that these changes can give a 20x speed up compared with returning a list of lists of values and a >50x speed up compared with converting a list of lists of values to a numpy array for subsequent analysis. See [here](https://gist.github.com/tillahoffmann/ee02e08fdb1f628b39f35a61694481d7) for details.

~Apologies for the whitespace changes; my editor was a bit overeager.~