### PR TITLE
Initialize edgeID datastructure when constr. graph with indexed edges.

### DIFF
--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -37,7 +37,8 @@ Graph::Graph(count n, bool weighted, bool directed, bool edgesIndexed)
       outgoing edges, for undirected graphs outEdges stores the adjacency list of
       undirected edges*/
       outEdges(n), inEdgeWeights(weighted && directed ? n : 0), outEdgeWeights(weighted ? n : 0),
-      inEdgeIds(), outEdgeIds(), nodeAttributeMap(this) {}
+      inEdgeIds(edgesIndexed && directed ? n : 0), outEdgeIds(edgesIndexed ? n : 0),
+      nodeAttributeMap(this) {}
 
 Graph::Graph(std::initializer_list<WeightedEdge> edges) : Graph(0, true) {
     using namespace std;

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -132,6 +132,21 @@ void GraphGTest::SetUp() {
 
 /** CONSTRUCTORS **/
 
+TEST(GraphGTest, testDefConstructorWithUndirIndex) {
+    // Test indexed + undirected graph
+    Graph GUndir(3, false, false, true);
+    GUndir.addEdge(0, 1);
+    EXPECT_EQ(GUndir.edgeId(0, 1), 0);
+    EXPECT_EQ(GUndir.edgeId(1, 0), 0);
+}
+
+TEST(GraphGTest, testDefConstructorWithDirIndex) {
+    // Test indexed + directed graph
+    Graph GDir(3, false, true, true);
+    GDir.addEdge(0, 1);
+    EXPECT_EQ(GDir.edgeId(0, 1), 0);
+}
+
 TEST_P(GraphGTest, testCopyConstructor) {
     Graph G = Graph(this->Ghouse, false, false);
     Graph GW = Graph(this->Ghouse, true, false);


### PR DESCRIPTION
Fixes #986.