### PR TITLE
Add DynAlgorithm bindings to python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,7 @@ if(NETWORKIT_PYTHON)
 	endif()
 
 	foreach (EXT base centrality clique coarsening community components correlation
-			 distance dynamics embedding engineering flow generators globals graph graphio
+			 distance dynamics dynbase embedding engineering flow generators globals graph graphio
 			 graphtools helpers independentset linkprediction matching
 			 randomization reachability scd simulation sparsification stats
 			 structures traversal viz)

--- a/docs/python_api/base.rst
+++ b/docs/python_api/base.rst
@@ -4,4 +4,3 @@ networkit.base
 .. automodule:: networkit.base
     :members:
     :undoc-members:
-    :show-inheritance:

--- a/docs/python_api/dynbase.rst
+++ b/docs/python_api/dynbase.rst
@@ -1,0 +1,7 @@
+networkit.dynbase
+=======================
+
+.. automodule:: networkit.dynbase
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/python_api/modules.rst
+++ b/docs/python_api/modules.rst
@@ -24,6 +24,7 @@ Modules
    distance
    dynamic
    dynamics
+   dynbase
    embedding
    engineering
    flow

--- a/include/networkit/centrality/DynBetweennessOneNode.hpp
+++ b/include/networkit/centrality/DynBetweennessOneNode.hpp
@@ -8,6 +8,7 @@
 #ifndef NETWORKIT_CENTRALITY_DYN_BETWEENNESS_ONE_NODE_HPP_
 #define NETWORKIT_CENTRALITY_DYN_BETWEENNESS_ONE_NODE_HPP_
 
+#include <networkit/base/Algorithm.hpp>
 #include <networkit/base/DynAlgorithm.hpp>
 #include <networkit/dynamics/GraphEvent.hpp>
 
