### PR TITLE
Fix crash of SPSP in case of unreachable targets

### DIFF
--- a/networkit/cpp/distance/MultiTargetBFS.cpp
+++ b/networkit/cpp/distance/MultiTargetBFS.cpp
@@ -1,6 +1,7 @@
 #include <networkit/distance/BFS.hpp>
 #include <networkit/distance/MultiTargetBFS.hpp>
 
+#include <limits>
 #include <queue>
 #include <unordered_set>
 
@@ -59,6 +60,12 @@ void MultiTargetBFS::run() {
         } while (!frontier.empty());
 
         toNextLevel();
+    }
+
+    // Mark targets not reached as unreachable
+    for (const node target : targetsSet) {
+        targetIdx.emplace(target, distances.size());
+        distances.emplace_back(std::numeric_limits<edgeweight>::max());
     }
 
     hasRun = true;

--- a/networkit/cpp/distance/MultiTargetDijkstra.cpp
+++ b/networkit/cpp/distance/MultiTargetDijkstra.cpp
@@ -41,6 +41,12 @@ void MultiTargetDijkstra::run() {
         });
     } while (!heap.empty());
 
+    // Mark targets not reached as unreachable
+    for (const node target : targetsSet) {
+        targetIdx.emplace(target, distances.size());
+        distances.emplace_back(std::numeric_limits<edgeweight>::max());
+    }
+
     hasRun = true;
 }
 

--- a/networkit/cpp/distance/test/DistanceGTest.cpp
+++ b/networkit/cpp/distance/test/DistanceGTest.cpp
@@ -533,6 +533,23 @@ TEST_P(DistanceGTest, testSPSPWithTargets) {
     }
 }
 
+TEST_P(DistanceGTest, testSPSPWithUnreachableTarget) {
+    Aux::Random::setSeed(42, true);
+    auto G = generateERGraph(100, 0.15);
+    const node unreachable = G.addNode();
+
+    APSP apsp(G);
+    apsp.run();
+
+    const std::vector<node> sources = {0}, targets = {unreachable};
+    SPSP spsp(G, sources.begin(), sources.end(), targets.begin(), targets.end());
+    spsp.run();
+
+    for (node source : sources)
+        for (node target : targets)
+            EXPECT_DOUBLE_EQ(apsp.getDistance(source, target), spsp.getDistance(source, target));
+}
+
 TEST_P(DistanceGTest, testMultiTargetBFS) {
     Aux::Random::setSeed(42, true);
     const auto G = generateERGraph(100, 0.15);


### PR DESCRIPTION
SPSP crashes if the user passes unreachable targets (the node -> distance map lookup fails for unreachable targets because they are never added to the map). This can easily be fixed by setting to infinity the distance to those targets.
This PR also adds a new test with an unreachable target that fails with the previous implementation of SPSP.