### PR TITLE
New Algorithm: Pruned Landmark Labeling

### DIFF
--- a/include/networkit/distance/PrunedLandmarkLabeling.hpp
+++ b/include/networkit/distance/PrunedLandmarkLabeling.hpp
@@ -1,0 +1,76 @@
+#ifndef NETWORKIT_DISTANCE_PRUNED_LANDMARK_LABELING_HPP_
+#define NETWORKIT_DISTANCE_PRUNED_LANDMARK_LABELING_HPP_
+
+#include <utility>
+#include <vector>
+
+#include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+class PrunedLandmarkLabeling : public Algorithm {
+
+public:
+    /**
+     * Pruned Landmark Labeling algorithm based on the paper "Fast exact shortest-path distance
+     * queries on large networks by pruned landmark labeling" from Akiba et al., ACM SIGMOD 2013.
+     * The algorithm computes distance labels by performing pruned breadth-first searches from each
+     * vertex. Labels are used to quickly retrieve shortest-path distances between node pairs.
+     * @note this algorithm only works for unweighted graphs.
+     *
+     * @param G The input graph.
+     */
+    PrunedLandmarkLabeling(const Graph &G);
+
+    /**
+     * Computes distance labels. Run this function before calling 'query'.
+     */
+    void run() override;
+
+    /**
+     * Returns the shortest-path distance between the two nodes.
+     *
+     * @param u Source node.
+     * @param v Target node.
+     *
+     * @return The shortest-path distance from @a u to @a v.
+     */
+    count query(node u, node v) const;
+
+private:
+    count queryImpl(node u, node v) const;
+
+    static constexpr count infDist = std::numeric_limits<count>::max();
+
+    struct Label {
+        Label() : node_(none), distance_(infDist) {}
+        Label(node node_, count distance_) : node_(node_), distance_(distance_) {}
+        node node_;
+        count distance_;
+    };
+
+    const Graph *G;
+    std::vector<node> nodesSortedByDegreeDesc;
+    std::vector<bool> visited;
+    std::vector<std::vector<Label>> labelsOut, labelsIn;
+    std::vector<Label> labelsUCopy, labelsVCopy;
+
+    template <bool Reverse = false>
+    void prunedBFS(node root, node rankOfRootNode);
+
+    auto getSourceLabelsIterators(node u, bool reverse = false) const {
+        if (reverse)
+            return std::make_pair(labelsIn[u].begin(), labelsIn[u].end());
+        else
+            return std::make_pair(labelsOut[u].begin(), labelsOut[u].end());
+    }
+
+    auto getTargetLabelsIterators(node u) const {
+        return std::make_pair(labelsOut[u].begin(), labelsOut[u].end());
+    }
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_DISTANCE_PRUNED_LANDMARK_LABELING_HPP_

