### PR TITLE
distance.pyx: repairs jaccardDistance

### DIFF
--- a/networkit/distance.pyx
+++ b/networkit/distance.pyx
@@ -870,7 +870,7 @@ cdef class Volume:
 cdef extern from "<networkit/distance/JaccardDistance.hpp>":
 
 	cdef cppclass _JaccardDistance "NetworKit::JaccardDistance":
-		_JaccardDistance(const _Graph& G, const vector[count]& triangles) except +
+		_JaccardDistance(const _Graph& G, const vector[count]& _triangles) except +
 		void preprocess() except +
 		vector[double] &getEdgeScores() except +
 
@@ -891,7 +891,7 @@ cdef class JaccardDistance:
 
 	cdef _JaccardDistance* _this
 	cdef Graph _G
-	cdef vector[count] triangles
+	cdef vector[count] _triangles
 
 	def __cinit__(self, Graph G, vector[count] triangles):
 		self._G = G


### PR DESCRIPTION
this PR splits up #1066 , this fix is necessary to test jaccardDistance in python (currently commented out in #1077)