### PR TITLE
CI: Raise llvm toolkit to v15.0 (clang, clang-format, clang-tidy)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,6 @@ Checks: >
     bugprone-copy-constructor-init,
     bugprone-dangling-handle,
     bugprone-dynamic-static-initializers,
-    bugprone-exception-escape,
     bugprone-fold-init-type,
     bugprone-forward-declaration-namespace,
     bugprone-forwarding-reference-overload,
@@ -43,6 +42,7 @@ Checks: >
     readability-avoid-const-params-in-decls,
     readability-const-return-type,
     readability-container-size-empty
+# temp. disabled: bugprone-exception-escape
 
 # Turn the warnings from the checks above into errors.
 # To turn all warnings into errors, simply write '*'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -103,6 +103,7 @@ jobs:
             brew install libomp ninja
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs }}
           CIBW_BUILD: "cp38-* cp39-* cp310-*"
+          CIBW_ENVIRONMENT: CXX='c++'
           CIBW_SKIP: pp*
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,17 +139,17 @@ jobs:
     strategy:
       matrix:
         os: ['11']
-        compiler: ['clang-13', 'gcc-11']
+        compiler: ['clang-15', 'gcc-11']
     steps:
       - name: Install prerequisites
         run: |
           brew install libomp
           brew install ninja
       - name: Install compiler llvm
-        if: matrix.compiler == 'clang-13'
+        if: matrix.compiler == 'clang-15'
         run: |
-          brew reinstall llvm@13
-          brew link --overwrite llvm@13
+          brew reinstall llvm@15
+          brew link --overwrite llvm@15
       - name: Install compiler gcc
         if: matrix.compiler == 'gcc-11'
         run: |
@@ -163,8 +163,8 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
         shell: bash
         env:
-          CC: ${{ matrix.compiler == 'clang-13' && '/usr/local/opt/llvm@13/bin/clang' || 'gcc-11' }}
-          CXX: ${{ matrix.compiler == 'clang-13' && '/usr/local/opt/llvm@13/bin/clang++' || 'g++-11' }}
+          CC: ${{ matrix.compiler == 'clang-15' && '/usr/local/opt/llvm@15/bin/clang' || 'gcc-11' }}
+          CXX: ${{ matrix.compiler == 'clang-15' && '/usr/local/opt/llvm@15/bin/clang++' || 'g++-11' }}
 
   linux-build-latest:
     name: "Linux (gcc-11${{ startsWith(matrix.build-configuration, 'full') && ', CPython 3.10' || '' }}): ${{ matrix.build-configuration }}"
@@ -209,14 +209,14 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        compiler: ['clang-13']
+        compiler: ['clang-15']
     steps:
       - name: Install prerequisites
         run:  |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-13 main" | sudo tee /etc/apt/sources.list.d/llvm13.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-15 main" | sudo tee /etc/apt/sources.list.d/llvm13.list
           sudo apt-get update
-          sudo apt-get install clang-13 libomp-13-dev ninja-build
+          sudo apt-get install clang-15 libomp-15-dev ninja-build
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:
@@ -230,8 +230,8 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
         shell: bash
         env:
-          CC: clang-13
-          CXX: clang++-13
+          CC: clang-15
+          CXX: clang++-15
 
   linux-build-min-support:
     name: "Linux (${{ matrix.compiler }}, CPython 3.7): full"
@@ -267,7 +267,7 @@ jobs:
           CXX: ${{ matrix.compiler == 'gcc-7' && 'g++-7' || 'clang++-5.0' }}
 
   linux-build-clang-tidy:
-    name: "Linux (clang-13): clang-tidy"
+    name: "Linux (clang-15): clang-tidy"
     runs-on: ubuntu-20.04
     env:
       CC: clang
@@ -276,9 +276,9 @@ jobs:
       - name: Install prerequisites
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-13 main" | sudo tee /etc/apt/sources.list.d/llvm13.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-15 main" | sudo tee /etc/apt/sources.list.d/llvm13.list
           sudo apt-get update
-          sudo apt-get install libomp-13-dev clang-13 clang-tidy-13 ninja-build
+          sudo apt-get install libomp-15-dev clang-15 clang-tidy-15 ninja-build
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:
@@ -446,9 +446,9 @@ jobs:
       - name: Install prerequisites
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-13 main" | sudo tee /etc/apt/sources.list.d/llvm11.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-15 main" | sudo tee /etc/apt/sources.list.d/llvm11.list
           sudo apt-get update
-          sudo apt-get install clang-format-13 python-yaml
+          sudo apt-get install clang-format-15 python-yaml
       - name: Checkout networkit
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/scripts/clang_tidy.sh
+++ b/.github/workflows/scripts/clang_tidy.sh
@@ -3,9 +3,9 @@ set -e
 set -o pipefail
 
 sudo rm -rf /usr/local/clang-*
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 9999
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 9999
-sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-13 9999
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 9999
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 9999
+sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 9999
 $CXX --version
 clang-tidy --version
 mkdir debug_test && cd "$_"

--- a/networkit/cpp/centrality/KadabraBetweenness.cpp
+++ b/networkit/cpp/centrality/KadabraBetweenness.cpp
@@ -250,7 +250,7 @@ void KadabraBetweenness::init() {
     epochFinished = std::vector<std::atomic<StateFrame *>>(omp_max_threads);
     samplerVec.reserve(omp_max_threads);
     for (count i = 0; i < omp_max_threads; ++i) {
-        samplerVec.emplace_back(SpSampler(G, *cc));
+        samplerVec.emplace_back(G, *cc);
         epochFinished[i].store(nullptr, std::memory_order_relaxed);
     }
 

--- a/networkit/cpp/distance/DynBFS.cpp
+++ b/networkit/cpp/distance/DynBFS.cpp
@@ -106,7 +106,7 @@ void DynBFS::updateBatch(const std::vector<GraphEvent> &batch) {
     for (count m = 1; m < maxDistance; m++) {
         if (m >= maxDistance - 1 && (!queues[m].empty() || !queues[m + 1].empty())) {
             maxDistance++;
-            queues.emplace_back(std::queue<node>());
+            queues.emplace_back();
         }
         mod = mod || (!queues[m].empty());
         while (!queues[m].empty()) {
@@ -155,7 +155,7 @@ void DynBFS::updateBatch(const std::vector<GraphEvent> &batch) {
                 if (con != infDist) {
                     if (con > maxDistance) {
                         for (count i = maxDistance; i < con; i++)
-                            queues.emplace_back(std::queue<node>());
+                            queues.emplace_back();
                         maxDistance = con;
                     }
                     queues[con].push(w);


### PR DESCRIPTION
This updates the tooling for llvm-based builds / tests. GCC compiler is not touched, since there are still problems with GCC 12+, which needs to be resolved beforehand.

This PR also solves problems on CI, since OpenMP is compatible with -/+ one major version. For the most recent GHA images, the version deviates by two (as seen on #998).