@@ -17,7 +18,7 @@ namespace NetworKit {
  * @ingroup graph
  * Dynamic betweenness of a single node.
  */
-class DynBetweennessOneNode : public DynAlgorithm {
+class DynBetweennessOneNode : public Algorithm, public DynAlgorithm {
 
 public:
     /**
@@ -29,7 +30,7 @@ public:
     DynBetweennessOneNode(Graph &G, node x);
 
     /** initialize distances and Pred by repeatedly running the Dijkstra2 algorithm */
-    void run();
+    void run() override;
 
     /**
      * Updates the betweenness centrality of x after an edge insertions on the graph.

--- a/networkit/base.pxd
+++ b/networkit/base.pxd
@@ -6,14 +6,8 @@ cdef extern from "<networkit/base/Algorithm.hpp>" namespace "NetworKit":
 		void run() nogil except +
 		bool_t hasFinished() except +
 
-cdef class Algorithm:
+cdef class _CythonParentClass:
 	cdef _Algorithm *_this
 
-# This creates a cyclic import and is currently unused
-#from .dynamics cimport _GraphEvent, GraphEvent
-
-#cdef extern from "<networkit/base/DynAlgorithm.hpp>":
-#
-#	cdef cppclass _DynAlgorithm "NetworKit::DynAlgorithm":
-#		void update(_GraphEvent) except +
-#		void updateBatch(vector[_GraphEvent]) except +
+cdef class Algorithm(_CythonParentClass):
+	pass

--- a/networkit/base.pyx
+++ b/networkit/base.pyx
@@ -1,6 +1,23 @@
 # distutils: language=c++
 
-cdef class Algorithm:
+
+cdef class _CythonParentClass:
+	""" Abstract base class for Cython 
+	The purpose of this class is to provide a single combined base cdef class for all classes that we use in this project.
+	Cython cannot handle multiple inheritance without this single common base class."""
+	def __init__(self, *args, **namedargs):
+		if type(self) == _CythonParentClass:
+			raise RuntimeError("Error, you may not use _CythonParentClass directly, use a sub-class instead")
+
+	def __cinit__(self, *args, **namedargs):
+		self._this = NULL
+
+	def __dealloc__(self):
+		if self._this != NULL:
+			del self._this
+		self._this = NULL
+
+cdef class Algorithm(_CythonParentClass):
 	""" Abstract base class for algorithms """
 	def __init__(self, *args, **namedargs):
 		if type(self) == Algorithm:

--- a/networkit/base.pyx
+++ b/networkit/base.pyx
@@ -4,7 +4,8 @@
 cdef class _CythonParentClass:
 	""" Abstract base class for Cython 
 	The purpose of this class is to provide a single combined base cdef class for all classes that we use in this project.
-	Cython cannot handle multiple inheritance without this single common base class."""
+	Cython cannot handle multiple inheritance without this single common base class.
+	"""
 	def __init__(self, *args, **namedargs):
 		if type(self) == _CythonParentClass:
 			raise RuntimeError("Error, you may not use _CythonParentClass directly, use a sub-class instead")

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -400,8 +400,6 @@ cdef extern from "<networkit/centrality/DynBetweenness.hpp>":
 
 	cdef cppclass _DynBetweenness "NetworKit::DynBetweenness"(_Algorithm, _DynAlgorithm):
 		_DynBetweenness(_Graph) except +
-		void update(_GraphEvent) except +
-		void updateBatch(vector[_GraphEvent]) except +
 		vector[double] scores() except +
 		vector[pair[node, double]] ranking() except +
 		double score(node) except +
@@ -473,8 +471,6 @@ cdef extern from "<networkit/centrality/DynApproxBetweenness.hpp>":
 
 	cdef cppclass _DynApproxBetweenness "NetworKit::DynApproxBetweenness"(_Algorithm, _DynAlgorithm):
 		_DynApproxBetweenness(_Graph, double, double, bool_t, double) except +
-		void update(_GraphEvent) except +
-		void updateBatch(vector[_GraphEvent]) except +
 		vector[double] scores() except +
 		vector[pair[node, double]] ranking() except +
 		double score(node) except +
@@ -575,9 +571,6 @@ cdef extern from "<networkit/centrality/DynBetweennessOneNode.hpp>":
 
 	cdef cppclass _DynBetweennessOneNode "NetworKit::DynBetweennessOneNode"(_Algorithm, _DynAlgorithm):
 		_DynBetweennessOneNode(_Graph, node) except +
-		void run() nogil except +
-		void update(_GraphEvent) except +
-		void updateBatch(vector[_GraphEvent]) except +
 		double getDistance(node, node) except +
 		double getSigma(node, node) except +
 		double getSigmax(node, node) except +
@@ -1074,8 +1067,6 @@ cdef extern from "<networkit/centrality/DynTopHarmonicCloseness.hpp>":
 		vector[pair[node, edgeweight]] ranking(bool_t) except +
 		vector[node] topkNodesList(bool_t) except +
 		vector[edgeweight] topkScoresList(bool_t) except +
-		void update(_GraphEvent) except +
-		void updateBatch(vector[_GraphEvent]) except +
 
 cdef class DynTopHarmonicCloseness(Algorithm, DynAlgorithm):
 	""" 
@@ -1935,8 +1926,6 @@ cdef extern from "<networkit/centrality/DynKatzCentrality.hpp>":
 
 	cdef cppclass _DynKatzCentrality "NetworKit::DynKatzCentrality" (_Centrality, _DynAlgorithm):
 		_DynKatzCentrality(_Graph G, count, bool_t, double) except +
-		void update(_GraphEvent) except +
-		void updateBatch(vector[_GraphEvent]) except +
 		node top(count) except +
 		double bound(node) except +
 		bool_t areDistinguished(node, node) except +

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -9,6 +9,8 @@ from libcpp cimport bool as bool_t
 import math
 
 from .base cimport _Algorithm, Algorithm
+from .dynbase cimport _DynAlgorithm
+from .dynbase import DynAlgorithm
 from .dynamics cimport _GraphEvent, GraphEvent
 from .graph cimport _Graph, Graph
 from .structures cimport _Cover, Cover, _Partition, Partition, count, index, node, edgeweight
@@ -396,7 +398,7 @@ cdef class KadabraBetweenness(Algorithm):
 
 cdef extern from "<networkit/centrality/DynBetweenness.hpp>":
 
-	cdef cppclass _DynBetweenness "NetworKit::DynBetweenness"(_Algorithm):
+	cdef cppclass _DynBetweenness "NetworKit::DynBetweenness"(_Algorithm, _DynAlgorithm):
 		_DynBetweenness(_Graph) except +
 		void update(_GraphEvent) except +
 		void updateBatch(vector[_GraphEvent]) except +
@@ -404,7 +406,7 @@ cdef extern from "<networkit/centrality/DynBetweenness.hpp>":
 		vector[pair[node, double]] ranking() except +
 		double score(node) except +
 
-cdef class DynBetweenness(Algorithm):
+cdef class DynBetweenness(Algorithm, DynAlgorithm):
 	""" 
 	DynBetweenness(G)
 	
@@ -421,35 +423,6 @@ cdef class DynBetweenness(Algorithm):
 	def __cinit__(self, Graph G):
 		self._G = G
 		self._this = new _DynBetweenness(G._this)
-
-	def update(self, ev):
-		"""
-		update(ev)
-		
-		Updates the betweenness centralities after the edge insertions.
-
-		Parameters
-		----------
-		ev : networkit.dynamics.GraphEvent
-			Update the Betweenness based on a given graph event.
-		"""
-		(<_DynBetweenness*>(self._this)).update(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-
-	def updateBatch(self, batch):
-		"""
-		updateBatch(batch)
-
-		Updates the betweenness centralities after the batch `batch` of edge insertions.
-
-		Parameters
-		----------
-		batch : list(networkit.dynamics.GraphEvent)
-			Update the Betweenness based on a given list of graph events.
-		"""
-		cdef vector[_GraphEvent] _batch
-		for ev in batch:
-			_batch.push_back(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-		(<_DynBetweenness*>(self._this)).updateBatch(_batch)
 
 	def scores(self):
 		""" 
@@ -498,7 +471,7 @@ cdef class DynBetweenness(Algorithm):
 
 cdef extern from "<networkit/centrality/DynApproxBetweenness.hpp>":
 
-	cdef cppclass _DynApproxBetweenness "NetworKit::DynApproxBetweenness"(_Algorithm):
+	cdef cppclass _DynApproxBetweenness "NetworKit::DynApproxBetweenness"(_Algorithm, _DynAlgorithm):
 		_DynApproxBetweenness(_Graph, double, double, bool_t, double) except +
 		void update(_GraphEvent) except +
 		void updateBatch(vector[_GraphEvent]) except +
@@ -507,7 +480,7 @@ cdef extern from "<networkit/centrality/DynApproxBetweenness.hpp>":
 		double score(node) except +
 		count getNumberOfSamples() except +
 
-cdef class DynApproxBetweenness(Algorithm):
+cdef class DynApproxBetweenness(Algorithm, DynAlgorithm):
 	""" 
 	DynApproxBetweenness(G, epsilon=0.01, delta=0.1, storePredecessors=True, universalConstant=1.0)
 	
@@ -539,35 +512,6 @@ cdef class DynApproxBetweenness(Algorithm):
 	def __cinit__(self, Graph G, epsilon=0.01, delta=0.1, storePredecessors = True, universalConstant=1.0):
 		self._G = G
 		self._this = new _DynApproxBetweenness(G._this, epsilon, delta, storePredecessors, universalConstant)
-
-	def update(self, ev):
-		""" 
-		update(ev)
-		
-		Updates the betweenness centralities after the edge insertions.
-
-		Parameters
-		----------
-		ev : networkit.dynamics.GraphEvent
-			Update the Betweenness based on a given graph event.
-		"""
-		(<_DynApproxBetweenness*>(self._this)).update(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-
-	def updateBatch(self, batch):
-		""" 
-		updateBatch(batch)
-		
-		Updates the betweenness centralities after the batch `batch` of edge insertions.
-
-		Parameters
-		----------
-		batch : list(networkit.dynamics.GraphEvent)
-			Update the Betweenness based on a given list of graph events.
-		"""
-		cdef vector[_GraphEvent] _batch
-		for ev in batch:
-			_batch.push_back(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-		(<_DynApproxBetweenness*>(self._this)).updateBatch(_batch)
 
 	def scores(self):
 		""" 
@@ -1160,7 +1104,7 @@ cdef class TopHarmonicCloseness(Algorithm):
 
 cdef extern from "<networkit/centrality/DynTopHarmonicCloseness.hpp>":
 
-	cdef cppclass _DynTopHarmonicCloseness "NetworKit::DynTopHarmonicCloseness"(_Algorithm):
+	cdef cppclass _DynTopHarmonicCloseness "NetworKit::DynTopHarmonicCloseness"(_Algorithm, _DynAlgorithm):
 		_DynTopHarmonicCloseness(_Graph G, count, bool_t) except +
 		vector[pair[node, edgeweight]] ranking(bool_t) except +
 		vector[node] topkNodesList(bool_t) except +
@@ -1168,7 +1112,7 @@ cdef extern from "<networkit/centrality/DynTopHarmonicCloseness.hpp>":
 		void update(_GraphEvent) except +
 		void updateBatch(vector[_GraphEvent]) except +
 
-cdef class DynTopHarmonicCloseness(Algorithm):
+cdef class DynTopHarmonicCloseness(Algorithm, DynAlgorithm):
 	""" 
 	DynTopHarmonicCloseness(G, k=1, useBFSbound=True)
 	
@@ -1267,35 +1211,6 @@ cdef class DynTopHarmonicCloseness(Algorithm):
 		return (<_DynTopHarmonicCloseness*>(self._this)).topkScoresList(includeTrail)
 
 
-
-	def update(self, ev):
-		""" 
-		update(ev)
-		
-		Updates the betweenness centralities after the edge insertions.
-
-		Parameters
-		----------
-		ev : networkit.dynamics.GraphEvent
-			Update the Betweenness based on a given graph event.
-		"""
-		(<_DynTopHarmonicCloseness*>(self._this)).update(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-
-	def updateBatch(self, batch):
-		""" 
-		updateBatch(batch)
-		
-		Updates the betweenness centralities after the batch `batch` of edge insertions.
-
-		Parameters
-		----------
-		batch : list(networkit.dynamics.GraphEvent)
-			Update the Betweenness based on a given list of graph events.
-		"""
-		cdef vector[_GraphEvent] _batch
-		for ev in batch:
-			_batch.push_back(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-		(<_DynTopHarmonicCloseness*>(self._this)).updateBatch(_batch)
 
 cdef extern from "<networkit/centrality/LocalPartitionCoverage.hpp>":
 
@@ -2053,7 +1968,7 @@ cdef class KatzCentrality(Centrality):
 
 cdef extern from "<networkit/centrality/DynKatzCentrality.hpp>":
 
-	cdef cppclass _DynKatzCentrality "NetworKit::DynKatzCentrality" (_Centrality):
+	cdef cppclass _DynKatzCentrality "NetworKit::DynKatzCentrality" (_Centrality, _DynAlgorithm):
 		_DynKatzCentrality(_Graph G, count, bool_t, double) except +
 		void update(_GraphEvent) except +
 		void updateBatch(vector[_GraphEvent]) except +
@@ -2082,35 +1997,6 @@ cdef class DynKatzCentrality(Centrality):
 	def __cinit__(self, Graph G, k, groupOnly=False, tolerance=1e-9):
 		self._G = G
 		self._this = new _DynKatzCentrality(G._this, k, groupOnly, tolerance)
-
-	def update(self, ev):
-		""" 
-		update(ev)
-		
-		Updates the centralities after the edge insertions.
-
-		Parameters
-		----------
-		ev : networkit.dynamics.GraphEvent
-			Update the Betweenness based on a given graph event.
-		"""
-		(<_DynKatzCentrality*>(self._this)).update(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-
-	def updateBatch(self, batch):
-		""" 
-		updateBatch(batch)
-		
-		Updates the centralities after the batch `batch` of edge insertions.
-
-		Parameters
-		----------
-		batch : list(networkit.dynamics.GraphEvent)
-			Update the Betweenness based on a given list of graph events.
-		"""
-		cdef vector[_GraphEvent] _batch
-		for ev in batch:
-			_batch.push_back(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-		(<_DynKatzCentrality*>(self._this)).updateBatch(_batch)
 
 	def top(self, n=0):
 		""" 

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -573,7 +573,7 @@ cdef class DynApproxBetweenness(Algorithm, DynAlgorithm):
 
 cdef extern from "<networkit/centrality/DynBetweennessOneNode.hpp>":
 
-	cdef cppclass _DynBetweennessOneNode "NetworKit::DynBetweennessOneNode":
+	cdef cppclass _DynBetweennessOneNode "NetworKit::DynBetweennessOneNode"(_Algorithm, _DynAlgorithm):
 		_DynBetweennessOneNode(_Graph, node) except +
 		void run() nogil except +
 		void update(_GraphEvent) except +
@@ -583,12 +583,12 @@ cdef extern from "<networkit/centrality/DynBetweennessOneNode.hpp>":
 		double getSigmax(node, node) except +
 		double getbcx() except +
 
-cdef class DynBetweennessOneNode:
+cdef class DynBetweennessOneNode(Algorithm, DynAlgorithm):
 	""" 
 	DynBetweennessOneNode(G, x)
 	
 	Dynamic exact algorithm for updating the betweenness of a specific node.
-	The algorithm aupdates the betweenness of a node after an edge insertions
+	The algorithm updates the betweenness of a node after an edge insertion
 	(faster than updating it for all nodes), based on the algorithm
 	proposed by Bergamini et al. "Improving the betweenness centrality of a node by adding links"
 
@@ -599,7 +599,6 @@ cdef class DynBetweennessOneNode:
 	x : int
 		The node for which you want to update betweenness
 	"""
-	cdef _DynBetweennessOneNode* _this
 	cdef Graph _G
 
 	def __cinit__(self, Graph G, node):
@@ -609,40 +608,6 @@ cdef class DynBetweennessOneNode:
 	# this is necessary so that the C++ object gets properly garbage collected
 	def __dealloc__(self):
 		del self._this
-
-	def run(self):
-		with nogil:
-			self._this.run()
-		return self
-
-	def update(self, ev):
-		""" 
-		update(ev)
-		
-		Updates the betweenness centralities after the edge insertions.
-
-		Parameters
-		----------
-		ev : networkit.dynamics.GraphEvent
-			Update the Betweenness based on a given graph event.
-		"""
-		self._this.update(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-
-	def updateBatch(self, batch):
-		""" 
-		updateBatch(batch)
-		
-		Updates the betweenness centralities after the batch `batch` of edge insertions.
-
-		Parameters
-		----------
-		batch : list(networkit.dynamics.GraphEvent)
-			Update the Betweenness based on a given list of graph events.
-		"""
-		cdef vector[_GraphEvent] _batch
-		for ev in batch:
-			_batch.push_back(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-		self._this.updateBatch(_batch)
 
 	def getDistance(self, u, v):
 		""" 
@@ -655,7 +620,7 @@ cdef class DynBetweennessOneNode:
 		float
 			Distance between u and v.
 		"""
-		return self._this.getDistance(u, v)
+		return (<_DynBetweennessOneNode*>(self._this)).getDistance(u, v)
 
 	def getSigma(self, u, v):
 		"""
@@ -668,7 +633,7 @@ cdef class DynBetweennessOneNode:
 		int
 			Number of shortest paths between u and v.
 		"""
-		return self._this.getSigma(u, v)
+		return (<_DynBetweennessOneNode*>(self._this)).getSigma(u, v)
 
 	def getSigmax(self, u, v):
 		""" 
@@ -682,7 +647,7 @@ cdef class DynBetweennessOneNode:
 			Number of shortest paths between u and v that go through x.
 		
 		"""
-		return self._this.getSigmax(u, v)
+		return (<_DynBetweennessOneNode*>(self._this)).getSigmax(u, v)
 
 	def getbcx(self):
 		""" 
@@ -695,7 +660,7 @@ cdef class DynBetweennessOneNode:
 		float
 			Betweenness centrality score of x.
 		"""
-		return self._this.getbcx()
+		return (<_DynBetweennessOneNode*>(self._this)).getbcx()
 
 cdef extern from "<networkit/centrality/Closeness.hpp>" namespace "NetworKit::ClosenessVariant":
 

--- a/networkit/components.pyx
+++ b/networkit/components.pyx
@@ -6,6 +6,8 @@ from libcpp.map cimport map
 from libcpp.unordered_set cimport unordered_set
 
 from .base cimport _Algorithm, Algorithm
+from .dynbase cimport _DynAlgorithm
+from .dynbase import DynAlgorithm
 from .dynamics cimport _GraphEvent, GraphEvent
 from .graph cimport _Graph, Graph
 from .structures cimport _Partition, Partition, count, index, node
@@ -300,7 +302,7 @@ cdef class BiconnectedComponents(Algorithm):
 
 cdef extern from "<networkit/components/DynConnectedComponents.hpp>":
 
-	cdef cppclass _DynConnectedComponents "NetworKit::DynConnectedComponents"(_ComponentDecomposition):
+	cdef cppclass _DynConnectedComponents "NetworKit::DynConnectedComponents"(_ComponentDecomposition, _DynAlgorithm):
 		_DynConnectedComponents(_Graph G) except +
 		void update(_GraphEvent) except +
 		void updateBatch(vector[_GraphEvent]) except +
@@ -309,7 +311,7 @@ cdef extern from "<networkit/components/DynConnectedComponents.hpp>":
 		map[index, count] getComponentSizes() except +
 		vector[vector[node]] getComponents() except +
 
-cdef class DynConnectedComponents(ComponentDecomposition):
+cdef class DynConnectedComponents(ComponentDecomposition, DynAlgorithm):
 	"""
 	DynConnectedComponents(G)
 
@@ -324,46 +326,16 @@ cdef class DynConnectedComponents(ComponentDecomposition):
 	def __cinit__(self, Graph G):
 		self._this = new _DynConnectedComponents(G._this)
 
-	def update(self, event):
-		"""
-		update(event)
-
-		Updates the connected components after an edge insertion or
-		deletion.
-
-		Parameters
-		----------
-		event : networkit.dynamics.GraphEvent
-			The event that happened (edge deletion or insertion).
-		"""
-		(<_DynConnectedComponents*>(self._this)).update(_GraphEvent(event.type, event.u, event.v, event.w))
-
-	def updateBatch(self, batch):
-		"""
-		updateBatch(batch)
-
-		Updates the connected components after a batch of edge insertions or
-		deletions.
-
-		Parameters
-		----------
-		batch : list(networkit.dynamics.GraphEvent)
-			A list that contains a batch of edge insertions or deletions.
-		"""
-		cdef vector[_GraphEvent] _batch
-		for event in batch:
-			_batch.push_back(_GraphEvent(event.type, event.u, event.v, event.w))
-		(<_DynConnectedComponents*>(self._this)).updateBatch(_batch)
 
 
 cdef extern from "<networkit/components/DynWeaklyConnectedComponents.hpp>":
 
-	cdef cppclass _DynWeaklyConnectedComponents "NetworKit::DynWeaklyConnectedComponents"(_ComponentDecomposition):
+	cdef cppclass _DynWeaklyConnectedComponents "NetworKit::DynWeaklyConnectedComponents"(_ComponentDecomposition, _DynAlgorithm):
 		_DynWeaklyConnectedComponents(_Graph G) except +
 		void update(_GraphEvent) except +
 		void updateBatch(vector[_GraphEvent]) except +
 
-cdef class DynWeaklyConnectedComponents(ComponentDecomposition):
+cdef class DynWeaklyConnectedComponents(ComponentDecomposition, DynAlgorithm):
 	"""
 	DynWeaklyConnectedComponents(G)
 
@@ -378,33 +350,3 @@ cdef class DynWeaklyConnectedComponents(ComponentDecomposition):
 	def __cinit__(self, Graph G):
 		self._this = new _DynWeaklyConnectedComponents(G._this)
 
-	def update(self, event):
-		"""
-		update(event)
-
-		Updates the connected components after an edge insertion or
-		deletion.
-
-		Parameters
-		----------
-		event : networkit.dynamics.GraphEvent
-			The event that happened (edge deletion or insertion).
-		"""
-		(<_DynWeaklyConnectedComponents*>(self._this)).update(_GraphEvent(event.type, event.u, event.v, event.w))
-
-	def updateBatch(self, batch):
-		"""
-		updateBatch(batch)
-
-		Updates the connected components after a batch of edge insertions or
-		deletions.
-
-		Parameters
-		----------
-		batch : list(networkit.dynamics.GraphEvent)
-			A vector that contains a batch of edge insertions or deletions.
-		"""
-		cdef vector[_GraphEvent] _batch
-		for event in batch:
-			_batch.push_back(_GraphEvent(event.type, event.u, event.v, event.w))
-		(<_DynWeaklyConnectedComponents*>(self._this)).updateBatch(_batch)

--- a/networkit/components.pyx
+++ b/networkit/components.pyx
@@ -304,8 +304,6 @@ cdef extern from "<networkit/components/DynConnectedComponents.hpp>":
 
 	cdef cppclass _DynConnectedComponents "NetworKit::DynConnectedComponents"(_ComponentDecomposition, _DynAlgorithm):
 		_DynConnectedComponents(_Graph G) except +
-		void update(_GraphEvent) except +
-		void updateBatch(vector[_GraphEvent]) except +
 		count numberOfComponents() except +
 		count componentOfNode(node query) except +
 		map[index, count] getComponentSizes() except +
@@ -332,8 +330,6 @@ cdef extern from "<networkit/components/DynWeaklyConnectedComponents.hpp>":
 
 	cdef cppclass _DynWeaklyConnectedComponents "NetworKit::DynWeaklyConnectedComponents"(_ComponentDecomposition, _DynAlgorithm):
 		_DynWeaklyConnectedComponents(_Graph G) except +
-		void update(_GraphEvent) except +
-		void updateBatch(vector[_GraphEvent]) except +
 
 cdef class DynWeaklyConnectedComponents(ComponentDecomposition, DynAlgorithm):
 	"""

--- a/networkit/distance.pyx
+++ b/networkit/distance.pyx
@@ -347,8 +347,6 @@ cdef extern from "<networkit/distance/DynSSSP.hpp>":
 
 	cdef cppclass _DynSSSP "NetworKit::DynSSSP"(_SSSP, _DynAlgorithm):
 		_DynSSSP(_Graph G, node source, bool_t storePaths, bool_t storeStack, node target) except +
-		void update(_GraphEvent ev) except +
-		void updateBatch(vector[_GraphEvent] batch) except +
 		bool_t modified() except +
 		void setTargetNode(node t) except +
 
@@ -1327,8 +1325,6 @@ cdef extern from "<networkit/distance/DynAPSP.hpp>":
 
 	cdef cppclass _DynAPSP "NetworKit::DynAPSP"(_APSP, _DynAlgorithm):
 		_DynAPSP(_Graph G) except +
-		void update(_GraphEvent ev) except +
-		void updateBatch(vector[_GraphEvent] batch) except +
 
 cdef class DynAPSP(APSP, DynAlgorithm):
 	""" 

--- a/networkit/distance.pyx
+++ b/networkit/distance.pyx
@@ -11,6 +11,8 @@ from libcpp.set cimport set
 from libcpp.unordered_map cimport unordered_map
 
 from .base cimport _Algorithm, Algorithm
+from .dynbase cimport _DynAlgorithm
+from .dynbase import DynAlgorithm
 from .dynamics cimport _GraphEvent
 from .graph cimport _Graph, Graph
 from .helpers import stdstring
@@ -343,14 +345,14 @@ cdef class SSSP(Algorithm):
 
 cdef extern from "<networkit/distance/DynSSSP.hpp>":
 
-	cdef cppclass _DynSSSP "NetworKit::DynSSSP"(_SSSP):
+	cdef cppclass _DynSSSP "NetworKit::DynSSSP"(_SSSP, _DynAlgorithm):
 		_DynSSSP(_Graph G, node source, bool_t storePaths, bool_t storeStack, node target) except +
 		void update(_GraphEvent ev) except +
 		void updateBatch(vector[_GraphEvent] batch) except +
 		bool_t modified() except +
 		void setTargetNode(node t) except +
 
-cdef class DynSSSP(SSSP):
+cdef class DynSSSP(SSSP, DynAlgorithm):
 	""" 
 	DynSSSP(G, source, storePredecessors, target)
 
@@ -359,35 +361,6 @@ cdef class DynSSSP(SSSP):
 	def __init__(self, *args, **namedargs):
 		if type(self) == SSSP:
 			raise RuntimeError("Error, you may not use DynSSSP directly, use a sub-class instead")
-
-	def update(self, ev):
-		""" 
-		update(ev)
-
-		Updates shortest paths with the edge insertion.
-
-		Parameters
-		----------
-		ev : networkit.dynamics.GraphEvent
-			A graph event.
-		"""
-		(<_DynSSSP*>(self._this)).update(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-
-	def updateBatch(self, batch):
-		""" 
-		updateBatch(batch)
-
-		Updates shortest paths with a batch of edge insertions.
-
-		Parameters
-		----------
-		batch : list(networkit.dynamics.GraphEvent)
-			List of graph events.
-		"""
-		cdef vector[_GraphEvent] _batch
-		for ev in batch:
-			_batch.push_back(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-		(<_DynSSSP*>(self._this)).updateBatch(_batch)
 
 	def modified(self):
 		""" 
@@ -1352,12 +1325,12 @@ cdef class SPSP(Algorithm):
 
 cdef extern from "<networkit/distance/DynAPSP.hpp>":
 
-	cdef cppclass _DynAPSP "NetworKit::DynAPSP"(_APSP):
+	cdef cppclass _DynAPSP "NetworKit::DynAPSP"(_APSP, _DynAlgorithm):
 		_DynAPSP(_Graph G) except +
 		void update(_GraphEvent ev) except +
 		void updateBatch(vector[_GraphEvent] batch) except +
 
-cdef class DynAPSP(APSP):
+cdef class DynAPSP(APSP, DynAlgorithm):
 	""" 
 	DynAPSP(G)
 	
@@ -1373,34 +1346,7 @@ cdef class DynAPSP(APSP):
 		self._G = G
 		self._this = new _DynAPSP(G._this)
 
-	def update(self, ev):
-		""" 
-		update(ev)
 
-		Updates shortest paths with the edge insertion.
-
-		Parameters
-		----------
-		ev : networkit.dynamics.GraphEvent
-			A graph event.
-		"""
-		(<_DynAPSP*>(self._this)).update(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-
-	def updateBatch(self, batch):
-		""" 
-		updateBatch(batch)
-
-		Updates shortest paths with a batch of edge insertions.
-
-		Parameters
-		----------
-		batch : list(networkit.dynamics.GraphEvent)
-			List of graph events.
-		"""
-		cdef vector[_GraphEvent] _batch
-		for ev in batch:
-			_batch.push_back(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
-		(<_DynAPSP*>(self._this)).updateBatch(_batch)
 
 cdef extern from "<networkit/distance/BFS.hpp>":
 

--- a/networkit/dynbase.pxd
+++ b/networkit/dynbase.pxd
@@ -1,0 +1,8 @@
+from libcpp.vector cimport vector
+
+from .dynamics cimport _GraphEvent, GraphEvent
+
+cdef extern from "<networkit/base/DynAlgorithm.hpp>":
+	cdef cppclass _DynAlgorithm "NetworKit::DynAlgorithm":
+		void update(_GraphEvent) nogil except +
+		void updateBatch(vector[_GraphEvent]) nogil except +

--- a/networkit/dynbase.pyx
+++ b/networkit/dynbase.pyx
@@ -1,0 +1,70 @@
+# distutils: language=c++
+
+from libcpp.cast cimport dynamic_cast
+
+from .dynamics cimport _GraphEvent, GraphEvent
+from .base cimport _CythonParentClass
+from typing import List
+
+ctypedef _DynAlgorithm* _DynAlgorithmPtr
+
+cdef class _CythonSubclassDynAlgorithm(_CythonParentClass):
+	""" Abstract base class for dynamic algorithms
+    Cython does not allow direct inheritance from two extension types (cdef classes).
+    Instead, inherit from the DynAlgorithm class! """
+	def __init__(self, *args, **namedargs):
+		if type(self) == _CythonSubclassDynAlgorithm:
+			raise RuntimeError("Error, you may not use _CythonSubclassDynAlgorithm directly, use a sub-class instead")
+
+	def __cinit__(self, *args, **namedargs):
+		self._this = NULL
+
+	def __dealloc__(self):
+		if self._this != NULL:
+			del self._this
+		self._this = NULL
+
+	def update(self, GraphEvent ev):
+		"""
+		update(ev)
+
+		The generic update method for updating data structure after an update.
+
+		Parameters
+		----------
+		ev : networkit.dynamics.GraphEvent
+			A graph event.
+		"""
+		if self._this == NULL:
+			raise RuntimeError("Error, object not properly initialized")
+		cdef _GraphEvent _ev = _GraphEvent(ev.type, ev.u, ev.v, ev.w)
+		with nogil:
+			dynamic_cast[_DynAlgorithmPtr](self._this).update(_ev)
+		return self
+	
+	def updateBatch(self, batch: List[GraphEvent]):
+		""" 
+		updateBatch(batch)
+
+		The generic update method for updating data structure after a batch of updates.
+
+		Parameters
+		----------
+		batch : list(networkit.dynamics.GraphEvent)
+			List of graph events.
+		"""
+		if self._this == NULL:
+			raise RuntimeError("Error, object not properly initialized")
+		cdef vector[_GraphEvent] _batch
+		for ev in batch:
+			_batch.push_back(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
+		with nogil:
+			dynamic_cast[_DynAlgorithmPtr](self._this).updateBatch(_batch)
+		return self
+
+class DynAlgorithm(_CythonSubclassDynAlgorithm):
+	__slots__ = ()
+	""" Abstract base class for dynamic algorithms """
+	def __init__(self, *args, **namedargs):
+		if type(self) == DynAlgorithm:
+			raise RuntimeError("Error, you may not use DynAlgorithm directly, use a sub-class instead")

--- a/networkit/dynbase.pyx
+++ b/networkit/dynbase.pyx
@@ -10,8 +10,9 @@ ctypedef _DynAlgorithm* _DynAlgorithmPtr
 
 cdef class _CythonSubclassDynAlgorithm(_CythonParentClass):
 	""" Abstract base class for dynamic algorithms
-    Cython does not allow direct inheritance from two extension types (cdef classes).
-    Instead, inherit from the DynAlgorithm class! """
+	Cython does not allow direct inheritance from two extension types (cdef classes).
+	Instead, inherit from the DynAlgorithm class! 
+	"""
 	def __init__(self, *args, **namedargs):
 		if type(self) == _CythonSubclassDynAlgorithm:
 			raise RuntimeError("Error, you may not use _CythonSubclassDynAlgorithm directly, use a sub-class instead")
@@ -35,7 +36,7 @@ cdef class _CythonSubclassDynAlgorithm(_CythonParentClass):
 		ev : networkit.dynamics.GraphEvent
 			A graph event.
 
-        Returns
+		Returns
 		-------
 		networkit.dynbase.DynAlgorithm
 			self
@@ -58,7 +59,7 @@ cdef class _CythonSubclassDynAlgorithm(_CythonParentClass):
 		batch : list(networkit.dynamics.GraphEvent)
 			List of graph events.
 
-        Returns
+		Returns
 		-------
 		networkit.dynbase.DynAlgorithm
 			self

--- a/networkit/dynbase.pyx
+++ b/networkit/dynbase.pyx
@@ -34,6 +34,11 @@ cdef class _CythonSubclassDynAlgorithm(_CythonParentClass):
 		----------
 		ev : networkit.dynamics.GraphEvent
 			A graph event.
+
+        Returns
+		-------
+		networkit.dynbase.DynAlgorithm
+			self
 		"""
 		if self._this == NULL:
 			raise RuntimeError("Error, object not properly initialized")
@@ -52,6 +57,11 @@ cdef class _CythonSubclassDynAlgorithm(_CythonParentClass):
 		----------
 		batch : list(networkit.dynamics.GraphEvent)
 			List of graph events.
+
+        Returns
+		-------
+		networkit.dynbase.DynAlgorithm
+			self
 		"""
 		if self._this == NULL:
 			raise RuntimeError("Error, object not properly initialized")

--- a/networkit/reachability.pyx
+++ b/networkit/reachability.pyx
@@ -131,7 +131,6 @@ cdef extern from "<networkit/reachability/AllSimplePaths.hpp>":
 
 	cdef cppclass _AllSimplePaths "NetworKit::AllSimplePaths"(_Algorithm):
 		_AllSimplePaths(_Graph G, node source, node target, count cutoff) except +
-		void run() nogil except +
 		count numberOfSimplePaths() except +
 		vector[vector[node]] getAllSimplePaths() except +
 		void forAllSimplePaths[Callback](Callback c) except +


### PR DESCRIPTION
This PR adds python bindings for the `DynAlgorithm` class in a new `dynalgorithm.pxd`/`dynalgorithm.pyx` file and updates all existing dynamic algorithms to use this base class.
Previously, all python bindings of dynamic algorithms implement the same `update` and `updateBatch` forwarding code, which is now moved to the `DynAlgorithm` base class.

The setup is a little weird because of Cython limitations. First, a figure of the new class hierarchy, where `MyAlgorithm` is any dynamic algorithm:
```
      _CythonParentClass
       ^              ^
       |              |
Algorithm          _CythonSubclassDynAlgorithm
       ^                     ^
       |                     |
MyAlgorithm    -->    DynAlgorithm
```

Explanation:
- Cython (or Python in general) does not allow multiple inheritance of `cdef class`es (also called 'extension types'). Since we use multiple inheritance for dynamic algorithms in c++ (inherit from both `Algorithm` and `DynAlgorithm`), we do need this functionality though. The workaround is to define a wrapper class (`DynAlgorithm`) in pure python which wraps the cdef class. Then we can inherit from `Algorithm` and the pure python wrapper.
- Cython also requires that all classes in a inheritance hierarchy have a common base class. Since there is no such class in C++ (and adding one would probably decrease performance because of more vtables), we instead add a dummy base class just for Cython (`CythonParentClass`). We move the `_Algorithm` pointer to this class s.t. both the `Algorithm` and the `DynAlgorithm` subclass trees have access to that pointer.

In the `_CythonSubclassDynAlgorithm.update` and `updateBatch` methods, we have to use a `dynamic_cast` call to cast the `_Algorithm` pointer to a `_DynAlgorithm` pointer. Regarding performance, I would not expect users to call this often enough to matter, but I also did a quick test and the difference seems to be around 100ns for a single call of dynamic_cast in this context.

With this new setup, implementation of a new dynamic algorithm `MyAlgorithm` now requires less boilerplate and repeated code: 
```py
from .base cimport _Algorithm, Algorithm
from .dynbase cimport _DynAlgorithm
from .dynbase import DynAlgorithm

cdef extern from "<MyAlgorithm.hpp>":
	cdef cppclass _MyAlgorithm "NetworKit::MyAlgorithm"(_Algorithm, _DynAlgorithm):
    # ...

cdef class MyAlgorithm(Algorithm, DynAlgorithm):
    # ... methods specific to MyAlgorithm
    # run, update, updateBatch are inherited from Algorithm and DynAlgorithm
```