### PR TITLE
Fix NetworkitBinaryWriter - writing graphs with deleted nodes

### DIFF
--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <fstream>
 #include <string>
+#include <unordered_map>
 
 #include <tlx/math/clz.hpp>
 
@@ -174,8 +175,8 @@ void NetworkitBinaryWriter::writeData(T &outStream, const Graph &G) {
     uint64_t transpWeightSize = 0;
     uint64_t adjIndexSize = 0;
     uint64_t transpIndexSize = 0;
-    std::vector<uint64_t> nrOutNbrs;
-    std::vector<uint64_t> nrInNbrs;
+    std::unordered_map<node, uint64_t> nrOutNbrs;
+    std::unordered_map<node, uint64_t> nrInNbrs;
     std::vector<size_t> adjOffsets;         // Prefix sum of size encoded adj arrays
     std::vector<size_t> transpOffsets;      // Prefix sum of encoded transposed adj arrays
     std::vector<size_t> adjWghtOffsets;     // Prefix sum of size encoded adj weights
@@ -254,11 +255,11 @@ void NetworkitBinaryWriter::writeData(T &outStream, const Graph &G) {
             }
             adjListSize += outNbrs;
             adjSize += nkbg::varIntEncode(outNbrs, tmp);
-            nrOutNbrs.push_back(outNbrs);
+            nrOutNbrs[n] = outNbrs;
 
             adjTransposeSize += inNbrs;
             transpSize += nkbg::varIntEncode(inNbrs, tmp);
-            nrInNbrs.push_back(inNbrs);
+            nrInNbrs[n] = inNbrs;
         }
         adjOffsets.push_back(adjSize);
         transpOffsets.push_back(transpSize);

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -1227,6 +1227,24 @@ TEST_F(IOGTest, testNetworkitBinaryZigzag) {
     }
 }
 
+TEST_F(IOGTest, testNetworkitWriterNonContinuousNodesIds) {
+    Graph G(20, true);
+    G.removeNode(10);
+    std::string path = "output/test.gt";
+    NetworkitBinaryWriter{}.write(G, path);
+    Graph GRead = NetworkitBinaryReader{}.read(path);
+    EXPECT_EQ(G.numberOfNodes(), GRead.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), GRead.numberOfEdges());
+    EXPECT_EQ(G.isDirected(), GRead.isDirected());
+    EXPECT_EQ(G.isWeighted(), GRead.isWeighted());
+    G.forNodes([&](node u) {
+        G.forEdgesOf(u, [&](node v) {
+            EXPECT_TRUE(GRead.hasEdge(u, v));
+            EXPECT_DOUBLE_EQ(G.weight(u, v), GRead.weight(u, v));
+        });
+    });
+}
+
 TEST_F(IOGTest, testMatrixMarketReaderUnweightedUndirected) {
     CSRMatrix csr = MatrixMarketReader{}.read("input/chesapeake.mtx");
     EXPECT_EQ(csr.numberOfRows(), 39);


### PR DESCRIPTION
This addresses  #963 by changing an array with a map to avoid errors when writing.