### PR TITLE
Modify addEdge to check for multi-edges

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1655,52 +1655,76 @@ public:
      * Insert an edge between the nodes @a u and @a v. If the graph is
      * weighted you can optionally set a weight for this edge. The default
      * weight is 1.0. Note: Multi-edges are not supported and will NOT be
-     * handled consistently by the graph data structure.
+     * handled consistently by the graph data structure. It is possible to check
+     * for multi-edges by enabling parameter "checkForMultiEdges". If already present,
+     * the new edge is not inserted. Enabling this check increases the complexity of the function
+     * to O(max(deg(u), deg(v))).
      * @param u Endpoint of edge.
      * @param v Endpoint of edge.
      * @param weight Optional edge weight.
+     * @param checkMultiEdge If true, this enables a check for a possible multi-edge.
+     * @return @c true if edge has been added, false otherwise (in case checkMultiEdge is set to
+     * true and the new edge would have been a multi-edge.)
      */
-    void addEdge(node u, node v, edgeweight ew = defaultEdgeWeight);
+    bool addEdge(node u, node v, edgeweight ew = defaultEdgeWeight, bool checkMultiEdge = false);
 
     /**
      * Insert an edge between the nodes @a u and @a v. Unline the addEdge function, this function
      * does not not add any information to v. If the graph is weighted you can optionally set a
      * weight for this edge. The default weight is 1.0. Note: Multi-edges are not supported and will
-     * NOT be handled consistently by the graph data structure.
+     * NOT be handled consistently by the graph data structure. It is possible to check
+     * for multi-edges by enabling parameter "checkForMultiEdges". If already present,
+     * the new edge is not inserted. Enabling this check increases the complexity of the function
+     * to O(max(deg(u), deg(v))).
      * @param u Endpoint of edge.
      * @param v Endpoint of edge.
      * @param weight Optional edge weight.
      * @param ew Optional edge weight.
      * @param index Optional edge index.
+     * @param checkMultiEdge If true, this enables a check for a possible multi-edge.
+     * @return @c true if edge has been added, false otherwise (in case checkMultiEdge is set to
+     * true and the new edge would have been a multi-edge.)
      */
-    void addPartialEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight,
-                        uint64_t index = 0);
+    bool addPartialEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight,
+                        uint64_t index = 0, bool checkForMultiEdges = false);
 
     /**
      * Insert an in edge between the nodes @a u and @a v in a directed graph. If the graph is
      * weighted you can optionally set a weight for this edge. The default
      * weight is 1.0. Note: Multi-edges are not supported and will NOT be
-     * handled consistently by the graph data structure.
+     * handled consistently by the graph data structure. It is possible to check
+     * for multi-edges by enabling parameter "checkForMultiEdges". If already present,
+     * the new edge is not inserted. Enabling this check increases the complexity of the function
+     * to O(max(deg(u), deg(v))).
      * @param u Endpoint of edge.
      * @param v Endpoint of edge.
      * @param ew Optional edge weight.
      * @param index Optional edge index.
+     * @param checkMultiEdge If true, this enables a check for a possible multi-edge.
+     * @return @c true if edge has been added, false otherwise (in case checkMultiEdge is set to
+     * true and the new edge would have been a multi-edge.)
      */
-    void addPartialInEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight,
-                          uint64_t index = 0);
+    bool addPartialInEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight,
+                          uint64_t index = 0, bool checkForMultiEdges = false);
 
     /**
      * Insert an out edge between the nodes @a u and @a v in a directed graph. If the graph is
      * weighted you can optionally set a weight for this edge. The default
      * weight is 1.0. Note: Multi-edges are not supported and will NOT be
-     * handled consistently by the graph data structure.
+     * handled consistently by the graph data structure. It is possible to check
+     * for multi-edges by enabling parameter "checkForMultiEdges". If already present,
+     * the new edge is not inserted. Enabling this check increases the complexity of the function
+     * to O(max(deg(u), deg(v))).
      * @param u Endpoint of edge.
      * @param v Endpoint of edge.
      * @param ew Optional edge weight.
      * @param index Optional edge index.
+     * @param checkMultiEdge If true, this enables a check for a possible multi-edge.
+     * @return @c true if edge has been added, false otherwise (in case checkMultiEdge is set to
+     * true and the new edge would have been a multi-edge.)
      */
-    void addPartialOutEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight,
-                           uint64_t index = 0);
+    bool addPartialOutEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight,
+                           uint64_t index = 0, bool checkForMultiEdges = false);
 
     /**
      * Removes the undirected edge {@a u,@a v}.

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -591,11 +591,15 @@ edgeweight Graph::weightedDegreeIn(node u, bool countSelfLoopsTwice) const {
 
 /** EDGE MODIFIERS **/
 
