### PR TITLE
Increase timeout for coverage build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
       - name: Prepare environment and run checks
         run:  ${{ github.workspace }}/.github/workflows/scripts/core_sanitizers_coverage.sh
         shell: bash
-        timeout-minutes: 60
+        timeout-minutes: 120
       - name: Create C++ coverage
         run: |
           cd ${{ github.workspace }}


### PR DESCRIPTION
Recently the coverage-run on GHA had several timeouts due to variatons in the CI runner performance. Therefore the timeout is increased.