### PR TITLE
Refactor TopCloseness, TopHarmonicCloseness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,7 +461,7 @@ if (NETWORKIT_BUILD_TESTS)
 			set( gtest_force_shared_crt ON CACHE BOOL "Always use msvcrt.dll" FORCE)
 		endif()
 		option(BUILD_GTEST "Builds the googletest subproject" ON)
-		option(BUILD_GMOCK "Builds the googlemock subproject" OFF)
+		option(BUILD_GMOCK "Builds the googlemock subproject" ON)
 		add_subdirectory(extlibs/googletest)
 	else()
 		message(FATAL_ERROR
@@ -475,18 +475,19 @@ if (NETWORKIT_BUILD_TESTS)
 		target_link_libraries(networkit_tests
 			PRIVATE
 				gtest
+				gmock
 				networkit
 				tlx
 				OpenMP::OpenMP_CXX
 		)
-		
+
 		if(WIN32)
 			target_link_libraries(networkit_tests
 				PRIVATE
 					networkit_state
 			)
 		endif()
-		
+
 		if(WIN32)
 			set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} /wd4996")
 		else()
@@ -520,6 +521,7 @@ if (NETWORKIT_BUILD_TESTS)
 		target_link_libraries(networkit_gtest_main
 				PUBLIC
 					gtest
+					gmock
 				PRIVATE
 					tlx
 					networkit_auxiliary

--- a/include/networkit/centrality/TopCloseness.hpp
+++ b/include/networkit/centrality/TopCloseness.hpp
@@ -41,9 +41,11 @@ public:
      * degree.
      * @param sec_heu If true, the BFSbound is re-computed at each iteration. If
      * false, BFScut is used.
-     * @
+     * @param nodeList Restrict closeness computation to a grou of nodes from the graph. In order to
+     * work, these nodes have to be present.
      */
-    TopCloseness(const Graph &G, count k = 1, bool first_heu = true, bool sec_heu = true);
+    TopCloseness(const Graph &G, count k = 1, bool first_heu = true, bool sec_heu = true,
+                 const std::vector<node> &nodeList = std::vector<node>());
 
     /**
      * Computes top-k closeness on the graph passed in the constructor.
@@ -78,6 +80,7 @@ private:
     count k;
     bool first_heu, sec_heu;
     std::vector<node> topk;
+    std::vector<node> nodeList;
     count visEdges;
     count n_op;
     count trail;

--- a/include/networkit/centrality/TopCloseness.hpp
+++ b/include/networkit/centrality/TopCloseness.hpp
@@ -41,8 +41,9 @@ public:
      * degree.
      * @param sec_heu If true, the BFSbound is re-computed at each iteration. If
      * false, BFScut is used.
-     * @param nodeList Restrict closeness computation to a grou of nodes from the graph. In order to
-     * work, these nodes have to be present.
+     * @param nodeList Restrict closeness computation to a group of nodes from the graph.
+     * If the list is empty (default), all nodes from the graph are used for computation.
+     * Note: Actual existence of included nodes in the graph is not checked.
      */
     TopCloseness(const Graph &G, count k = 1, bool first_heu = true, bool sec_heu = true,
                  const std::vector<node> &nodeList = std::vector<node>());

--- a/include/networkit/centrality/TopCloseness.hpp
+++ b/include/networkit/centrality/TopCloseness.hpp
@@ -41,12 +41,8 @@ public:
      * degree.
      * @param sec_heu If true, the BFSbound is re-computed at each iteration. If
      * false, BFScut is used.
-     * @param nodeList Restrict closeness computation to a group of nodes from the graph.
-     * If the list is empty (default), all nodes from the graph are used for computation.
-     * Note: Actual existence of included nodes in the graph is not checked.
      */
-    TopCloseness(const Graph &G, count k = 1, bool first_heu = true, bool sec_heu = true,
-                 const std::vector<node> &nodeList = std::vector<node>());
+    TopCloseness(const Graph &G, count k = 1, bool first_heu = true, bool sec_heu = true);
 
     /**
      * Computes top-k closeness on the graph passed in the constructor.
@@ -75,13 +71,24 @@ public:
      */
     std::vector<edgeweight> topkScoresList(bool includeTrail = false);
 
+    /**
+     * @brief Restricts the top-k closeness computation to a subset of nodes.
+     * If the given list is empty, all nodes in the graph will be considered.
+     * Note: Actual existence of included nodes in the graph is not checked.
+     *
+     * @param nodeList Subset of nodes.
+     */
+    void restrictTopKComputationToNodes(const std::vector<node> &nodeList) {
+        nodeListPtr = &nodeList;
+    };
+
 private:
     const Graph &G;
     count n;
     count k;
     bool first_heu, sec_heu;
     std::vector<node> topk;
-    std::vector<node> nodeList;
+    const std::vector<node> *nodeListPtr;
     count visEdges;
     count n_op;
     count trail;

--- a/include/networkit/centrality/TopHarmonicCloseness.hpp
+++ b/include/networkit/centrality/TopHarmonicCloseness.hpp
@@ -41,12 +41,8 @@ public:
      * @param k Number of nodes with highest harmonic closeness that have to be found.
      * For example, k = 10, the top 10 nodes with highest harmonic closeness will be computed.
      * @param useNBbound If true, the NBbound variation will be used, otherwise NBcut.
-     * @param nodeList Restrict closeness computation to a group of nodes from the graph.
-     * If the list is empty (default), all nodes from the graph are used for computation.
-     * Note: Actual existence of included nodes in the graph is not checked.
      */
-    explicit TopHarmonicCloseness(const Graph &G, count k = 1, bool useNBbound = false,
-                                  const std::vector<node> &nodeList = std::vector<node>());
+    explicit TopHarmonicCloseness(const Graph &G, count k = 1, bool useNBbound = false);
 
     ~TopHarmonicCloseness() override;
 
@@ -80,6 +76,17 @@ public:
      */
     std::vector<edgeweight> topkScoresList(bool includeTrail = false);
 
+    /**
+     * @brief Restricts the top-k harmonic closeness computation to a subset of nodes.
+     * If the given list is empty, all nodes in the graph will be considered.
+     * Note: Actual existence of included nodes in the graph is not checked.
+     *
+     * @param nodeList Subset of nodes.
+     */
+    void restrictTopKComputationToNodes(const std::vector<node> &nodeList) {
+        nodeListPtr = &nodeList;
+    };
+
 private:
     const Graph *G;
     const count k;
@@ -92,7 +99,7 @@ private:
 
     std::vector<node> topKNodes;
     std::vector<double> topKScores;
-    std::vector<node> nodeList;
+    const std::vector<node> *nodeListPtr;
 
     // For NBbound
     std::vector<count> reachU, reachL;
@@ -110,8 +117,8 @@ private:
         }
     }
 