--- a/networkit/cpp/distance/CMakeLists.txt
+++ b/networkit/cpp/distance/CMakeLists.txt
@@ -21,6 +21,7 @@ networkit_add_module(distance
     NeighborhoodFunction.cpp
     NeighborhoodFunctionApproximation.cpp
     NeighborhoodFunctionHeuristic.cpp
+    PrunedLandmarkLabeling.cpp
     ReverseBFS.cpp
     SPSP.cpp
     SSSP.cpp

--- a/networkit/cpp/distance/PrunedLandmarkLabeling.cpp
+++ b/networkit/cpp/distance/PrunedLandmarkLabeling.cpp
@@ -1,0 +1,126 @@
+#include <algorithm>
+#include <queue>
+#include <vector>
+
+#include <networkit/auxiliary/Log.hpp>
+#include <networkit/auxiliary/Parallel.hpp>
+#include <networkit/distance/PrunedLandmarkLabeling.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+PrunedLandmarkLabeling::PrunedLandmarkLabeling(const Graph &G)
+    : G(&G), nodesSortedByDegreeDesc(G.nodeRange().begin(), G.nodeRange().end()) {
+
+    if (G.isWeighted())
+        WARN("This algorithm ignores edge weights.");
+
+    if (G.isDirected())
+        Aux::Parallel::sort(nodesSortedByDegreeDesc.begin(), nodesSortedByDegreeDesc.end(),
+                            [&G](node u, node v) {
+                                count degU = G.degree(u), degV = G.degree(v);
+                                if (degU != degV)
+                                    return degU > degV;
+                                return G.degreeIn(u) > G.degreeIn(v);
+                            });
+    else
+        Aux::Parallel::sort(nodesSortedByDegreeDesc.begin(), nodesSortedByDegreeDesc.end(),
+                            [&G](node u, node v) { return G.degree(u) > G.degree(v); });
+
+    visited.resize(G.upperNodeIdBound());
+
+    labelsOut.resize(G.upperNodeIdBound());
+    if (G.isDirected())
+        labelsIn.resize(G.upperNodeIdBound());
+
+    labelsUCopy.reserve(G.upperNodeIdBound());
+    labelsVCopy.reserve(G.upperNodeIdBound());
+}
+
+template <bool Reverse>
+void PrunedLandmarkLabeling::prunedBFS(node root, node rankOfRootNode) {
+    std::fill(visited.begin(), visited.end(), false);
+    visited[root] = true;
+
+    std::queue<node> q1, q2;
+    q1.push(root);
+
+    index level = 0;
+
+    const auto visitNeighbor = [&](node v) -> void {
+        if (visited[v])
+            return;
+        visited[v] = true;
+        q2.push(v);
+    };
+
+    do {
+        do {
+            const node u = q1.front();
+            q1.pop();
+            if constexpr (Reverse) {
+                if (u != root && queryImpl(u, root) <= level)
+                    continue;
+            } else {
+                if (u != root && queryImpl(root, u) <= level)
+                    continue;
+            }
+
+            if constexpr (Reverse) {
+                labelsIn[u].emplace_back(rankOfRootNode, level);
+                G->forInNeighborsOf(u, visitNeighbor);
+            } else {
+                labelsOut[u].emplace_back(rankOfRootNode, level);
+                G->forNeighborsOf(u, visitNeighbor);
+            }
+
+        } while (!q1.empty());
+
+        ++level;
+        std::swap(q1, q2);
+    } while (!q1.empty());
+}
+
+void PrunedLandmarkLabeling::run() {
+    index rankOfRootNode = 0;
+    for (node root : nodesSortedByDegreeDesc) {
+        prunedBFS(root, rankOfRootNode);
+        if (G->isDirected())
+            prunedBFS<true>(root, rankOfRootNode);
+        ++rankOfRootNode;
+    }
+
+    hasRun = true;
+}
+
+count PrunedLandmarkLabeling::queryImpl(node u, node v) const {
+    if (u == v)
+        return 0;
+
+    auto [iterLabelsU, iterLabelsUEnd] = getSourceLabelsIterators(u, G->isDirected());
+    auto [iterLabelsV, iterLabelsVEnd] = getSourceLabelsIterators(v);
+
+    count result = infDist;
+
+    while (iterLabelsU != iterLabelsUEnd && iterLabelsV != iterLabelsVEnd) {
+        if (iterLabelsU->node_ < iterLabelsV->node_)
+            ++iterLabelsU;
+        else if (iterLabelsV->node_ < iterLabelsU->node_)
+            ++iterLabelsV;
+        else {
+            result = std::min(result, iterLabelsU->distance_ + iterLabelsV->distance_);
+
+            ++iterLabelsU;
+            ++iterLabelsV;
+        }
+    }
+
+    return result;
+}
+
+count PrunedLandmarkLabeling::query(node u, node v) const {
+    assureFinished();
+    return queryImpl(u, v);
+}
+
+} // namespace NetworKit

--- a/networkit/distance.pyx
+++ b/networkit/distance.pyx
@@ -1791,3 +1791,53 @@ cdef class ReverseBFS(SSSP):
 	def __cinit__(self, Graph G, source, storePaths=True, storeNodesSortedByDistance=False, target=none):
 		self._G = G
 		self._this = new _ReverseBFS(G._this, source, storePaths, storeNodesSortedByDistance, target)
