### PR TITLE
Update sklearn -> scikit-learn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /var/lib/apt/lists/partial && \
 # Also see: https://jupyter.readthedocs.io/en/latest/community/content-community.html#what-is-a-jovyan
 USER 1000
 RUN pip install --upgrade pip 
-RUN pip install setuptools cython powerlaw sklearn seaborn pandas tabulate matplotlib networkx ipycytoscape
+RUN pip install setuptools cython powerlaw scikit-learn seaborn pandas tabulate matplotlib networkx ipycytoscape
 
 # Create working environment
 # This has to be done as root in order to avoid access denied errors.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 seaborn
-sklearn
+scikit-learn
 matplotlib
 pandas
 networkx


### PR DESCRIPTION
`sklearn` is deprecated [1], update to `scikit-learn`.

[1] https://scikit-learn.org/stable/modules/generated/sklearn.utils.deprecated.html