-    tlx::d_ary_addressable_int_heap<node, 2, Aux::GreaterInVector<double>> prioQ;
     tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<double>> topKNodesPQ;
+    tlx::d_ary_addressable_int_heap<node, 2, Aux::GreaterInVector<double>> prioQ;
     std::vector<node> trail;
 
     // For weighted graphs
@@ -122,6 +129,7 @@ private:
 
     omp_lock_t lock;
 
+    void init();
     void runNBcut();
     void runNBbound();
     bool bfscutUnweighted(node source, double kthCloseness);

--- a/include/networkit/centrality/TopHarmonicCloseness.hpp
+++ b/include/networkit/centrality/TopHarmonicCloseness.hpp
@@ -41,8 +41,9 @@ public:
      * @param k Number of nodes with highest harmonic closeness that have to be found.
      * For example, k = 10, the top 10 nodes with highest harmonic closeness will be computed.
      * @param useNBbound If true, the NBbound variation will be used, otherwise NBcut.
-     * @param nodeList Restrict closeness computation to a grou of nodes from the graph. In order to
-     * work, these nodes have to be present.
+     * @param nodeList Restrict closeness computation to a group of nodes from the graph.
+     * If the list is empty (default), all nodes from the graph are used for computation.
+     * Note: Actual existence of included nodes in the graph is not checked.
      */
     explicit TopHarmonicCloseness(const Graph &G, count k = 1, bool useNBbound = false,
                                   const std::vector<node> &nodeList = std::vector<node>());

--- a/include/networkit/centrality/TopHarmonicCloseness.hpp
+++ b/include/networkit/centrality/TopHarmonicCloseness.hpp
@@ -41,8 +41,11 @@ public:
      * @param k Number of nodes with highest harmonic closeness that have to be found.
      * For example, k = 10, the top 10 nodes with highest harmonic closeness will be computed.
      * @param useNBbound If true, the NBbound variation will be used, otherwise NBcut.
+     * @param nodeList Restrict closeness computation to a grou of nodes from the graph. In order to
+     * work, these nodes have to be present.
      */
-    explicit TopHarmonicCloseness(const Graph &G, count k = 1, bool useNBbound = false);
+    explicit TopHarmonicCloseness(const Graph &G, count k = 1, bool useNBbound = false,
+                                  const std::vector<node> &nodeList = std::vector<node>());
 
     ~TopHarmonicCloseness() override;
 
@@ -88,6 +91,7 @@ private:
 
     std::vector<node> topKNodes;
     std::vector<double> topKScores;
+    std::vector<node> nodeList;
 
     // For NBbound
     std::vector<count> reachU, reachL;

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -949,7 +949,7 @@ cdef class HarmonicCloseness(Centrality):
 cdef extern from "<networkit/centrality/TopCloseness.hpp>":
 
 	cdef cppclass _TopCloseness "NetworKit::TopCloseness"(_Algorithm):
