### PR TITLE
Update MIT license for 2022.

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,4 +1,7 @@
-Copyright (c) 2013 Christian Staudt, Henning Meyerhenke
+Copyright (c) 2013-2022 Henning Meyerhenke, NetworKit Contributors
+Copyright (c) 2013-2017 Karlsruhe Institute of Technology
+Copyright (c) 2017-2018 University of Cologne
+Copyright (c) 2018-2022 Humboldt-Universität zu Berlin
 
 MIT License (http://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
Updated the license. @hmeyerhenke Not sure, whether legally the involved universites should be named.

