### PR TITLE
Fix segmentation fault in ParallelConnectedComponents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,7 +486,12 @@ if (NETWORKIT_BUILD_TESTS)
 					networkit_state
 			)
 		endif()
-
+		
+		if(WIN32)
+			set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} /wd4996")
+		else()
+			set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} -Wno-deprecated-declarations")
+		endif()
 		set_target_properties(networkit_tests PROPERTIES
 			CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
 			COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"

--- a/networkit/cpp/components/ParallelConnectedComponents.cpp
+++ b/networkit/cpp/components/ParallelConnectedComponents.cpp
@@ -24,6 +24,7 @@ void ParallelConnectedComponents::run() {
 
     DEBUG("initializing labels");
     component.reset(z, none);
+    component.allToSingletons();
 
     DEBUG("initializing active nodes");
     const char INACTIVE = 0;
@@ -73,6 +74,11 @@ void ParallelConnectedComponents::run() {
         auto nodeMapping = con.getFineToCoarseNodeMapping();
         G->parallelForNodes([&](node u) { component[u] = cc.componentOfNode(nodeMapping[u]); });
     }
+    component.parallelForEntries([&](node u, index) {
+        if (!G->hasNode(u))
+            component.remove(u);
+    });
+    component.compact(true);
 
     hasRun = true;
 }
@@ -82,6 +88,7 @@ void ParallelConnectedComponents::runSequential() {
     count z = G->upperNodeIdBound();
     DEBUG("initializing labels");
     component.reset(z, none);
+    component.allToSingletons();
 
     DEBUG("initializing active nodes");
     std::vector<bool> activeNodes(z, true); // record if node must be processed
@@ -130,6 +137,11 @@ void ParallelConnectedComponents::runSequential() {
         auto nodeMapping = con.getFineToCoarseNodeMapping();
         G->forNodes([&](node u) { component[u] = cc.componentOfNode(nodeMapping[u]); });
     }
+    component.forEntries([&](node u, index) {
+        if (!G->hasNode(u))
+            component.remove(u);
+    });
+    component.compact(true);
 
     hasRun = true;
 }

--- a/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
@@ -87,9 +87,14 @@ TEST_F(ConnectedComponentsGTest, testParallelConnectedComponents) {
         count seqNum = cc.numberOfComponents();
         ParallelConnectedComponents ccPar(G);
         ccPar.run();
-        count parNum = cc.numberOfComponents();
+        count parNum = ccPar.numberOfComponents();
         DEBUG("Number of components: ", seqNum);
         EXPECT_EQ(seqNum, parNum);
+        G.forNodes([&](node u) { EXPECT_EQ(cc.componentOfNode(u), ccPar.componentOfNode(u)); });
+        ccPar.runSequential();
+        parNum = ccPar.numberOfComponents();
+        EXPECT_EQ(seqNum, parNum);
+        G.forNodes([&](node u) { EXPECT_EQ(cc.componentOfNode(u), ccPar.componentOfNode(u)); });
     }
 }
 


### PR DESCRIPTION
this addresses #942 

It was previously just initializing everything to the `none` which caused just for the label `none` to be passed around in the algorithm, not assigning anything. So now all nodes are now assigned to their own partition. As none of the nodes were being assigned it would fail the `assert(component[u] != none);` from `ComponentDecomposition::componentOfNode`.

Also, the partition needed to be compacted at the end because the partition IDs would not be continuous and the number of partitions is not updated. Non-existing node entries also need to be removed from the partition in the case where the Graph node Ids are not continuous so that the number of components is correct, otherwise, they would be seen as single node components(the vectors for those partitions would be empty in the result from `getComponents()`). 