-		_TopCloseness(_Graph G, count, bool_t, bool_t) except +
+		_TopCloseness(_Graph G, count, bool_t, bool_t, vector[node]) except +
 		node maximum() except +
 		edgeweight maxSum() except +
 		count iterations() except +
@@ -960,7 +960,7 @@ cdef extern from "<networkit/centrality/TopCloseness.hpp>":
 
 cdef class TopCloseness(Algorithm):
 	"""
-	TopCloseness(G, k=1, first_heu=True, sec_heu=True)
+	TopCloseness(G, k=1, first_heu=True, sec_heu=True, nodeList=list())
 	
 	Finds the top k nodes with highest closeness centrality faster than computing it for all nodes, 
 	based on "Computing Top-k Closeness Centrality Faster in Unweighted Graphs", Bergamini et al., ALENEX16.
@@ -988,9 +988,9 @@ cdef class TopCloseness(Algorithm):
 	"""
 	cdef Graph _G
 
-	def __cinit__(self,  Graph G, k=1, first_heu=True, sec_heu=True):
+	def __cinit__(self,  Graph G, k=1, first_heu=True, sec_heu=True, nodeList=list()):
 		self._G = G
-		self._this = new _TopCloseness(G._this, k, first_heu, sec_heu)
+		self._this = new _TopCloseness(G._this, k, first_heu, sec_heu, nodeList)
 
 	def topkNodesList(self, includeTrail=False):
 		""" 
@@ -1039,14 +1039,14 @@ cdef class TopCloseness(Algorithm):
 cdef extern from "<networkit/centrality/TopHarmonicCloseness.hpp>":
 
 	cdef cppclass _TopHarmonicCloseness "NetworKit::TopHarmonicCloseness"(_Algorithm):
-		_TopHarmonicCloseness(_Graph G, count, bool_t) except +
+		_TopHarmonicCloseness(_Graph G, count, bool_t, vector[node]) except +
 		vector[node] topkNodesList(bool_t) except +
 		vector[edgeweight] topkScoresList(bool_t) except +
 
 
 cdef class TopHarmonicCloseness(Algorithm):
 	""" 
-	TopHarmonicCloseness(G, k=1, useNBbound=True)
+	TopHarmonicCloseness(G, k=1, useNBbound=False)
 
 	Finds the top k nodes with highest harmonic closeness centrality faster
 	than computing it for all nodes. The implementation is based on "Computing
@@ -1072,13 +1072,13 @@ cdef class TopHarmonicCloseness(Algorithm):
 	useNBbound : bool, optional
 		If True, the NBbound is re-computed at each iteration. If False, NBcut is used. The worst case 
 		running time of the algorithm is :math:`O(nm)`, where n is the number of nodes and m is the number of edges.
-		However, for most networks the empirical running time is :math:`O(m)`. Default: True
+		However, for most networks the empirical running time is :math:`O(m)`. Default: False
 	"""
 	cdef Graph _G
 
-	def __cinit__(self,  Graph G, k=1, useNBbound=False):
+	def __cinit__(self,  Graph G, k=1, useNBbound=False, nodeList=list()):
 		self._G = G
-		self._this = new _TopHarmonicCloseness(G._this, k, useNBbound)
+		self._this = new _TopHarmonicCloseness(G._this, k, useNBbound, nodeList)
 
 	def topkNodesList(self, includeTrail=False):
 		"""

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -985,6 +985,10 @@ cdef class TopCloseness(Algorithm):
 		If false, nodes are simply sorted by degree. Default: True
 	sec_heu : bool, optional
 		If true, the BFSbound is re-computed at each iteration. If false, BFScut is used. Default: True
+	nodeList : list(), optional
+	    Restrict closeness computation to a group of nodes from the graph. If the list is empty, all 
+		nodes from the graph are used for computation. Note: Actual existence of included nodes 
+		in the graph is not checked. Default: list()
 	"""
 	cdef Graph _G
 
@@ -1046,7 +1050,7 @@ cdef extern from "<networkit/centrality/TopHarmonicCloseness.hpp>":
 
 cdef class TopHarmonicCloseness(Algorithm):
 	""" 
-	TopHarmonicCloseness(G, k=1, useNBbound=False)
+	TopHarmonicCloseness(G, k=1, useNBbound=False, nodeList=list())
 
 	Finds the top k nodes with highest harmonic closeness centrality faster
 	than computing it for all nodes. The implementation is based on "Computing
@@ -1073,6 +1077,10 @@ cdef class TopHarmonicCloseness(Algorithm):
 		If True, the NBbound is re-computed at each iteration. If False, NBcut is used. The worst case 
 		running time of the algorithm is :math:`O(nm)`, where n is the number of nodes and m is the number of edges.
 		However, for most networks the empirical running time is :math:`O(m)`. Default: False
