### PR TITLE
Remove possibility to ignore unformatted files

### DIFF
--- a/docs/DevGuide.rst
+++ b/docs/DevGuide.rst
@@ -159,9 +159,7 @@ We want to ensure that code across NetworKit is easy to understand for existing 
 
 In order to maintain the same standard of code across the entire NetworKit code base, some coding standards are enforced. However, there is some automation to help developers with this. Below is a list of these standards and instructions on how to use the available automation tools that ensure your code adheres to them.
 
--  ``CppClangFormat`` applies clang-format to all C++ files unless they contain the
-   string ``no-networkit-format``. New code files, however, should not use
-   ``no-networkit-format``.
+-  ``CppClangFormat`` applies clang-format to all C++ files.
 -  ``CppIndentation`` checks that all C++ code is indented with spaces
    and not tabs.
 -  ``CppIncludeGuards`` ensures that the header files contain an include guard and

--- a/extrafiles/tooling/CppClangFormat.py
+++ b/extrafiles/tooling/CppClangFormat.py
@@ -49,11 +49,6 @@ def findClangFormat():
 
 	raise FileNotFoundError("clang-format binary not found. We searched for:\n " + "\n ".join(allowed))
 
-def unsubscribedToFormat(filename, pattern = "no-networkit-format"):
-	"""If pattern is present within the file, this file unsubscribed to auto formatting."""
-	with open(filename, 'r') as file:
-		return any( ((pattern in line) for line in file) )
-
 def runClangFormat(inputFilename, outputFilename, clangFormatBinary = 'clang-format-8'):
 	"""Execute clang-format onto inputFilename and stores the result in outputFilename"""
 	with open(outputFilename, "w") as outfile:
@@ -66,15 +61,11 @@ nkt.setup()
 os.chdir(nkt.getNetworKitRoot())
 
 numberNonCompliant = 0
-numberFileSkipped = 0
 
 clangFormatCommand = findClangFormat()
 with tempfile.TemporaryDirectory(dir=nkt.getNetworKitRoot()) as tempDir:
 	files = nkt.getCXXFiles()
 	for file in files:
-		if unsubscribedToFormat(file):
-			numberFileSkipped += 1
-			continue
 
 		tempFile = os.path.join(tempDir, 'cfOutput')
 		runClangFormat(file, tempFile, clangFormatCommand)
@@ -89,8 +80,7 @@ with tempfile.TemporaryDirectory(dir=nkt.getNetworKitRoot()) as tempDir:
 			if not nkt.isReadonly():
 				os.replace(tempFile, file)
 
-print("Scanned %d files (skipped %d files without subscription). Non-compliant files: %d." %
-	  (len(files), numberFileSkipped, numberNonCompliant))
+print(f"Scanned {len(files)} files. Non-compliant files: {numberNonCompliant}.")
 
 if numberNonCompliant > 0:
 	nkt.failIfReadonly(__file__)


### PR DESCRIPTION
Unformatted files can be skipped by adding the line `//no-networkit-format` at the top of cpp files. Since all cpp files are
now formatted, this option is not needed anymore.