### PR TITLE
Fix unused variable warnings.

### DIFF
--- a/networkit/cpp/centrality/ApproxSpanningEdge.cpp
+++ b/networkit/cpp/centrality/ApproxSpanningEdge.cpp
@@ -10,6 +10,8 @@
 #include <omp.h>
 #include <queue>
 
+#include <tlx/unused.hpp>
+
 #include <networkit/centrality/ApproxSpanningEdge.hpp>
 #include <networkit/components/BiconnectedComponents.hpp>
 

--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -425,7 +425,7 @@ void TopCloseness::run() {
                         omp_set_lock(&lock);
                         if (farness[v] < S[v] && toAnalyze[v]) { // Have to check again, because the
                                                                  // variables might have changed
-                            imp++;
+                            ++imp;
                             farness[v] = S[v];
                             Q.update(v);
                         }

--- a/networkit/cpp/distance/test/SSSPGTest.cpp
+++ b/networkit/cpp/distance/test/SSSPGTest.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stack>
+
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/distance/BFS.hpp>
 #include <networkit/distance/Dijkstra.hpp>
@@ -15,8 +17,6 @@
 #include <networkit/io/METISGraphReader.hpp>
 
 #include <tlx/unused.hpp>
-
-#include <stack>
 
 namespace NetworKit {
 
@@ -73,7 +73,8 @@ TEST_F(SSSPGTest, testShortestPaths) {
     tlx::unused(i);
     for (const auto &path : paths) {
         DEBUG("Path number ", i);
-        i++;
+        ++i;
+        tlx::unused(i);
         DEBUG(path);
         EXPECT_EQ(path[0], source);
         EXPECT_EQ(path[dist], x);

--- a/networkit/cpp/generators/DynamicBarabasiAlbertGenerator.cpp
+++ b/networkit/cpp/generators/DynamicBarabasiAlbertGenerator.cpp
@@ -53,7 +53,6 @@ void DynamicBarabasiAlbertGenerator::generate() {
     std::unordered_set<node> targets; // avoid duplicate edges by collecting target nodes in a set
 
     while (targets.size() < k) {
-
         // 2) pick a random number that is 0 or greater and is less than the sum of the weights
         uint64_t rand = Aux::Random::integer(degSum);
 

--- a/networkit/cpp/generators/LFRGenerator.cpp
+++ b/networkit/cpp/generators/LFRGenerator.cpp
@@ -1,8 +1,8 @@
 #include <algorithm>
 #include <numeric>
 #include <random>
-
 #include <utility>
+
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
 #include <networkit/auxiliary/Random.hpp>
@@ -12,6 +12,8 @@
 #include <networkit/generators/PowerlawDegreeSequence.hpp>
 #include <networkit/generators/PubWebGenerator.hpp>
 #include <networkit/graph/GraphTools.hpp>
+
+#include <tlx/unused.hpp>
 
 NetworKit::LFRGenerator::LFRGenerator(NetworKit::count n)
     : n(n), hasDegreeSequence(false), hasCommunitySizeSequence(false),

--- a/networkit/cpp/generators/quadtree/test/QuadTreeGTest.cpp
+++ b/networkit/cpp/generators/quadtree/test/QuadTreeGTest.cpp
@@ -5,21 +5,19 @@
  *      Author: Moritz v. Looz (moritz.looz-corswarem@kit.edu)
  */
 
+#include <gtest/gtest.h>
+
 #include <algorithm>
 #include <cmath>
 #include <stack>
-
-#include <cmath>
 #include <vector>
-#include <gtest/gtest.h>
-#include <networkit/generators/quadtree/Quadtree.hpp>
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
-#include <networkit/geometric/HyperbolicSpace.hpp>
-
+#include <networkit/generators/quadtree/Quadtree.hpp>
 #include <networkit/generators/quadtree/QuadtreeCartesianEuclid.hpp>
 #include <networkit/generators/quadtree/QuadtreePolarEuclid.hpp>
+#include <networkit/geometric/HyperbolicSpace.hpp>
 
 #include <tlx/unused.hpp>
 
@@ -138,7 +136,7 @@ TEST_F(QuadTreeGTest, testQuadTreeHyperbolicCircle) {
                                                           responsibleNode.getRightAngle(),
                                                           responsibleNode.getMaxR()));
                 } else {
-                    didfind++;
+                    ++didfind;
                 }
             }
         }
@@ -146,6 +144,8 @@ TEST_F(QuadTreeGTest, testQuadTreeHyperbolicCircle) {
             DEBUG("Found only ", didfind, " of ", didfind + notfound, " neighbours");
             tlx::unused(didfind);
         }
+
+        tlx::unused(didfind);
     }
 }
 
@@ -721,7 +721,7 @@ TEST_F(QuadTreeGTest, debugTreeExport) {
             index i = 0;
             tlx::unused(i);
             for (index elem : current.getElements()) {
-                i++;
+                ++i;
                 double p = edgeProb(HyperbolicSpace::poincareMetric(angles[elem], radii[elem],
                                                                     angles[query], radii[query]));
                 DEBUG("\\drawPoint{", deg(angles[elem]), "}{",
@@ -729,6 +729,7 @@ TEST_F(QuadTreeGTest, debugTreeExport) {
                       current.getID(), "}{", i, "}");
                 DEBUG("Leaf contains: ", angles[elem], ", ", radii[elem], " p: ", p);
                 tlx::unused(p);
+                tlx::unused(i);
             }
         }
 

--- a/networkit/cpp/io/SNAPEdgeListPartitionReader.cpp
+++ b/networkit/cpp/io/SNAPEdgeListPartitionReader.cpp
@@ -57,7 +57,7 @@ Cover SNAPEdgeListPartitionReader::read(const std::string &path,
 #ifndef NDEBUG
                 uniqueIDs.insert(current);
 #endif
-                totalCounter++;
+                ++totalCounter;
                 if (mapNodeIds.find(current) != mapNodeIds.end()) {
                     communities.addToSubset(i, mapNodeIds[current]);
                 } else {
@@ -70,6 +70,7 @@ Cover SNAPEdgeListPartitionReader::read(const std::string &path,
     DEBUG("read ", uniqueIDs.size(),
           " unique node IDs with the total amount of occurrences: ", totalCounter);
 #endif
+    tlx::unused(totalCounter);
     count emptyElements = 0;
     count output = 0;
     std::stringstream outputString;
@@ -77,7 +78,7 @@ Cover SNAPEdgeListPartitionReader::read(const std::string &path,
     outputString << "first 10 unassigned IDs: ";
     for (index i = 0, end = communities.numberOfElements(); i < end; ++i) {
         if (communities[i].empty()) {
-            emptyElements++;
+            ++emptyElements;
             if (output < 10) {
                 outputIDs.push_back(i);
                 output++;


### PR DESCRIPTION
- Remove unused variables
- Use `tlx::unused` for variables used only in debug mode
- Use pre-increment instead of post-increment where possible