### PR TITLE
Update GHA: Fix Python 3.11 wheel build, increase timeout for coverage, modernize GH-actions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,36 +13,36 @@ jobs:
     strategy:
       matrix:
         cibw_archs: ["x86_64"]
-        manylinux_image: ["manylinux2010"]
+        manylinux_image: ["manylinux2014"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
         with:
           python-version: '3.10'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_BEFORE_BUILD: pip install cython
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs }}
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
-          CIBW_SKIP: pp*
-      - uses: actions/upload-artifact@v2
+          CIBW_SKIP: "pp* *-musllinux_*"
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp38*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp39*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp310*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp311*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
@@ -61,27 +61,27 @@ jobs:
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
         with:
           python-version: '3.9'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_BEFORE_BUILD: pip install cython
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs }}
           CIBW_BUILD: ${{ github.ref == 'refs/heads/master' && 'cp39-* cp310-*' || 'cp310-*' }}
-          CIBW_SKIP: pp*
-      - uses: actions/upload-artifact@v2
+          CIBW_SKIP: "pp* *-musllinux_*"
+      - uses: actions/upload-artifact@v3
         if: github.ref == 'refs/heads/master'
         with:
           path: ./wheelhouse/*cp39*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp310*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
@@ -93,15 +93,15 @@ jobs:
       matrix:
         cibw_archs: ["x86_64"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
         with:
           python-version: '3.10'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_BEFORE_BUILD: 
             pip install cython &&
@@ -109,20 +109,20 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs }}
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
           CIBW_ENVIRONMENT: CXX='c++'
-          CIBW_SKIP: pp*
-      - uses: actions/upload-artifact@v2
+          CIBW_SKIP: "pp* *-musllinux_*"
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp38*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp39*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp310*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp311*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
@@ -176,35 +176,35 @@ jobs:
       matrix:
         cibw_archs: [amd64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Setup devCmd (vstools)
         uses: ilammy/msvc-dev-cmd@v1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
         with:
           python-version: '3.10'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_BEFORE_BUILD: pip install cython ipython
           CIBW_ARCHS: "AMD64"
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
           CIBW_SKIP: pp*
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp38*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp39*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp310*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*cp311*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
@@ -213,10 +213,10 @@ jobs:
     name: 'Source distribution'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
         with:
           python-version: '3.10'
@@ -225,7 +225,7 @@ jobs:
           pip install cython
           python3 setup.py build_ext
           python3 setup.py sdist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./dist/*networkit*.tar.gz
           retention-days: ${{ env.ARTIFACT_RETENTION }}
@@ -253,10 +253,10 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [cpython-macos-x86_64, cpython-linux-aarch64, cpython-linux-x86_64, cpython-windows, source-distribution, check-release-tag]
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: ./dist
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
         with:
           python-version: '3.10'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ env:
 
 jobs:
   macos-build-latest-version-apple-clang:
-    name: "macOS ${{ matrix.os }} (apple-clang, CPython 3.10): ${{ matrix.build-configuration }}"
+    name: "macOS ${{ matrix.os }} (apple-clang, CPython 3.11): ${{ matrix.build-configuration }}"
     runs-on: macos-${{ matrix.os }}
     env:
       CC: cc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,11 @@ jobs:
         with:
           python-version: '3.11.0'
       - name: Checkout networkit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Checkout tlx
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: tlx/tlx
           path: tlx
@@ -156,7 +156,7 @@ jobs:
           brew reinstall gcc@12
           brew link --overwrite gcc@12
       - name: Checkout networkit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Prepare environment and run checks
@@ -186,12 +186,12 @@ jobs:
         with:
           python-version: '3.11.0'
       - name: Checkout networkit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Checkout tlx
         if: ${{ startsWith(matrix.build-configuration, 'full') }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: tlx/tlx
           path: tlx
@@ -218,11 +218,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install clang-15 libomp-15-dev ninja-build
       - name: Checkout networkit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Checkout tlx
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: tlx/tlx
           path: tlx
@@ -247,15 +247,15 @@ jobs:
           sudo apt-get install libomp5 libomp-dev clang-5.0 clang++-5.0
           sudo apt-get install gcc-7 g++-7
       - name: Setup Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.7'
       - name: Checkout networkit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Checkout tlx
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: tlx/tlx
           path: tlx
@@ -280,7 +280,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libomp-15-dev clang-15 clang-tidy-15 ninja-build
       - name: Checkout networkit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Prepare environment and run checks
@@ -307,13 +307,13 @@ jobs:
         with:
           python-version: '3.11.0'
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Prepare environment and run checks
         run:  ${{ github.workspace }}/.github/workflows/scripts/core_sanitizers_coverage.sh
         shell: bash
-        timeout-minutes: 120
+        timeout-minutes: 180
       - name: Create C++ coverage
         run: |
           cd ${{ github.workspace }}
@@ -343,7 +343,7 @@ jobs:
         build-configuration: ['core']
     steps:
       - name: Checkout networkit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Setup devCmd (vstools)
@@ -368,11 +368,11 @@ jobs:
         with:
           python-version: '3.11.0'
       - name: Checkout networkit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Checkout tlx
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: tlx/tlx
           path: tlx
@@ -421,7 +421,7 @@ jobs:
         with:
           python-version: '3.11.0'
       - name: Checkout networkit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Prepare environment and run checks
@@ -450,7 +450,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install clang-format-15 python-yaml
       - name: Checkout networkit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Prepare environment and run checks


### PR DESCRIPTION
This PR fixes issue #1048. In addition, the timeout for the coverage built is increased and v2-actions from GitHub are exchanged for their v3 counterpart due to deprecation warnings.

Will look into decreasing the coverage build time outside of this PR (some test cases again take several minutes).