### PR TITLE
Fix DynBfs

### DIFF
--- a/networkit/cpp/distance/DynBFS.cpp
+++ b/networkit/cpp/distance/DynBFS.cpp
@@ -78,8 +78,9 @@ void DynBFS::update(GraphEvent e) {
 void DynBFS::updateBatch(const std::vector<GraphEvent> &batch) {
     std::vector<std::queue<node>> queues(maxDistance + 2);
     mod = false;
+
     // insert nodes from the batch whose distance has changed (affected nodes) into the queues
-    for (GraphEvent edge : batch) {
+    for (const GraphEvent &edge : batch) {
         if (edge.type == GraphEvent::EDGE_ADDITION) {
             if (distances[edge.u] == infDist && (G->isDirected() || distances[edge.v] == infDist))
                 continue;
@@ -105,12 +106,11 @@ void DynBFS::updateBatch(const std::vector<GraphEvent> &batch) {
     // extract nodes from the queues and scan incident edges
     std::queue<node> visited;
 
-    for (count m = 1; m < maxDistance; m++) {
+    for (count m = 1; m < maxDistance; ++m) {
         if (m >= maxDistance - 1 && (!queues[m].empty() || !queues[m + 1].empty())) {
-            maxDistance++;
+            ++maxDistance;
             queues.emplace_back();
         }
-        assert(queues.size() > m);
         mod = mod || (!queues[m].empty());
         while (!queues[m].empty()) {
             node w = queues[m].front();
@@ -157,8 +157,7 @@ void DynBFS::updateBatch(const std::vector<GraphEvent> &batch) {
                 }
                 if (con != infDist) {
                     if (con > maxDistance) {
-                        for (count i = maxDistance; i < con; i++)
-                            queues.emplace_back();
+                        queues.resize(con + 1);
                         maxDistance = con;
                     }
                     queues[con].push(w);


### PR DESCRIPTION
`DynBetweennessGTest.testDynApproxBetweenessGeneratedGraph` fails with segfault, see the screenshot below:

<img width="1164" alt="Screenshot 2023-03-23 at 23 51 46" src="https://user-images.githubusercontent.com/7772926/227382552-80528eab-5989-4fcd-9c97-b428651604ff.png">

I compiled NetworKit on macOS 13.2.1 (M2 chip), llvm Clang 15.0.7 and with these flags:
```
cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_WITH_SANITIZERS=address -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=17 ..
```

This happens for two reasons:
- There seems to be a pretty obvious mistake in `DynBFS.cpp`: the `queues` vector has size `maxDistance + 1`
https://github.com/networkit/networkit/blob/333cb9a7e431dfadf016323491dcfd24227112c5/networkit/cpp/distance/DynBFS.cpp#L77 and the heap-buffer-overflow happens at this line
https://github.com/networkit/networkit/blob/333cb9a7e431dfadf016323491dcfd24227112c5/networkit/cpp/distance/DynBFS.cpp#L88 which could access the vector outside its. Thus, the size of `queues` should be `maxDistance + 2`.
- `maxDistance` is not correctly updated. I observed that, when `updateBatch` is called, `maxDistance` is sometimes smaller than the highest non-infinite value in `distances`.

This PR fixes these issues. For the second one, I simply get the highest non-infinite value in `distances`. This is not the optimal solution, but it should not pessimize considerably the performance of the algorithm. The logic of the algorithm is quite complex, and I did not have time to find the bug in updating `maxDistance`.

Additionally, I included a few improvements in a separate commit.