### PR TITLE
Fix #916

### DIFF
--- a/notebooks/Centrality.ipynb
+++ b/notebooks/Centrality.ipynb
@@ -685,7 +685,7 @@
    "outputs": [],
    "source": [
     "# PageRank\n",
-    "pr = nk.centrality.PageRank(K, 1e-6)\n",
+    "pr = nk.centrality.PageRank(K, damp=0.85, tol=1e-9)\n",
     "pr.run()\n",
     "pr.ranking()[:10] # the 10 most central nodes"
    ]
@@ -705,7 +705,7 @@
    "outputs": [],
    "source": [
     "# PageRank using L1 norm, and a 100 maximum iterations\n",
-    "pr = nk.centrality.PageRank(K, 1e-6)\n",
+    "pr = nk.centrality.PageRank(K, damp=0.85, tol=1e-9)\n",
     "pr.norm = nk.centrality.Norm.l1norm\n",
     "pr.maxIterations = 100\n",
     "pr.run()\n",


### PR DESCRIPTION
This PR fixes #916 by removing the tolerance parameter from the PageRank example notebook -- which is read instead as the damping factor.