### PR TITLE
Merge Python module 'exceptions' into 'helpers'

### DIFF
--- a/networkit/exceptions.py
+++ b/networkit/exceptions.py
@@ -1,3 +1,0 @@
-class ReducedFunctionalityWarning(Warning):
-    "Reduced networkit functionality warning"
-    pass

--- a/networkit/helpers.pyx
+++ b/networkit/helpers.pyx
@@ -12,6 +12,10 @@ cdef extern from "<networkit/auxiliary/Parallel.hpp>" namespace "Aux::Parallel":
 	void sort[Iter](Iter begin, Iter end) nogil
 	void sort[Iter, Comp](Iter begin, Iter end, Comp compare) nogil
 
+class ReducedFunctionalityWarning(Warning):
+	"Reduced networkit functionality warning"
+	pass
+
 def ranked(sample):
 	"""
 	ranked(sample)

--- a/networkit/simulation.pyx
+++ b/networkit/simulation.pyx
@@ -1,10 +1,10 @@
 # distutils: language=c++
 
-from networkit.exceptions import ReducedFunctionalityWarning
 from libcpp.vector cimport vector
 
 from .base cimport _Algorithm, Algorithm
 from .graph cimport _Graph, Graph
+from .helpers import ReducedFunctionalityWarning
 from .structures cimport count, index, node
 
 import warnings


### PR DESCRIPTION
This PR merges the exception module into helpers, since there is only one custom warning/exception. Instead of deprecation the functionality is directly moved, since I assume this functionality is only used internally.