### PR TITLE
GHA: Change ubuntu repo for gcc-11 from impish to jammy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run:  |
-          sudo add-apt-repository 'deb http://mirrors.kernel.org/ubuntu impish main universe'
+          sudo add-apt-repository 'deb http://mirrors.kernel.org/ubuntu jammy main universe'
           sudo apt-get update
           sudo apt-get install gcc-11 g++-11 ninja-build
       - name: Setup Python 3.10
@@ -412,7 +412,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run:  |
-          sudo add-apt-repository 'deb http://mirrors.kernel.org/ubuntu impish main universe'
+          sudo add-apt-repository 'deb http://mirrors.kernel.org/ubuntu jammy main universe'
           sudo apt-get update
           sudo apt-get install gcc-11 g++-11 ninja-build
           sudo apt-get install doxygen pandoc


### PR DESCRIPTION
Impish (short-term release of Ubuntu) is not available anymore in (some) official repos. Switching to jammy (22.04 LTS) should fix the errors with missing repositories on the pipeline.