### PR TITLE
Add square clustering centrality measure.

### DIFF
--- a/include/networkit/centrality/LocalSquareClusteringCoefficient.hpp
+++ b/include/networkit/centrality/LocalSquareClusteringCoefficient.hpp
@@ -1,0 +1,45 @@
+/*
+ * LocalSquareClusteringCoefficient.hpp
+ *
+ *  Created on: 07.04.2022
+ *      Author: tillahoffmann
+ */
+
+#ifndef NETWORKIT_CENTRALITY_LOCAL_SQUARE_CLUSTERING_COEFFICIENT_HPP_
+#define NETWORKIT_CENTRALITY_LOCAL_SQUARE_CLUSTERING_COEFFICIENT_HPP_
+
+#include <networkit/centrality/Centrality.hpp>
+
+namespace NetworKit {
+
+/**
+ * @ingroup centrality
+ */
+class LocalSquareClusteringCoefficient : public Centrality {
+public:
+    /**
+     * Constructs the LocalSquareClusteringCoefficient class for the given Graph @a G.
+     *
+     * @param G The graph.
+     */
+    LocalSquareClusteringCoefficient(const Graph &G);
+
+    /**
+     * Computes the local clustering coefficient on the graph passed in constructor.
+     */
+    void run() override;
+
+    /**
+     * Get the theoretical maximum of centrality score in the given graph.
+     *
+     * @return The maximum centrality score.
+     */
+    double maximum() override;
+
+protected:
+    bool turbo;
+};
+
+} /* namespace NetworKit */
+
+#endif // NETWORKIT_CENTRALITY_LOCAL_SQUARE_CLUSTERING_COEFFICIENT_HPP_

--- a/include/networkit/centrality/LocalSquareClusteringCoefficient.hpp
+++ b/include/networkit/centrality/LocalSquareClusteringCoefficient.hpp
@@ -35,9 +35,6 @@ public:
      * @return The maximum centrality score.
      */
     double maximum() override;
-
-protected:
-    bool turbo;
 };
 
 } /* namespace NetworKit */

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -2165,6 +2165,28 @@ cdef class LocalClusteringCoefficient(Centrality):
 		self._G = G
 		self._this = new _LocalClusteringCoefficient(G._this, turbo)
 
+cdef extern from "<networkit/centrality/LocalSquareClusteringCoefficient.hpp>":
+
+	cdef cppclass _LocalSquareClusteringCoefficient "NetworKit::LocalSquareClusteringCoefficient" (_Centrality):
+		_LocalSquareClusteringCoefficient(_Graph) except +
+
+
+cdef class LocalSquareClusteringCoefficient(Centrality):
+	"""
+	LocalSquareClusteringCoefficient(G)
+
+	Constructs the LocalSquareClusteringCoefficient class for the given Graph `G`.
+
+	Parameters
+	----------
+	G : networkit.Graph
+		The input graph.
+	"""
+
+	def __cinit__(self, Graph G):
+		self._G = G
+		self._this = new _LocalSquareClusteringCoefficient(G._this)
+
 
 cdef extern from "<networkit/centrality/Sfigality.hpp>":
 

--- a/networkit/cpp/centrality/CMakeLists.txt
+++ b/networkit/cpp/centrality/CMakeLists.txt
@@ -48,6 +48,7 @@ networkit_module_link_modules(centrality
         dyn_distance
         dynamics
         graph
+        linkprediction
         reachability
         structures
     )