-void Graph::addEdge(node u, node v, edgeweight ew) {
+bool Graph::addEdge(node u, node v, edgeweight ew, bool checkForMultiEdges) {
     assert(u < z);
     assert(exists[u]);
     assert(v < z);
     assert(exists[v]);
+
+    if (checkForMultiEdges && hasEdge(u, v)) {
+        return false;
+    }
 
     // increase number of edges
     ++m;
@@ -639,12 +643,20 @@ void Graph::addEdge(node u, node v, edgeweight ew) {
     if (u == v) { // count self loop
         ++storedNumberOfSelfLoops;
     }
+
+    return true;
 }
-void Graph::addPartialEdge(Unsafe, node u, node v, edgeweight ew, uint64_t index) {
+bool Graph::addPartialEdge(Unsafe, node u, node v, edgeweight ew, uint64_t index,
+                           bool checkForMultiEdges) {
     assert(u < z);
     assert(exists[u]);
     assert(v < z);
     assert(exists[v]);
+
+    if (checkForMultiEdges
+        && (std::find(outEdges[u].begin(), outEdges[u].end(), v) != outEdges[u].end())) {
+        return false;
+    }
 
     outEdges[u].push_back(v);
 
@@ -655,12 +667,20 @@ void Graph::addPartialEdge(Unsafe, node u, node v, edgeweight ew, uint64_t index
     if (weighted) {
         outEdgeWeights[u].push_back(ew);
     }
+
+    return true;
 }
-void Graph::addPartialOutEdge(Unsafe, node u, node v, edgeweight ew, uint64_t index) {
+bool Graph::addPartialOutEdge(Unsafe, node u, node v, edgeweight ew, uint64_t index,
+                              bool checkForMultiEdges) {
     assert(u < z);
     assert(exists[u]);
     assert(v < z);
     assert(exists[v]);
+
+    if (checkForMultiEdges
+        && (std::find(outEdges[u].begin(), outEdges[u].end(), v) != outEdges[u].end())) {
+        return false;
+    }
 
     outEdges[u].push_back(v);
 
@@ -671,12 +691,20 @@ void Graph::addPartialOutEdge(Unsafe, node u, node v, edgeweight ew, uint64_t in
     if (weighted) {
         outEdgeWeights[u].push_back(ew);
     }
+
+    return true;
 }
-void Graph::addPartialInEdge(Unsafe, node u, node v, edgeweight ew, uint64_t index) {
+bool Graph::addPartialInEdge(Unsafe, node u, node v, edgeweight ew, uint64_t index,
+                             bool checkForMultiEdges) {
     assert(u < z);
     assert(exists[u]);
     assert(v < z);
     assert(exists[v]);
+
+    if (checkForMultiEdges
+        && (std::find(inEdges[u].begin(), inEdges[u].end(), v) != inEdges[u].end())) {
+        return false;
+    }
 
     inEdges[u].push_back(v);
 
@@ -686,6 +714,8 @@ void Graph::addPartialInEdge(Unsafe, node u, node v, edgeweight ew, uint64_t ind
     if (weighted) {
         inEdgeWeights[u].push_back(ew);
     }
+
+    return true;
 }
 
 template <typename T>

--- a/networkit/cpp/io/DibapGraphReader.cpp
+++ b/networkit/cpp/io/DibapGraphReader.cpp
@@ -161,7 +161,8 @@ Graph DibapGraphReader::read(const std::string &path) {
         for (index v = 0; v < (count)V; ++v) {
             for (index e = of[v]; e < (index)of[v + 1]; ++e) {
                 if (v <= (index)to[e]) {
-                    graph.addEdge(v, to[e], ew[e]);
+                    if (!graph.addEdge(v, to[e], ew[e], true))
+                        WARN("Not adding edge ", v, "-", to[e], " since it is already present.");
                 }
             }
         }
@@ -169,7 +170,8 @@ Graph DibapGraphReader::read(const std::string &path) {
         for (index v = 0; v < (count)V; ++v) {
             for (index e = of[v]; e < (index)of[v + 1]; ++e) {
                 if (v <= (index)to[e]) {
-                    graph.addEdge(v, to[e]);
+                    if (!graph.addEdge(v, to[e], defaultEdgeWeight, true))
+                        WARN("Not adding edge ", v, "-", to[e], " since it is already present.");
                 }
             }
         }

--- a/networkit/cpp/io/GMLGraphReader.cpp
+++ b/networkit/cpp/io/GMLGraphReader.cpp
@@ -106,8 +106,10 @@ Graph GMLGraphReader::read(const std::string &path) {
                 }
                 std::getline(graphFile, line);
             }
-            G.addEdge(u, v);
-            DEBUG("added edge ", u, ", ", v);
+            if (!G.addEdge(u, v, defaultEdgeWeight, true))
+                WARN("Not adding edge ", u, "-", v, " since it is already present.");
+            else
+                DEBUG("added edge ", u, ", ", v);
         } else {
             return false;
         }

--- a/networkit/cpp/io/GraphToolBinaryReader.cpp
+++ b/networkit/cpp/io/GraphToolBinaryReader.cpp
@@ -124,7 +124,8 @@ void GraphToolBinaryReader::addOutNeighbours(std::ifstream &file, uint64_t numNo
         for (uint64_t v = 0; v < numOutNeighbours; ++v) {
             // read current adjacency and add edge
             uint64_t node = readType<uint64_t>(file, width);
-            G.addEdge(u, node);
+            if (!G.addEdge(u, node, defaultEdgeWeight, true))
+                WARN("Not adding edge ", u, "-", node, " since it is already present.");
         }
     }
 }

--- a/networkit/cpp/io/KONECTGraphReader.cpp
+++ b/networkit/cpp/io/KONECTGraphReader.cpp
@@ -215,7 +215,8 @@ Graph KONECTGraphReader::read(const std::string &path) {
     // Helper function for handling edges
     auto handleEdge = [&](node source, node target, edgeweight weight) {
         if (!graph.hasEdge(source, target)) {
-            graph.addEdge(source, target, weight);
+            if (!graph.addEdge(source, target, weight, true))
+                WARN("Not adding edge ", source, "-", target, " since it is already present.");
         } else if (multiple) {
             switch (multipleEdgesHandlingMethod) {
             case DISCARD_EDGES:

--- a/networkit/cpp/io/METISGraphReader.cpp
+++ b/networkit/cpp/io/METISGraphReader.cpp
@@ -64,7 +64,8 @@ Graph METISGraphReader::read(const std::string &path) {
                     edgeCounter++;
                     selfLoops++;
                 }
-                G.addPartialEdge(unsafe, u, v);
+                if (!G.addPartialEdge(unsafe, u, v, defaultEdgeWeight, 0, true))
+                    WARN("Not adding edge ", u, "-", v, " since it is already present.");
             }
             u++; // next node
 #ifndef NETWORKIT_RELEASE_LOGGING
@@ -94,8 +95,10 @@ Graph METISGraphReader::read(const std::string &path) {
                     selfLoops++;
                 }
                 double weight = adjacencies[i].second;
-                G.addPartialEdge(unsafe, u, v, weight);
-                TRACE("(", u, ",", v, ",", adjacencies[i].second, ")");
+                if (!G.addPartialEdge(unsafe, u, v, weight, 0, true))
+                    WARN("Not adding edge ", u, "-", v, " since it is already present.");
+                else
+                    TRACE("(", u, ",", v, ",", adjacencies[i].second, ")");
             }
             u += 1; // next node
 #ifndef NETWORKIT_RELEASE_LOGGING

--- a/networkit/cpp/io/NetworkitBinaryReader.cpp
+++ b/networkit/cpp/io/NetworkitBinaryReader.cpp
@@ -217,9 +217,11 @@ Graph NetworkitBinaryReader::readData(const T &source) {
                         omega = id;
                 }
                 if (!directed) {
-                    G.addPartialEdge(unsafe, curr, add, weight, id);
+                    if (!G.addPartialEdge(unsafe, curr, add, weight, id, true))
+                        WARN("Not adding edge ", curr, "-", add, " since it is already present.");
                 } else {
-                    G.addPartialOutEdge(unsafe, curr, add, weight, id);
+                    if (!G.addPartialOutEdge(unsafe, curr, add, weight, id, true))
+                        WARN("Not adding edge ", curr, "-", add, " since it is already present.");
                 }
                 if (curr == add) {
                     selfLoops.fetch_add(1, std::memory_order_relaxed);
@@ -268,10 +270,13 @@ Graph NetworkitBinaryReader::readData(const T &source) {
                 }
                 if (!directed) {
                     if (curr != add) {
-                        G.addPartialEdge(unsafe, curr, add, weight, id);
+                        if (G.addPartialEdge(unsafe, curr, add, weight, id, true))
+                            WARN("Not adding edge ", curr, "-", add,
+                                 " since it is already present.");
                     }
                 } else {
-                    G.addPartialInEdge(unsafe, curr, add, weight, id);
+                    if (!G.addPartialInEdge(unsafe, curr, add, weight, id, true))
+                        WARN("Not adding edge ", curr, "-", add, " since it is already present.");
                 }
             }
         }

--- a/networkit/graph.pxd
+++ b/networkit/graph.pxd
@@ -57,7 +57,7 @@ cdef extern from "<networkit/graph/Graph.hpp>":
 		void removeNode(node u) except +
 		bool_t hasNode(node u) except +
 		void restoreNode(node u) except +
-		void addEdge(node u, node v, edgeweight w) except +
+		bool_t addEdge(node u, node v, edgeweight w, bool_t checkMultiEdge) except +
 		void setWeight(node u, node v, edgeweight w) except +
 		void increaseWeight(node u, node v, edgeweight w) except +
 		void removeEdge(node u, node v) except +

--- a/networkit/graph.pyx
+++ b/networkit/graph.pyx
@@ -346,16 +346,17 @@ cdef class Graph:
 		"""
 		return self._this.hasNode(u)
 
-	def addEdge(self, u, v, w=1.0, addMissing = False):
+	def addEdge(self, u, v, w=1.0, addMissing = False, checkMultiEdge = False):
 		""" 
-		addEdge(u, v, w=1.0, addMissing=False)
+		addEdge(u, v, w=1.0, addMissing=False, checkMultiEdge=False)
 		
 		Insert an undirected edge between the nodes `u` and `v`. If the graph is weighted you can optionally set a weight for this edge. 
 		The default weight is 1.0. If one or both end-points do not exists and addMissing is set, they are silently added.
 		
 		Note
 		----
-		It is not checked whether this edge already exists, thus it is possible to create multi-edges.
+		By default it is not checked whether this edge already exists, thus it is possible to create multi-edges. Multi-edges are not supported and will NOT be
+		handled consistently by the graph data structure. To enable set :code:`checkMultiEdge` to True. Note that this increases the runtime of the function by O(max(deg(u), deg(v))).
 
 	 	Parameters
 	 	----------
@@ -367,6 +368,13 @@ cdef class Graph:
 			Edge weight.
 		addMissing : bool, optional
 			Add missing endpoints if necessary (i.e., increase numberOfNodes). Default: False
+		checkMultiEdge : bool, optional
+			Check if edge is already present in the graph. If detected, do not insert the edge. Default: False
+
+		Returns
+		-------
+		bool
+			Indicates whether the edge has been added. Is `False` in case :code:`checkMultiEdge` is set to `True` and the new edge would have been a multi-edge.
 		"""
 		if not (self._this.hasNode(u) and self._this.hasNode(v)):
 			if not addMissing:
@@ -382,8 +390,7 @@ cdef class Graph:
 			if not self._this.hasNode(v):
 				self._this.restoreNode(v)
 
-		self._this.addEdge(u, v, w)
-		return self
+		return self._this.addEdge(u, v, w, checkMultiEdge)
 
 	def setWeight(self, u, v, w):
 		""" 

--- a/notebooks/GraphNotebook.ipynb
+++ b/notebooks/GraphNotebook.ipynb
@@ -161,6 +161,48 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that in default mode NetworKit allows you to add an edge multiple times, most algorithms (and also io-functions) do not support it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.addNode()\n",
+    "G.addEdge(0, 6)\n",
+    "print(G.numberOfEdges())\n",
+    "# NetworKit does not complain when inserting the same edge a second time \n",
+    "G.addEdge(0, 6)\n",
+    "print(G.numberOfEdges())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If wanted, this behavior can be changed. This increases the running time of adding an edge by the degree of the involved nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove one of the multiple edges\n",
+    "G.removeEdge(0, 6)\n",
+    "print(G.numberOfEdges())\n",
+    "# The multi-edge is not added to the graph. \n",
+    "G.addEdge(0, 6, checkMultiEdge = True)\n",
+    "print(G.numberOfEdges())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "NetworKit provides iterators that enable iterating over all nodes or edges in a simple manner. There are two kinds of iterators: one is based on ranges, the other one accepts callback a function.\n",
     "The easiest to use are the range-based iterators, they can be used in a simple for loop:"
    ]


### PR DESCRIPTION
This PR add an additional (opt.) parameter to addEdge in C++/Python for checking whether an edge is already present in the graph. The documentation/tutorials are updated accordingly.

Also checked for other places, where a warning about unsupported multi-edges might be missing in the documentation. Maybe we could also use the modified addEdge for reader/writer or converter to ensure a warning is triggered when inserting multi-edges (like in #953).

Another approach would be an additional method like `addEdgeSafe`, where multi-edges are checked first.