+
+cdef extern from "<networkit/distance/PrunedLandmarkLabeling.hpp>":
+
+	cdef cppclass _PrunedLandmarkLabeling "NetworKit::PrunedLandmarkLabeling"(_Algorithm):
+		_PrunedLandmarkLabeling(_Graph G) except +
+		count query(node u, node v) except +
+
+cdef class PrunedLandmarkLabeling(Algorithm):
+	""" 
+	PrunedLandmarkLabeling(G)
+
+	Pruned Landmark Labeling algorithm based on the paper "Fast exact shortest-path distance
+	queries on large networks by pruned landmark labeling" from Akiba et al., ACM SIGMOD 2013.
+	The algorithm computes distance labels by performing pruned breadth-first searches from each
+	vertex. Labels are used to quickly retrieve shortest-path distances between node pairs.
+	Note: this algorithm only works for unweighted graphs.
+
+	Parameters
+	----------
+	G : networkit.Graph
+		The input graph.
+	"""
+	cdef Graph _G
+
+	def __cinit__(self, Graph G):
+		self._G = G
+		self._this = new _PrunedLandmarkLabeling(G._this)
+
+	def __dealloc__(self):
+		self._G = None
+
+	def query(self, node u, node v):
+		"""
+		query(u, v)
+
+		Returns the shortest-path distance between the two nodes.
+
+		Parameters
+		----------
+		u : node
+			Source node.
+		v : node
+			Target node.
+
+		Returns
+		-------
+		int
+			The shortest-path distances from the source node to the target node.
+		"""
+		return (<_PrunedLandmarkLabeling*>(self._this)).query(u, v)

--- a/networkit/test/test_distance_algorithms.py
+++ b/networkit/test/test_distance_algorithms.py
@@ -175,5 +175,22 @@ class TestDistanceAlgorithms(unittest.TestCase):
 				algo.run()
 				self.assertEqual(len(algo.getDistances()), len(targets))
 
+	def testPrunedLandmarkLabeling(self):
+		for g in self.genERGraphs():
+			pll = nk.distance.PrunedLandmarkLabeling(g)
+			pll.run()
+
+			if g.isWeighted():
+				g = nk.graphtools.toUnweighted(g)
+			apsp = nk.distance.APSP(g)
+			apsp.run()
+
+			for u in g.iterNodes():
+				for v in g.iterNodes():
+					if apsp.getDistance(u, v) > g.numberOfNodes():
+						self.assertEqual(pll.query(u, v), nk.none)
+					else:
+						self.assertEqual(pll.query(u, v), int(apsp.getDistance(u, v)))
+
 if __name__ == "__main__":
 	unittest.main()

--- a/notebooks/Distance.ipynb
+++ b/notebooks/Distance.ipynb
@@ -141,6 +141,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Pruned Landmark Labeling\n",
+    "\n",
+    "Pruned Landmark Labeling is an alternative to APSP. It computes distance labels by performing a *pruned* BFS from each node in the graph. Distance labels are then used to quickly compute shortest-path distances between node pairs. This algorithm only works for unweighted graphs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize the algorithm - in case of weighted graphs, edge weights are ignored\n",
+    "pll = nk.distance.PrunedLandmarkLabeling(G)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run - this step computes the distance labels\n",
+    "pll.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve the shortest-path distance\n",
+    "print(pll.query(source, target))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Some-Pairs Shortest-Paths (SPSP)\n",
     "\n",
     "SPSP is an alternative to APSP, it computes the shortest-path distances from a set of user-specified source nodes to all the other nodes of the graph.\n",


### PR DESCRIPTION
This PR brings the Pruned Landmark Labeling algorithm by Akiba et al. [1]. The algorithm computes distance labels which are used to answer shortest-path distance queries.

I wrote this code a few years ago and, finally, I found some time to polish it.

[1] https://dl.acm.org/doi/10.1145/2463676.2465315