### PR TITLE
New algorithm: dynamic approx electrical closeness

### DIFF
--- a/include/networkit/centrality/ApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/ApproxElectricalCloseness.hpp
@@ -30,13 +30,13 @@ class ApproxElectricalCloseness final : public Centrality {
 public:
     /**
      * Approximates the electrical closeness of all the vertices of the graph by approximating the
-     * diagonal of the laplacian's pseudoinverse of @a G. Every element of the diagonal is
-     * guaranteed to have a maximum absolute error of @a epsilon. Based on "Approximation of the
-     * Diagonal of a Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al., ESA
-     * 2020. The algorithm does two steps: solves a linear system and samples uniform spanning trees
-     * (USTs). The parameter @a kappa balances the tolerance of solver for the linear system and the
-     * number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver converges
-     * faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
+     * diagonal of the laplacian's pseudoinverse of @a G. Every element of the diagonal has
+     * a maximum absolute error of @a epsilon with probability (1-(1/n)). Based on "Approximation of
+     * the Diagonal of a Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al.,
+     * ESA 2020. The algorithm does two steps: solves a linear system and samples uniform spanning
+     * trees (USTs). The parameter @a kappa balances the tolerance of solver for the linear system
+     * and the number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver
+     * converges faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
      *
      * @param G The input graph.
      * @param epsilon Maximum absolute error of the elements in the diagonal.

--- a/include/networkit/centrality/DynApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/DynApproxElectricalCloseness.hpp
@@ -41,9 +41,10 @@ public:
      * and the number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver
      * converges faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
      *
-     * This dynamic algorithm supports addition of arbitrary edges and deletion of edges which are
-     * not in the bfs tree sourced from the pivot node. The algorithm depends on G having a single
-     * connected component - edge deletions which disconnect the graph are not supported.
+     * @note This dynamic algorithm supports addition of arbitrary edges and deletion of edges which
+     * are not in the bfs tree sourced from the pivot node. The algorithm depends on G having a
+     * single connected component - edge deletions which disconnect the graph are not supported.
+     * @note Batch updates are not supported.
      *
      * @param G The input graph.
      * @param epsilon Maximum absolute error of the elements in the diagonal.
@@ -79,6 +80,9 @@ public:
      */
     void update(GraphEvent e) override;
 
+    /**
+     * @note batch updates are not supported.
+     */
     void updateBatch([[maybe_unused]] const std::vector<GraphEvent> &batch) override {
         throw std::runtime_error("Error: batch updates are not supported.");
     }

--- a/include/networkit/centrality/DynApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/DynApproxElectricalCloseness.hpp
@@ -50,17 +50,7 @@ public:
 
     /** copy constructor that copies internal data structures, but still references the same graph
      * as @a other */
-    DynApproxElectricalCloseness(const DynApproxElectricalCloseness &other)
-        : Centrality(other), epsilon(other.epsilon), delta(other.delta), kappa(other.kappa),
-          tol(other.tol), numberOfUSTs(other.numberOfUSTs), root(other.root),
-          rootEcc(other.rootEcc), laplacian(other.laplacian), statusGlobal(other.statusGlobal),
-          bccPtr(new BiconnectedComponents(*other.bccPtr)), sequences(other.sequences),
-          ustRepository(other.ustRepository), bfsTree(other.bfsTree), biParent(other.biParent),
-          biAnchor(other.biAnchor), topOrder(other.topOrder),
-          approxEffResistanceGlobal(other.approxEffResistanceGlobal), diagonal(other.diagonal),
-          resistanceToRoot(other.resistanceToRoot), rootCol(other.rootCol),
-          lcaGlobal(other.lcaGlobal), generators(other.generators), degDist(other.degDist),
-          round(other.round), roundWeight(other.roundWeight) {}
+    DynApproxElectricalCloseness(const DynApproxElectricalCloseness &other) = default;
 
     ~DynApproxElectricalCloseness() override = default;
 
@@ -141,7 +131,7 @@ private:
     // Used to mark the status of each node, one vector per thread
     std::vector<std::vector<NodeStatus>> statusGlobal;
 
-    std::unique_ptr<BiconnectedComponents> bccPtr;
+    BiconnectedComponents bcc;
 
     // Nodes in each biconnected components sorted by their degree.
     std::vector<std::vector<node>> sequences;
@@ -172,8 +162,6 @@ private:
 
     // lpinv column of root
     Vector rootCol;
-    // Vector lpinvColA;
-    // Vector lpinvColB;
 
     // Least common ancestor vectors, per thread
     std::vector<std::vector<node>> lcaGlobal;

--- a/include/networkit/centrality/DynApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/DynApproxElectricalCloseness.hpp
@@ -25,16 +25,6 @@
 
 namespace NetworKit {
 
-struct Tree {
-    std::vector<node> parent;
-    std::vector<node> sibling;
-    std::vector<node> child;
-
-    std::vector<count> tVisit;
-    std::vector<count> tFinish;
-    bool timesComputed = false;
-};
-
 /**
  * @ingroup centrality
  */
@@ -69,9 +59,8 @@ public:
           biAnchor(other.biAnchor), topOrder(other.topOrder),
           approxEffResistanceGlobal(other.approxEffResistanceGlobal), diagonal(other.diagonal),
           resistanceToRoot(other.resistanceToRoot), rootCol(other.rootCol),
-          lpinvColA(other.lpinvColA), lpinvColB(other.lpinvColB), lcaGlobal(other.lcaGlobal),
-          generators(other.generators), degDist(other.degDist), round(other.round),
-          roundWeight(other.roundWeight) {}
+          lcaGlobal(other.lcaGlobal), generators(other.generators), degDist(other.degDist),
+          round(other.round), roundWeight(other.roundWeight) {}
 
     ~DynApproxElectricalCloseness() override = default;
 
@@ -114,41 +103,10 @@ public:
     std::vector<double> computeExactDiagonal(double tol = 1e-9) const;
 
     /**
-     * Compute and return the nearly-exact values of the column of the laplacian's pseudoinverse.
-     * The values are computed by solving Lx = e_u - 1 / n with a
-     * CG solver.
-     *
-     * @param tol Tolerance for the LAMG solver.
-     *
-     * @return Nearly-exact values of the diagonal of the laplacian's pseudoinverse.
-     */
-    std::vector<double> computeExactColumn(node u, double tol = 1e-9) const;
-
-    /**
-     * Compute an approximation of the @a i -th column of the laplacian's pseudoinverse.
-     *
-     * @return Approximation of the column vector.
-     */
-    std::vector<double> approxColumn(node i);
-
-    // TODO remove this
-    // void testSampleUSTWithEdge(node a, node b);
-
-    /**
      * To be called when an edge is added to the graph. Samples more trees, approximate the diagonal
      * again.
      */
     void edgeAdded(node a, node b);
-
-    /**
-     * After an edge is added, the lpinv columns of the vertices can be obtained here
-     */
-    std::pair<Vector, Vector> getEdgeLpinvVectors();
-
-    /**
-     * Laplacian matrix of G
-     */
-    inline NetworKit::CSRMatrix getLaplacianMatrix() { return laplacian; }
 
     inline NetworKit::count getUstCount() { return numberOfUSTs; }
 
@@ -168,6 +126,16 @@ private:
         IN_SPANNING_TREE,
         NOT_VISITED,
         VISITED
+    };
+
+    struct Tree {
+        std::vector<node> parent;
+        std::vector<node> sibling;
+        std::vector<node> child;
+
+        std::vector<count> tVisit;
+        std::vector<count> tFinish;
+        bool timesComputed = false;
     };
 
     // Used to mark the status of each node, one vector per thread
@@ -204,8 +172,8 @@ private:
 
     // lpinv column of root
     Vector rootCol;
-    Vector lpinvColA;
-    Vector lpinvColB;
+    // Vector lpinvColA;
+    // Vector lpinvColB;
 
     // Least common ancestor vectors, per thread
     std::vector<std::vector<node>> lcaGlobal;
@@ -221,14 +189,13 @@ private:
     // specific sequence of nodes. In this function we compute those sequences.
     void computeNodeSequence();
 
-    void setDFSTimes(Tree &tree, node r = none);
+    void setDFSTimes(Tree &tree);
 
     void computeBFSTree();
     void sampleUST(Tree &result);
     void sampleUSTWithEdge(Tree &result, node a, node b);
 
     void aggregateUST(Tree &tree, double weight);
-    void aggregateUSTNonRoot(Tree &tree, node column_index, double weight);
 
     node approxMinEccNode();
 

--- a/include/networkit/centrality/DynApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/DynApproxElectricalCloseness.hpp
@@ -1,0 +1,248 @@
+/*
+ * DynApproxElectricalCloseness.hpp
+ *
+ *  Created on: 19.04.2023
+ *     Authors: Matthias Görg <goergmat@informatik.hu-berlin.de>
+ *              Maria Predari <predarimaria@gmail.com>
+ *              Lukas Berner <Lukas.Berner@hu-berlin.de>
+ */
+
+#ifndef NETWORKIT_CENTRALITY_DYN_APPROX_ELECTRICAL_CLOSENESS_HPP_
+#define NETWORKIT_CENTRALITY_DYN_APPROX_ELECTRICAL_CLOSENESS_HPP_
+
+#include <cmath>
+#include <memory>
+#include <random>
+#include <unordered_map>
+#include <vector>
+
+#include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/base/DynAlgorithm.hpp>
+#include <networkit/centrality/Centrality.hpp>
+#include <networkit/components/BiconnectedComponents.hpp>
+#include <networkit/distance/Diameter.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+struct Tree {
+    std::vector<node> parent;
+    std::vector<node> sibling;
+    std::vector<node> child;
+
+    std::vector<count> tVisit;
+    std::vector<count> tFinish;
+    bool timesComputed = false;
+};
+
+/**
+ * @ingroup centrality
+ */
+class DynApproxElectricalCloseness final : public Centrality, public DynAlgorithm {
+
+public:
+    /**
+     * Approximates the electrical closeness of all the vertices of the graph by approximating the
+     * diagonal of the laplacian's pseudoinverse of @a G. Every element of the diagonal is
+     * guaranteed to have a maximum absolute error of @a epsilon. Based on "Approximation of the
+     * Diagonal of a Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al., ESA
+     * 2020. The algorithm does two steps: solves a linear system and samples uniform spanning trees
+     * (USTs). The parameter @a kappa balances the tolerance of solver for the linear system and the
+     * number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver converges
+     * faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
+     *
+     * @param G The input graph.
+     * @param epsilon Maximum absolute error of the elements in the diagonal.
+     * @param kappa Balances the tolerance of the solver for the linear system and the number of
+     * USTs to be sampled.
+     */
+    DynApproxElectricalCloseness(const Graph &G, double epsilon = 0.1, double kappa = 0.3);
+
+    /** copy constructor that copies internal data structures, but still references the same graph
+     * as @a other */
+    DynApproxElectricalCloseness(const DynApproxElectricalCloseness &other)
+        : Centrality(other), epsilon(other.epsilon), delta(other.delta), kappa(other.kappa),
+          tol(other.tol), numberOfUSTs(other.numberOfUSTs), root(other.root),
+          rootEcc(other.rootEcc), laplacian(other.laplacian), statusGlobal(other.statusGlobal),
+          bccPtr(new BiconnectedComponents(*other.bccPtr)), sequences(other.sequences),
+          ustRepository(other.ustRepository), bfsTree(other.bfsTree), biParent(other.biParent),
+          biAnchor(other.biAnchor), topOrder(other.topOrder),
+          approxEffResistanceGlobal(other.approxEffResistanceGlobal), diagonal(other.diagonal),
+          resistanceToRoot(other.resistanceToRoot), rootCol(other.rootCol),
+          lpinvColA(other.lpinvColA), lpinvColB(other.lpinvColB), lcaGlobal(other.lcaGlobal),
+          generators(other.generators), degDist(other.degDist), round(other.round),
+          roundWeight(other.roundWeight) {}
+
+    ~DynApproxElectricalCloseness() override = default;
+
+    /**
+     * Run the algorithm.
+     */
+    void run() override;
+
+    void update(GraphEvent e) override {
+        if (e.type == GraphEvent::EDGE_ADDITION)
+            edgeAdded(e.u, e.v);
+        else
+            throw std::runtime_error("Error: Events other than EDGE_ADDITION are not supported.");
+    }
+
+    void updateBatch(const std::vector<GraphEvent> &batch) override {
+        for (GraphEvent e : batch)
+            update(e);
+    }
+
+    /**
+     * Return an epsilon-approximation of the diagonal of the laplacian's pseudoinverse.
+     *
+     * @return Approximation of the diagonal of the laplacian's pseudoinverse.
+     */
+    const std::vector<double> &getDiagonal() const {
+        assureFinished();
+        return diagonal;
+    }
+
+    /**
+     * Compute and return the nearly-exact values of the diagonal of the laplacian's pseudoinverse.
+     * The values are computed by solving Lx = e_u - 1 / n for every vertex u of the graph with a
+     * LAMG solver.
+     *
+     * @param tol Tolerance for the LAMG solver.
+     *
+     * @return Nearly-exact values of the diagonal of the laplacian's pseudoinverse.
+     */
+    std::vector<double> computeExactDiagonal(double tol = 1e-9) const;
+
+    /**
+     * Compute and return the nearly-exact values of the column of the laplacian's pseudoinverse.
+     * The values are computed by solving Lx = e_u - 1 / n with a
+     * CG solver.
+     *
+     * @param tol Tolerance for the LAMG solver.
+     *
+     * @return Nearly-exact values of the diagonal of the laplacian's pseudoinverse.
+     */
+    std::vector<double> computeExactColumn(node u, double tol = 1e-9) const;
+
+    /**
+     * Compute an approximation of the @a i -th column of the laplacian's pseudoinverse.
+     *
+     * @return Approximation of the column vector.
+     */
+    std::vector<double> approxColumn(node i);
+
+    // TODO remove this
+    // void testSampleUSTWithEdge(node a, node b);
+
+    /**
+     * To be called when an edge is added to the graph. Samples more trees, approximate the diagonal
+     * again.
+     */
+    void edgeAdded(node a, node b);
+
+    /**
+     * After an edge is added, the lpinv columns of the vertices can be obtained here
+     */
+    std::pair<Vector, Vector> getEdgeLpinvVectors();
+
+    /**
+     * Laplacian matrix of G
+     */
+    inline NetworKit::CSRMatrix getLaplacianMatrix() { return laplacian; }
+
+    inline NetworKit::count getUstCount() { return numberOfUSTs; }
+
+private:
+    const double epsilon, delta, kappa;
+    double tol;
+    count numberOfUSTs;
+    node root = 0;
+    count rootEcc;
+    NetworKit::CSRMatrix laplacian;
+
+    // #of BFSs used to estimate a vertex with low eccentricity.
+    static constexpr uint32_t sweeps = 10;
+
+    enum class NodeStatus : unsigned char {
+        NOT_IN_COMPONENT,
+        IN_SPANNING_TREE,
+        NOT_VISITED,
+        VISITED
+    };
+
+    // Used to mark the status of each node, one vector per thread
+    std::vector<std::vector<NodeStatus>> statusGlobal;
+
+    std::unique_ptr<BiconnectedComponents> bccPtr;
+
+    // Nodes in each biconnected components sorted by their degree.
+    std::vector<std::vector<node>> sequences;
+
+    // Repository of USTs, organized as buckets per round.
+    std::vector<std::vector<Tree>> ustRepository;
+
+    // Shortest path tree
+    Tree bfsTree;
+
+    // Index of the parent component of the current component (after the topological order has been
+    // determined)
+    std::vector<index> biParent;
+    // Node within the bionnected component that points to the node in the parent component
+    std::vector<node> biAnchor;
+
+    // Topological order of the biconencted components
+    std::vector<index> topOrder;
+
+    // approx effective resistance, summed contribution per tree, one per thread.
+    std::vector<std::vector<double>> approxEffResistanceGlobal;
+
+    // Pseudo-inverse diagonal
+    std::vector<double> diagonal;
+
+    // Resistance of node with root
+    std::vector<double> resistanceToRoot;
+
+    // lpinv column of root
+    Vector rootCol;
+    Vector lpinvColA;
+    Vector lpinvColB;
+
+    // Least common ancestor vectors, per thread
+    std::vector<std::vector<node>> lcaGlobal;
+
+    // Random number generators
+    std::vector<std::mt19937_64> generators;
+    std::vector<std::uniform_int_distribution<index>> degDist;
+
+    count round = 0;
+    std::vector<double> roundWeight;
+
+    // Nodes sequences: Wilson's algorithm runs faster if we start the random walks following a
+    // specific sequence of nodes. In this function we compute those sequences.
+    void computeNodeSequence();
+
+    void setDFSTimes(Tree &tree, node r = none);
+
+    void computeBFSTree();
+    void sampleUST(Tree &result);
+    void sampleUSTWithEdge(Tree &result, node a, node b);
+
+    void aggregateUST(Tree &tree, double weight);
+    void aggregateUSTNonRoot(Tree &tree, node column_index, double weight);
+
+    node approxMinEccNode();
+
+    count computeNumberOfUSTs() const;
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    // Debugging methods
+    void checkBFSTree() const;
+    void checkUST(const Tree &tree) const;
+    void checkTwoNodesSequence(const std::vector<node> &sequence, std::vector<node> &parent) const;
+    void checkTimeStamps(const Tree &tree) const;
+#endif // NETWORKIT_SANITY_CHECKS
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_CENTRALITY_DYN_APPROX_ELECTRICAL_CLOSENESS_HPP_

--- a/include/networkit/centrality/DynApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/DynApproxElectricalCloseness.hpp
@@ -79,7 +79,7 @@ public:
      */
     void update(GraphEvent e) override;
 
-    void updateBatch(const std::vector<GraphEvent> &batch) override {
+    void updateBatch([[maybe_unused]] const std::vector<GraphEvent> &batch) override {
         throw std::runtime_error("Error: batch updates are not supported.");
     }
 

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -19,6 +19,12 @@ from networkit.algebraic import adjacencyEigenvector, PageRankMatrix, symmetricE
 cdef extern from "limits.h":
 	cdef uint64_t ULONG_MAX
 
+cdef extern from "<networkit/Globals.hpp>" namespace "NetworKit":
+
+	index _none "NetworKit::none"
+
+none = _none
+
 cdef extern from "<networkit/centrality/Centrality.hpp>":
 
 	cdef cppclass _Centrality "NetworKit::Centrality"(_Algorithm):
@@ -2541,6 +2547,57 @@ cdef class ApproxElectricalCloseness(Centrality):
 		"""
 		return (<_ApproxElectricalCloseness*>self._this).computeExactDiagonal(tol)
 
+cdef extern from "<networkit/centrality/DynApproxElectricalCloseness.hpp>":
+	cdef cppclass _DynApproxElectricalCloseness "NetworKit::DynApproxElectricalCloseness"(_Centrality, _DynAlgorithm):
+		_DynApproxElectricalCloseness(_Graph G, double eps, double kappa, node pivot) except +
+		_DynApproxElectricalCloseness(_Graph G, double eps, double kappa, node pivot, double delta) except +
+		vector[double] getDiagonal() except +
+
+cdef class DynApproxElectricalCloseness(Centrality, DynAlgorithm):
+	"""
+	DynApproxElectricalCloseness(G, eps = 0.1, kappa = 0.3, pivot = None, delta = 1/n)
+	
+	Approximates the electrical closeness of all the vertices of the graph by approximating the
+	diagonal of the laplacian's pseudoinverse of G. Every element of the diagonal has a maximum absolute error of eps with probability 1-delta. Based on "Approximation of the
+	Diagonal of a Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al., ESA
+	2020. The algorithm does two steps: solves a linear system and samples uniform spanning trees
+	(USTs). The parameter kappa balances the tolerance of solver for the linear system and the
+	number of USTs to be sampled. A high value of kappa raises the tolerance (solver converges
+	faster) but more USTs need to be sampled, vice versa for a low value of kappa.
+
+	This dynamic algorithm supports addition of arbitrary edges and deletion of edges which are
+	not in the bfs tree sourced from the pivot node. The algorithm depends on G having a single
+	connected component - edge deletions which disconnect the graph are not supported.
+
+	Parameters
+	----------
+	G : networkit.Graph
+		The input graph.
+	eps : float, optional
+		Maximum absolute error of the elements in the diagonal.
+	kappa : float, optional
+		Balances the tolerance of the solver for the linear system and the
+		number of USTs to be sampled.
+	"""
+	def __cinit__(self, Graph G, double eps = 0.1, double kappa = 0.3, node pivot = none, delta = None):
+		self._G = G
+		if delta:
+			self._this = new _DynApproxElectricalCloseness(G._this, eps, kappa, pivot, delta)
+		else:
+			self._this = new _DynApproxElectricalCloseness(G._this, eps, kappa, pivot)
+
+	def getDiagonal(self):
+		"""
+		getDiagonal()
+
+		Return an epsilon-approximation of the diagonal of the laplacian's pseudoinverse.
+
+		Returns
+		-------
+		list(float)
+			Approximation of the diagonal of the laplacian's pseudoinverse.
+		"""
+		return (<_DynApproxElectricalCloseness*>self._this).getDiagonal()
 
 cdef extern from "<networkit/centrality/ForestCentrality.hpp>":
 	cdef cppclass _ForestCentrality "NetworKit::ForestCentrality"(_Centrality):

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -2491,10 +2491,10 @@ cdef class ApproxElectricalCloseness(Centrality):
 	ApproxElectricalCloseness(G, eps = 0.1, kappa = 0.3)
 	
 	Approximates the electrical closeness of all the vertices of the graph by approximating the
-	diagonal of the laplacian's pseudoinverse of G. Every element of the diagonal is
-	guaranteed to have a maximum absolute error of eps. Based on "Approximation of the
-	Diagonal of a Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al., ESA
-	2020. The algorithm does two steps: solves a linear system and samples uniform spanning trees
+	diagonal of the laplacian's pseudoinverse of G. Every element of the diagonal has a maximum 
+	absolute error of eps with probability 1-(1/n). Based on "Approximation of the Diagonal of a 
+	Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al., ESA 2020. 
+	The algorithm does two steps: solves a linear system and samples uniform spanning trees
 	(USTs). The parameter kappa balances the tolerance of solver for the linear system and the
 	number of USTs to be sampled. A high value of kappa raises the tolerance (solver converges
 	faster) but more USTs need to be sampled, vice versa for a low value of kappa.

--- a/networkit/cpp/centrality/CMakeLists.txt
+++ b/networkit/cpp/centrality/CMakeLists.txt
@@ -10,6 +10,7 @@ networkit_add_module(centrality
     CoreDecomposition.cpp
     DegreeCentrality.cpp
     DynApproxBetweenness.cpp
+    DynApproxElectricalCloseness.cpp
     DynBetweenness.cpp
     DynBetweennessOneNode.cpp
     DynKatzCentrality.cpp

--- a/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
@@ -1,0 +1,1137 @@
+/*
+ * DynApproxElectricalCloseness.cpp
+ *
+ *  Created on: 17.10.2019
+ *     Authors: Eugenio Angriman <angrimae@hu-berlin.de>
+ *              Alexander van der Grinten <avdgrinten@hu-berlin.de>
+ */
+
+#include <algorithm>
+#include <numeric>
+#include <omp.h>
+#include <queue>
+
+#include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/auxiliary/Random.hpp>
+#include <networkit/centrality/DynApproxElectricalCloseness.hpp>
+#include <networkit/numerics/ConjugateGradient.hpp>
+#include <networkit/numerics/LAMG/Lamg.hpp>
+#include <networkit/numerics/Preconditioner/DiagonalPreconditioner.hpp>
+
+#include <networkit/auxiliary/Log.hpp>
+
+namespace NetworKit {
+
+DynApproxElectricalCloseness::DynApproxElectricalCloseness(const Graph &G, double epsilon,
+                                                           double kappa)
+    : Centrality(G), epsilon(epsilon), delta(1.0 / static_cast<double>(G.numberOfNodes())),
+      kappa(kappa), bccPtr(new BiconnectedComponents(G)) {
+
+    if (G.isDirected())
+        throw std::runtime_error("Error: the input graph must be undirected.");
+
+    if (G.isWeighted())
+        throw std::runtime_error("Error: the input graph must be unweighted.");
+
+    if (G.numberOfNodes() < 2)
+        throw std::runtime_error("Error: the graph should have at leasts two vertices");
+
+    if (G.upperNodeIdBound() != G.numberOfNodes())
+        throw std::runtime_error("Error, graph is not compact. Use getCompactedGraph in GraphTools "
+                                 "before using this algorithm.");
+
+    const count n = G.upperNodeIdBound(), threads = omp_get_max_threads();
+    statusGlobal.resize(threads, std::vector<NodeStatus>(n, NodeStatus::NOT_VISITED));
+    approxEffResistanceGlobal.resize(threads, std::vector<double>(n));
+    scoreData.resize(n);
+    diagonal.resize(n);
+    resistanceToRoot.resize(n);
+    generators.reserve(threads);
+    for (omp_index i = 0; i < threads; ++i)
+        generators.emplace_back(Aux::Random::getURNG());
+
+    degDist.reserve(G.upperNodeIdBound());
+    G.forNodes([&](node u) { degDist.emplace_back(0, G.degree(u) - 1); });
+
+    lcaGlobal.resize(threads, std::vector<node>(n, none));
+}
+
+count DynApproxElectricalCloseness::computeNumberOfUSTs() const {
+    return rootEcc * rootEcc
+           * static_cast<count>(
+               std::ceil(std::log(2.0 * static_cast<double>(G.numberOfEdges()) / delta)
+                         / (2.0 * epsilon * epsilon * (1. - kappa) * (1. - kappa))));
+}
+
+node DynApproxElectricalCloseness::approxMinEccNode() {
+    auto &status = statusGlobal[0];
+    std::vector<count> distance(G.upperNodeIdBound());
+    std::vector<count> eccLowerBound(G.upperNodeIdBound());
+
+    auto maxDegreeNode = [&]() -> node {
+        node maxDegNode = 0;
+        count maxDeg = 0;
+        G.forNodes([&](const node u) {
+            const auto degU = G.degree(u);
+            if (degU > maxDeg) {
+                maxDeg = degU;
+                maxDegNode = u;
+            }
+        });
+        return maxDegNode;
+    };
+
+    auto doBFS = [&](const node source) -> node {
+        std::queue<node> q;
+        q.push(source);
+        status[source] = NodeStatus::VISITED;
+        distance[source] = 0;
+        node farthest = 0;
+
+        do {
+            const node u = q.front();
+            q.pop();
+            eccLowerBound[u] = std::max(eccLowerBound[u], distance[u]);
+            farthest = u;
+
+            G.forNeighborsOf(u, [&](const node v) {
+                if (status[v] == NodeStatus::NOT_VISITED) {
+                    q.push(v);
+                    status[v] = NodeStatus::VISITED;
+                    distance[v] = distance[u] + 1;
+                }
+            });
+
+        } while (!q.empty());
+
+        std::fill(status.begin(), status.end(), NodeStatus::NOT_VISITED);
+        return farthest;
+    };
+
+    node source = maxDegreeNode();
+
+    for (uint32_t i = 0; i < sweeps; ++i)
+        source = doBFS(source);
+
+    // Return node with minimum ecc lower bound
+    return static_cast<node>(std::min_element(eccLowerBound.begin(), eccLowerBound.end())
+                             - eccLowerBound.begin());
+}
+
+void DynApproxElectricalCloseness::computeNodeSequence() {
+    // We use thread 0's vector
+    auto &status = statusGlobal[0];
+
+    // Compute the biconnected components
+    auto &bcc = *bccPtr;
+    bcc.run();
+    auto components = bcc.getComponents();
+
+    std::queue<node> queue;
+    std::vector<node> curSequence;
+
+    for (const auto &curComponent : components) {
+        // Biconnected components with 2 vertices can be handled trivially.
+        if (curComponent.size() == 2) {
+            sequences.push_back({curComponent[0], curComponent[1]});
+            continue;
+        }
+
+        // We take the node with highest degree in the component as source
+        node source = curComponent[0];
+        for (node u : curComponent) {
+            source = G.degree(u) > G.degree(source) ? u : source;
+            status[u] = NodeStatus::VISITED;
+        }
+
+        // Start a BFS from source to determine the order of the nodes.
+        // Later, we need to re-explore the graph again, so in the beginning we mark all nodes to be
+        // visited as VISITED, and we set them as NOT_VISITED during the BFS. This avoids a call to
+        // std::fill.
+        queue.push(source);
+        status[source] = NodeStatus::NOT_VISITED;
+
+        do {
+            const node u = queue.front();
+            queue.pop();
+            curSequence.push_back(u);
+            G.forNeighborsOf(u, [&](node v) {
+                if (status[v] == NodeStatus::VISITED) {
+                    status[v] = NodeStatus::NOT_VISITED;
+                    queue.push(v);
+                }
+            });
+        } while (!queue.empty());
+
+        sequences.push_back(std::move(curSequence));
+        curSequence.clear();
+    }
+
+    // Set the root to the highest degree node within the largest biconnected component
+    root = approxMinEccNode();
+
+    biAnchor.resize(bcc.numberOfComponents(), none);
+    biParent.resize(bcc.numberOfComponents(), none);
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    G.forNodes([&](node u) { assert(status[u] == NodeStatus::NOT_VISITED); });
+#endif
+
+    // Topological order of biconnected components: tree of biconnected components starting from the
+    // root's biconnected component. If the root is in multiple biconnected components, arbitrarily
+    // select one of them.
+    std::queue<std::pair<node, index>> q;
+    const auto &rootComps = bcc.getComponentsOfNode(root);
+    q.push({root, *(rootComps.begin())});
+
+    topOrder.reserve(bcc.numberOfComponents());
+    topOrder.insert(topOrder.begin(), rootComps.begin(), rootComps.end());
+
+    std::vector<count> distance(G.upperNodeIdBound());
+    status[root] = NodeStatus::VISITED;
+    rootEcc = 0;
+
+    do {
+        const auto front = q.front();
+        q.pop();
+        G.forNeighborsOf(front.first, [&](const node v) {
+            if (status[v] == NodeStatus::NOT_VISITED) {
+                distance[v] = distance[front.first] + 1;
+                rootEcc = std::max(rootEcc, distance[v]);
+                const auto &vComps = bcc.getComponentsOfNode(v);
+                for (const node vComponentIndex : vComps) {
+                    // Check if a new biconnected components has been found.
+                    if (vComponentIndex != front.second && biAnchor[vComponentIndex] == none
+                        && rootComps.find(vComponentIndex) == rootComps.end()) {
+                        // The anchor cannot be the root, because the anchor does not have a parent.
+                        // We handle biAnchor = none cases later.
+                        biAnchor[vComponentIndex] = (v == root) ? none : v;
+                        biParent[vComponentIndex] = front.second;
+                        topOrder.push_back(vComponentIndex);
+                    }
+                }
+                q.push({v, *(vComps.begin())});
+                status[v] = NodeStatus::VISITED;
+            }
+        });
+    } while (!q.empty());
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    G.forNodes([&](node u) { assert(status[u] == NodeStatus::VISITED); });
+    assert(topOrder.size() == bcc.numberOfComponents());
+    assert(std::unordered_set<index>(topOrder.begin(), topOrder.end()).size()
+           == bcc.numberOfComponents());
+#endif
+}
+
+void DynApproxElectricalCloseness::computeBFSTree() {
+    // Using thread 0's vector
+    auto &status = statusGlobal[0];
+    auto n = G.numberOfNodes();
+    bfsTree.parent.resize(n);
+    bfsTree.child.resize(n);
+    bfsTree.sibling.resize(n);
+    std::fill(status.begin(), status.end(), NodeStatus::NOT_VISITED);
+    std::fill(bfsTree.parent.begin(), bfsTree.parent.end(), none);
+    std::fill(bfsTree.child.begin(), bfsTree.child.end(), none);
+    std::fill(bfsTree.sibling.begin(), bfsTree.sibling.end(), none);
+
+    std::queue<node> queue;
+    queue.push(root);
+    status[root] = NodeStatus::VISITED;
+
+    do {
+        const node currentNode = queue.front();
+        queue.pop();
+        node previous = none;
+        node first = none;
+        G.forNeighborsOf(currentNode, [&](const node v) {
+            if (status[v] == NodeStatus::NOT_VISITED) {
+                status[v] = NodeStatus::VISITED;
+                queue.push(v);
+                bfsTree.parent[v] = currentNode;
+                if (previous != none) {
+                    bfsTree.sibling[previous] = v;
+                }
+                previous = v;
+                if (first == none) {
+                    bfsTree.child[currentNode] = v;
+                    first = v;
+                }
+            }
+        });
+    } while (!queue.empty());
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    checkBFSTree();
+#endif
+}
+
+void DynApproxElectricalCloseness::sampleUST(Tree &result) {
+    // Getting thread-local vectors
+    auto &status = statusGlobal[omp_get_thread_num()];
+    auto &parent = result.parent;
+    auto &childPtr = result.child;
+    auto &siblingPtr = result.sibling;
+
+    auto n = G.numberOfNodes();
+    status.resize(n);
+    parent.resize(n);
+    childPtr.resize(n);
+    siblingPtr.resize(n);
+    std::fill(status.begin(), status.end(), NodeStatus::NOT_IN_COMPONENT);
+    std::fill(parent.begin(), parent.end(), none);
+    std::fill(childPtr.begin(), childPtr.end(), none);
+    std::fill(siblingPtr.begin(), siblingPtr.end(), none);
+
+    auto &generator = generators[omp_get_thread_num()];
+
+    // Iterate over the biconnected components in their topological order.
+    for (const auto componentIndex : topOrder) {
+        // Current component, sorted by vertex degree.
+        const auto &sequence = sequences[componentIndex];
+        auto curAnchor = biAnchor[componentIndex];
+
+        // Finds the parent of the current anchor node i.e., the anchor's neighbor that is in the
+        // parent component.
+        auto updateParentOfAnchor = [&]() -> void {
+            for (const node v : G.neighborRange(curAnchor)) {
+                const auto &vComps = bccPtr->getComponentsOfNode(v);
+                if (vComps.find(biParent[componentIndex]) != vComps.end()) {
+                    parent[curAnchor] = v;
+                    break;
+                }
+            }
+            assert(parent[curAnchor] != none);
+        };
+
+        if (sequence.size() == 2) {
+            // Happens when the current component is the root component in the topological
+            // order. In this case, the root plays the anchor's role.
+            if (curAnchor == none) {
+                const node v = (sequence[0] == root) ? sequence[1] : sequence[0];
+                assert(sequence.front() == root || sequence.back() == root);
+                assert(v != root);
+                parent[v] = root;
+            } else {
+                const node v = (sequence[0] == curAnchor) ? sequence[1] : sequence[0];
+                assert(v != curAnchor);
+                assert(v != root);
+                parent[v] = curAnchor;
+                if (parent[curAnchor] == none)
+                    updateParentOfAnchor();
+            }
+#ifdef NETWORKIT_SANITY_CHECKS
+            checkTwoNodesSequence(sequence, parent);
+#endif
+            continue;
+        }
+
+        // We start building the spanning tree from the first node of the
+        // sequence.
+        // Root of the spanning tree
+        status[sequence[0]] = NodeStatus::IN_SPANNING_TREE;
+        const node curAnchorParent = (curAnchor != none) ? parent[curAnchor] : none;
+
+        // All the remaining nodes in the components need to be visited.
+        std::for_each(sequence.begin() + 1, sequence.end(),
+                      [&status](node u) { status[u] = NodeStatus::NOT_VISITED; });
+
+        count nodesInSpanningTree = 1;
+        // Iterate over the remaining nodes to create the spanning tree.
+        for (auto it = sequence.begin() + 1; it != sequence.end(); ++it) {
+            const node walkStart = *it;
+            if (status[walkStart] == NodeStatus::IN_SPANNING_TREE)
+                // Node already added to the spanning tree
+                continue;
+
+            node currentNode = walkStart;
+
+            // Start a new random walk from the current node.
+            do {
+                // Get a random neighbor within the component
+                node randomNeighbor;
+                do {
+                    randomNeighbor = G.getIthNeighbor(currentNode, degDist[currentNode](generator));
+                } while (status[randomNeighbor] == NodeStatus::NOT_IN_COMPONENT);
+
+                assert(randomNeighbor != none);
+                parent[currentNode] = randomNeighbor;
+                currentNode = randomNeighbor;
+
+            } while (status[currentNode] != NodeStatus::IN_SPANNING_TREE);
+
+            // Last node encountered in the random walk (it is in the spanning tree);
+            const node walkEnd = currentNode;
+            assert(status[walkEnd] == NodeStatus::IN_SPANNING_TREE);
+            // Add the random walk to the spanning tree; eventually, reverse the path if the
+            // anchor/root is encountered
+            for (currentNode = walkStart; currentNode != walkEnd;
+                 currentNode = parent[currentNode]) {
+
+                status[currentNode] = NodeStatus::IN_SPANNING_TREE;
+                ++nodesInSpanningTree;
+                if (currentNode == curAnchor || currentNode == root) {
+
+                    // Anchor of current component in the walk, we have to reverse the
+                    // parent pointers
+                    node next = parent[currentNode];
+                    node nextParent = none;
+                    node tmp = currentNode;
+                    do {
+                        status[next] = NodeStatus::IN_SPANNING_TREE;
+                        nextParent = parent[next];
+                        parent[next] = currentNode;
+                        currentNode = next;
+                        next = nextParent;
+                    } while (next != none);
+
+                    if (tmp == root)
+                        parent[root] = none;
+                    else if (parent[curAnchor] == none)
+                        // Not none if articulation node visited by the parent component before
+                        updateParentOfAnchor();
+                    else
+                        parent[curAnchor] = curAnchorParent;
+
+                    break;
+                }
+            }
+
+            if (nodesInSpanningTree == sequence.size())
+                break;
+        }
+
+        for (node u : sequence)
+            status[u] = NodeStatus::NOT_IN_COMPONENT;
+    }
+
+    count visitedNodes = 0;
+    for (node u : G.nodeRange()) {
+        while (status[u] == NodeStatus::NOT_IN_COMPONENT) {
+            status[u] = NodeStatus::NOT_VISITED;
+            ++visitedNodes;
+            node parentU = parent[u];
+            if (parent[u] != none) {
+                assert(siblingPtr[u] == none);
+                if (childPtr[parentU] != none)
+                    siblingPtr[u] = childPtr[parentU];
+                childPtr[parentU] = u;
+                u = parentU;
+            } else
+                break;
+        }
+        if (visitedNodes == G.numberOfNodes())
+            break;
+    }
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    checkUST(result);
+#endif
+}
+
+void DynApproxElectricalCloseness::sampleUSTWithEdge(Tree &result, node a, node b) {
+    auto n = G.numberOfNodes();
+    assert(0 <= a && a < n && 0 <= b && b < n);
+
+    auto &parent = result.parent;
+    auto &status = statusGlobal[omp_get_thread_num()];
+    auto &childPtr = result.child;
+    auto &siblingPtr = result.sibling;
+
+    status.resize(n);
+    parent.resize(n, none);
+    childPtr.resize(n, none);
+    siblingPtr.resize(n, none);
+    std::fill(status.begin(), status.end(), NodeStatus::NOT_IN_COMPONENT);
+    std::fill(parent.begin(), parent.end(), none);
+    std::fill(childPtr.begin(), childPtr.end(), none);
+    std::fill(siblingPtr.begin(), siblingPtr.end(), none);
+
+    auto &generator = generators[omp_get_thread_num()];
+
+    // Initialize UST with only (a, b) in the tree.
+    parent[a] = b;
+    status[a] = NodeStatus::IN_SPANNING_TREE;
+    status[b] = NodeStatus::IN_SPANNING_TREE;
+    int nodesInSpanningTree = 2;
+
+    // The tree is generated using Wilson's algorithm, rooted in b.
+    // Afterwards reroot it to this->root.
+    for (const auto componentIndex : topOrder) {
+        const auto &sequence = sequences[componentIndex];
+        for (const auto walkStart : sequence) {
+            if (status[walkStart] == NodeStatus::IN_SPANNING_TREE) {
+                continue;
+            }
+
+            // Random Walk
+            node currentNode = walkStart;
+            do {
+                node randomNeighbor =
+                    G.getIthNeighbor(currentNode, degDist[currentNode](generator));
+
+                assert(randomNeighbor != none);
+                parent[currentNode] = randomNeighbor;
+                currentNode = randomNeighbor;
+
+            } while (status[currentNode] != NodeStatus::IN_SPANNING_TREE);
+
+            // Last node encountered in the random walk (it is in the spanning tree);
+            const node walkEnd = currentNode;
+            assert(status[walkEnd] == NodeStatus::IN_SPANNING_TREE);
+            // Add the random walk to the spanning tree;
+            for (currentNode = walkStart; currentNode != walkEnd;
+                 currentNode = parent[currentNode]) {
+
+                status[currentNode] = NodeStatus::IN_SPANNING_TREE;
+                ++nodesInSpanningTree;
+            }
+        }
+    }
+
+    assert(nodesInSpanningTree == n);
+
+    // Switch root from b to `root`.
+    node currentNode = root;
+    node next = parent[root];
+    while (next != none) {
+        node tmp = parent[next];
+        parent[next] = currentNode;
+        currentNode = next;
+        next = tmp;
+    }
+    parent[root] = none;
+
+    // Set child and sibling pointers
+    count visitedNodes = 0;
+    for (node u : G.nodeRange()) {
+        while (status[u] == NodeStatus::IN_SPANNING_TREE) {
+            status[u] = NodeStatus::NOT_VISITED;
+            ++visitedNodes;
+            node parentU = parent[u];
+            if (parentU != none) {
+                assert(siblingPtr[u] == none);
+                if (childPtr[parentU] != none)
+                    siblingPtr[u] = childPtr[parentU];
+                childPtr[parentU] = u;
+                u = parentU;
+            } else
+                break;
+        }
+        if (visitedNodes == G.numberOfNodes())
+            break;
+    }
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    checkUST(result);
+#endif
+}
+
+void DynApproxElectricalCloseness::setDFSTimes(Tree &tree, node r) {
+    if (tree.timesComputed) {
+        return;
+    }
+    tree.tVisit.resize(G.numberOfNodes());
+    tree.tFinish.resize(G.numberOfNodes());
+
+    if (r == none) {
+        r = root;
+    }
+
+    std::stack<std::pair<node, node>> stack;
+    stack.push({r, tree.child[r]});
+    count timestamp = 0;
+
+    do {
+        // v is a child of u that has not been visited yet.
+        const node u = stack.top().first;
+        const node v = stack.top().second;
+
+        if (v == none) {
+            stack.pop();
+            tree.tFinish[u] = ++timestamp;
+        } else {
+            stack.top().second = tree.sibling[v];
+            tree.tVisit[v] = ++timestamp;
+            stack.push({v, tree.child[v]});
+        }
+    } while (!stack.empty());
+
+    tree.timesComputed = true;
+}
+
+void DynApproxElectricalCloseness::aggregateUST(Tree &tree, double weight) {
+#ifdef NETWORKIT_SANITY_CHECKS
+    checkTimeStamps(tree);
+#endif
+
+    auto &approxEffResistance = approxEffResistanceGlobal[omp_get_thread_num()];
+    const auto &tVisit = tree.tVisit;
+    const auto &tFinish = tree.tFinish;
+    const auto &parent = tree.parent;
+
+    // Doing aggregation
+    G.forNodes([&](const node u) {
+        node p = bfsTree.parent[u];
+        node c = u;
+
+        auto goUp = [&]() -> void {
+            c = p;
+            p = bfsTree.parent[p];
+        };
+
+        while (p != none) {
+            // Edge in BSTree: e1 -> e2
+            node e1 = p, e2 = c;
+            bool reverse = false;
+            if (e1 != parent[e2]) {
+                if (e2 != parent[e1]) {
+                    goUp();
+                    continue;
+                }
+                std::swap(e1, e2);
+                reverse = true;
+            }
+
+            if (tVisit[u] >= tVisit[e2] && tFinish[u] <= tFinish[e2])
+                approxEffResistance[u] += reverse ? -weight : weight;
+
+            goUp();
+        }
+    });
+}
+
+void DynApproxElectricalCloseness::aggregateUSTNonRoot(Tree &tree, node i, double weight) {
+    auto &approxEffResistance = approxEffResistanceGlobal[omp_get_thread_num()];
+
+    if (!tree.timesComputed) {
+        setDFSTimes(tree);
+    }
+    if (i == root) {
+        aggregateUST(tree, weight);
+        return;
+    }
+
+    const auto &tVisit = tree.tVisit;
+    const auto &tFinish = tree.tFinish;
+    const auto &parent = tree.parent;
+
+    // Determine lca of all nodes with i in bfstree, via dfs search in B_u
+    // auto &lca_i = lcaGlobal[omp_get_thread_num()];
+    // lca_i.resize(G.numberOfNodes());
+    // std::fill(lca_i.begin(), lca_i.end(), none);
+
+    /*
+    std::stack<std::pair<node,node>> stack;
+    stack.push({root, bfsTree.child[root]});
+    lca_i[root] = root;
+    do {
+        // v is a child of u that has not been visited yet.
+        const node u = stack.top().first;
+        const node v = stack.top().second;
+
+        if (v == none) {
+            stack.pop();
+        } else {
+            // If i is below v, the lca of v and i is v, otherwise it is the same as the parent's
+            if (bfsTree.tVisit[v] <= bfsTree.tVisit[i] && bfsTree.tFinish[i] <= bfsTree.tFinish[v])
+    { lca_i[v] = v; } else { lca_i[v] = lca_i[u];
+            }
+
+            stack.top().second = bfsTree.sibling[v];
+            stack.push({v, bfsTree.child[v]});
+        }
+    } while (!stack.empty());
+    */
+
+    auto isEdgeOnPathFromRoot = [&](node a, node b, node to) -> bool {
+        return tVisit[b] <= tVisit[to] && tFinish[to] <= tFinish[b];
+    };
+    /*auto isEdgeOnPath = [&] (node a, node b, node from, node to) -> bool {
+        return (isEdgeOnPathFromRoot(b, a, from)
+                && !(isEdgeOnPathFromRoot(b, a, to)))
+            || (isEdgeOnPathFromRoot(a, b, from)
+                && !isEdgeOnPathFromRoot(a, b, to));
+    };*/
+
+    G.forNodes([&](const node u) {
+        // find the contribution of a single edge
+        auto eval_edge = [&](node a, node b) {
+            // edge (a, b) downwards facing in T
+            if (a == parent[b]) {
+                bool rpi = isEdgeOnPathFromRoot(a, b, i);
+                bool rpu = isEdgeOnPathFromRoot(a, b, u);
+                if (!rpi && rpu) {
+                    approxEffResistance[u] += weight;
+                }
+                if (rpi && !rpu) {
+                    approxEffResistance[u] -= weight;
+                }
+                // else (a, b) is not on the path from i to u or u to i, skip.
+            }
+            // edge (a, b) upwards facing in T
+            if (b == parent[a]) {
+                bool ipr = isEdgeOnPathFromRoot(b, a, i);
+                bool upr = isEdgeOnPathFromRoot(b, a, u);
+                if (ipr && !upr) {
+                    approxEffResistance[u] += weight;
+                } else if (!ipr && upr) {
+                    approxEffResistance[u] -= weight;
+                }
+                // else (b, a) is not on the path from i to u or u to i, skip.
+            }
+            // else (a,b) and (b,a) are not in T in either orientation, skip.
+        };
+
+        // go from i to u
+        node p = bfsTree.parent[i];
+        node c = i;
+        while (p != none /* && c != lca_i[u]*/) {
+            eval_edge(c, p);
+            c = p;
+            p = bfsTree.parent[p];
+        }
+
+        // from u to lca(i, u)
+        p = bfsTree.parent[u];
+        c = u;
+        while (p != none /*&& c != lca_i[u]*/) {
+            eval_edge(p, c);
+            c = p;
+            p = bfsTree.parent[p];
+        }
+    });
+}
+
+void DynApproxElectricalCloseness::edgeAdded(node a, node b) {
+    assert(G.hasEdge(a, b));
+    assert(hasRun);
+    round += 1;
+
+    // Compute lpinv columns for a and b exactly.
+    const count n = G.numberOfNodes();
+    const double n_double = static_cast<double>(n);
+
+    /// double laa = laplacian(a, a), lab = laplacian(a, b), lba = laplacian(b, a), lbb =
+    /// laplacian(b, b);
+    laplacian.setValue(a, a, laplacian(a, a) + 1.);
+    laplacian.setValue(b, b, laplacian(b, b) + 1.);
+    laplacian.setValue(a, b, laplacian(a, b) - 1.);
+    laplacian.setValue(b, a, laplacian(b, a) - 1.);
+
+    ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg(tol);
+    cg.setupConnected(laplacian);
+
+    Vector rhs_a(n), rhs_b(n);
+    lpinvColA = Vector(n);
+    lpinvColB = Vector(n);
+    G.forNodes([&](node u) {
+        rhs_a[u] = -1.0 / n_double;
+        rhs_b[u] = -1.0 / n_double;
+    });
+    rhs_a[a] += 1.;
+    rhs_b[b] += 1.;
+    auto status = cg.solve(rhs_a, lpinvColA);
+    assert(status.converged);
+    status = cg.solve(rhs_b, lpinvColB);
+    assert(status.converged);
+
+    double sum_a = 0., sum_b = 0.;
+    G.forNodes([&](node u) {
+        sum_a += lpinvColA[u];
+        sum_b += lpinvColB[u];
+    });
+    lpinvColA -= sum_a / n_double;
+    lpinvColB -= sum_b / n_double;
+
+    // update weights and delete unneeded trees
+    double w = lpinvColA[a] + lpinvColB[b] - 2. * lpinvColA[b];
+    assert(0 <= w && w <= 1.);
+    // w = (1. - w) / w;
+
+    for (count i = 0; i < round; i++) {
+        roundWeight[i] *= (1. - w);
+        ustRepository[i].resize(std::ceil(roundWeight[i] * numberOfUSTs));
+    }
+    roundWeight.push_back(w);
+
+    // rootCol -= 1. / (1.-w) * (lpinvColA[root] - lpinvColB[root]) * (lpinvColA - lpinvColB);
+
+    Vector rhs(n);
+    G.forNodes([&](node u) { rhs[u] = -1.0 / n_double; });
+    rhs[root] += 1.;
+    Vector exactRootCol(n);
+    cg.solve(rhs, exactRootCol);
+    double sum = 0.;
+    G.forNodes([&](node u) { sum += exactRootCol[u]; });
+    exactRootCol -= sum / n_double;
+    rootCol = exactRootCol;
+
+    // Sample and aggregate USTs
+    count ustsCurrentRound = std::ceil(w * numberOfUSTs);
+    INFO("USTS: ", ustsCurrentRound);
+
+    ustRepository.push_back(std::vector<Tree>(ustsCurrentRound));
+
+    auto threads = approxEffResistanceGlobal.size();
+    for (int i = 0; i < threads; i++) {
+        std::fill(approxEffResistanceGlobal[i].begin(), approxEffResistanceGlobal[i].end(), 0.);
+    }
+
+    // update degDist
+    degDist[a] = std::uniform_int_distribution<index>(0, G.degree(a) - 1);
+    degDist[b] = std::uniform_int_distribution<index>(0, G.degree(b) - 1);
+
+#pragma omp parallel for
+    for (omp_index i = 0; i < ustsCurrentRound; ++i) {
+        auto &tree = ustRepository[round][i];
+        sampleUSTWithEdge(tree, a, b);
+        setDFSTimes(tree);
+        aggregateUST(tree, 1. / static_cast<double>(ustsCurrentRound));
+    }
+
+    // Aggregate results
+    Vector currentRoundResistanceApprox(n);
+
+    G.parallelForNodes([&](const node u) {
+        // Accumulate all results on first thread vector
+        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
+            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
+        currentRoundResistanceApprox[u] = approxEffResistanceGlobal[0][u];
+        resistanceToRoot[u] = (1. - w) * resistanceToRoot[u] + w * currentRoundResistanceApprox[u];
+        diagonal[u] = resistanceToRoot[u] - rootCol[root] + 2. * rootCol[u];
+    });
+    // diagonal = computeExactDiagonal();
+
+    diagonal[root] = rootCol[root];
+    diagonal[a] = lpinvColA[a];
+    diagonal[b] = lpinvColB[b];
+    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.);
+
+    G.parallelForNodes(
+        [&](node u) { scoreData[u] = (n_double - 1.) / (n_double * diagonal[u] + trace); });
+
+    auto countTrees = [&]() {
+        std::map<count, count> treeCount;
+        for (auto &treesInRound : ustRepository) {
+            for (auto &tree : treesInRound) {
+                count key = 0;
+                for (count i = 0; i < n; i++) {
+                    count p = tree.parent[i] == none ? 0 : tree.parent[i];
+                    key += static_cast<count>(std::pow(n, i)) * p;
+                }
+                if (treeCount.find(key) == treeCount.end()) {
+                    treeCount[key] = 0;
+                }
+                treeCount[key] += 1;
+            }
+        }
+        for (const auto &kv : treeCount) {
+            INFO(kv.first, ": ", kv.second);
+        }
+    };
+    // countTrees();
+}
+
+std::pair<Vector, Vector> DynApproxElectricalCloseness::getEdgeLpinvVectors() {
+    return std::pair<Vector, Vector>(lpinvColA, lpinvColB);
+}
+
+void DynApproxElectricalCloseness::run() {
+    // Preprocessing
+    computeNodeSequence();
+    computeBFSTree();
+
+    numberOfUSTs = computeNumberOfUSTs();
+    rootCol = Vector(G.numberOfNodes());
+    roundWeight.push_back(1.);
+
+    auto n_int = G.numberOfNodes();
+    ustRepository.push_back(std::vector<Tree>(numberOfUSTs));
+    double weight = 1. / static_cast<double>(numberOfUSTs);
+
+#pragma omp parallel
+    {
+        // Thread 0 solves the linear system
+        if (omp_get_thread_num() == 0) {
+            const count n = G.numberOfNodes();
+
+            laplacian = CSRMatrix::laplacianMatrix(G);
+            Diameter diamAlgo(G, estimatedRange, 0);
+            diamAlgo.run();
+            // Getting diameter upper bound
+            const double diam = diamAlgo.getDiameter().second;
+            tol = epsilon * kappa
+                  / (std::sqrt(static_cast<double>((n * G.numberOfEdges())) * std::log(n)) * diam
+                     * 3.);
+            ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg(tol);
+            cg.setupConnected(laplacian);
+
+            Vector rhs(n);
+            G.forNodes([&](node u) { rhs[u] = -1.0 / static_cast<double>(n); });
+            rhs[root] += 1.;
+            cg.solve(rhs, rootCol);
+
+            double sum = 0.0;
+            G.forNodes([&](node u) { sum += rootCol[u]; });
+            rootCol -= sum / static_cast<double>(n);
+        }
+
+        // All threads sample and aggregate USTs in parallel
+#pragma omp for
+        for (omp_index i = 0; i < numberOfUSTs; ++i) {
+            Tree &tree = ustRepository[0][i];
+            sampleUST(tree);
+            setDFSTimes(tree);
+            aggregateUST(tree, weight);
+        }
+    }
+
+    // Aggregating thread-local results
+    G.parallelForNodes([&](const node u) {
+        // Accumulate all results on thread 0 vector
+        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
+            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
+        resistanceToRoot[u] = approxEffResistanceGlobal[0][u];
+        diagonal[u] = resistanceToRoot[u] - rootCol[root] + 2. * rootCol[u];
+    });
+
+    diagonal[root] = rootCol[root];
+    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.);
+    const double n = G.numberOfNodes();
+
+    G.parallelForNodes([&](node u) { scoreData[u] = (n - 1.) / (n * diagonal[u] + trace); });
+
+    hasRun = true;
+}
+
+std::vector<double> DynApproxElectricalCloseness::approxColumn(node v) {
+    assureFinished();
+    int threads = approxEffResistanceGlobal.size();
+    for (int i = 0; i < threads; i++) {
+        std::fill(approxEffResistanceGlobal[i].begin(), approxEffResistanceGlobal[i].end(), 0.);
+    }
+    count n = G.numberOfNodes();
+
+    if (!bfsTree.timesComputed) {
+        setDFSTimes(bfsTree);
+    }
+
+    /*for (count rnd = 0; rnd < round + 1; rnd++) {
+        for (count i = 0; i < ustRepository[rnd].size(); i++) {
+            auto& tree = ustRepository[rnd][i];
+            tree.parent.resize(n, none);
+            tree.child.resize(n, none);
+            tree.sibling.resize(n, none);
+            std::fill(tree.parent.begin(), tree.parent.end(), none);
+            std::fill(tree.child.begin(), tree.child.end(), none);
+            std::fill(tree.sibling.begin(), tree.sibling.end(), none);
+        }
+    }
+    */
+
+    // if trees in each round are too few, run the rounds in parallel, otherwise run the rounds
+    // sequentially
+    if (numberOfUSTs < 2 * round * threads) {
+#pragma omp parallel for
+        for (count rnd = 0; rnd < round + 1; rnd++) {
+            for (auto &tree : ustRepository[rnd]) {
+                double weight = roundWeight[rnd] / static_cast<double>(ustRepository[rnd].size());
+                aggregateUSTNonRoot(tree, v, weight);
+            }
+        }
+    } else {
+        for (count rnd = 0; rnd < round + 1; rnd++) {
+#pragma omp parallel for
+            for (count i = 0; i < ustRepository[rnd].size(); i++) {
+                double weight = roundWeight[rnd] / static_cast<double>(ustRepository[rnd].size());
+                auto &tree = ustRepository[rnd][i];
+                aggregateUSTNonRoot(tree, v, weight);
+            }
+        }
+    }
+
+    std::vector<double> column(G.numberOfNodes());
+
+    G.parallelForNodes([&](const node u) {
+        // Accumulate all results on thread 0 vector
+        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
+            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
+        column[u] = (diagonal[u] + diagonal[v] - approxEffResistanceGlobal[0][u]) / 2.;
+    });
+    return column;
+}
+
+std::vector<double> DynApproxElectricalCloseness::computeExactDiagonal(double tol) const {
+    Lamg<CSRMatrix> lamg(tol);
+    if (!hasRun) {
+        auto L = CSRMatrix::laplacianMatrix(G);
+        lamg.setupConnected(L);
+    } else {
+        lamg.setupConnected(laplacian);
+    }
+
+    const count n = G.numberOfNodes();
+    const count maxThreads = static_cast<count>(omp_get_max_threads());
+
+    // Solution vectors: one per thread
+    std::vector<Vector> solutions(maxThreads, Vector(n));
+
+    // Right hand side vectors: one per thread
+    std::vector<Vector> rhss(maxThreads, Vector(n));
+
+    std::vector<double> diag(n);
+
+    const count iters = (n % maxThreads == 0) ? n / maxThreads : n / maxThreads + 1;
+    for (count i = 0; i < iters; ++i) {
+        // Index of the next vertex to process
+        const index base = i * maxThreads;
+
+#pragma omp parallel
+        {
+            // Each thread solves a linear system from `base` to `base + #threads - 1`
+            const index thread = omp_get_thread_num();
+            const node v = base + thread;
+            if (v < n) {
+                // Reset solution and rhs vector of the current thread
+                solutions[thread].fill(0.0);
+
+                // Set up system to compute the diagonal entry L^+[v, v]
+                rhss[thread].fill(-1. / static_cast<double>(n));
+                rhss[thread][v] += 1.;
+            }
+        }
+
+        if (base + maxThreads >= n) {
+            // Last iteration: some threads cannot be used.
+            // Resize rhss and solutions to the number of vertices left to be processed.
+            rhss.resize(n - base);
+            solutions.resize(rhss.size());
+        }
+
+        lamg.parallelSolve(rhss, solutions);
+
+        // Store the results
+        for (index idx = 0; idx < solutions.size(); ++idx) {
+            const node v = base + idx;
+            if (v < n)
+                diag[v] = solutions[idx][v];
+            else
+                break;
+        }
+    }
+
+    return diag;
+}
+
+std::vector<double> DynApproxElectricalCloseness::computeExactColumn(node u, double tol) const {
+    NetworKit::ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg(tol);
+
+    if (!hasRun) {
+        auto L = CSRMatrix::laplacianMatrix(G);
+        cg.setupConnected(L);
+    } else {
+        cg.setupConnected(laplacian);
+    }
+
+    const count n = G.numberOfNodes();
+    Vector rhs(n), sol(n);
+
+    G.forNodes([&](node i) { rhs[i] = -1.0 / static_cast<double>(n); });
+    rhs[u] += 1.;
+
+    cg.solve(rhs, sol);
+
+    double sum = 0.;
+    G.forNodes([&](node i) { sum += sol[i]; });
+    sol -= sum / static_cast<double>(n);
+
+    std::vector<double> result(n);
+
+    G.forNodes([&](node i) { result[i] = sol[i]; });
+    return result;
+}
+
+#ifdef NETWORKIT_SANITY_CHECKS
+/*
+ * Methods for sanity check.
+ */
+void DynApproxElectricalCloseness::checkUST(const Tree &tree) const {
+    std::vector<bool> visitedNodes(G.upperNodeIdBound());
+    const auto &parent = tree.parent;
+    const auto &childPtr = tree.child;
+    const auto &siblingPtr = tree.sibling;
+
+    // To debug
+    G.forNodes([&](node u) {
+        if (childPtr[u] != none) {
+            assert(u == parent[childPtr[u]]);
+        }
+        if (siblingPtr[u] != none) {
+            assert(parent[u] == parent[siblingPtr[u]]);
+        }
+        if (u == root) {
+            assert(parent[u] == none);
+        } else {
+            assert(parent[u] != none);
+            std::fill(visitedNodes.begin(), visitedNodes.end(), 0);
+            visitedNodes[u] = 1;
+            do {
+                u = parent[u];
+                assert(!visitedNodes[u]);
+                visitedNodes[u] = 1;
+            } while (u != root);
+        }
+    });
+}
+
+void DynApproxElectricalCloseness::checkBFSTree() const {
+    G.forNodes([&](node u) {
+        if (u == root) {
+            assert(bfsTree.parent[u] == none);
+        } else {
+            std::vector<bool> visited(G.upperNodeIdBound());
+            do {
+                assert(!visited[u]);
+                visited[u] = true;
+                assert(bfsTree.parent[u] != none);
+                u = bfsTree.parent[u];
+            } while (u != root);
+        }
+    });
+}
+
+void DynApproxElectricalCloseness::checkTwoNodesSequence(const std::vector<node> &sequence,
+                                                         std::vector<node> &parent) const {
+    for (node u : sequence) {
+        if (u == root) {
+            assert(parent[u] == none);
+        } else {
+            std::vector<bool> visited(G.upperNodeIdBound());
+            visited[u] = true;
+            do {
+                u = parent[u];
+                assert(!visited[u]);
+                visited[u] = true;
+            } while (u != root);
+        }
+    }
+}
+
+void DynApproxElectricalCloseness::checkTimeStamps(const Tree &tree) const {
+    const auto &tVisit = tree.tVisit;
+    const auto &tFinish = tree.tFinish;
+    G.forNodes([&](const node u) {
+        assert(tVisit[u] < tFinish[u]);
+        if (u == root)
+            assert(tVisit[u] == 0);
+        else
+            assert(tVisit[u] > 0);
+        assert(tVisit[u] < 2 * G.numberOfNodes());
+    });
+}
+
+#endif // NETWORKIT_SANITY_CHECKS
+
+} // namespace NetworKit

--- a/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
@@ -438,7 +438,7 @@ void DynApproxElectricalCloseness::sampleUST(Tree &result) {
 
 void DynApproxElectricalCloseness::sampleUSTWithEdge(Tree &result, node a, node b) {
     auto n = G.numberOfNodes();
-    assert(0 <= a && a < n && 0 <= b && b < n);
+    assert(a < n && b < n);
 
     auto &parent = result.parent;
     auto &status = statusGlobal[omp_get_thread_num()];
@@ -459,7 +459,7 @@ void DynApproxElectricalCloseness::sampleUSTWithEdge(Tree &result, node a, node 
     parent[a] = b;
     status[a] = NodeStatus::IN_SPANNING_TREE;
     status[b] = NodeStatus::IN_SPANNING_TREE;
-    int nodesInSpanningTree = 2;
+    unsigned int nodesInSpanningTree = 2;
 
     // The tree is generated using Wilson's algorithm, rooted in b.
     // Afterwards reroot it to this->root.
@@ -659,7 +659,7 @@ void DynApproxElectricalCloseness::edgeAdded(node a, node b) {
     count ustsCurrentRound = std::ceil(w * numberOfUSTs);
     INFO("USTS: ", ustsCurrentRound);
 
-    for (auto approxEffResistanceLocal : approxEffResistanceGlobal) {
+    for (auto &approxEffResistanceLocal : approxEffResistanceGlobal) {
         std::fill(approxEffResistanceLocal.begin(), approxEffResistanceLocal.end(), 0.);
     }
 
@@ -766,7 +766,7 @@ void DynApproxElectricalCloseness::edgeRemoved(node a, node b) {
     count ustsCurrentRound = std::ceil(w * numberOfUSTs);
     INFO("USTS: ", ustsCurrentRound);
 
-    for (auto approxEffResistanceLocal : approxEffResistanceGlobal) {
+    for (auto &approxEffResistanceLocal : approxEffResistanceGlobal) {
         std::fill(approxEffResistanceLocal.begin(), approxEffResistanceLocal.end(), 0.);
     }
 

--- a/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
@@ -25,7 +25,7 @@ namespace NetworKit {
 DynApproxElectricalCloseness::DynApproxElectricalCloseness(const Graph &G, double epsilon,
                                                            double kappa)
     : Centrality(G), epsilon(epsilon), delta(1.0 / static_cast<double>(G.numberOfNodes())),
-      kappa(kappa), bccPtr(new BiconnectedComponents(G)) {
+      kappa(kappa), bcc(BiconnectedComponents(G)) {
 
     if (G.isDirected())
         throw std::runtime_error("Error: the input graph must be undirected.");
@@ -123,7 +123,6 @@ void DynApproxElectricalCloseness::computeNodeSequence() {
     auto &status = statusGlobal[0];
 
     // Compute the biconnected components
-    auto &bcc = *bccPtr;
     bcc.run();
     auto components = bcc.getComponents();
 
@@ -295,7 +294,7 @@ void DynApproxElectricalCloseness::sampleUST(Tree &result) {
         // parent component.
         auto updateParentOfAnchor = [&]() -> void {
             for (const node v : G.neighborRange(curAnchor)) {
-                const auto &vComps = bccPtr->getComponentsOfNode(v);
+                const auto &vComps = bcc.getComponentsOfNode(v);
                 if (vComps.find(biParent[componentIndex]) != vComps.end()) {
                     parent[curAnchor] = v;
                     break;

--- a/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
@@ -24,8 +24,8 @@ namespace NetworKit {
 
 DynApproxElectricalCloseness::DynApproxElectricalCloseness(const Graph &G, double epsilon,
                                                            double kappa, node pivot, double delta)
-    : Centrality(G), epsilon(epsilon), delta(delta), kappa(kappa), bcc(BiconnectedComponents(G)),
-      pivot(pivot) {
+    : Centrality(G), epsilon(epsilon), delta(delta), kappa(kappa), pivot(pivot),
+      bcc(BiconnectedComponents(G)) {
 
     if (G.isDirected())
         throw std::runtime_error("Error: the input graph must be undirected.");
@@ -659,9 +659,8 @@ void DynApproxElectricalCloseness::edgeAdded(node a, node b) {
     count ustsCurrentRound = std::ceil(w * numberOfUSTs);
     INFO("USTS: ", ustsCurrentRound);
 
-    auto threads = approxEffResistanceGlobal.size();
-    for (int i = 0; i < threads; i++) {
-        std::fill(approxEffResistanceGlobal[i].begin(), approxEffResistanceGlobal[i].end(), 0.);
+    for (auto approxEffResistanceLocal : approxEffResistanceGlobal) {
+        std::fill(approxEffResistanceLocal.begin(), approxEffResistanceLocal.end(), 0.);
     }
 
     // update degDist
@@ -767,9 +766,8 @@ void DynApproxElectricalCloseness::edgeRemoved(node a, node b) {
     count ustsCurrentRound = std::ceil(w * numberOfUSTs);
     INFO("USTS: ", ustsCurrentRound);
 
-    auto threads = approxEffResistanceGlobal.size();
-    for (int i = 0; i < threads; i++) {
-        std::fill(approxEffResistanceGlobal[i].begin(), approxEffResistanceGlobal[i].end(), 0.);
+    for (auto approxEffResistanceLocal : approxEffResistanceGlobal) {
+        std::fill(approxEffResistanceLocal.begin(), approxEffResistanceLocal.end(), 0.);
     }
 
     // update degDist

--- a/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
+++ b/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
@@ -18,11 +18,12 @@ class ApproxElectricalClosenessGTest : public testing::Test {};
 
 TEST_F(ApproxElectricalClosenessGTest, testApproxElectricalCloseness) {
     const double eps = 0.1;
-    const count n = 75;
+    const count n_gen = 75;
     for (int seed : {1, 2, 3}) {
         Aux::Random::setSeed(seed, true);
-        auto G = HyperbolicGenerator(n, 10, 3).generate();
+        auto G = HyperbolicGenerator(n_gen, 10, 3).generate();
         G = ConnectedComponents::extractLargestConnectedComponent(G, true);
+        count n = G.numberOfNodes();
 
         // Create a biconnected component with size 2.
         G.addNodes(2);
@@ -40,11 +41,12 @@ TEST_F(ApproxElectricalClosenessGTest, testApproxElectricalCloseness) {
 
 TEST_F(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_run) {
     const double eps = 0.1;
-    const count n = 75;
+    const count n_gen = 75;
     for (int seed : {1, 2, 3}) {
         Aux::Random::setSeed(seed, true);
-        auto G = HyperbolicGenerator(n, 10, 3).generate();
+        auto G = HyperbolicGenerator(n_gen, 10, 3).generate();
         G = ConnectedComponents::extractLargestConnectedComponent(G, true);
+        count n = G.numberOfNodes();
 
         // Create a biconnected component with size 2.
         G.addNodes(2);
@@ -64,13 +66,13 @@ TEST_F(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_run) {
 
 TEST_F(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_batchEdgeAddition) {
     const double eps = 0.1;
-    count n;
+    count n_gen;
     for (int seed : {1, 2, 3}) {
-        n = 300;
+        n_gen = 300;
         Aux::Random::setSeed(seed, true);
-        auto G = HyperbolicGenerator(n, 6, 3).generate();
+        auto G = HyperbolicGenerator(n_gen, 6, 3).generate();
         G = ConnectedComponents::extractLargestConnectedComponent(G, true);
-        n = G.numberOfNodes();
+        count n = G.numberOfNodes();
 
         // Create a biconnected component with size 2.
         G.addNodes(2);
@@ -110,6 +112,53 @@ TEST_F(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_batchEdg
         G.forNodes([&](node u) { EXPECT_NEAR(diag[u], ddiag[u], eps); });
         EXPECT_EQ(dapx.scores().size(), G.numberOfNodes());
     }
+}
+
+TEST_F(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_copy) {
+    const double eps = 0.1;
+    const count n_gen = 75;
+    auto G = HyperbolicGenerator(n_gen, 10, 3).generate();
+    G = ConnectedComponents::extractLargestConnectedComponent(G, true);
+    count n = G.numberOfNodes();
+
+    // Create a biconnected component with size 2.
+    G.addNodes(2);
+    G.addEdge(n - 1, n);
+    G.addEdge(n, n + 1);
+
+    DynApproxElectricalCloseness dapx(G);
+    dapx.run();
+    std::random_device dev;
+    std::mt19937 rng(dev());
+    std::uniform_int_distribution<std::mt19937::result_type> distN(0, n + 1);
+
+    node a, b;
+
+    // add 10 random edges
+    std::vector<GraphEvent> batch(10);
+    for (count i = 0; i < 10; i++) {
+        do {
+            a = distN(rng);
+            b = distN(rng);
+        } while (G.hasEdge(a, b) || a == b);
+
+        G.addEdge(a, b);
+
+        batch[i].type = GraphEvent::EDGE_ADDITION;
+        batch[i].u = a;
+        batch[i].v = b;
+    }
+
+    DynApproxElectricalCloseness dapx2 = dapx;
+
+    dapx2.updateBatch(batch);
+    ApproxElectricalCloseness apx(G);
+    apx.run();
+
+    const auto diag = apx.getDiagonal();
+    const auto ddiag2 = dapx2.getDiagonal();
+    G.forNodes([&](node u) { EXPECT_NEAR(diag[u], ddiag2[u], eps); });
+    EXPECT_EQ(dapx2.scores().size(), G.numberOfNodes());
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
+++ b/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <networkit/centrality/ApproxElectricalCloseness.hpp>
+#include <networkit/centrality/DynApproxElectricalCloseness.hpp>
 #include <networkit/components/ConnectedComponents.hpp>
 #include <networkit/generators/HyperbolicGenerator.hpp>
 
@@ -34,6 +35,82 @@ TEST_F(ApproxElectricalClosenessGTest, testApproxElectricalCloseness) {
         const auto gt = apx.computeExactDiagonal(1e-12);
         G.forNodes([&](node u) { EXPECT_NEAR(diag[u], gt[u], eps); });
         EXPECT_EQ(apx.scores().size(), G.numberOfNodes());
+    }
+}
+
+TEST_F(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_run) {
+    const double eps = 0.1;
+    const count n = 75;
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, true);
+        auto G = HyperbolicGenerator(n, 10, 3).generate();
+        G = ConnectedComponents::extractLargestConnectedComponent(G, true);
+
+        // Create a biconnected component with size 2.
+        G.addNodes(2);
+        G.addEdge(n - 1, n);
+        G.addEdge(n, n + 1);
+
+        ApproxElectricalCloseness apx(G);
+        DynApproxElectricalCloseness dapx(G);
+        apx.run();
+        dapx.run();
+        const auto diag = apx.getDiagonal();
+        const auto ddiag = dapx.getDiagonal();
+        G.forNodes([&](node u) { EXPECT_NEAR(diag[u], ddiag[u], eps); });
+        EXPECT_EQ(dapx.scores().size(), G.numberOfNodes());
+    }
+}
+
+TEST_F(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_batchEdgeAddition) {
+    const double eps = 0.1;
+    count n;
+    for (int seed : {1, 2, 3}) {
+        n = 300;
+        Aux::Random::setSeed(seed, true);
+        auto G = HyperbolicGenerator(n, 6, 3).generate();
+        G = ConnectedComponents::extractLargestConnectedComponent(G, true);
+        n = G.numberOfNodes();
+
+        // Create a biconnected component with size 2.
+        G.addNodes(2);
+        G.addEdge(n - 1, n);
+        G.addEdge(n, n + 1);
+
+        DynApproxElectricalCloseness dapx(G);
+        dapx.run();
+
+        std::random_device dev;
+        std::mt19937 rng(dev());
+        std::uniform_int_distribution<std::mt19937::result_type> distN(1, n + 2);
+
+        node a, b;
+
+        // add 10 random edges
+        std::vector<GraphEvent> batch(10);
+        for (count i = 0; i < 10; i++) {
+            do {
+                a = distN(rng);
+                b = distN(rng);
+            } while (G.hasEdge(a, b) || a == b);
+
+            batch[i].type = GraphEvent::EDGE_ADDITION;
+            batch[i].u = a;
+            batch[i].v = b;
+        }
+
+        for (GraphEvent edge : batch) {
+            G.addEdge(edge.u, edge.v);
+        }
+
+        dapx.updateBatch(batch);
+        ApproxElectricalCloseness apx(G);
+        apx.run();
+
+        const auto diag = apx.getDiagonal();
+        const auto ddiag = dapx.getDiagonal();
+        G.forNodes([&](node u) { EXPECT_NEAR(diag[u], ddiag[u], eps); });
+        EXPECT_EQ(dapx.scores().size(), G.numberOfNodes());
     }
 }
 

--- a/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
+++ b/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
@@ -83,7 +83,7 @@ TEST_P(ApproxElectricalClosenessGTest, testApproxElectricalCloseness) {
     apx.run();
     const auto diag = apx.getDiagonal();
     const auto gt = apx.computeExactDiagonal(1e-12);
-    G.forNodes([&](node u) { EXPECT_NEAR(diag[u], gt[u], eps); });
+    G.forNodes([&eps = eps, &gt, &diag](node u) { EXPECT_NEAR(diag[u], gt[u], eps); });
     EXPECT_EQ(apx.scores().size(), G.numberOfNodes());
 }
 
@@ -98,7 +98,7 @@ TEST_P(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_run) {
     dapx.run();
     const auto diag = apx.getDiagonal();
     const auto ddiag = dapx.getDiagonal();
-    G.forNodes([&](node u) {
+    G.forNodes([&eps = eps, &ddiag, &diag](node u) {
         EXPECT_NEAR(diag[u], ddiag[u], 2 * eps);
     }); // 2 * eps because both have max abs error of eps
     EXPECT_EQ(dapx.scores().size(), G.numberOfNodes());
@@ -122,7 +122,7 @@ TEST_P(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_EdgeAddi
 
     const auto diag = apx.getDiagonal();
     const auto ddiag = dapx.getDiagonal();
-    G.forNodes([&](node u) { EXPECT_NEAR(diag[u], ddiag[u], 2 * eps); });
+    G.forNodes([&eps = eps, &ddiag, &diag](node u) { EXPECT_NEAR(diag[u], ddiag[u], 2 * eps); });
     EXPECT_EQ(dapx.scores().size(), G.numberOfNodes());
 }
 
@@ -150,7 +150,7 @@ TEST_P(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_EdgeDele
 
     const auto diag = apx.getDiagonal();
     const auto ddiag = dapx.getDiagonal();
-    G.forNodes([&](node u) { EXPECT_NEAR(diag[u], ddiag[u], 2 * eps); });
+    G.forNodes([&eps = eps, &ddiag, &diag](node u) { EXPECT_NEAR(diag[u], ddiag[u], 2 * eps); });
     EXPECT_EQ(dapx.scores().size(), G.numberOfNodes());
 }
 
@@ -173,7 +173,7 @@ TEST_P(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_copy) {
 
     const auto diag = apx.getDiagonal();
     const auto ddiag2 = dapx2.getDiagonal();
-    G.forNodes([&](node u) { EXPECT_NEAR(diag[u], ddiag2[u], 2 * eps); });
+    G.forNodes([&eps = eps, &ddiag2, &diag](node u) { EXPECT_NEAR(diag[u], ddiag2[u], 2 * eps); });
     EXPECT_EQ(dapx2.scores().size(), G.numberOfNodes());
 }
 

--- a/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
+++ b/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
@@ -82,7 +82,7 @@ TEST_F(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_batchEdg
 
         std::random_device dev;
         std::mt19937 rng(dev());
-        std::uniform_int_distribution<std::mt19937::result_type> distN(1, n + 2);
+        std::uniform_int_distribution<std::mt19937::result_type> distN(0, n + 1);
 
         node a, b;
 
@@ -94,13 +94,11 @@ TEST_F(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_batchEdg
                 b = distN(rng);
             } while (G.hasEdge(a, b) || a == b);
 
+            G.addEdge(a, b);
+
             batch[i].type = GraphEvent::EDGE_ADDITION;
             batch[i].u = a;
             batch[i].v = b;
-        }
-
-        for (GraphEvent edge : batch) {
-            G.addEdge(edge.u, edge.v);
         }
 
         dapx.updateBatch(batch);

--- a/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
+++ b/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
@@ -1,0 +1,40 @@
+/*
+ * ApproxElectricalClosenessGTest.cpp
+ *
+ *  Created on: 18.04.2023
+ *      Author: Lukas Berner <Lukas.Berner@hu-berlin.de>
+ */
+
+#include <gtest/gtest.h>
+
+#include <networkit/centrality/ApproxElectricalCloseness.hpp>
+#include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/generators/HyperbolicGenerator.hpp>
+
+namespace NetworKit {
+
+class ApproxElectricalClosenessGTest : public testing::Test {};
+
+TEST_F(ApproxElectricalClosenessGTest, testApproxElectricalCloseness) {
+    const double eps = 0.1;
+    const count n = 75;
+    for (int seed : {1, 2, 3}) {
+        Aux::Random::setSeed(seed, true);
+        auto G = HyperbolicGenerator(n, 10, 3).generate();
+        G = ConnectedComponents::extractLargestConnectedComponent(G, true);
+
+        // Create a biconnected component with size 2.
+        G.addNodes(2);
+        G.addEdge(n - 1, n);
+        G.addEdge(n, n + 1);
+
+        ApproxElectricalCloseness apx(G);
+        apx.run();
+        const auto diag = apx.getDiagonal();
+        const auto gt = apx.computeExactDiagonal(1e-12);
+        G.forNodes([&](node u) { EXPECT_NEAR(diag[u], gt[u], eps); });
+        EXPECT_EQ(apx.scores().size(), G.numberOfNodes());
+    }
+}
+
+} /* namespace NetworKit */

--- a/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
+++ b/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
@@ -68,7 +68,7 @@ TEST_F(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_batchEdg
     const double eps = 0.1;
     count n_gen;
     for (int seed : {1, 2, 3}) {
-        n_gen = 300;
+        n_gen = 75;
         Aux::Random::setSeed(seed, true);
         auto G = HyperbolicGenerator(n_gen, 6, 3).generate();
         G = ConnectedComponents::extractLargestConnectedComponent(G, true);

--- a/networkit/cpp/centrality/test/CMakeLists.txt
+++ b/networkit/cpp/centrality/test/CMakeLists.txt
@@ -3,7 +3,7 @@ networkit_add_test(centrality ApproxBetweennessGTest
 networkit_add_test(centrality CentralityGTest
     auxiliary generators io structures)
 networkit_add_test(centrality ApproxElectricalClosenessGTest
-    generators)
+    auxiliary generators io structures algebraic)
 networkit_add_test(centrality DynBetweennessGTest
     auxiliary generators graph io)
 networkit_add_test(centrality SpanningEdgeCentralityGTest

--- a/networkit/cpp/centrality/test/CMakeLists.txt
+++ b/networkit/cpp/centrality/test/CMakeLists.txt
@@ -2,6 +2,8 @@ networkit_add_test(centrality ApproxBetweennessGTest
     distance generators)
 networkit_add_test(centrality CentralityGTest
     auxiliary generators io structures)
+networkit_add_test(centrality ApproxElectricalClosenessGTest
+    generators)
 networkit_add_test(centrality DynBetweennessGTest
     auxiliary generators graph io)
 networkit_add_test(centrality SpanningEdgeCentralityGTest

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1801,28 +1801,6 @@ TEST_P(CentralityGTest, testGedWalk) {
     }
 }
 
-TEST_F(CentralityGTest, testApproxElectricalCloseness) {
-    const double eps = 0.1;
-    const count n = 75;
-    for (int seed : {1, 2, 3}) {
-        Aux::Random::setSeed(seed, true);
-        auto G = HyperbolicGenerator(n, 10, 3).generate();
-        G = ConnectedComponents::extractLargestConnectedComponent(G, true);
-
-        // Create a biconnected component with size 2.
-        G.addNodes(2);
-        G.addEdge(n - 1, n);
-        G.addEdge(n, n + 1);
-
-        ApproxElectricalCloseness apx(G);
-        apx.run();
-        const auto diag = apx.getDiagonal();
-        const auto gt = apx.computeExactDiagonal(1e-12);
-        G.forNodes([&](node u) { EXPECT_NEAR(diag[u], gt[u], eps); });
-        EXPECT_EQ(apx.scores().size(), G.numberOfNodes());
-    }
-}
-
 TEST_P(CentralityGTest, testGroupClosenessGrowShrink) {
     if (isDirected()) { // directed graphs are not supported
         Graph G(10, isWeighted(), true);

--- a/networkit/test/test_centrality.py
+++ b/networkit/test/test_centrality.py
@@ -82,8 +82,6 @@ class TestCentrality(unittest.TestCase):
 		g.addEdge(n, n+1)
 		g.addEdge(n - 1, n)
 
-		nk.overview(g)
-
 		dapx = nk.centrality.DynApproxElectricalCloseness(g, eps)
 		dapx.run()
 


### PR DESCRIPTION
This algorithm is based on the `ApproxElectricalCloseness` algorithm in networkit.
The dynamic algorithm supports:
- edge addition. Algorithm details can be found in our recent paper (which I think is not published yet (?))
- edge deletion. Based on the same idea as edge addition, with small changes to the math / reordering some terms. 

This implementation currently does not support arbitrary edge deletions: edges on the BFS tree from the pivot element `u` (which is used to approximate r(u,v) for all `v`) may not be deleted, because this would require a larger update computation. In principle, this is possible, but for my use case this is not a problem right now. The code can easily be extended when the need arises.

Additional changes in this PR:
- updated the description of `ApproxElectricalCloseness` to a more accurate description of the results properties
- created a new GTest file which now contains the tests for the static and dynamic algorithm