### PR TITLE
node2vec: Add checks in order to avoid unexpected behavior and segfaults

### DIFF
--- a/networkit/cpp/embedding/Node2Vec.cpp
+++ b/networkit/cpp/embedding/Node2Vec.cpp
@@ -31,9 +31,21 @@ namespace NetworKit {
 
 Node2Vec::Node2Vec(const Graph &G, double P, double Q, count L, count N, count D)
     : G(&G), P(P), Q(Q), L(L), N(N), D(D) {
+    if (G.isDirected()) {
+        throw std::runtime_error("Current implementation can only deal with undirected graphs");
+    }
     if (G.numberOfNodes() != G.upperNodeIdBound()) {
         throw std::runtime_error("The node ids of the graph must be continuous.");
     }
+    bool hasIsolatedNodes = false;
+    for (node u : G.nodeRange()) {
+        if (G.degree(u) == 0) {
+            hasIsolatedNodes = true;
+            break;
+        }
+    }
+    if (hasIsolatedNodes)
+        throw std::runtime_error("Isolated nodes are not allowed.");
 }
 
 void Node2Vec::run() {

--- a/networkit/cpp/embedding/test/FiniteEmbeddingTest.cpp
+++ b/networkit/cpp/embedding/test/FiniteEmbeddingTest.cpp
@@ -30,6 +30,29 @@ bool allFinite(const Embeddings &e) {
     return true;
 }
 
+TEST_F(FiniteEmbeddingTest, testNode2VecOnDirectedGraph) {
+    // Directed graph with two nodes.
+    Graph G(2, false, true);
+    G.addEdge(0, 1);
+    EXPECT_THROW(NetworKit::Node2Vec{G}, std::runtime_error);
+}
+
+TEST_F(FiniteEmbeddingTest, testNode2VecOnGraphWithIsolatedNodes) {
+    // Undirected graph with three nodes; node with id 2 is isolated.
+    Graph G(3);
+    G.addEdge(0, 1);
+    EXPECT_THROW(NetworKit::Node2Vec{G}, std::runtime_error);
+}
+
+TEST_F(FiniteEmbeddingTest, testNode2VecOnGraphWithNonContinuousIds) {
+    // Undirected graph with two nodes; only id 0 and id 2 are present.
+    Graph G(3);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+    G.removeNode(1);
+    EXPECT_THROW(NetworKit::Node2Vec{G}, std::runtime_error);
+}
+
 TEST_F(FiniteEmbeddingTest, testFiniteEmbeddingOnSmallGraph) {
 
     NetworKit::METISGraphReader reader;


### PR DESCRIPTION
This PR adds checks for node2vec (directed, has isolated nodes) in order to avoid segfaults (see #1011). Not included here, but on the roadmap: Adding the support of directed graphs for node2vec.