### PR TITLE
SpanningEdgeCentrality: make indexing edges mandatory for running the algorithm.

### DIFF
--- a/networkit/cpp/centrality/SpanningEdgeCentrality.cpp
+++ b/networkit/cpp/centrality/SpanningEdgeCentrality.cpp
@@ -18,7 +18,7 @@
 
 namespace NetworKit {
 
-SpanningEdgeCentrality::SpanningEdgeCentrality(const Graph& G, double tol): Centrality(G), tol(tol), lamg(1e-5) {
+SpanningEdgeCentrality::SpanningEdgeCentrality(const Graph& G, double tol): Centrality(G, false, true), tol(tol), lamg(1e-5) {
     // prepare LAMG
     CSRMatrix matrix = CSRMatrix::laplacianMatrix(G);
     Aux::Timer t;

--- a/notebooks/Centrality.ipynb
+++ b/notebooks/Centrality.ipynb
@@ -808,6 +808,7 @@
    "outputs": [],
    "source": [
     "# Initialize algorithm\n",
+    "G.indexEdges()\n",
     "span = nk.centrality.SpanningEdgeCentrality(G, 1e-6)\n",
     "span.run()"
    ]


### PR DESCRIPTION
Fixes #967.