### PR TITLE
Refactor PLP

### DIFF
--- a/networkit/cpp/community/PLP.cpp
+++ b/networkit/cpp/community/PLP.cpp
@@ -61,8 +61,7 @@ void PLP::run() {
      * iteration.
      */
 
-    std::vector<bool> activeNodes(z); // record if node must be processed
-    activeNodes.assign(z, true);
+    std::vector<bool> activeNodes(z, true); // record if node must be processed
 
     Aux::Timer runtime;
 

--- a/networkit/cpp/community/PLP.cpp
+++ b/networkit/cpp/community/PLP.cpp
@@ -42,8 +42,8 @@ void PLP::run() {
         updateThreshold = (count)(n / 1e5);
     }
 
-    count nUpdated; // number of nodes which have been updated in last iteration
-    nUpdated = n;   // all nodes have new labels -> first loop iteration runs
+    // number of nodes which have been updated in last iteration
+    count nUpdated = n; // all nodes have new labels -> first loop iteration runs
 
     nIterations = 0; // number of iterations
 
@@ -104,25 +104,9 @@ void PLP::run() {
 
             if (result.subsetOf(v) != heaviest) { // UPDATE
                 result.moveToSubset(heaviest, v); // result[v] = heaviest;
-                nUpdated += 1;                    // TODO: atomic update?
+#pragma omp atomic
+                ++nUpdated;
                 G->forNeighborsOf(v, [&](node u) { activeNodes[u] = true; });
-
-                // get heaviest label
-                label heaviest = std::max_element(labelWeights.begin(), labelWeights.end(),
-                                                  [](const std::pair<label, edgeweight> &p1,
-                                                     const std::pair<label, edgeweight> &p2) {
-                                                      return p1.second < p2.second;
-                                                  })
-                                     ->first;
-
-                if (result.subsetOf(v) != heaviest) { // UPDATE
-                    result.moveToSubset(heaviest, v); // result[v] = heaviest;
-                    nUpdated += 1;                    // TODO: atomic update?
-                    G->forNeighborsOf(v, [&](node u) { activeNodes[u] = true; });
-                } else {
-                    activeNodes[v] = false;
-                }
-
             } else {
                 activeNodes[v] = false;
             }

--- a/networkit/cpp/community/PLP.cpp
+++ b/networkit/cpp/community/PLP.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <omp.h>
+#include <unordered_map>
 
 #include <networkit/Globals.hpp>
 #include <networkit/auxiliary/Log.hpp>
@@ -80,12 +81,17 @@ void PLP::run() {
                 return; // node is isolated
 
             // neighborLabelCounts maps label -> frequency in the neighbors
-            std::map<label, double> labelWeights;
+            std::unordered_map<label, edgeweight> labelWeights;
 
             // weigh the labels in the neighborhood of v
             G->forNeighborsOf(v, [&](node w, edgeweight weight) {
                 label lw = result.subsetOf(w);
-                labelWeights[lw] += weight; // add weight of edge {v, w}
+                auto it = labelWeights.find(lw);
+                // add weight of edge {v, w}
+                if (it == labelWeights.end())
+                    labelWeights.emplace(lw, weight);
+                else
+                    it->second += weight;
             });
 
             // get heaviest label

--- a/networkit/cpp/community/PLP.cpp
+++ b/networkit/cpp/community/PLP.cpp
@@ -127,6 +127,7 @@ void PLP::setUpdateThreshold(count th) {
 }
 
 count PLP::numberOfIterations() {
+    assureFinished();
     return this->nIterations;
 }
 


### PR DESCRIPTION
- Fix a potential bug in PLP (a variable was updated non-atomically in a parallel loop)
- Replace `std::map` with `std::unordered_map` because the order of the elements is not needed
- Minor stylistic changes