### PR TITLE
Fix APSP for non-existing nodes

### DIFF
--- a/networkit/cpp/distance/APSP.cpp
+++ b/networkit/cpp/distance/APSP.cpp
@@ -32,13 +32,12 @@ void APSP::run() {
             sssps[i] = std::unique_ptr<SSSP>(new BFS(G, 0, false));
     }
 
-#pragma omp parallel for schedule(dynamic)
-    for (omp_index source = 0; source < n; ++source) {
+    G.parallelForNodes([&](node source) {
         auto sssp = sssps[omp_get_thread_num()].get();
         sssp->setSource(source);
         sssp->run();
         distances[source] = sssp->getDistances();
-    }
+    });
 
     hasRun = true;
 }

--- a/networkit/cpp/distance/APSP.cpp
+++ b/networkit/cpp/distance/APSP.cpp
@@ -1,4 +1,3 @@
-// no-networkit-format
 /*
  * APSP.cpp
  *
@@ -17,12 +16,10 @@ namespace NetworKit {
 APSP::APSP(const Graph &G) : Algorithm(), G(G) {}
 
 void APSP::run() {
-    count n = G.upperNodeIdBound();
-    std::vector<edgeweight> distanceVector(n, 0.0);
-    distances.resize(n, distanceVector);
+    const count n = G.upperNodeIdBound();
+    distances.assign(n, std::vector<edgeweight>(n));
 
-    count nThreads = omp_get_max_threads();
-    sssps.resize(nThreads);
+    sssps.resize(omp_get_max_threads());
 #pragma omp parallel
     {
         omp_index i = omp_get_thread_num();

--- a/networkit/cpp/distance/test/APSPGTest.cpp
+++ b/networkit/cpp/distance/test/APSPGTest.cpp
@@ -100,6 +100,25 @@ TEST_F(APSPGTest, testAPSPWeightedER) {
     });
 }
 
+TEST_F(APSPGTest, testAPSPRemovedNodeER) {
+    Aux::Random::setSeed(42, false);
+    auto G = ErdosRenyiGenerator(100, 0.01, false).generate();
+    G.removeNode(0);
+    G.removeNode(1);
+    G.removeNode(3);
+
+    APSP apsp(G);
+    apsp.run();
+    G.forNodes([&](const node u) {
+        BFS bfs(G, u, false);
+        bfs.run();
+        const auto &dist = bfs.getDistances();
+        G.forNodes([&](const node v) {
+            EXPECT_DOUBLE_EQ(dist[v], apsp.getDistance(u, v));
+        });
+    });
+}
+
 TEST_F(APSPGTest, debugAPSP) {
     count n = 1000;
     count m = int(n * n);

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -606,5 +606,30 @@ class TestSelfLoops(unittest.TestCase):
 			for u in g.iterNodes():
 				self.assertLessEqual(abs(apx[u] - pinv[u]), eps)
 
+	def testDistanceSPSP(self):
+		nk.engineering.setSeed(1, True)
+		random.seed(1)
+		for directed in [True, False]:
+			for weighted in [True, False]:
+				g = nk.generators.ErdosRenyiGenerator(100, 0.15, directed).generate()
+				if weighted:
+					g = nk.graphtools.toWeighted(g)
+					g.forEdges(lambda u, v, ew, eid: g.setWeight(u, v, random.random()))
+				for nSources in [1, 10, 50]:
+					sources = set()
+					while len(sources) < nSources:
+						sources.add(nk.graphtools.randomNode(g))
+
+					spsp = nk.distance.SPSP(g, list(sources))
+					spsp.run()
+					spsp.getDistances()
+
+	def testDistanceWithNonConsecutiveNodeLabelsAPSP(self):
+		nk.engineering.setSeed(1, True)
+		random.seed(1)
+		g = nk.generators.ErdosRenyiGenerator(100, 0.15).generate()
+		g.removeNode(0)
+		nk.distance.APSP(g).run()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/notebooks/Centrality.ipynb
+++ b/notebooks/Centrality.ipynb
@@ -685,7 +685,7 @@
    "outputs": [],
    "source": [
     "# PageRank\n",
-    "pr = nk.centrality.PageRank(K, 1e-6)\n",
+    "pr = nk.centrality.PageRank(K, damp=0.85, tol=1e-9)\n",
     "pr.run()\n",
     "pr.ranking()[:10] # the 10 most central nodes"
    ]
@@ -705,7 +705,7 @@
    "outputs": [],
    "source": [
     "# PageRank using L1 norm, and a 100 maximum iterations\n",
-    "pr = nk.centrality.PageRank(K, 1e-6)\n",
+    "pr = nk.centrality.PageRank(K, damp=0.85, tol=1e-9)\n",
     "pr.norm = nk.centrality.Norm.l1norm\n",
     "pr.maxIterations = 100\n",
     "pr.run()\n",


### PR DESCRIPTION
As described in #918, APSP does not support graphs with removed nodes. This PR fixes this issue -- distances from/to removed nodes are set to infinity -- and it is based on the fix written by @tillahoffmann (see https://github.com/tillahoffmann/networkit/commit/d1fe1b2288e9251f812f61afc172a25bde79f8b2).