### PR TITLE
make testMocnikGeneratorBasic actually test MocnikGeneratorBasic

### DIFF
--- a/networkit/cpp/generators/test/GeneratorsGTest.cpp
+++ b/networkit/cpp/generators/test/GeneratorsGTest.cpp
@@ -1132,7 +1132,7 @@ TEST_F(GeneratorsGTest, testMocnikGeneratorBasic) {
     count n = 5000;
     double k = 2.6;
 
-    MocnikGenerator Mocnik(dim, n, k);
+    MocnikGeneratorBasic Mocnik(dim, n, k);
     Graph G(0);
     EXPECT_TRUE(G.isEmpty());
     G = Mocnik.generate();


### PR DESCRIPTION
testMocnikGeneratorBasic was testing testMocnikGenerator instead of testMocnikGeneratorBasic for some reason.