### PR TITLE
Added a missing piece of information to the documentation

### DIFF
--- a/include/networkit/generators/BarabasiAlbertGenerator.hpp
+++ b/include/networkit/generators/BarabasiAlbertGenerator.hpp
@@ -37,7 +37,7 @@ public:
      *   https://kops.uni-konstanz.de/bitstream/handle/123456789/5799/random.pdf?sequence=1
      * Running time is O(n+m)
      *
-     * The generator will emit a simple graph (given that the seed graph is simple), where all
+     * The generator will emit a simple graph, where all
      * new nodes are initially connected to k random neighbors.
      *
      * @param k     Number of attachments per node
@@ -48,6 +48,26 @@ public:
      */
     BarabasiAlbertGenerator(count k, count nMax, count n0 = 0, bool batagelj = true);
 
+    /**
+     * This generator implements the preferential attachment model as introduced by Barabasi and
+     * Albert[1]. The original algorithm is very slow and thus, the much faster method from Batagelj
+     * and Brandes[2] is implemented and the current default. The original method is no longer
+     * supported and the \p batagelj parameter will be removed in future releases.
+     * [1] Barabasi, Albert: Emergence of Scaling in Random Networks
+     *   http://arxiv.org/pdf/cond-mat/9910332.pdf
+     * [2] ALG 5 of Batagelj, Brandes: Efficient Generation of Large Random Networks
+     *   https://kops.uni-konstanz.de/bitstream/handle/123456789/5799/random.pdf?sequence=1
+     * Running time is O(n+m)
+     *
+     * The generator will emit a simple graph (given that the seed graph is simple), where all
+     * new nodes are initially connected to k random neighbors.
+     *
+     * @param k     Number of attachments per node
+     * @param nMax  Number of nodes in the graph
+     * @param initGraph   The initial graph to start from
+     * @param batagelj Specifies whether to use Batagelj and Brandes's method (much faster)
+     *              rather than the naive one; default: true
+     */
     BarabasiAlbertGenerator(count k, count nMax, const Graph &initGraph, bool batagelj = true);
 
     Graph generate() override;

--- a/networkit/generators.pyx
+++ b/networkit/generators.pyx
@@ -98,7 +98,7 @@ cdef class BarabasiAlbertGenerator(StaticGraphGenerator):
 	nMax : int
 		Maximum number of nodes produced.
 	n0 : int or networkit.Graph
-		Number of starting nodes or the initial seed graph.
+		Number of starting nodes or the initial starting graph.
 	batagelj : bool
 		Specifies whether to use batagelj's method or the original one.
 	"""

--- a/networkit/generators.pyx
+++ b/networkit/generators.pyx
@@ -97,8 +97,8 @@ cdef class BarabasiAlbertGenerator(StaticGraphGenerator):
 		Number of edges that come with a new node.
 	nMax : int
 		Maximum number of nodes produced.
-	n0 : int
-		Number of starting nodes.
+	n0 : int or networkit.Graph
+		Number of starting nodes or the initial seed graph.
 	batagelj : bool
 		Specifies whether to use batagelj's method or the original one.
 	"""


### PR DESCRIPTION
The ability to expand a given graph with the Babarasi-Albert generator is already implemented in C++ and in Python as well. But this ability is not reflected in the documentation which mistakes the user into believing that such a thing is not possible. This merge request updates the documentation to reflect the underlying capabilities of the framework.

Contribution Guidelines: 
1. Sorry I could not find a development branch, therefore this pull request is on the master branch.
2. No code has been changed only the documentation, therefore no unit tests have been run on this change.
3. No additional Code in the form of notebooks is provided due to this updating **only** the documentation

Thanks for the great library!