### PR TITLE
Make non-existing edge ids return as none instead of 0

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -2316,7 +2316,7 @@ inline edgeid Graph::getOutEdgeId(node u, index i) const {
 // implementation for hasEdgeIds == false
 template <>
 inline edgeid Graph::getOutEdgeId<false>(node, index) const {
-    return 0;
+    return none;
 }
 
 // implementation for hasEdgeIds == true
@@ -2328,7 +2328,7 @@ inline edgeid Graph::getInEdgeId(node u, index i) const {
 // implementation for hasEdgeIds == false
 template <>
 inline edgeid Graph::getInEdgeId<false>(node, index) const {
-    return 0;
+    return none;
 }
 
 // implementation for graphIsDirected == true

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -1925,7 +1925,7 @@ TEST_P(GraphGTest, testForEdgesWithIds) {
 
         count m = 0;
         graph->forEdges([&](node, node, edgeid eid) {
-            EXPECT_EQ(0, eid);
+            EXPECT_EQ(none, eid);
             m++;
         });
         ASSERT_EQ(3u, m);
@@ -1961,7 +1961,7 @@ TEST_P(GraphGTest, testForWeightedEdgesWithIds) {
         count m = 0;
         edgeweight sum = 0;
         graph->forEdges([&](node, node, edgeweight ew, edgeid eid) {
-            EXPECT_EQ(0, eid);
+            EXPECT_EQ(none, eid);
             m++;
             sum += ew;
         });
@@ -2013,10 +2013,8 @@ TEST_P(GraphGTest, testParallelForEdgesWithIds) {
         graph->parallelForEdges([&](node, node, edgeid eid) {
 #pragma omp atomic
             m++;
-#pragma omp atomic
-            sumedgeid += eid;
+            ASSERT_EQ(none, eid);
         });
-        ASSERT_EQ(0, sumedgeid);
         ASSERT_EQ(3u, m);
 
         // With edge indices
@@ -2061,10 +2059,8 @@ TEST_P(GraphGTest, testParallelForWeightedEdgesWithIds) {
             m++;
 #pragma omp atomic
             sum += ew;
-#pragma omp atomic
-            sumedgeid += eid;
+            ASSERT_EQ(none, eid);
         });
-        ASSERT_EQ(0, sumedgeid);
         ASSERT_EQ(3u, m);
 
         if (graph->isWeighted()) {


### PR DESCRIPTION
Previously non-existing edge ids were returned as `0` which could be misleading. Now they return as `none` to be clear that the edge id doesn't exist.

This addresses #747 