--- a/networkit/cpp/centrality/CMakeLists.txt
+++ b/networkit/cpp/centrality/CMakeLists.txt
@@ -31,6 +31,7 @@ networkit_add_module(centrality
     LaplacianCentrality.cpp
     LocalClusteringCoefficient.cpp
     LocalPartitionCoverage.cpp
+    LocalSquareClusteringCoefficient.cpp
     PageRank.cpp
     PermanenceCentrality.cpp
     Sfigality.cpp

--- a/networkit/cpp/centrality/LocalSquareClusteringCoefficient.cpp
+++ b/networkit/cpp/centrality/LocalSquareClusteringCoefficient.cpp
@@ -24,8 +24,7 @@ void LocalSquareClusteringCoefficient::run() {
         // Iterate over all combinations of neighbors.
         for (auto iterV = neighborsU.begin(); iterV != neighborsU.end(); iterV++) {
             const auto neighborsV = G.neighborRange(*iterV);
-            auto iterW = iterV;
-            for (++iterW; iterW != neighborsU.end(); iterW++) {
+            for (auto iterW = std::next(iterV); iterW != neighborsU.end(); ++iterW) {
                 // Find the number of common neighbors (including the node `u`) and count squares.
                 const auto numCommonNeighbors = NeighborhoodUtility::getCommonNeighbors(G, *iterV, *iterW).size();
                 squares += numCommonNeighbors - 1;

--- a/networkit/cpp/centrality/LocalSquareClusteringCoefficient.cpp
+++ b/networkit/cpp/centrality/LocalSquareClusteringCoefficient.cpp
@@ -1,14 +1,19 @@
-// no-networkit-format
-#include <networkit/centrality/LocalSquareClusteringCoefficient.hpp>
-#include <networkit/linkprediction/NeighborhoodUtility.hpp>
-#include <networkit/graph/Graph.hpp>
 #include <omp.h>
+#include <networkit/centrality/LocalSquareClusteringCoefficient.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/linkprediction/NeighborhoodUtility.hpp>
 
 namespace NetworKit {
 
-LocalSquareClusteringCoefficient::LocalSquareClusteringCoefficient(const Graph& G) : Centrality(G, false, false) {
-    if (G.isDirected()) throw std::runtime_error("Not implemented: Local square clustering coefficient is currently not implemented for directed graphs");
-    if (G.numberOfSelfLoops()) throw std::runtime_error("Local square clustering coefficient implementation does not support graphs with self-loops. Call Graph.removeSelfLoops() first.");
+LocalSquareClusteringCoefficient::LocalSquareClusteringCoefficient(const Graph &G)
+    : Centrality(G, false, false) {
+    if (G.isDirected())
+        throw std::runtime_error("Not implemented: Local square clustering coefficient is "
+                                 "currently not implemented for directed graphs");
+    if (G.numberOfSelfLoops())
+        throw std::runtime_error(
+            "Local square clustering coefficient implementation does not support graphs with "
+            "self-loops. Call Graph.removeSelfLoops() first.");
 }
 
 void LocalSquareClusteringCoefficient::run() {
@@ -17,8 +22,8 @@ void LocalSquareClusteringCoefficient::run() {
     scoreData.resize(z);
 
     G.balancedParallelForNodes([&](const node u) {
-        double squares = 0;  // Number of squares found.
-        double potential_squares = 0;  // Maximum number of possible squares.
+        double squares = 0;           // Number of squares found.
+        double potential_squares = 0; // Maximum number of possible squares.
         const auto neighborsU = G.neighborRange(u);
 
         // Iterate over all combinations of neighbors.
@@ -26,7 +31,8 @@ void LocalSquareClusteringCoefficient::run() {
             const auto neighborsV = G.neighborRange(*iterV);
             for (auto iterW = std::next(iterV); iterW != neighborsU.end(); ++iterW) {
                 // Find the number of common neighbors (including the node `u`) and count squares.
-                const auto numCommonNeighbors = NeighborhoodUtility::getCommonNeighbors(G, *iterV, *iterW).size();
+                const auto numCommonNeighbors =
+                    NeighborhoodUtility::getCommonNeighbors(G, *iterV, *iterW).size();
                 squares += numCommonNeighbors - 1;
                 // Update the number of squares that could be realized.
                 potential_squares += G.degree(*iterV) + G.degree(*iterW) - numCommonNeighbors - 1;
@@ -44,9 +50,8 @@ void LocalSquareClusteringCoefficient::run() {
     hasRun = true;
 }
 
-
 double LocalSquareClusteringCoefficient::maximum() {
     return 1.0;
 }
 
-}
+} // namespace NetworKit

--- a/networkit/cpp/centrality/LocalSquareClusteringCoefficient.cpp
+++ b/networkit/cpp/centrality/LocalSquareClusteringCoefficient.cpp
@@ -28,7 +28,6 @@ void LocalSquareClusteringCoefficient::run() {
 
         // Iterate over all combinations of neighbors.
         for (auto iterV = neighborsU.begin(); iterV != neighborsU.end(); iterV++) {
-            const auto neighborsV = G.neighborRange(*iterV);
             for (auto iterW = std::next(iterV); iterW != neighborsU.end(); ++iterW) {
                 // Find the number of common neighbors (including the node `u`) and count squares.
                 const auto numCommonNeighbors =

--- a/networkit/cpp/centrality/LocalSquareClusteringCoefficient.cpp
+++ b/networkit/cpp/centrality/LocalSquareClusteringCoefficient.cpp
@@ -1,0 +1,53 @@
+// no-networkit-format
+#include <networkit/centrality/LocalSquareClusteringCoefficient.hpp>
+#include <networkit/linkprediction/NeighborhoodUtility.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <omp.h>
+
+namespace NetworKit {
+
+LocalSquareClusteringCoefficient::LocalSquareClusteringCoefficient(const Graph& G) : Centrality(G, false, false) {
+    if (G.isDirected()) throw std::runtime_error("Not implemented: Local square clustering coefficient is currently not implemented for directed graphs");
+    if (G.numberOfSelfLoops()) throw std::runtime_error("Local square clustering coefficient implementation does not support graphs with self-loops. Call Graph.removeSelfLoops() first.");
+}
+
+void LocalSquareClusteringCoefficient::run() {
+    count z = G.upperNodeIdBound();
+    scoreData.clear();
+    scoreData.resize(z);
+
+    G.balancedParallelForNodes([&](const node u) {
+        double squares = 0;  // Number of squares found.
+        double potential_squares = 0;  // Maximum number of possible squares.
+        const auto neighborsU = G.neighborRange(u);
+
+        // Iterate over all combinations of neighbors.
+        for (auto iterV = neighborsU.begin(); iterV != neighborsU.end(); iterV++) {
+            const auto neighborsV = G.neighborRange(*iterV);
+            auto iterW = iterV;
+            for (++iterW; iterW != neighborsU.end(); iterW++) {
+                // Find the number of common neighbors (including the node `u`) and count squares.
+                const auto numCommonNeighbors = NeighborhoodUtility::getCommonNeighbors(G, *iterV, *iterW).size();
+                squares += numCommonNeighbors - 1;
+                // Update the number of squares that could be realized.
+                potential_squares += G.degree(*iterV) + G.degree(*iterW) - numCommonNeighbors - 1;
+                if (G.hasEdge(*iterV, *iterW)) {
+                    potential_squares -= 2;
+                }
+            }
+        }
+        if (potential_squares > 0) {
+            squares /= potential_squares;
+        }
+        scoreData[u] = squares;
+    });
+
+    hasRun = true;
+}
+
+
+double LocalSquareClusteringCoefficient::maximum() {
+    return 1.0;
+}
+
+}

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -40,6 +40,7 @@
 #include <networkit/centrality/KatzCentrality.hpp>
 #include <networkit/centrality/LaplacianCentrality.hpp>
 #include <networkit/centrality/LocalClusteringCoefficient.hpp>
+#include <networkit/centrality/LocalSquareClusteringCoefficient.hpp>
 #include <networkit/centrality/PageRank.hpp>
 #include <networkit/centrality/PermanenceCentrality.hpp>
 #include <networkit/centrality/SpanningEdgeCentrality.hpp>
@@ -1185,6 +1186,27 @@ TEST_F(CentralityGTest, testLocalClusteringCoefficientUndirected2) {
     std::vector<double> reference = {0.6666666666666666, 0.6666666666666666,
                                      0.6666666666666666, 0.6666666666666666,
                                      0.3333333333333333, 0.3333333333333333};
+
+    EXPECT_EQ(reference, lccScores);
+}
+
+TEST_F(CentralityGTest, testLocalSquareClusteringCoefficientUndirected) {
+    Graph G(7, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(3, 0);
+    G.addEdge(3, 4);
+    G.addEdge(4, 5);
+    G.addEdge(5, 6);
+    G.addEdge(6, 3);
+    LocalSquareClusteringCoefficient lscc(G);
+    lscc.run();
+    std::vector<double> lccScores = lscc.scores();
+    std::vector<double> reference = {
+        0.3333333333333333, 1.0, 0.3333333333333333, 0.2,
+        0.3333333333333333, 1.0, 0.3333333333333333
+    };
 
     EXPECT_EQ(reference, lccScores);
 }

--- a/networkit/test/test_centrality.py
+++ b/networkit/test/test_centrality.py
@@ -28,5 +28,16 @@ class Test_Centrality(unittest.TestCase):
 
 		self.assertListEqual(expected_result, dc)
 
+	def test_SquareClusteringCoefficient(self):
+		g = nk.Graph()
+		g.addNodes(7)
+		edges = [(0, 1), (1, 2), (2, 3), (0, 3), (3, 4), (4, 5), (5, 6), (6, 3)]
+		[g.addEdge(*edge) for edge in edges]
+
+		expected_result = [1 / 3, 1.0, 1 / 3, 0.2, 1 / 3, 1.0, 1 / 3]
+		scores = nk.centrality.LocalSquareClusteringCoefficient(g).run().scores()
+		self.assertListEqual(expected_result, scores)
+
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This PR adds the `LocalSquareClusteringCoefficient`. It is analogous to the `LocalClusteringCoefficient` but evaluates the proportion of realized squares (rather than triangles). See, e.g. https://arxiv.org/abs/cond-mat/0504241.