+	nodeList : list(), optional
+	    Restrict closeness computation to a group of nodes from the graph. If the list is empty, all 
+		nodes from the graph are used for computation. Note: Actual existence of included nodes 
+		in the graph is not checked. Default: list()
 	"""
 	cdef Graph _G
 

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -949,18 +949,19 @@ cdef class HarmonicCloseness(Centrality):
 cdef extern from "<networkit/centrality/TopCloseness.hpp>":
 
 	cdef cppclass _TopCloseness "NetworKit::TopCloseness"(_Algorithm):
-		_TopCloseness(_Graph G, count, bool_t, bool_t, vector[node]) except +
+		_TopCloseness(_Graph G, count, bool_t, bool_t) except +
 		node maximum() except +
 		edgeweight maxSum() except +
 		count iterations() except +
 		count operations() except +
 		vector[node] topkNodesList(bool_t) except +
 		vector[edgeweight] topkScoresList(bool_t) except +
+		void restrictTopKComputationToNodes(const vector[node] &nodeList) except +
 
 
 cdef class TopCloseness(Algorithm):
 	"""
-	TopCloseness(G, k=1, first_heu=True, sec_heu=True, nodeList=list())
+	TopCloseness(G, k=1, first_heu=True, sec_heu=True)
 	
 	Finds the top k nodes with highest closeness centrality faster than computing it for all nodes, 
 	based on "Computing Top-k Closeness Centrality Faster in Unweighted Graphs", Bergamini et al., ALENEX16.
@@ -985,16 +986,12 @@ cdef class TopCloseness(Algorithm):
 		If false, nodes are simply sorted by degree. Default: True
 	sec_heu : bool, optional
 		If true, the BFSbound is re-computed at each iteration. If false, BFScut is used. Default: True
-	nodeList : list(), optional
-	    Restrict closeness computation to a group of nodes from the graph. If the list is empty, all 
-		nodes from the graph are used for computation. Note: Actual existence of included nodes 
-		in the graph is not checked. Default: list()
 	"""
 	cdef Graph _G
 
-	def __cinit__(self,  Graph G, k=1, first_heu=True, sec_heu=True, nodeList=list()):
+	def __cinit__(self,  Graph G, k=1, first_heu=True, sec_heu=True):
 		self._G = G
-		self._this = new _TopCloseness(G._this, k, first_heu, sec_heu, nodeList)
+		self._this = new _TopCloseness(G._this, k, first_heu, sec_heu)
 
 	def topkNodesList(self, includeTrail=False):
 		""" 
@@ -1040,17 +1037,33 @@ cdef class TopCloseness(Algorithm):
 		"""
 		return (<_TopCloseness*>(self._this)).topkScoresList(includeTrail)
 
+	def restrictTopKComputationToNodes(self, nodeList):
+		"""
+		restrictTopKComputationToNodes(nodeList)
+
+		Restricts the top-k closeness computation to a subset of nodes.
+		If the given list is empty, all nodes in the graph will be considered.
+		Note: Actual existence of included nodes in the graph is not checked.
+
+		Parameters
+		----------
+		nodeList : list()
+			List containing a subset of nodes from the graph.
+		"""
+		return (<_TopCloseness*>(self._this)).restrictTopKComputationToNodes(nodeList)
+
 cdef extern from "<networkit/centrality/TopHarmonicCloseness.hpp>":
 
 	cdef cppclass _TopHarmonicCloseness "NetworKit::TopHarmonicCloseness"(_Algorithm):
-		_TopHarmonicCloseness(_Graph G, count, bool_t, vector[node]) except +
+		_TopHarmonicCloseness(_Graph G, count, bool_t) except +
 		vector[node] topkNodesList(bool_t) except +
 		vector[edgeweight] topkScoresList(bool_t) except +
+		void restrictTopKComputationToNodes(const vector[node] &nodeList) except +
 
 
 cdef class TopHarmonicCloseness(Algorithm):
 	""" 
-	TopHarmonicCloseness(G, k=1, useNBbound=False, nodeList=list())
+	TopHarmonicCloseness(G, k=1, useNBbound=False)
 
 	Finds the top k nodes with highest harmonic closeness centrality faster
 	than computing it for all nodes. The implementation is based on "Computing
@@ -1077,16 +1090,12 @@ cdef class TopHarmonicCloseness(Algorithm):
 		If True, the NBbound is re-computed at each iteration. If False, NBcut is used. The worst case 
 		running time of the algorithm is :math:`O(nm)`, where n is the number of nodes and m is the number of edges.
 		However, for most networks the empirical running time is :math:`O(m)`. Default: False
