### PR TITLE
Fix #928: Use correct CFF key

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,7 +22,7 @@ preferred-citation:
     year: "2016"
     month: "12"
     volume: 4
-    number: 4
+    issue: 4
     journal: Network Science
     publisher:
         name: "Cambridge University Press"


### PR DESCRIPTION
- Replace the `number` key (reserved for library accession numbers) with the `issue` key (for issue numbers)
- Fixes #928 