### PR TITLE
Refactor Tests for Dynamic Betweenness

### DIFF
--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -175,6 +175,16 @@ TEST_F(CentralityGTest, runApproxBetweennessSmallGraph) {
     DEBUG("scores: ", bc);
 }
 
+TEST_F(CentralityGTest, runApproxBetweenness) {
+    DorogovtsevMendesGenerator generator(100);
+    Graph G1 = generator.generate();
+    Graph G(G1, true, false);
+    ApproxBetweenness bc(G, 0.1, 0.1);
+    bc.run();
+    ApproxBetweenness bc1(G1, 0.1, 0.1);
+    bc1.run();
+}
+
 TEST_F(CentralityGTest, testBetweennessCentralityWeighted) {
     /* Graph:
      0    3   6

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -81,7 +81,7 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraph) {
         EXPECT_NEAR(dynbc_scores[i], bc_scores[i]/double(n*(n-1)), epsilon);
     });
 
-    GraphEvent event(GraphEvent::EDGE_ADDITION, 0, 6, 1.0);
+    GraphEvent event(GraphEvent::EDGE_ADDITION, 0, 6);
     G.addEdge(event.u, event.v);
     bc.run();
     dynbc.update(event);
@@ -208,7 +208,7 @@ TEST_F(DynBetweennessGTest, runDynVsStatic) {
         node v2 = GraphTools::randomNode(G);
         if (v1 != v2 && !G.hasEdge(v1, v2)) {
             G.addEdge(v1, v2);
-            batch.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, v1, v2, 1.0));
+            batch.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, v1, v2));
             i++;
         }
     }

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -80,11 +80,11 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraph) {
     G.forNodes([&](const node i) {
         EXPECT_NEAR(dynbc_scores[i], bc_scores[i]/double(n*(n-1)), epsilon);
     });
-    std::vector<GraphEvent> batch;
-    batch.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, 0, 6, 1.0));
-    G.addEdge(batch[0].u, batch[0].v);
+
+    GraphEvent event(GraphEvent::EDGE_ADDITION, 0, 6, 1.0);
+    G.addEdge(event.u, event.v);
     bc.run();
-    dynbc.updateBatch(batch);
+    dynbc.update(event);
     dynbc_scores = dynbc.scores();
     bc_scores = bc.scores();
     G.forNodes([&](const node i) {
@@ -105,11 +105,11 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraphEdgeDeletion) {
     G.forNodes([&](const node i) {
         EXPECT_NEAR(dynbc_scores[i], bc_scores[i]/double(n*(n-1)), epsilon);
     });
-    std::vector<GraphEvent> batch;
-    batch.push_back(GraphEvent(GraphEvent::EDGE_REMOVAL, 3, 5));
-    G.removeEdge(batch[0].u, batch[0].v);
+
+    GraphEvent event(GraphEvent::EDGE_REMOVAL, 3, 5);
+    G.removeEdge(event.u, event.v);
     bc.run();
-    dynbc.updateBatch(batch);
+    dynbc.update(event);
     dynbc_scores = dynbc.scores();
     bc_scores = bc.scores();
     G.forNodes([&](const node i) {
@@ -142,9 +142,9 @@ TEST_P(DynBetweennessGTest, testDynApproxBetweenessGeneratedGraph) {
             i++;
             DEBUG("Adding edge number ", i);
             G.addEdge(v1, v2);
-            std::vector<GraphEvent> batch;
-            batch.push_back(GraphEvent(GraphEvent::EDGE_ADDITION, v1, v2, 1.0));
-            dynbc.updateBatch(batch);
+
+            GraphEvent event(GraphEvent::EDGE_ADDITION, v1, v2);
+            dynbc.update(event);
             bc.run();
             std::vector<double> dynbc_scores = dynbc.scores();
             std::vector<double> bc_scores = bc.scores();
@@ -175,9 +175,8 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweenessGeneratedGraphEdgeDeletion) {
         auto randomEdge = GraphTools::randomEdge(G);
         DEBUG("Deleting edge number ", i);
         G.removeEdge(randomEdge.first, randomEdge.second);
-        std::vector<GraphEvent> batch;
-        batch.emplace_back(GraphEvent::EDGE_REMOVAL, randomEdge.first, randomEdge.second);
-        dynbc.updateBatch(batch);
+        GraphEvent event(GraphEvent::EDGE_REMOVAL, randomEdge.first, randomEdge.second);
+        dynbc.update(event);
         bc.run();
         std::vector<double> dynbc_scores = dynbc.scores();
         std::vector<double> bc_scores = bc.scores();

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -131,11 +131,9 @@ TEST_P(DynBetweennessGTest, testDynApproxBetweenessGeneratedGraph) {
         G.forEdges([&](node u, node v) { G.setWeight(u, v, Aux::Random::probability()); });
     }
 
-    DEBUG("Generated graph of dimension ", G.upperNodeIdBound());
     DynApproxBetweenness dynbc(G, epsilon, delta);
     Betweenness bc(G);
     dynbc.run();
-    DEBUG("Before the edge insertion: ");
     for (int i = 0; i < 10; ++i) {
         auto [v1, v2] = getNonAdjacentNodes(G);
         G.addEdge(v1, v2);
@@ -153,15 +151,11 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweenessGeneratedGraphEdgeDeletion) {
     ErdosRenyiGenerator generator(100, 0.25, isDirected());
     Graph G = generator.generate();
 
-    DEBUG("Generated graph of dimension ", G.upperNodeIdBound());
     DynApproxBetweenness dynbc(G, epsilon, delta);
     Betweenness bc(G);
     dynbc.run();
-    DEBUG("Before the edge deletion: ");
     for(count i = 0; i < 10; i++) {
-        DEBUG("Selecting a random edge");
         auto randomEdge = GraphTools::randomEdge(G);
-        DEBUG("Deleting edge number ", i);
         G.removeEdge(randomEdge.first, randomEdge.second);
         GraphEvent event(GraphEvent::EDGE_REMOVAL, randomEdge.first, randomEdge.second);
         dynbc.update(event);
@@ -175,32 +169,23 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweenessGeneratedGraphEdgeDeletion) {
 TEST_F(DynBetweennessGTest, runDynVsStatic) {
     Graph G = METISGraphReader{}.read("input/celegans_metabolic.graph");
 
-    DEBUG("Initializing DynApproxBetweenness");
     DynApproxBetweenness dynbc(G, epsilon, delta, false);
-    DEBUG("Initializing ApproxBetweenness");
     ApproxBetweenness bc(G, epsilon, delta);
-    DEBUG("Running DynApproxBetweenness");
     dynbc.run();
-    DEBUG("Running ApproxBetweenness");
     bc.run();
     std::vector<double> dynbc_scores = dynbc.scores();
     std::vector<double> bc_scores = bc.scores();
     compareAgainstBaseline(G, dynbc_scores, bc_scores);
 
-    DEBUG("Before the edge insertion: ");
     std::vector<GraphEvent> batch;
     for (int i = 0; i < 10; ++i) {
         auto [u, v] = getNonAdjacentNodes(G);
         G.addEdge(u, v);
         batch.emplace_back(GraphEvent::EDGE_ADDITION, u, v);
     }
-    DEBUG("Running ApproxBetweenness (again)");
     bc.run();
-    DEBUG("Updating DynApproxBetweenness");
     dynbc.updateBatch(batch);
-    DEBUG("Calling DynApproxBetweenness Scores");
     dynbc_scores = dynbc.scores();
-    DEBUG("Calling ApproxBetweenness Scores");
     bc_scores = bc.scores();
     compareAgainstBaseline(G, dynbc_scores, bc_scores);
 }

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -159,11 +159,6 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweenessGeneratedGraphEdgeDeletion) {
     ErdosRenyiGenerator generator(100, 0.25, isDirected());
     Graph G = generator.generate();
     count n = G.numberOfNodes();
-    if (isWeighted()) {
-        G = GraphTools::toWeighted(G);
-        Aux::Random::setSeed(42, false);
-        G.forEdges([&](node u, node v) { G.setWeight(u, v, Aux::Random::probability()); });
-    }
 
     DEBUG("Generated graph of dimension ", G.upperNodeIdBound());
     DynApproxBetweenness dynbc(G, epsilon, delta);

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -214,18 +214,6 @@ TEST_F(DynBetweennessGTest, runDynVsStaticEdgeDeletion) {
     compareAgainstBaseline(G, dynbc_scores, bc_scores);
 }
 
-TEST_F(DynBetweennessGTest, runApproxBetweenness) {
-    DorogovtsevMendesGenerator generator(100);
-    Graph G1 = generator.generate();
-    Graph G(G1, true, false);
-    ApproxBetweenness bc(G, 0.1, 0.1);
-    bc.run();
-    DEBUG("Number of samples: ", bc.numberOfSamples());
-    ApproxBetweenness bc1(G1, 0.1, 0.1);
-    bc1.run();
-    DEBUG("Number of samples: ", bc1.numberOfSamples());
-}
-
 TEST_F(DynBetweennessGTest, runDynVsStaticCaseInsertDirected){
     Aux::Random::setSeed(0, false);
 

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -89,6 +89,7 @@ Graph DynBetweennessGTest::generateSmallGraph() const {
 }
 
 TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraph) {
+    Aux::Random::setSeed(42, false);
     Graph G = generateSmallGraph();
     DynApproxBetweenness dynbc(G, epsilon, delta);
     Betweenness bc(G);
@@ -104,6 +105,7 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraph) {
 }
 
 TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraphEdgeDeletion) {
+    Aux::Random::setSeed(42, false);
     Graph G = generateSmallGraph();
     DynApproxBetweenness dynbc(G, epsilon, delta);
     Betweenness bc(G);
@@ -140,6 +142,7 @@ TEST_P(DynBetweennessGTest, testDynApproxBetweenessGeneratedGraph) {
 }
 
 TEST_P(DynBetweennessGTest, runDynApproxBetweenessGeneratedGraphEdgeDeletion) {
+    Aux::Random::setSeed(42, false);
     ErdosRenyiGenerator generator(100, 0.25, isDirected());
     Graph G = generator.generate();
 

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -28,6 +28,12 @@ protected:
     bool isWeighted() const noexcept { return GetParam().second; };
     Graph generateSmallGraph() const;
 
+    void generateRandomWeights(Graph &G) const {
+        if (!G.isWeighted())
+            G = GraphTools::toWeighted(G);
+        G.forEdges([&](node u, node v) { G.setWeight(u, v, Aux::Random::probability()); });
+    }
+
     static constexpr double epsilon = 0.1, delta = 0.1;
 
     void compareAgainstBaseline(const Graph &G, const std::vector<double> &apxScores,
@@ -77,10 +83,8 @@ Graph DynBetweennessGTest::generateSmallGraph() const {
         G.addEdge(5, 2);
     }
 
-    if (isWeighted()) {
-        Aux::Random::setSeed(42, false);
-        G.forEdges([&](node u, node v) { G.setWeight(u, v, Aux::Random::probability()); });
-    }
+    if (isWeighted())
+        generateRandomWeights(G);
     return G;
 }
 
@@ -115,13 +119,11 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraphEdgeDeletion) {
 }
 
 TEST_P(DynBetweennessGTest, testDynApproxBetweenessGeneratedGraph) {
+    Aux::Random::setSeed(42, false);
     ErdosRenyiGenerator generator(100, 0.25, isDirected());
     Graph G = generator.generate();
-    if (isWeighted()) {
-        G = GraphTools::toWeighted(G);
-        Aux::Random::setSeed(42, false);
-        G.forEdges([&](node u, node v) { G.setWeight(u, v, Aux::Random::probability()); });
-    }
+    if (isWeighted())
+        generateRandomWeights(G);
 
     DynApproxBetweenness dynbc(G, epsilon, delta);
     Betweenness bc(G);

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -90,17 +90,13 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraph) {
     Betweenness bc(G);
     dynbc.run();
     bc.run();
-    std::vector<double> dynbc_scores = dynbc.scores();
-    std::vector<double> bc_scores = bc.scores();
-    compareAgainstBaseline(G, dynbc_scores, bc_scores, true);
+    compareAgainstBaseline(G, dynbc.scores(), bc.scores(), true);
 
     GraphEvent event(GraphEvent::EDGE_ADDITION, 0, 6);
     G.addEdge(event.u, event.v);
     bc.run();
     dynbc.update(event);
-    dynbc_scores = dynbc.scores();
-    bc_scores = bc.scores();
-    compareAgainstBaseline(G, dynbc_scores, bc_scores, true);
+    compareAgainstBaseline(G, dynbc.scores(), bc.scores(), true);
 }
 
 TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraphEdgeDeletion) {
@@ -109,17 +105,13 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraphEdgeDeletion) {
     Betweenness bc(G);
     dynbc.run();
     bc.run();
-    std::vector<double> dynbc_scores = dynbc.scores();
-    std::vector<double> bc_scores = bc.scores();
-    compareAgainstBaseline(G, dynbc_scores, bc_scores, true);
+    compareAgainstBaseline(G, dynbc.scores(), bc.scores(), true);
 
     GraphEvent event(GraphEvent::EDGE_REMOVAL, 3, 5);
     G.removeEdge(event.u, event.v);
     bc.run();
     dynbc.update(event);
-    dynbc_scores = dynbc.scores();
-    bc_scores = bc.scores();
-    compareAgainstBaseline(G, dynbc_scores, bc_scores, true);
+    compareAgainstBaseline(G, dynbc.scores(), bc.scores(), true);
 }
 
 TEST_P(DynBetweennessGTest, testDynApproxBetweenessGeneratedGraph) {
@@ -141,9 +133,7 @@ TEST_P(DynBetweennessGTest, testDynApproxBetweenessGeneratedGraph) {
         GraphEvent event(GraphEvent::EDGE_ADDITION, v1, v2);
         dynbc.update(event);
         bc.run();
-        std::vector<double> dynbc_scores = dynbc.scores();
-        std::vector<double> bc_scores = bc.scores();
-        compareAgainstBaseline(G, dynbc_scores, bc_scores, true);
+        compareAgainstBaseline(G, dynbc.scores(), bc.scores(), true);
     }
 }
 
@@ -160,9 +150,7 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweenessGeneratedGraphEdgeDeletion) {
         GraphEvent event(GraphEvent::EDGE_REMOVAL, randomEdge.first, randomEdge.second);
         dynbc.update(event);
         bc.run();
-        std::vector<double> dynbc_scores = dynbc.scores();
-        std::vector<double> bc_scores = bc.scores();
-        compareAgainstBaseline(G, dynbc_scores, bc_scores, true);
+        compareAgainstBaseline(G, dynbc.scores(), bc.scores(), true);
     }
 }
 
@@ -173,9 +161,7 @@ TEST_F(DynBetweennessGTest, runDynVsStatic) {
     ApproxBetweenness bc(G, epsilon, delta);
     dynbc.run();
     bc.run();
-    std::vector<double> dynbc_scores = dynbc.scores();
-    std::vector<double> bc_scores = bc.scores();
-    compareAgainstBaseline(G, dynbc_scores, bc_scores);
+    compareAgainstBaseline(G, dynbc.scores(), bc.scores());
 
     std::vector<GraphEvent> batch;
     for (int i = 0; i < 10; ++i) {
@@ -185,9 +171,7 @@ TEST_F(DynBetweennessGTest, runDynVsStatic) {
     }
     bc.run();
     dynbc.updateBatch(batch);
-    dynbc_scores = dynbc.scores();
-    bc_scores = bc.scores();
-    compareAgainstBaseline(G, dynbc_scores, bc_scores);
+    compareAgainstBaseline(G, dynbc.scores(), bc.scores());
 }
 
 TEST_F(DynBetweennessGTest, runDynVsStaticEdgeDeletion) {
@@ -197,9 +181,7 @@ TEST_F(DynBetweennessGTest, runDynVsStaticEdgeDeletion) {
     ApproxBetweenness bc(G, epsilon, delta);
     dynbc.run();
     bc.run();
-    std::vector<double> dynbc_scores = dynbc.scores();
-    std::vector<double> bc_scores = bc.scores();
-    compareAgainstBaseline(G, dynbc_scores, bc_scores);
+    compareAgainstBaseline(G, dynbc.scores(), bc.scores());
 
     std::vector<GraphEvent> batch;
     for (int i = 0; i < 10; ++i) {
@@ -209,9 +191,7 @@ TEST_F(DynBetweennessGTest, runDynVsStaticEdgeDeletion) {
     }
     bc.run();
     dynbc.updateBatch(batch);
-    dynbc_scores = dynbc.scores();
-    bc_scores = bc.scores();
-    compareAgainstBaseline(G, dynbc_scores, bc_scores);
+    compareAgainstBaseline(G, dynbc.scores(), bc.scores());
 }
 
 TEST_F(DynBetweennessGTest, runDynVsStaticCaseInsertDirected){

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -24,8 +24,8 @@ namespace NetworKit {
 
 class DynBetweennessGTest: public testing::TestWithParam<std::pair<bool, bool>> {
 protected:
-    bool isDirected() const noexcept;
-    bool isWeighted() const noexcept;
+    bool isDirected() const noexcept { return GetParam().first; };
+    bool isWeighted() const noexcept { return GetParam().second; };
     Graph generateSmallGraph() const;
 };
 
@@ -33,10 +33,6 @@ INSTANTIATE_TEST_SUITE_P(InstantiationName, DynBetweennessGTest,
         testing::Values(std::make_pair(false, false), std::make_pair(true, false),
                         std::make_pair(false, true),
                         std::make_pair(true, true)));
-
-bool DynBetweennessGTest::isWeighted() const noexcept { return GetParam().first; }
-
-bool DynBetweennessGTest::isDirected() const noexcept { return GetParam().second; }
 
 Graph DynBetweennessGTest::generateSmallGraph() const {
 /* Graph:

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -54,7 +54,7 @@ Graph DynBetweennessGTest::generateSmallGraph() const {
     G.addEdge(4, 5);
     G.addEdge(5, 6);
     G.addEdge(5, 7);
-    
+
     if (isDirected()) {
         G.addEdge(4, 1);
         G.addEdge(3, 0);
@@ -182,10 +182,7 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweenessGeneratedGraphEdgeDeletion) {
 }
 
 TEST_F(DynBetweennessGTest, runDynVsStatic) {
-    METISGraphReader reader;
-    //Graph G = reader.read("input/PGPgiantcompo.graph");
-    Graph G = reader.read("input/celegans_metabolic.graph");
-    count n = G.upperNodeIdBound();
+    Graph G = METISGraphReader{}.read("input/celegans_metabolic.graph");
 
     DEBUG("Initializing DynApproxBetweenness");
     DynApproxBetweenness dynbc(G, epsilon, delta, false);
@@ -226,9 +223,7 @@ TEST_F(DynBetweennessGTest, runDynVsStatic) {
 }
 
 TEST_F(DynBetweennessGTest, runDynVsStaticEdgeDeletion) {
-    METISGraphReader reader;
-    Graph G = reader.read("input/celegans_metabolic.graph");
-    count n = G.upperNodeIdBound();
+    Graph G = METISGraphReader{}.read("input/celegans_metabolic.graph");
 
     DynApproxBetweenness dynbc(G, epsilon, delta, false);
     ApproxBetweenness bc(G, epsilon, delta);
@@ -255,7 +250,6 @@ TEST_F(DynBetweennessGTest, runDynVsStaticEdgeDeletion) {
 }
 
 TEST_F(DynBetweennessGTest, runApproxBetweenness) {
-    //METISGraphReader reader;
     DorogovtsevMendesGenerator generator(100);
     Graph G1 = generator.generate();
     Graph G(G1, true, false);
@@ -339,6 +333,5 @@ TEST_F(DynBetweennessGTest, runDynVsStaticCaseInsertUndirected){
             });
         }
 }
-
 
 } /* namespace NetworKit */

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -27,6 +27,8 @@ protected:
     bool isDirected() const noexcept { return GetParam().first; };
     bool isWeighted() const noexcept { return GetParam().second; };
     Graph generateSmallGraph() const;
+
+    static constexpr double epsilon = 0.1, delta = 0.1;
 };
 
 INSTANTIATE_TEST_SUITE_P(InstantiationName, DynBetweennessGTest,
@@ -69,8 +71,6 @@ Graph DynBetweennessGTest::generateSmallGraph() const {
 TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraph) {
     Graph G = generateSmallGraph();
     const auto n = G.numberOfNodes();
-    double epsilon = 0.1; // error
-    double delta = 0.1; // confidence
     DynApproxBetweenness dynbc(G, epsilon, delta);
     Betweenness bc(G);
     dynbc.run();
@@ -96,8 +96,6 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraph) {
 TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraphEdgeDeletion) {
     Graph G = generateSmallGraph();
     const auto n = G.numberOfNodes();
-    double epsilon = 0.1; // error
-    double delta = 0.1; // confidence
     DynApproxBetweenness dynbc(G, epsilon, delta);
     Betweenness bc(G);
     dynbc.run();
@@ -131,8 +129,6 @@ TEST_P(DynBetweennessGTest, testDynApproxBetweenessGeneratedGraph) {
     }
 
     DEBUG("Generated graph of dimension ", G.upperNodeIdBound());
-    double epsilon = 0.1; // error
-    double delta = 0.1; // confidence
     DynApproxBetweenness dynbc(G, epsilon, delta);
     Betweenness bc(G);
     dynbc.run();
@@ -170,8 +166,6 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweenessGeneratedGraphEdgeDeletion) {
     }
 
     DEBUG("Generated graph of dimension ", G.upperNodeIdBound());
-    double epsilon = 0.1; // error
-    double delta = 0.1; // confidence
     DynApproxBetweenness dynbc(G, epsilon, delta);
     Betweenness bc(G);
     dynbc.run();
@@ -199,8 +193,6 @@ TEST_F(DynBetweennessGTest, runDynVsStatic) {
     Graph G = reader.read("input/celegans_metabolic.graph");
     count n = G.upperNodeIdBound();
 
-    double epsilon = 0.1; // error
-    double delta = 0.01; // confidence
     DEBUG("Initializing DynApproxBetweenness");
     DynApproxBetweenness dynbc(G, epsilon, delta, false);
     DEBUG("Initializing ApproxBetweenness");
@@ -244,8 +236,6 @@ TEST_F(DynBetweennessGTest, runDynVsStaticEdgeDeletion) {
     Graph G = reader.read("input/celegans_metabolic.graph");
     count n = G.upperNodeIdBound();
 
-    double epsilon = 0.1; // error
-    double delta = 0.1; // confidence
     DynApproxBetweenness dynbc(G, epsilon, delta, false);
     ApproxBetweenness bc(G, epsilon, delta);
     dynbc.run();


### PR DESCRIPTION
`DynBetweennessGTest` has a lot of useless/duplicate code. This PR simplifies the tests and sets fixed random seeds to make the tests reproducible.