-	nodeList : list(), optional
-	    Restrict closeness computation to a group of nodes from the graph. If the list is empty, all 
-		nodes from the graph are used for computation. Note: Actual existence of included nodes 
-		in the graph is not checked. Default: list()
 	"""
 	cdef Graph _G
 
-	def __cinit__(self,  Graph G, k=1, useNBbound=False, nodeList=list()):
+	def __cinit__(self,  Graph G, k=1, useNBbound=False):
 		self._G = G
-		self._this = new _TopHarmonicCloseness(G._this, k, useNBbound, nodeList)
+		self._this = new _TopHarmonicCloseness(G._this, k, useNBbound)
 
 	def topkNodesList(self, includeTrail=False):
 		"""
@@ -1131,6 +1140,23 @@ cdef class TopHarmonicCloseness(Algorithm):
 			The k highest closeness harmonic scores.
 		"""
 		return (<_TopHarmonicCloseness*>(self._this)).topkScoresList(includeTrail)
+
+	def restrictTopKComputationToNodes(self, nodeList):
+		"""
+		topkScoresList(nodeList)
+
+		Restricts the top-k closeness computation to a subset of nodes.
+		If the given list is empty, all nodes in the graph will be considered.
+		Note: Actual existence of included nodes in the graph is not checked.
+
+		Parameters
+		----------
+		nodeList : list()
+			List containing a subset of nodes from the graph.
+		"""
+		return (<_TopHarmonicCloseness*>(self._this)).restrictTopKComputationToNodes(nodeList)
+
+
 
 cdef extern from "<networkit/centrality/DynTopHarmonicCloseness.hpp>":
 

--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -347,12 +347,9 @@ void TopCloseness::run() {
     tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<double>> Q{farness};
 
     if (nodeList.empty()) {
-        std::vector<node> nodes;
-        nodes.reserve(G.numberOfNodes());
-        G.forNodes([&](const node u) { nodes.emplace_back(u); });
-        Q.build_heap(std::move(nodes));
+        Q.build_heap(G.nodeRange().begin(), G.nodeRange().end());
     } else {
-        Q.build_heap(nodeList);
+        Q.build_heap(nodeList.begin(), nodeList.end());
     }
     DEBUG("Done filling the queue");
 

--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -20,9 +20,8 @@
 
 namespace NetworKit {
 
-TopCloseness::TopCloseness(const Graph &G, count k, bool first_heu, bool sec_heu,
-                           const std::vector<node> &nodeList)
-    : G(G), k(k), first_heu(first_heu), sec_heu(sec_heu), nodeList(nodeList) {}
+TopCloseness::TopCloseness(const Graph &G, count k, bool first_heu, bool sec_heu)
+    : G(G), k(k), first_heu(first_heu), sec_heu(sec_heu), nodeListPtr(nullptr) {}
 
 void TopCloseness::init() {
     n = G.upperNodeIdBound();
@@ -346,10 +345,10 @@ void TopCloseness::run() {
     });
     tlx::d_ary_addressable_int_heap<node, 2, Aux::LessInVector<double>> Q{farness};
 
-    if (nodeList.empty()) {
+    if (!nodeListPtr || nodeListPtr->empty()) {
         Q.build_heap(G.nodeRange().begin(), G.nodeRange().end());
     } else {
-        Q.build_heap(nodeList.begin(), nodeList.end());
+        Q.build_heap(nodeListPtr->begin(), nodeListPtr->end());
     }
     DEBUG("Done filling the queue");
 
@@ -365,12 +364,12 @@ void TopCloseness::run() {
 
     // Disable analyzing nodes, which are not part of the nodeList (if given).
     // Otherwise all nodes need to be checked.
-    if (nodeList.empty()) {
+    if (!nodeListPtr || nodeListPtr->empty()) {
         std::fill(toAnalyze.begin(), toAnalyze.end(), true);
     } else {
 #pragma omp parallel
-        for (omp_index u = 0; u < static_cast<omp_index>(nodeList.size()); ++u) {
-            toAnalyze[nodeList[u]] = true;
+        for (omp_index u = 0; u < static_cast<omp_index>(nodeListPtr->size()); ++u) {
+            toAnalyze[(*nodeListPtr)[u]] = true;
         }
     }
 

--- a/networkit/cpp/centrality/test/CMakeLists.txt
+++ b/networkit/cpp/centrality/test/CMakeLists.txt
@@ -6,4 +6,6 @@ networkit_add_test(centrality DynBetweennessGTest
     auxiliary generators graph io)
 networkit_add_test(centrality SpanningEdgeCentralityGTest
     graph io)
+networkit_add_test(centrality TopClosenessGTest
+    generators graph io)
 

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -8,7 +8,6 @@
 #include <iomanip>
 #include <iostream>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <networkit/auxiliary/Log.hpp>
@@ -45,8 +44,6 @@
 #include <networkit/centrality/PageRank.hpp>
 #include <networkit/centrality/PermanenceCentrality.hpp>
 #include <networkit/centrality/SpanningEdgeCentrality.hpp>
-#include <networkit/centrality/TopCloseness.hpp>
-#include <networkit/centrality/TopHarmonicCloseness.hpp>
 #include <networkit/components/ConnectedComponents.hpp>
 #include <networkit/distance/Dijkstra.hpp>
 #include <networkit/generators/DorogovtsevMendesGenerator.hpp>
@@ -1268,118 +1265,6 @@ TEST_F(CentralityGTest, testSimplePermanence) {
 
     EXPECT_NEAR(-0.19048, perm.getPermanence(u), 0.0005);
     EXPECT_NEAR(0.167, perm.getPermanence(v), 0.0005);
-}
-
-TEST_P(CentralityGTest, testTopCloseness) {
-    constexpr count size = 400;
-    constexpr count k = 10;
-    Aux::Random::setSeed(42, false);
-    const auto G1 = DorogovtsevMendesGenerator(size).generate();
-    Graph G(G1, false, isDirected());
-
-    Closeness cc(G1, true, ClosenessVariant::GENERALIZED);
-    cc.run();
-    auto exactScores = cc.scores();
-    auto ranking = cc.ranking();
-    for (auto firstHeu : {true, false}) {
-        for (auto secHeu : {true, false}) {
-            TopCloseness topcc(G, k, firstHeu, secHeu);
-            topcc.run();
-            auto scores = topcc.topkScoresList();
-            EXPECT_EQ(topcc.topkNodesList().size(), k);
-            for (count i = 0; i < k; i++) {
-                EXPECT_DOUBLE_EQ(ranking[i].second, scores[i]);
-            }
-        }
-    }
-}
-
-TEST_F(CentralityGTest, testTopClosenessWithNodeList) {
-    METISGraphReader reader;
-    Graph G = reader.read("input/lesmis.graph");
-    constexpr count k = 10;
-    const std::vector<node> nodeList{0, 1, 2, 3, 4, 5, 11, 26, 48, 64};
-
-    // We expect complete TopCloseness to not contain nodes 0-5, while
-    // restricted should. The first element for both complete and
-    // restricted TopCC should be 11. {26, 48, 64} should also be present
-    // in both results (but position might differ).
-    for (auto firstHeu : {true, false}) {
-        for (auto secHeu : {true, false}) {
-            TopCloseness topC(G, k, firstHeu, secHeu);
-            topC.run();
-            auto topCNodes = topC.topkNodesList();
-            topC.restrictTopKComputationToNodes(nodeList);
-            topC.run();
-            auto topCRNodes = topC.topkNodesList();
-            auto topCRScores = topC.topkScoresList();
-            EXPECT_EQ(topCNodes[0], topCRNodes[0]);
-            EXPECT_THAT(topCRNodes, testing::IsSupersetOf({0, 1, 2, 3, 4, 5, 26, 48, 64}));
-            EXPECT_THAT(topCNodes, testing::IsSupersetOf({26, 48, 64}));
-            EXPECT_THAT(topCNodes, testing::Not(testing::IsSupersetOf({0, 1, 2, 3, 4, 5})));
-            EXPECT_TRUE(
-                std::is_sorted(topCRScores.begin(), topCRScores.end(), std::greater<node>()));
-        }
-    }
-}
-
-TEST_P(CentralityGTest, testTopHarmonicCloseness) {
-    const count size = 400;
-    const double tol = 1e-6;
-
-    for (int seed : {1, 2, 3}) {
-        Aux::Random::setSeed(seed, false);
-        auto G = ErdosRenyiGenerator(size, 0.01, isDirected()).generate();
-        if (isWeighted()) {
-            G = GraphTools::toWeighted(G);
-            G.forEdges([&G](node u, node v) { G.setWeight(u, v, Aux::Random::probability()); });
-        }
-        HarmonicCloseness cc(G, false);
-        cc.run();
-        const auto ranking = cc.ranking();
-        for (bool useNBbound : {true, false}) {
-            for (count k : {5, 10, 20}) {
-                if (isWeighted() && useNBbound)
-                    continue;
-                TopHarmonicCloseness topcc(G, k, useNBbound);
-                topcc.run();
-                auto topkScores = topcc.topkScoresList();
-                EXPECT_EQ(topcc.topkNodesList().size(), k);
-                EXPECT_EQ(topkScores.size(), k);
-
-                topkScores = topcc.topkScoresList(true);
-
-                for (count i = 0; i < topkScores.size(); ++i)
-                    EXPECT_NEAR(ranking[i].second, topkScores[i], tol);
-                for (count i = k; i < topkScores.size(); ++i)
-                    EXPECT_NEAR(topkScores[i], topkScores[k - 1], tol);
-            }
-        }
-    }
-}
-
-TEST_F(CentralityGTest, testTopHarmonicClosenessWithNodeList) {
-    METISGraphReader reader;
-    Graph G = reader.read("input/lesmis.graph");
-    constexpr count k = 10;
-    const std::vector<node> nodeList{0, 1, 2, 3, 4, 5, 6, 11, 27, 48};
-
-    // We expect complete TopHarmonicCloseness to not contain nodes 0-6,
-    // while restricted should. {11, 27, 48} should be present in both
-    // results (but position might differ).
-    for (bool useNBbound : {true, false}) {
-        TopHarmonicCloseness topHC(G, k, useNBbound);
-        topHC.run();
-        auto topHCNodes = topHC.topkNodesList();
-        topHC.restrictTopKComputationToNodes(nodeList);
-        topHC.run();
-        auto topHCRNodes = topHC.topkNodesList();
-        auto topHCRScores = topHC.topkScoresList();
-        EXPECT_THAT(topHCRNodes, testing::IsSupersetOf({0, 1, 2, 3, 4, 5, 6, 11, 27, 48}));
-        EXPECT_THAT(topHCNodes, testing::IsSupersetOf({11, 27, 48}));
-        EXPECT_THAT(topHCNodes, testing::Not(testing::IsSupersetOf({0, 1, 2, 3, 4, 5, 6})));
-        EXPECT_TRUE(std::is_sorted(topHCRScores.begin(), topHCRScores.end(), std::greater<node>()));
-    }
 }
 
 TEST_F(CentralityGTest, testLaplacianCentrality) {

--- a/networkit/cpp/centrality/test/TopClosenessGTest.cpp
+++ b/networkit/cpp/centrality/test/TopClosenessGTest.cpp
@@ -1,0 +1,163 @@
+/*
+ * TopClosenessGTest.cpp
+ *
+ *  Created on: 17.11.2022
+ *      Author: cls, Fabian Brandt-Tumescheit
+ */
+
+#include <iomanip>
+#include <iostream>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <networkit/centrality/Closeness.hpp>
+#include <networkit/centrality/HarmonicCloseness.hpp>
+#include <networkit/centrality/TopCloseness.hpp>
+#include <networkit/centrality/TopHarmonicCloseness.hpp>
+#include <networkit/generators/DorogovtsevMendesGenerator.hpp>
+#include <networkit/generators/ErdosRenyiGenerator.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/io/METISGraphReader.hpp>
+
+namespace NetworKit {
+
+class TopClosenessGTest : public testing::TestWithParam<std::pair<bool, bool>> {
+protected:
+    bool useFirstHeu() const noexcept;
+    bool useSecondHeu() const noexcept;
+};
+
+bool TopClosenessGTest::useFirstHeu() const noexcept {
+    return GetParam().first;
+}
+
+bool TopClosenessGTest::useSecondHeu() const noexcept {
+    return GetParam().second;
+}
+
+class TopHarmonicClosenessGTest : public testing::TestWithParam<bool> {
+protected:
+    bool useNBBound() const noexcept;
+};
+
+bool TopHarmonicClosenessGTest::useNBBound() const noexcept {
+    return GetParam();
+}
+
+INSTANTIATE_TEST_SUITE_P(InstantiationName, TopClosenessGTest,
+                         testing::Values(std::make_pair(false, false), std::make_pair(true, false),
+                                         std::make_pair(false, true), std::make_pair(true, true)));
+
+INSTANTIATE_TEST_SUITE_P(InstantiationName, TopHarmonicClosenessGTest,
+                         testing::Values(false, true));
+
+TEST_P(TopClosenessGTest, testTopCloseness) {
+    constexpr count size = 400;
+    constexpr count k = 10;
+
+    for (bool isDirected : {false, true}) {
+        Aux::Random::setSeed(42, false);
+        const auto G1 = DorogovtsevMendesGenerator(size).generate();
+        Graph G(G1, false, isDirected);
+
+        Closeness cc(G1, true, ClosenessVariant::GENERALIZED);
+        cc.run();
+        auto exactScores = cc.scores();
+        auto ranking = cc.ranking();
+        TopCloseness topcc(G, k, useFirstHeu(), useSecondHeu());
+        topcc.run();
+        auto scores = topcc.topkScoresList();
+        EXPECT_EQ(topcc.topkNodesList().size(), k);
+        for (count i = 0; i < k; i++) {
+            EXPECT_DOUBLE_EQ(ranking[i].second, scores[i]);
+        }
+    }
+}
+
+TEST_P(TopClosenessGTest, testTopClosenessWithNodeList) {
+    METISGraphReader reader;
+    Graph G = reader.read("input/lesmis.graph");
+    constexpr count k = 10;
+    const std::vector<node> nodeList{0, 1, 2, 3, 4, 5, 11, 26, 48, 64};
+
+    // We expect complete TopCloseness to not contain nodes 0-5, while
+    // restricted should. The first element for both complete and
+    // restricted TopCC should be 11. {26, 48, 64} should also be present
+    // in both results (but position might differ).
+    TopCloseness topC(G, k, useFirstHeu(), useSecondHeu());
+    topC.run();
+    auto topCNodes = topC.topkNodesList();
+    topC.restrictTopKComputationToNodes(nodeList);
+    topC.run();
+    auto topCRNodes = topC.topkNodesList();
+    auto topCRScores = topC.topkScoresList();
+    EXPECT_EQ(topCNodes[0], topCRNodes[0]);
+    EXPECT_THAT(topCRNodes, testing::IsSupersetOf({0, 1, 2, 3, 4, 5, 26, 48, 64}));
+    EXPECT_THAT(topCNodes, testing::IsSupersetOf({26, 48, 64}));
+    EXPECT_THAT(topCNodes, testing::Not(testing::IsSupersetOf({0, 1, 2, 3, 4, 5})));
+    EXPECT_TRUE(std::is_sorted(topCRScores.begin(), topCRScores.end(), std::greater<node>()));
+}
+
+TEST_P(TopHarmonicClosenessGTest, testTopHarmonicCloseness) {
+    const count size = 400;
+    const double tol = 1e-6;
+
+    for (int seed : {1, 2, 3}) {
+        for (bool isDirected : {false, true}) {
+            for (bool isWeighted : {false, true}) {
+                Aux::Random::setSeed(seed, false);
+                auto G = ErdosRenyiGenerator(size, 0.01, isDirected).generate();
+                if (isWeighted) {
+                    G = GraphTools::toWeighted(G);
+                    G.forEdges(
+                        [&G](node u, node v) { G.setWeight(u, v, Aux::Random::probability()); });
+                }
+                HarmonicCloseness cc(G, false);
+                cc.run();
+                const auto ranking = cc.ranking();
+                for (count k : {5, 10, 20}) {
+                    if (isWeighted && useNBBound())
+                        continue;
+                    TopHarmonicCloseness topcc(G, k, useNBBound());
+                    topcc.run();
+
+                    auto topkScores = topcc.topkScoresList();
+                    EXPECT_EQ(topcc.topkNodesList().size(), k);
+                    EXPECT_EQ(topkScores.size(), k);
+
+                    topkScores = topcc.topkScoresList(true);
+
+                    for (count i = 0; i < topkScores.size(); ++i)
+                        EXPECT_NEAR(ranking[i].second, topkScores[i], tol);
+                    for (count i = k; i < topkScores.size(); ++i)
+                        EXPECT_NEAR(topkScores[i], topkScores[k - 1], tol);
+                }
+            }
+        }
+    }
+}
+
+TEST_P(TopHarmonicClosenessGTest, testTopHarmonicClosenessWithNodeList) {
+    METISGraphReader reader;
+    Graph G = reader.read("input/lesmis.graph");
+    constexpr count k = 10;
+    const std::vector<node> nodeList{0, 1, 2, 3, 4, 5, 6, 11, 27, 48};
+
+    // We expect complete TopHarmonicCloseness to not contain nodes 0-6,
+    // while restricted should. {11, 27, 48} should be present in both
+    // results (but position might differ).
+    TopHarmonicCloseness topHC(G, k, useNBBound());
+    topHC.run();
+    auto topHCNodes = topHC.topkNodesList();
+    topHC.restrictTopKComputationToNodes(nodeList);
+    topHC.run();
+    auto topHCRNodes = topHC.topkNodesList();
+    auto topHCRScores = topHC.topkScoresList();
+    EXPECT_THAT(topHCRNodes, testing::IsSupersetOf({0, 1, 2, 3, 4, 5, 6, 11, 27, 48}));
+    EXPECT_THAT(topHCNodes, testing::IsSupersetOf({11, 27, 48}));
+    EXPECT_THAT(topHCNodes, testing::Not(testing::IsSupersetOf({0, 1, 2, 3, 4, 5, 6})));
+    EXPECT_TRUE(std::is_sorted(topHCRScores.begin(), topHCRScores.end(), std::greater<node>()));
+}
+
+} /* namespace NetworKit */


### PR DESCRIPTION
This PR introduces the following changes:

- Support for passing a list of nodes, restricting top-k calculation to only this nodes (but based on the truth given by graph G).
- Tests for new parameter
- Minor refactor of documentation, bug fixes for both Python + C++ code
- Refactor TopHarmonicCloseness to support multiple consecutive runs

If the number of nodes in the list << number of nodes in the graph, the running time is improved significantly. Example: 

- 200k nodes in graph
- 100 nodes in input list
- speedup 165x (TopCloseness)
- speedup 55x (TopHarmonicCloseness)

~~Currently the PR is still work in progress.~~