### PR TITLE
Use std::sample

### DIFF
--- a/include/networkit/distance/NeighborhoodFunctionHeuristic.hpp
+++ b/include/networkit/distance/NeighborhoodFunctionHeuristic.hpp
@@ -47,7 +47,6 @@ private:
     std::vector<count> result;
 
     /* selection schemes implemented as private functions */
-    std::vector<node> random(const Graph &G, count nSamples);
     std::vector<node> split(const Graph &G, count nSamples);
 };
 

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -244,21 +244,20 @@ TEST_F(DynBetweennessGTest, runDynVsStatic) {
 }
 
 TEST_F(DynBetweennessGTest, runDynVsStaticEdgeDeletion) {
-    METISGraphReader reader;
-    Graph G = reader.read("input/celegans_metabolic.graph");
-    count n = G.upperNodeIdBound();
+    Aux::Random::setSeed(1, true);
+    Graph G = METISGraphReader{}.read("input/celegans_metabolic.graph");
+    G.indexEdges();
 
     double epsilon = 0.1; // error
     double delta = 0.1; // confidence
     DynApproxBetweenness dynbc(G, epsilon, delta, false);
-    ApproxBetweenness bc(G, epsilon, delta);
     dynbc.run();
+    Betweenness bc(G, epsilon, delta);
     bc.run();
     std::vector<double> dynbc_scores = dynbc.scores();
     std::vector<double> bc_scores = bc.scores();
-    for(count i=0; i<n; i++) {
-        EXPECT_NEAR(dynbc_scores[i], bc_scores[i], epsilon);
-    }
+    G.forNodes([&](node i) { EXPECT_NEAR(dynbc_scores[i], bc_scores[i], epsilon); });
+
     std::vector<GraphEvent> batch;
     for (int i = 0; i < 10; ++i) {
         auto randomEdge = GraphTools::randomEdge(G);
@@ -269,9 +268,7 @@ TEST_F(DynBetweennessGTest, runDynVsStaticEdgeDeletion) {
     dynbc.updateBatch(batch);
     dynbc_scores = dynbc.scores();
     bc_scores = bc.scores();
-    for(count i=0; i<n; i++) {
-        EXPECT_NEAR(dynbc_scores[i], bc_scores[i], epsilon);
-    }
+    G.forNodes([&](node i) { EXPECT_NEAR(dynbc_scores[i], bc_scores[i], epsilon); });
 }
 
 TEST_F(DynBetweennessGTest, runApproxBetweenness) {

--- a/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
@@ -5,6 +5,7 @@
 *      Author: Maximilian Vogel
 */
 
+#include <algorithm>
 #include <cmath>
 #include <map>
 #include <omp.h>
@@ -55,7 +56,7 @@ void NeighborhoodFunctionHeuristic::run() {
     if (strategy == SPLIT) {
         start_nodes = split(*G, nSamples);
     } else if (strategy == RANDOM) {
-        start_nodes = random(*G, nSamples);
+        std::sample(G->nodeRange().begin(), G->nodeRange().end(), start_nodes.begin(), nSamples, Aux::Random::getURNG());
     }
 
     // run nSamples BFS and count the distances.
@@ -103,15 +104,6 @@ void NeighborhoodFunctionHeuristic::run() {
 const std::vector<count> &NeighborhoodFunctionHeuristic::getNeighborhoodFunction() const {
     assureFinished();
     return result;
-}
-
-std::vector<node> NeighborhoodFunctionHeuristic::random(const Graph& G, count nSamples) {
-    std::vector<node> start_nodes(nSamples, 0);
-    // the vector of start nodes is chosen completely at random with the graphs "randomNode()" function.
-    for (index i = 0; i < nSamples; ++i) {
-        start_nodes[i] = GraphTools::randomNode(G);
-    }
-    return start_nodes;
 }
 
 std::vector<node> NeighborhoodFunctionHeuristic::split(const Graph& G, count nSamples) {

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -1,4 +1,3 @@
-
 #include <algorithm>
 
 #include <networkit/auxiliary/Log.hpp>
@@ -75,43 +74,10 @@ node randomNode(const Graph &G) {
 }
 
 std::vector<node> randomNodes(const Graph &G, count n) {
-    assert(n <= G.numberOfNodes());
-    std::vector<node> selectedNodes;
-    std::vector<bool> alreadySelected(G.numberOfNodes(), false);
-
-    if (n == G.numberOfNodes()) {
-        selectedNodes.insert(selectedNodes.begin(), G.nodeRange().begin(), G.nodeRange().end());
-    } else if (n > G.numberOfNodes() / 2) { // in order to minimize the calls to randomNode
-                                            // we randomize the ones that aren't pivot
-                                            // if the are more to be selected than not-selected
-        std::fill(alreadySelected.begin(), alreadySelected.end(), true);
-
-        for (count i = 0; i < G.numberOfNodes() - n; ++i) { // we have to sample distinct nodes
-            node v = GraphTools::randomNode(G);
-            while (!alreadySelected[v]) {
-                v = GraphTools::randomNode(G);
-            }
-            alreadySelected[v] = false;
-        }
-
-        for (const auto sample : G.nodeRange()) {
-            if (alreadySelected[sample]) {
-                selectedNodes.push_back(sample);
-                if (selectedNodes.size() == n)
-                    break;
-            }
-        }
-    } else {
-        for (count i = 0; i < n; ++i) { // we have to selected distinct nodes
-            node v = GraphTools::randomNode(G);
-            while (alreadySelected[v]) {
-                v = GraphTools::randomNode(G);
-            }
-            selectedNodes.push_back(v);
-            alreadySelected[v] = true;
-        }
-    }
-    return selectedNodes;
+    std::vector<node> result(n);
+    std::sample(G.nodeRange().begin(), G.nodeRange().end(), result.begin(), n,
+                Aux::Random::getURNG());
+    return result;
 }
 
 std::pair<node, node> randomEdge(const Graph &G, bool uniformDistribution) {


### PR DESCRIPTION
Use the `std::sample` algorithm introduced in C++17 to sample random nodes.

The failures in the tests for dynamic betweenness do not seem related to my changes. However, the test looks wrong to me: it uses as a baseline an inexact algorithm instead of the exact one. Changing the baseline with the exact algorithm seems to resolve the issue -- see the second commit.