### PR TITLE
Refactor Matrices and MatricesGTest

### DIFF
--- a/include/networkit/algebraic/DenseMatrix.hpp
+++ b/include/networkit/algebraic/DenseMatrix.hpp
@@ -14,6 +14,7 @@
 #include <networkit/Globals.hpp>
 #include <networkit/algebraic/AlgebraicGlobals.hpp>
 #include <networkit/algebraic/Vector.hpp>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
@@ -247,6 +248,32 @@ public:
     void apply(F unaryElementFunction);
 
     /**
+     * Returns the (weighted) adjacency matrix of the (weighted) Graph @a graph.
+     * @param graph
+     */
+    static DenseMatrix adjacencyMatrix(const Graph &graph, double zero = 0.0);
+
+    /**
+     * Creates a diagonal matrix with dimension equal to the dimension of the Vector @a
+     * diagonalElements. The values on the diagonal are the ones stored in @a diagonalElements (i.e.
+     * D(i,i) = diagonalElements[i]).
+     * @param diagonalElements
+     */
+    static DenseMatrix diagonalMatrix(const Vector &diagonalElements, double zero = 0.0);
+
+    /**
+     * Returns the (weighted) incidence matrix of the (weighted) Graph @a graph.
+     * @param graph
+     */
+    static DenseMatrix incidenceMatrix(const Graph &graph, double zero = 0.0);
+
+    /**
+     * Returns the (weighted) Laplacian matrix of the (weighteD) Graph @a graph.
+     * @param graph
+     */
+    static DenseMatrix laplacianMatrix(const Graph &graph, double zero = 0.0);
+
+    /**
      * Decomposes the given @a matrix into lower L and upper U matrix (in-place).
      * @param matrix The matrix to decompose into LU.
      */
@@ -273,28 +300,28 @@ public:
     static DenseMatrix binaryOperator(const DenseMatrix &A, const DenseMatrix &B, L binaryOp);
 
     /**
-     * Iterate over all non-zero elements of row @a row in the matrix and call handler(index column,
+     * Iterate over all elements of row @a row in the matrix and call handler(index column,
      * double value)
      */
     template <typename L>
     void forElementsInRow(index row, L handle) const;
 
     /**
-     * Iterate in parallel over all non-zero elements of row @a row in the matrix and call
+     * Iterate in parallel over all elements of row @a row in the matrix and call
      * handler(index column, double value)
      */
     template <typename L>
     void parallelForElementsInRow(index row, L handle) const;
 
     /**
-     * Iterate over all non-zero elements of the matrix in row order and call handler (lambda
+     * Iterate over all elements of the matrix in row order and call handler (lambda
      * closure).
      */
     template <typename L>
     void forElementsInRowOrder(L handle) const;
 
     /**
-     * Iterate in parallel over all rows and call handler (lambda closure) on non-zero elements of
+     * Iterate in parallel over all rows and call handler (lambda closure) on elements of
      * the matrix.
      */
     template <typename L>

--- a/networkit/cpp/Unittests-X.cpp
+++ b/networkit/cpp/Unittests-X.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[]) {
         auto setFilter = [&](const char *filter) { ::testing::GTEST_FLAG(filter) = filter; };
 
         if (options.modeTests) {
-            setFilter("*Test.test*");
+            setFilter("*Test.test*:*Test/*:test*");
         } else if (options.modeDebug) {
             setFilter("*Test.debug*");
         } else if (options.modeBenchmarks) {

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -1302,21 +1302,25 @@ TEST_F(MatricesGTest, testBigMatrixMultiplcation) {
 TEST_F(MatricesGTest, testAdjacencyMatrixOfGraph) {
     testAdjacencyMatrix<DynamicMatrix>();
     testAdjacencyMatrix<CSRMatrix>();
+    testAdjacencyMatrix<DenseMatrix>();
 }
 
 TEST_F(MatricesGTest, testDiagonalMatrix) {
     testDiagonalMatrix<DynamicMatrix>();
+    testDiagonalMatrix<CSRMatrix>();
     testDiagonalMatrix<CSRMatrix>();
 }
 
 TEST_F(MatricesGTest, testIncidenceMatrix) {
     testIncidenceMatrix<DynamicMatrix>();
     testIncidenceMatrix<CSRMatrix>();
+    testIncidenceMatrix<DenseMatrix>();
 }
 
 TEST_F(MatricesGTest, testLaplacianMatrixOfGraph) {
     testLaplacianOfGraph<DynamicMatrix>();
     testLaplacianOfGraph<CSRMatrix>();
+    testLaplacianOfGraph<DenseMatrix>();
 }
 
 TEST_F(MatricesGTest, testForElementsInRow) {
@@ -1337,15 +1341,20 @@ TEST_F(MatricesGTest, testForNonZeroElementsInRow) {
 
 TEST_F(MatricesGTest, testParallelForNonZeroElementsInRow) {
     testParallelForNonZeroElementsInRow<CSRMatrix>();
+    testParallelForNonZeroElementsInRow<DynamicMatrix>();
     testParallelForNonZeroElementsInRow<DenseMatrix>();
 }
 
 TEST_F(MatricesGTest, testForElementsInRowOrder) {
     testForElementsInRowOrder<DenseMatrix>();
+    testForElementsInRowOrder<DynamicMatrix>();
+    testForElementsInRowOrder<CSRMatrix>();
 }
 
 TEST_F(MatricesGTest, testParallelForElementsInRowOrder) {
     testParallelForElementsInRowOrder<DenseMatrix>();
+    testParallelForElementsInRowOrder<CSRMatrix>();
+    testParallelForElementsInRowOrder<DynamicMatrix>();
 }
 
 TEST_F(MatricesGTest, testForNonZeroElementsInRowOrder) {

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -5,6 +5,8 @@
  *      Author: Michael Wegner (michael.wegner@student.kit.edu)
  */
 
+#include <type_traits>
+
 #include <gtest/gtest.h>
 
 #include <networkit/algebraic/AlgebraicGlobals.hpp>
@@ -14,19 +16,21 @@
 #include <networkit/algebraic/MatrixTools.hpp>
 #include <networkit/algebraic/Vector.hpp>
 #include <networkit/auxiliary/Random.hpp>
+#include <networkit/graph/Graph.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 
 namespace NetworKit {
 
+namespace {
+
+template <class Type>
 class MatricesGTest : public testing::Test {
 protected:
-    virtual void SetUp() {
-        METISGraphReader reader;
-        graph = reader.read("input/PGPgiantcompo.graph");
-    }
+    using Matrix = Type;
 
-    template <class Matrix>
-    Matrix get4x4Matrix() const {
+    void SetUp() { graph = METISGraphReader{}.read("input/PGPgiantcompo.graph"); }
+
+    static Matrix get4x4Matrix() {
         std::vector<Triplet> triplets = {{0, 0, 1}, {0, 1, 2},  {0, 2, 3},  {1, 0, 2}, {1, 1, 2},
                                          {2, 0, 3}, {2, 3, -1}, {3, 2, -1}, {3, 3, 4}};
 
@@ -35,239 +39,31 @@ protected:
 
     Graph graph;
 
-public:
-    MatricesGTest() = default;
-    virtual ~MatricesGTest() = default;
-
-    template <class Matrix>
-    void testDimension();
-
-    template <class Matrix>
-    void testNNZInRow();
-
-    template <class Matrix>
-    void testRowAndColumnAccess();
-
-    template <class Matrix>
-    void testDiagonalVector();
-
-    template <class Matrix>
-    void testTranspose();
-
-    template <class Matrix>
-    void testExtract();
-
-    template <class Matrix>
-    void testAssign();
-
-    template <class Matrix>
-    void testApply();
-
-    template <class Matrix>
-    void testMatrixAddition();
-
-    template <class Matrix>
-    void testMatrixSubtraction();
-
-    template <class Matrix>
-    void testScalarMultiplication();
-
-    template <class Matrix>
-    void testMatrixDivisionOperator();
-
-    template <class Matrix>
-    void testMatrixVectorProduct();
-
-    template <class Matrix>
-    void testMatrixMultiplication();
-
-    template <class Matrix>
-    void testBigMatrixMultiplication();
-
-    template <class Matrix>
-    void testAdjacencyMatrix();
-
-    template <class Matrix>
-    void testDiagonalMatrix();
-
-    template <class Matrix>
-    void testIncidenceMatrix();
-
-    template <class Matrix>
-    void testLaplacianOfGraph();
-
-    template <class Matrix>
-    void testForElementsInRow();
-
-    template <class Matrix>
-    void testParallelForElementsInRow();
-
-    template <class Matrix>
-    void testForNonZeroElementsInRow();
-
-    template <class Matrix>
-    void testParallelForNonZeroElementsInRow();
-
-    template <class Matrix>
-    void testForElementsInRowOrder();
-
-    template <class Matrix>
-    void testParallelForElementsInRowOrder();
-
-    template <class Matrix>
-    void testForNonZeroElementsInRowOrder();
-
-    template <class Matrix>
-    void testParallelForNonZeroElementsInRowOrder();
-
-    template <class Matrix>
-    void testMatrixToGraph();
-
     // TODO: Test other matrix classes
 
     // TODO: Test mmT multiplication, etc.!
 };
 
-template <class Matrix>
-void MatricesGTest::testMatrixToGraph() {
+using Matrices = testing::Types<DynamicMatrix, CSRMatrix, DenseMatrix>;
+TYPED_TEST_SUITE(MatricesGTest, Matrices, /*Comma needed for variadic macro.*/);
 
-    Matrix mat = Matrix::adjacencyMatrix(METISGraphReader{}.read("input/power.graph"));
-    Graph G = MatrixTools::matrixToGraph(mat);
-
-    EXPECT_EQ(G.numberOfNodes(), 4941);
-    EXPECT_EQ(G.numberOfEdges(), 6594);
-}
-
-template <class Matrix>
-void MatricesGTest::testDimension() {
+TYPED_TEST(MatricesGTest, testDimension) {
+    using Matrix = typename TestFixture::Matrix;
     Matrix mat(10);
 
-    ASSERT_EQ(10u, mat.numberOfRows());
-    ASSERT_EQ(10u, mat.numberOfColumns());
+    EXPECT_EQ(mat.numberOfRows(), 10);
+    EXPECT_EQ(mat.numberOfColumns(), 10);
 
     mat = Matrix(5, 10, 0.0);
-    ASSERT_EQ(5u, mat.numberOfRows());
-    ASSERT_EQ(10u, mat.numberOfColumns());
+    EXPECT_EQ(mat.numberOfRows(), 5);
+    EXPECT_EQ(mat.numberOfColumns(), 10);
 
     mat = Matrix(10, 5, 0.0);
-    ASSERT_EQ(10u, mat.numberOfRows());
-    ASSERT_EQ(5u, mat.numberOfColumns());
+    EXPECT_EQ(mat.numberOfRows(), 10);
+    EXPECT_EQ(mat.numberOfColumns(), 5);
 }
 
-template <class Matrix>
-void MatricesGTest::testForElementsInRow() {
-    auto mat = get4x4Matrix<Matrix>();
-    count nnz = 0;
-
-    for (index row = 0; row < 4; ++row)
-        mat.forElementsInRow(row, [&](index col, double value) {
-            ASSERT_EQ(mat(row, col), value);
-            if (value != mat.getZero())
-                ++nnz;
-        });
-
-    ASSERT_EQ(nnz, mat.nnz());
-}
-
-template <class Matrix>
-void MatricesGTest::testParallelForElementsInRow() {
-    auto mat = get4x4Matrix<Matrix>();
-    std::atomic<count> nnz{0};
-
-    for (index row = 0; row < 4; ++row)
-        mat.parallelForElementsInRow(row, [&](index col, double value) {
-            ASSERT_EQ(mat(row, col), value);
-            if (value != mat.getZero())
-                nnz.fetch_add(1, std::memory_order_relaxed);
-        });
-
-    ASSERT_EQ(mat.nnz(), nnz.load(std::memory_order_relaxed));
-}
-
-template <class Matrix>
-void MatricesGTest::testForNonZeroElementsInRow() {
-    auto mat = get4x4Matrix<Matrix>();
-    count nnz = 0;
-
-    for (index row = 0; row < 4; ++row)
-        mat.forNonZeroElementsInRow(row, [&](index col, double value) {
-            ASSERT_EQ(mat(row, col), value);
-            ++nnz;
-        });
-
-    ASSERT_EQ(nnz, mat.nnz());
-}
-
-template <class Matrix>
-void MatricesGTest::testParallelForNonZeroElementsInRow() {
-    auto mat = get4x4Matrix<Matrix>();
-    std::atomic<count> nnz{0};
-
-    for (index row = 0; row < 4; ++row)
-        mat.parallelForNonZeroElementsInRow(row, [&](index col, double value) {
-            ASSERT_EQ(mat(row, col), value);
-            nnz.fetch_add(1, std::memory_order_relaxed);
-        });
-
-    ASSERT_EQ(nnz.load(std::memory_order_relaxed), mat.nnz());
-}
-
-template <class Matrix>
-void MatricesGTest::testForElementsInRowOrder() {
-    auto mat = get4x4Matrix<Matrix>();
-    count nnz = 0;
-
-    mat.forElementsInRowOrder([&](index row, index col, double value) {
-        ASSERT_EQ(mat(row, col), value);
-        if (value != mat.getZero())
-            ++nnz;
-    });
-
-    ASSERT_EQ(nnz, mat.nnz());
-}
-
-template <class Matrix>
-void MatricesGTest::testParallelForElementsInRowOrder() {
-    auto mat = get4x4Matrix<Matrix>();
-    std::atomic<count> nnz{0};
-
-    mat.parallelForElementsInRowOrder([&](index row, index col, double value) {
-        ASSERT_EQ(mat(row, col), value);
-        if (value != mat.getZero())
-            nnz.fetch_add(1, std::memory_order_relaxed);
-    });
-
-    ASSERT_EQ(nnz.load(std::memory_order_relaxed), mat.nnz());
-}
-
-template <class Matrix>
-void MatricesGTest::testForNonZeroElementsInRowOrder() {
-    auto mat = get4x4Matrix<Matrix>();
-    count nnz = 0;
-
-    mat.forNonZeroElementsInRowOrder([&](index row, index col, double value) {
-        ASSERT_EQ(mat(row, col), value);
-        ++nnz;
-    });
-
-    ASSERT_EQ(nnz, mat.nnz());
-}
-
-template <class Matrix>
-void MatricesGTest::testParallelForNonZeroElementsInRowOrder() {
-    auto mat = get4x4Matrix<Matrix>();
-    std::atomic<count> nnz{0};
-
-    mat.parallelForNonZeroElementsInRowOrder([&](index row, index col, double value) {
-        ASSERT_EQ(mat(row, col), value);
-        nnz.fetch_add(1, std::memory_order_relaxed);
-    });
-
-    ASSERT_EQ(nnz.load(std::memory_order_relaxed), mat.nnz());
-}
-
-template <class Matrix>
-void MatricesGTest::testNNZInRow() {
+TYPED_TEST(MatricesGTest, testNNZInRow) {
     /*
      * 1.0  0.0  2.0
      * 4.0  0.0  0.0
@@ -276,43 +72,45 @@ void MatricesGTest::testNNZInRow() {
      */
     std::vector<Triplet> triplets = {{0, 0, 1.0}, {0, 2, 2.0}, {1, 0, 4.0}, {3, 3, 2.0}};
 
-    Matrix mat(4, triplets);
-    EXPECT_EQ(2u, mat.nnzInRow(0));
-    EXPECT_EQ(1u, mat.nnzInRow(1));
-    EXPECT_EQ(0u, mat.nnzInRow(2));
-    EXPECT_EQ(1u, mat.nnzInRow(3));
+    typename TestFixture::Matrix mat(4, triplets);
+    EXPECT_EQ(mat.nnzInRow(0), 2);
+    EXPECT_EQ(mat.nnzInRow(1), 1);
+    EXPECT_EQ(mat.nnzInRow(2), 0);
+    EXPECT_EQ(mat.nnzInRow(3), 1);
 }
 
-template <class Matrix>
-void MatricesGTest::testRowAndColumnAccess() {
+TYPED_TEST(MatricesGTest, testRowAndColumnAccess) {
+    const count num_triplets = 1000;
     std::vector<Triplet> triplets;
+    triplets.reserve(num_triplets);
 
-    for (index i = 0; i < 1000; ++i) {
+    for (index i = 0; i < num_triplets; ++i) {
         triplets.push_back({3, i, (double)i});
     }
 
     triplets.push_back({10, 10, 42.123});
 
-    Matrix mat(1000, triplets);
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat(num_triplets, triplets);
 
     Vector v = mat.row(3);
     ASSERT_EQ(mat.numberOfColumns(), v.getDimension());
 
-    for (index i = 0; i < 1000; ++i) {
+    for (index i = 0; i < num_triplets; ++i) {
         EXPECT_EQ(i, v[i]);
     }
 
     v = mat.row(10);
     ASSERT_EQ(v.getDimension(), mat.numberOfColumns());
     ASSERT_TRUE(v.isTransposed());
-    EXPECT_EQ(42.123, v[10]);
+    EXPECT_EQ(v[10], 42.123);
 
     v = mat.column(10);
     ASSERT_EQ(mat.numberOfRows(), v.getDimension());
     ASSERT_FALSE(v.isTransposed());
 
-    EXPECT_EQ(10.0, v[3]);
-    EXPECT_EQ(42.123, v[10]);
+    EXPECT_EQ(v[3], 10.0);
+    EXPECT_EQ(v[10], 42.123);
 
     // rectangular matrix
     // n x m (n < m)
@@ -322,17 +120,17 @@ void MatricesGTest::testRowAndColumnAccess() {
 
     mat = Matrix(5, 10, triplets);
     v = mat.row(0);
-    ASSERT_EQ(v.getDimension(), 10u);
+    ASSERT_EQ(v.getDimension(), 10);
     for (index i = 0; i < v.getDimension(); ++i) {
         if (i == 0) {
-            EXPECT_EQ(42, v[i]);
+            EXPECT_EQ(v[i], 42);
         } else {
-            EXPECT_EQ(0, v[i]);
+            EXPECT_EQ(v[i], 0);
         }
     }
 
     v = mat.column(9);
-    ASSERT_EQ(v.getDimension(), 5u);
+    ASSERT_EQ(v.getDimension(), 5);
     for (index i = 0; i < v.getDimension(); ++i) {
         if (i == v.getDimension() - 1) {
             EXPECT_EQ(11, v[i]);
@@ -350,28 +148,27 @@ void MatricesGTest::testRowAndColumnAccess() {
 
     mat = Matrix(10, 5, triplets);
     v = mat.row(0);
-    ASSERT_EQ(v.getDimension(), 5u);
+    ASSERT_EQ(v.getDimension(), 5);
     for (index i = 0; i < v.getDimension(); ++i) {
         if (i == 0) {
-            EXPECT_EQ(42, v[i]);
+            EXPECT_EQ(v[i], 42);
         } else {
-            EXPECT_EQ(0, v[i]);
+            EXPECT_EQ(v[i], 0);
         }
     }
 
     v = mat.column(4);
-    ASSERT_EQ(v.getDimension(), 10u);
+    ASSERT_EQ(v.getDimension(), 10);
     for (index i = 0; i < v.getDimension(); ++i) {
         if (i == v.getDimension() - 1) {
-            EXPECT_EQ(11, v[i]);
+            EXPECT_EQ(v[i], 11);
         } else {
-            EXPECT_EQ(0, v[i]);
+            EXPECT_EQ(v[i], 0);
         }
     }
 }
 
-template <class Matrix>
-void MatricesGTest::testDiagonalVector() {
+TYPED_TEST(MatricesGTest, testDiagonalVector) {
     // 1  2  3  0
     // 2  2  0  0
     // 3  0  0 -1
@@ -379,13 +176,15 @@ void MatricesGTest::testDiagonalVector() {
     std::vector<Triplet> triplets = {{0, 0, 1}, {0, 1, 2},  {0, 2, 3},  {1, 0, 2}, {1, 1, 2},
                                      {2, 0, 3}, {2, 3, -1}, {3, 2, -1}, {3, 3, 4}};
 
+    using Matrix = typename TestFixture::Matrix;
+
     Matrix mat(4, 4, triplets);
     Vector diagonal = mat.diagonal();
-    EXPECT_EQ(4u, diagonal.getDimension());
-    EXPECT_EQ(1, diagonal[0]);
-    EXPECT_EQ(2, diagonal[1]);
-    EXPECT_EQ(0, diagonal[2]);
-    EXPECT_EQ(4, diagonal[3]);
+    EXPECT_EQ(diagonal.getDimension(), 4);
+    EXPECT_EQ(diagonal[0], 1);
+    EXPECT_EQ(diagonal[1], 2);
+    EXPECT_EQ(diagonal[2], 0);
+    EXPECT_EQ(diagonal[3], 4);
 
     // rectangular matrix
     //
@@ -394,9 +193,9 @@ void MatricesGTest::testDiagonalVector() {
     triplets = {{0, 0, 1}, {1, 2, 3}};
     mat = Matrix(2, 5, triplets);
     diagonal = mat.diagonal();
-    EXPECT_EQ(2u, diagonal.getDimension());
-    EXPECT_EQ(1, diagonal[0]);
-    EXPECT_EQ(0, diagonal[1]);
+    EXPECT_EQ(diagonal.getDimension(), 2);
+    EXPECT_EQ(diagonal[0], 1);
+    EXPECT_EQ(diagonal[1], 0);
 
     // rectangular matrix
     //
@@ -408,13 +207,12 @@ void MatricesGTest::testDiagonalVector() {
     triplets = {{0, 0, 1.0}, {1, 1, -3.0}};
     mat = Matrix(5, 2, triplets);
     diagonal = mat.diagonal();
-    EXPECT_EQ(2u, diagonal.getDimension());
-    EXPECT_EQ(1, diagonal[0]);
-    EXPECT_EQ(-3, diagonal[1]);
+    EXPECT_EQ(diagonal.getDimension(), 2);
+    EXPECT_EQ(diagonal[0], 1);
+    EXPECT_EQ(diagonal[1], -3);
 }
 
-template <class Matrix>
-void MatricesGTest::testTranspose() {
+TYPED_TEST(MatricesGTest, testTranspose) {
     // 1  0  1  0
     // 2  2  0  0
     // 3  0  0 -1
@@ -422,27 +220,28 @@ void MatricesGTest::testTranspose() {
     std::vector<Triplet> triplets = {{0, 0, 1}, {0, 2, 1},  {1, 0, 2}, {1, 1, 2},
                                      {2, 0, 3}, {2, 3, -1}, {3, 2, 1}, {3, 3, 4}};
 
+    using Matrix = typename TestFixture::Matrix;
     Matrix mat(4, 4, triplets);
     Matrix matT = mat.transpose();
-    EXPECT_EQ(4u, matT.numberOfRows());
-    EXPECT_EQ(4u, matT.numberOfColumns());
+    EXPECT_EQ(matT.numberOfRows(), 4);
+    EXPECT_EQ(matT.numberOfColumns(), 4);
 
-    EXPECT_EQ(1, matT(0, 0));
-    EXPECT_EQ(2, matT(0, 1));
-    EXPECT_EQ(3, matT(0, 2));
-    EXPECT_EQ(0, matT(0, 3));
-    EXPECT_EQ(0, matT(1, 0));
-    EXPECT_EQ(2, matT(1, 1));
-    EXPECT_EQ(0, matT(1, 2));
-    EXPECT_EQ(0, matT(1, 3));
-    EXPECT_EQ(1, matT(2, 0));
-    EXPECT_EQ(0, matT(2, 1));
-    EXPECT_EQ(0, matT(2, 2));
-    EXPECT_EQ(1, matT(2, 3));
-    EXPECT_EQ(0, matT(3, 0));
-    EXPECT_EQ(0, matT(3, 1));
-    EXPECT_EQ(-1, matT(3, 2));
-    EXPECT_EQ(4, matT(3, 3));
+    EXPECT_EQ(matT(0, 0), 1);
+    EXPECT_EQ(matT(0, 1), 2);
+    EXPECT_EQ(matT(0, 2), 3);
+    EXPECT_EQ(matT(0, 3), 0);
+    EXPECT_EQ(matT(1, 0), 0);
+    EXPECT_EQ(matT(1, 1), 2);
+    EXPECT_EQ(matT(1, 2), 0);
+    EXPECT_EQ(matT(1, 3), 0);
+    EXPECT_EQ(matT(2, 0), 1);
+    EXPECT_EQ(matT(2, 1), 0);
+    EXPECT_EQ(matT(2, 2), 0);
+    EXPECT_EQ(matT(2, 3), 1);
+    EXPECT_EQ(matT(3, 0), 0);
+    EXPECT_EQ(matT(3, 1), 0);
+    EXPECT_EQ(matT(3, 2), -1);
+    EXPECT_EQ(matT(3, 3), 4);
 
     // rectangular matrix
     //
@@ -451,19 +250,19 @@ void MatricesGTest::testTranspose() {
     triplets = {{0, 0, 1}, {1, 2, 3}};
     mat = Matrix(2, 5, triplets);
     matT = mat.transpose();
-    EXPECT_EQ(5u, matT.numberOfRows());
-    EXPECT_EQ(2u, matT.numberOfColumns());
+    EXPECT_EQ(matT.numberOfRows(), 5);
+    EXPECT_EQ(matT.numberOfColumns(), 2);
 
-    EXPECT_EQ(1, matT(0, 0));
-    EXPECT_EQ(0, matT(0, 1));
-    EXPECT_EQ(0, matT(1, 0));
-    EXPECT_EQ(0, matT(1, 1));
-    EXPECT_EQ(0, matT(2, 0));
-    EXPECT_EQ(3, matT(2, 1));
-    EXPECT_EQ(0, matT(3, 0));
-    EXPECT_EQ(0, matT(3, 1));
-    EXPECT_EQ(0, matT(4, 0));
-    EXPECT_EQ(0, matT(4, 1));
+    EXPECT_EQ(matT(0, 0), 1);
+    EXPECT_EQ(matT(0, 1), 0);
+    EXPECT_EQ(matT(1, 0), 0);
+    EXPECT_EQ(matT(1, 1), 0);
+    EXPECT_EQ(matT(2, 0), 0);
+    EXPECT_EQ(matT(2, 1), 3);
+    EXPECT_EQ(matT(3, 0), 0);
+    EXPECT_EQ(matT(3, 1), 0);
+    EXPECT_EQ(matT(4, 0), 0);
+    EXPECT_EQ(matT(4, 1), 0);
 
     // rectangular matrix
     //
@@ -475,30 +274,31 @@ void MatricesGTest::testTranspose() {
     triplets = {{0, 0, 1.0}, {2, 1, 3.0}};
     mat = Matrix(5, 2, triplets);
     matT = mat.transpose();
-    EXPECT_EQ(2u, matT.numberOfRows());
-    EXPECT_EQ(5u, matT.numberOfColumns());
+    EXPECT_EQ(matT.numberOfRows(), 2);
+    EXPECT_EQ(matT.numberOfColumns(), 5);
 
-    EXPECT_EQ(1, matT(0, 0));
-    EXPECT_EQ(0, matT(0, 1));
-    EXPECT_EQ(0, matT(0, 2));
-    EXPECT_EQ(0, matT(0, 3));
-    EXPECT_EQ(0, matT(0, 4));
-    EXPECT_EQ(0, matT(1, 0));
-    EXPECT_EQ(0, matT(1, 1));
-    EXPECT_EQ(3, matT(1, 2));
-    EXPECT_EQ(0, matT(1, 3));
-    EXPECT_EQ(0, matT(1, 4));
+    EXPECT_EQ(matT(0, 0), 1);
+    EXPECT_EQ(matT(0, 1), 0);
+    EXPECT_EQ(matT(0, 2), 0);
+    EXPECT_EQ(matT(0, 3), 0);
+    EXPECT_EQ(matT(0, 4), 0);
+    EXPECT_EQ(matT(1, 0), 0);
+    EXPECT_EQ(matT(1, 1), 0);
+    EXPECT_EQ(matT(1, 2), 3);
+    EXPECT_EQ(matT(1, 3), 0);
+    EXPECT_EQ(matT(1, 4), 0);
 }
 
-template <class Matrix>
-void MatricesGTest::testExtract() {
-    Matrix mat = Matrix::adjacencyMatrix(graph);
-    std::vector<index> rows(500);
-    std::vector<index> columns(500);
+TYPED_TEST(MatricesGTest, testExtract) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = Matrix::adjacencyMatrix(this->graph);
+    const index n = 500;
+    std::vector<index> rows(n);
+    std::vector<index> columns(n);
 
-    for (index i = 0; i < 500; ++i) {
-        rows[i] = Aux::Random::integer(graph.numberOfNodes() - 1);
-        columns[i] = Aux::Random::integer(graph.numberOfNodes() - 1);
+    for (index i = 0; i < n; ++i) {
+        rows[i] = Aux::Random::integer(this->graph.numberOfNodes() - 1);
+        columns[i] = Aux::Random::integer(this->graph.numberOfNodes() - 1);
     }
 
     Matrix subMatrix = mat.extract(rows, columns);
@@ -528,25 +328,24 @@ void MatricesGTest::testExtract() {
     // 0 1 1 0
     //
     subMatrix = mat.extract(rows, columns);
-    ASSERT_EQ(3u, subMatrix.numberOfRows());
-    ASSERT_EQ(4u, subMatrix.numberOfColumns());
+    ASSERT_EQ(subMatrix.numberOfRows(), 3);
+    ASSERT_EQ(subMatrix.numberOfColumns(), 4);
 
-    EXPECT_EQ(0, subMatrix(0, 0));
-    EXPECT_EQ(1, subMatrix(0, 1));
-    EXPECT_EQ(1, subMatrix(0, 2));
-    EXPECT_EQ(0, subMatrix(0, 3));
-    EXPECT_EQ(0, subMatrix(1, 0));
-    EXPECT_EQ(3, subMatrix(1, 1));
-    EXPECT_EQ(0, subMatrix(1, 2));
-    EXPECT_EQ(0, subMatrix(1, 3));
-    EXPECT_EQ(0, subMatrix(2, 0));
-    EXPECT_EQ(1, subMatrix(2, 1));
-    EXPECT_EQ(1, subMatrix(2, 2));
-    EXPECT_EQ(0, subMatrix(2, 3));
+    EXPECT_EQ(subMatrix(0, 0), 0);
+    EXPECT_EQ(subMatrix(0, 1), 1);
+    EXPECT_EQ(subMatrix(0, 2), 1);
+    EXPECT_EQ(subMatrix(0, 3), 0);
+    EXPECT_EQ(subMatrix(1, 0), 0);
+    EXPECT_EQ(subMatrix(1, 1), 3);
+    EXPECT_EQ(subMatrix(1, 2), 0);
+    EXPECT_EQ(subMatrix(1, 3), 0);
+    EXPECT_EQ(subMatrix(2, 0), 0);
+    EXPECT_EQ(subMatrix(2, 1), 1);
+    EXPECT_EQ(subMatrix(2, 2), 1);
+    EXPECT_EQ(subMatrix(2, 3), 0);
 }
 
-template <class Matrix>
-void MatricesGTest::testAssign() {
+TYPED_TEST(MatricesGTest, testAssign) {
     // 1  0  1  0
     // 2  2  0  0
     // 3  0  0 -1
@@ -554,6 +353,7 @@ void MatricesGTest::testAssign() {
     std::vector<Triplet> triplets = {{0, 0, 1}, {0, 2, 1},  {1, 0, 2}, {1, 1, 2},
                                      {2, 0, 3}, {2, 3, -1}, {3, 2, 1}, {3, 3, 4}};
 
+    using Matrix = typename TestFixture::Matrix;
     Matrix mat(4, 4, triplets);
 
     // -1 1
@@ -565,82 +365,83 @@ void MatricesGTest::testAssign() {
     std::vector<index> columns = {0, 2};
     mat.assign(rows, columns, sourceMat);
 
-    EXPECT_EQ(1, mat(0, 0));
-    EXPECT_EQ(0, mat(0, 1));
-    EXPECT_EQ(1, mat(0, 2));
-    EXPECT_EQ(0, mat(0, 3));
-    EXPECT_EQ(2, mat(1, 0));
-    EXPECT_EQ(2, mat(1, 1));
-    EXPECT_EQ(0, mat(1, 2));
-    EXPECT_EQ(0, mat(1, 3));
-    EXPECT_EQ(-1, mat(2, 0));
-    EXPECT_EQ(0, mat(2, 1));
-    EXPECT_EQ(1, mat(2, 2));
-    EXPECT_EQ(-1, mat(2, 3));
-    EXPECT_EQ(3, mat(3, 0));
-    EXPECT_EQ(0, mat(3, 1));
-    EXPECT_EQ(0, mat(3, 2));
-    EXPECT_EQ(4, mat(3, 3));
+    EXPECT_EQ(mat(0, 0), 1);
+    EXPECT_EQ(mat(0, 1), 0);
+    EXPECT_EQ(mat(0, 2), 1);
+    EXPECT_EQ(mat(0, 3), 0);
+    EXPECT_EQ(mat(1, 0), 2);
+    EXPECT_EQ(mat(1, 1), 2);
+    EXPECT_EQ(mat(1, 2), 0);
+    EXPECT_EQ(mat(1, 3), 0);
+    EXPECT_EQ(mat(2, 0), -1);
+    EXPECT_EQ(mat(2, 1), 0);
+    EXPECT_EQ(mat(2, 2), 1);
+    EXPECT_EQ(mat(2, 3), -1);
+    EXPECT_EQ(mat(3, 0), 3);
+    EXPECT_EQ(mat(3, 1), 0);
+    EXPECT_EQ(mat(3, 2), 0);
+    EXPECT_EQ(mat(3, 3), 4);
 
     rows = {2, 3};
     columns = {2, 3};
     mat.assign(rows, columns, sourceMat);
 
-    EXPECT_EQ(1, mat(0, 0));
-    EXPECT_EQ(0, mat(0, 1));
-    EXPECT_EQ(1, mat(0, 2));
-    EXPECT_EQ(0, mat(0, 3));
-    EXPECT_EQ(2, mat(1, 0));
-    EXPECT_EQ(2, mat(1, 1));
-    EXPECT_EQ(0, mat(1, 2));
-    EXPECT_EQ(0, mat(1, 3));
-    EXPECT_EQ(-1, mat(2, 0));
-    EXPECT_EQ(0, mat(2, 1));
-    EXPECT_EQ(-1, mat(2, 2));
-    EXPECT_EQ(1, mat(2, 3));
-    EXPECT_EQ(3, mat(3, 0));
-    EXPECT_EQ(0, mat(3, 1));
-    EXPECT_EQ(3, mat(3, 2));
-    EXPECT_EQ(0, mat(3, 3));
+    EXPECT_EQ(mat(0, 0), 1);
+    EXPECT_EQ(mat(0, 1), 0);
+    EXPECT_EQ(mat(0, 2), 1);
+    EXPECT_EQ(mat(0, 3), 0);
+    EXPECT_EQ(mat(1, 0), 2);
+    EXPECT_EQ(mat(1, 1), 2);
+    EXPECT_EQ(mat(1, 2), 0);
+    EXPECT_EQ(mat(1, 3), 0);
+    EXPECT_EQ(mat(2, 0), -1);
+    EXPECT_EQ(mat(2, 1), 0);
+    EXPECT_EQ(mat(2, 2), -1);
+    EXPECT_EQ(mat(2, 3), 1);
+    EXPECT_EQ(mat(3, 0), 3);
+    EXPECT_EQ(mat(3, 1), 0);
+    EXPECT_EQ(mat(3, 2), 3);
+    EXPECT_EQ(mat(3, 3), 0);
 }
 
-template <class Matrix>
-void MatricesGTest::testApply() {
-    Matrix mat = Matrix::adjacencyMatrix(graph);
+TYPED_TEST(MatricesGTest, testApply) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = Matrix::adjacencyMatrix(this->graph);
 
     mat.apply([&](double value) { return 2 * value; });
-    graph.forEdges([&](index i, index j, double value) { EXPECT_EQ(2 * value, mat(i, j)); });
+    this->graph.forEdges([&](index i, index j, double value) { EXPECT_EQ(2 * value, mat(i, j)); });
 }
 
-template <class Matrix>
-void MatricesGTest::testMatrixAddition() {
-    std::vector<Triplet> triplets1;
-    std::vector<Triplet> triplets2;
+TYPED_TEST(MatricesGTest, testMatrixAddition) {
+    const int num_triplets = 100;
+    std::vector<Triplet> triplets1(num_triplets);
+    std::vector<Triplet> triplets2(num_triplets);
 
-    for (index i = 0; i < 100; ++i) {
-        triplets1.push_back({i, i, 1});
-        triplets2.push_back({i, i, (double)i});
+    for (index i = 0; i < num_triplets; ++i) {
+        triplets1[i] = {i, i, 1};
+        triplets2[i] = {i, i, (double)i};
     }
 
     triplets1.push_back({2, 71, 1.8});
     triplets2.push_back({42, 43, 3.14});
 
-    Matrix mat1(100, triplets1);
-    Matrix mat2(100, triplets2);
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat1(num_triplets, triplets1);
+    Matrix mat2(num_triplets, triplets2);
 
     Matrix result = mat1 + mat2;
     ASSERT_EQ(mat1.numberOfRows(), result.numberOfRows());
     ASSERT_EQ(mat1.numberOfColumns(), result.numberOfColumns());
 
-    EXPECT_EQ(0.0, result(10, 13));
+    EXPECT_EQ(result(10, 13), 0.0);
 
     for (index i = 0; i < result.numberOfRows(); ++i) {
         EXPECT_EQ((i + 1), result(i, i));
     }
-    EXPECT_EQ(1.8, result(2, 71));
-    EXPECT_EQ(3.14, result(42, 43));
+    EXPECT_EQ(result(2, 71), 1.8);
+    EXPECT_EQ(result(42, 43), 3.14);
 
-    EXPECT_EQ(0.0, result(3, 14));
+    EXPECT_EQ(result(3, 14), 0.0);
 
     // rectangular matrix
     // n x m (n < m)
@@ -660,15 +461,15 @@ void MatricesGTest::testMatrixAddition() {
 
     result = mat1 + mat2;
 
-    ASSERT_EQ(2u, result.numberOfRows());
-    ASSERT_EQ(5u, result.numberOfColumns());
+    ASSERT_EQ(result.numberOfRows(), 2);
+    ASSERT_EQ(result.numberOfColumns(), 5);
 
-    EXPECT_EQ(1, result(0, 0));
-    EXPECT_EQ(1, result(0, 2));
-    EXPECT_EQ(4, result(1, 2));
+    EXPECT_EQ(result(0, 0), 1);
+    EXPECT_EQ(result(0, 2), 1);
+    EXPECT_EQ(result(1, 2), 4);
 
-    EXPECT_EQ(0, result(0, 1));
-    EXPECT_EQ(0, result(1, 4));
+    EXPECT_EQ(result(0, 1), 0);
+    EXPECT_EQ(result(1, 4), 0);
 
     // rectangular matrix
     // n x m (n > m)
@@ -696,46 +497,47 @@ void MatricesGTest::testMatrixAddition() {
 
     result = mat1 + mat2;
 
-    ASSERT_EQ(5u, result.numberOfRows());
-    ASSERT_EQ(2u, result.numberOfColumns());
+    ASSERT_EQ(result.numberOfRows(), 5);
+    ASSERT_EQ(result.numberOfColumns(), 2);
 
-    EXPECT_EQ(1, result(0, 0));
-    EXPECT_EQ(1, result(2, 0));
-    EXPECT_EQ(4, result(2, 1));
+    EXPECT_EQ(result(0, 0), 1);
+    EXPECT_EQ(result(2, 0), 1);
+    EXPECT_EQ(result(2, 1), 4);
 
-    EXPECT_EQ(0, result(0, 1));
-    EXPECT_EQ(0, result(4, 1));
+    EXPECT_EQ(result(0, 1), 0);
+    EXPECT_EQ(result(4, 1), 0);
 }
 
-template <class Matrix>
-void MatricesGTest::testMatrixSubtraction() {
-    std::vector<Triplet> triplets1;
-    std::vector<Triplet> triplets2;
+TYPED_TEST(MatricesGTest, testMatrixSubtraction) {
+    const int num_triplets = 100;
+    std::vector<Triplet> triplets1(num_triplets);
+    std::vector<Triplet> triplets2(num_triplets);
 
-    for (index i = 0; i < 100; ++i) {
-        triplets1.push_back({i, i, 1});
-        triplets2.push_back({i, i, (double)i});
+    for (index i = 0; i < num_triplets; ++i) {
+        triplets1[i] = {i, i, 1};
+        triplets2[i] = {i, i, (double)i};
     }
 
     triplets1.push_back({2, 71, 1.8});
     triplets2.push_back({42, 43, 3.14});
 
-    Matrix mat1(100, triplets1);
-    Matrix mat2(100, triplets2);
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat1(num_triplets, triplets1);
+    Matrix mat2(num_triplets, triplets2);
 
     Matrix result = mat2 - mat1;
     ASSERT_EQ(mat1.numberOfRows(), result.numberOfRows());
     ASSERT_EQ(mat1.numberOfColumns(), result.numberOfColumns());
 
-    EXPECT_EQ(0.0, result(10, 13));
+    EXPECT_EQ(result(10, 13), 0.0);
 
     for (index i = 0; i < result.numberOfRows(); ++i) {
         EXPECT_EQ(((int)i - 1), result(i, i));
     }
-    EXPECT_EQ(-1.8, result(2, 71));
-    EXPECT_EQ(3.14, result(42, 43));
+    EXPECT_EQ(result(2, 71), -1.8);
+    EXPECT_EQ(result(42, 43), 3.14);
 
-    EXPECT_EQ(0.0, result(3, 14));
+    EXPECT_EQ(result(3, 14), 0.0);
 
     // rectangular matrix
     // n x m (n < m)
@@ -755,15 +557,15 @@ void MatricesGTest::testMatrixSubtraction() {
 
     result = mat1 - mat2;
 
-    ASSERT_EQ(2u, result.numberOfRows());
-    ASSERT_EQ(5u, result.numberOfColumns());
+    ASSERT_EQ(result.numberOfRows(), 2);
+    ASSERT_EQ(result.numberOfColumns(), 5);
 
-    EXPECT_EQ(1, result(0, 0));
-    EXPECT_EQ(-1, result(0, 2));
-    EXPECT_EQ(2, result(1, 2));
+    EXPECT_EQ(result(0, 0), 1);
+    EXPECT_EQ(result(0, 2), -1);
+    EXPECT_EQ(result(1, 2), 2);
 
-    EXPECT_EQ(0, result(0, 1));
-    EXPECT_EQ(0, result(1, 4));
+    EXPECT_EQ(result(0, 1), 0);
+    EXPECT_EQ(result(1, 4), 0);
 
     // rectangular matrix
     // n x m (n > m)
@@ -794,42 +596,43 @@ void MatricesGTest::testMatrixSubtraction() {
     ASSERT_EQ(5u, result.numberOfRows());
     ASSERT_EQ(2u, result.numberOfColumns());
 
-    EXPECT_EQ(1, result(0, 0));
-    EXPECT_EQ(-1, result(2, 0));
-    EXPECT_EQ(2, result(2, 1));
+    EXPECT_EQ(result(0, 0), 1);
+    EXPECT_EQ(result(2, 0), -1);
+    EXPECT_EQ(result(2, 1), 2);
 
-    EXPECT_EQ(0, result(0, 1));
-    EXPECT_EQ(0, result(4, 1));
+    EXPECT_EQ(result(0, 1), 0);
+    EXPECT_EQ(result(4, 1), 0);
 }
 
-template <class Matrix>
-void MatricesGTest::testScalarMultiplication() {
-    std::vector<Triplet> triplets;
+TYPED_TEST(MatricesGTest, testScalarMultiplication) {
+    const int num_triplets = 100;
+    std::vector<Triplet> triplets(num_triplets);
 
-    for (index i = 0; i < 100; ++i) {
-        triplets.push_back({i, i, (double)i});
+    for (index i = 0; i < num_triplets; ++i) {
+        triplets[i] = {i, i, (double)i};
     }
 
     triplets.push_back({42, 43, 42.0});
 
-    Matrix mat(100, triplets);
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat(num_triplets, triplets);
     mat *= 2;
-    ASSERT_EQ(100u, mat.numberOfRows());
-    ASSERT_EQ(100u, mat.numberOfColumns());
+    ASSERT_EQ(mat.numberOfRows(), 100);
+    ASSERT_EQ(mat.numberOfColumns(), 100);
 
-    for (index i = 0; i < 100; ++i) {
+    for (index i = 0; i < num_triplets; ++i) {
         EXPECT_EQ(i * 2, mat(i, i));
     }
-    EXPECT_EQ(84.0, mat(42, 43));
-    EXPECT_EQ(0.0, mat(55, 99));
+    EXPECT_EQ(mat(42, 43), 84.0);
+    EXPECT_EQ(mat(55, 99), 0.0);
 
     mat *= 0.5;
 
-    for (index i = 0; i < 100; ++i) {
+    for (index i = 0; i < num_triplets; ++i) {
         EXPECT_EQ(i, mat(i, i));
     }
-    EXPECT_EQ(42.0, mat(42, 43));
-    EXPECT_EQ(0.0, mat(55, 99));
+    EXPECT_EQ(mat(42, 43), 42.0);
+    EXPECT_EQ(mat(55, 99), 0.0);
 
     // rectangular matrix
     //
@@ -840,38 +643,39 @@ void MatricesGTest::testScalarMultiplication() {
 
     mat *= 2;
 
-    EXPECT_EQ(2, mat(0, 0));
-    EXPECT_EQ(6, mat(1, 2));
+    EXPECT_EQ(mat(0, 0), 2);
+    EXPECT_EQ(mat(1, 2), 6);
 }
 
-template <class Matrix>
-void MatricesGTest::testMatrixDivisionOperator() {
-    std::vector<Triplet> triplets;
+TYPED_TEST(MatricesGTest, testMatrixDivisionOperator) {
+    const int num_triplets = 100;
+    std::vector<Triplet> triplets(num_triplets);
 
-    for (index i = 0; i < 100; ++i) {
-        triplets.push_back({i, i, (double)i});
+    for (index i = 0; i < num_triplets; ++i) {
+        triplets[i] = {i, i, (double)i};
     }
 
     triplets.push_back({42, 43, 42.0});
 
-    Matrix mat(100, triplets);
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat(num_triplets, triplets);
     mat /= (1.0 / 2.0);
-    ASSERT_EQ(100u, mat.numberOfRows());
-    ASSERT_EQ(100u, mat.numberOfColumns());
+    ASSERT_EQ(mat.numberOfRows(), 100);
+    ASSERT_EQ(mat.numberOfColumns(), 100);
 
-    for (index i = 0; i < 100; ++i) {
+    for (index i = 0; i < num_triplets; ++i) {
         EXPECT_EQ(i * 2, mat(i, i));
     }
-    EXPECT_EQ(84.0, mat(42, 43));
-    EXPECT_EQ(0.0, mat(55, 99));
+    EXPECT_EQ(mat(42, 43), 84.0);
+    EXPECT_EQ(mat(55, 99), 0.0);
 
     mat /= 2;
 
-    for (index i = 0; i < 100; ++i) {
+    for (index i = 0; i < num_triplets; ++i) {
         EXPECT_EQ(i, mat(i, i));
     }
-    EXPECT_EQ(42.0, mat(42, 43));
-    EXPECT_EQ(0.0, mat(55, 99));
+    EXPECT_EQ(mat(42, 43), 42.0);
+    EXPECT_EQ(mat(55, 99), 0.0);
 
     // rectangular matrix
     //
@@ -882,37 +686,38 @@ void MatricesGTest::testMatrixDivisionOperator() {
 
     mat /= 2;
 
-    EXPECT_EQ(0.5, mat(0, 0));
-    EXPECT_EQ(1.5, mat(1, 2));
+    EXPECT_EQ(mat(0, 0), 0.5);
+    EXPECT_EQ(mat(1, 2), 1.5);
 }
 
-template <class Matrix>
-void MatricesGTest::testMatrixVectorProduct() {
-    std::vector<Triplet> triplets;
+TYPED_TEST(MatricesGTest, testMatrixVectorProduct) {
+    const int num_triplets = 1000;
+    std::vector<Triplet> triplets(num_triplets);
 
-    for (index i = 0; i < 1000; ++i) {
-        triplets.push_back({i, i, (double)i});
+    for (index i = 0; i < num_triplets; ++i) {
+        triplets[i] = {i, i, (double)i};
     }
 
     triplets.push_back({42, 43, 42.0});
 
-    Vector vector(1000, 1.0);
+    Vector vector(num_triplets, 1.0);
     vector[500] = 3.5;
 
-    Matrix mat(1000, triplets);
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat(num_triplets, triplets);
 
     Vector result = mat * vector;
     ASSERT_EQ(mat.numberOfRows(), result.getDimension());
 
-    for (index i = 0; i < 1000; ++i) {
+    for (index i = 0; i < num_triplets; ++i) {
         if (i != 500 && i != 42 && i != 43) {
             EXPECT_EQ(i, result[i]);
         }
     }
 
-    EXPECT_EQ(42.0, mat(42, 43));
-    EXPECT_EQ(84.0, result[42]);
-    EXPECT_EQ(1750.0, result[500]);
+    EXPECT_EQ(mat(42, 43), 42.0);
+    EXPECT_EQ(result[42], 84.0);
+    EXPECT_EQ(result[500], 1750.0);
 
     //		  1  2  3  0
     //        2  2  0  0
@@ -927,10 +732,10 @@ void MatricesGTest::testMatrixVectorProduct() {
     Vector res = mat2 * v;
     ASSERT_EQ(mat2.numberOfRows(), res.getDimension());
 
-    EXPECT_EQ(14, res[0]);
-    EXPECT_EQ(6, res[1]);
-    EXPECT_EQ(12, res[2]);
-    EXPECT_EQ(-3, res[3]);
+    EXPECT_EQ(res[0], 14);
+    EXPECT_EQ(res[1], 6);
+    EXPECT_EQ(res[2], 12);
+    EXPECT_EQ(res[3], -3);
 
     // rectangular matrix
     //
@@ -943,13 +748,12 @@ void MatricesGTest::testMatrixVectorProduct() {
     v = {0, 1, 2, 3, 0};
     res = mat * v;
 
-    ASSERT_EQ(2u, res.getDimension());
-    EXPECT_EQ(0, res[0]);
-    EXPECT_EQ(6, res[1]);
+    ASSERT_EQ(res.getDimension(), 2);
+    EXPECT_EQ(res[0], 0);
+    EXPECT_EQ(res[1], 6);
 }
 
-template <class Matrix>
-void MatricesGTest::testMatrixMultiplication() {
+TYPED_TEST(MatricesGTest, testMatrixMultiplication) {
     std::vector<Triplet> triplets = {{0, 0, 1}, {0, 1, 2}, {0, 2, 3},  {1, 0, 2},  {1, 1, 2},
                                      {2, 0, 3}, {2, 2, 3}, {2, 3, -1}, {3, 2, -1}, {3, 3, 4}};
 
@@ -959,13 +763,14 @@ void MatricesGTest::testMatrixMultiplication() {
     // mat1 = mat2 = 3  0  3 -1
     //				 0  0 -1  4
     //
+    using Matrix = typename TestFixture::Matrix;
     Matrix mat1(4, triplets);
-    ASSERT_EQ(4u, mat1.numberOfRows());
-    ASSERT_EQ(4u, mat1.numberOfColumns());
+    ASSERT_EQ(mat1.numberOfRows(), 4);
+    ASSERT_EQ(mat1.numberOfColumns(), 4);
 
     Matrix mat2(4, triplets);
-    ASSERT_EQ(4u, mat2.numberOfRows());
-    ASSERT_EQ(4u, mat2.numberOfColumns());
+    ASSERT_EQ(mat2.numberOfRows(), 4);
+    ASSERT_EQ(mat2.numberOfColumns(), 4);
 
     //
     //			14  6  12  -3
@@ -977,22 +782,22 @@ void MatricesGTest::testMatrixMultiplication() {
     ASSERT_EQ(mat1.numberOfRows(), result.numberOfRows());
     ASSERT_EQ(mat1.numberOfColumns(), result.numberOfColumns());
 
-    EXPECT_EQ(14, result(0, 0));
-    EXPECT_EQ(6, result(0, 1));
-    EXPECT_EQ(12, result(0, 2));
-    EXPECT_EQ(-3, result(0, 3));
-    EXPECT_EQ(6, result(1, 0));
-    EXPECT_EQ(8, result(1, 1));
-    EXPECT_EQ(6, result(1, 2));
-    EXPECT_EQ(0, result(1, 3));
-    EXPECT_EQ(12, result(2, 0));
-    EXPECT_EQ(6, result(2, 1));
-    EXPECT_EQ(19, result(2, 2));
-    EXPECT_EQ(-7, result(2, 3));
-    EXPECT_EQ(-3, result(3, 0));
-    EXPECT_EQ(0, result(3, 1));
-    EXPECT_EQ(-7, result(3, 2));
-    EXPECT_EQ(17, result(3, 3));
+    EXPECT_EQ(result(0, 0), 14);
+    EXPECT_EQ(result(0, 1), 6);
+    EXPECT_EQ(result(0, 2), 12);
+    EXPECT_EQ(result(0, 3), -3);
+    EXPECT_EQ(result(1, 0), 6);
+    EXPECT_EQ(result(1, 1), 8);
+    EXPECT_EQ(result(1, 2), 6);
+    EXPECT_EQ(result(1, 3), 0);
+    EXPECT_EQ(result(2, 0), 12);
+    EXPECT_EQ(result(2, 1), 6);
+    EXPECT_EQ(result(2, 2), 19);
+    EXPECT_EQ(result(2, 3), -7);
+    EXPECT_EQ(result(3, 0), -3);
+    EXPECT_EQ(result(3, 1), 0);
+    EXPECT_EQ(result(3, 2), -7);
+    EXPECT_EQ(result(3, 3), 17);
 
     // rectangular matrices
     //
@@ -1015,24 +820,15 @@ void MatricesGTest::testMatrixMultiplication() {
     ASSERT_EQ(mat1.numberOfRows(), result.numberOfRows());
     ASSERT_EQ(mat2.numberOfColumns(), result.numberOfColumns());
 
-    EXPECT_EQ(85, result(0, 0));
-    EXPECT_EQ(2, result(0, 1));
-    EXPECT_EQ(0, result(1, 0));
-    EXPECT_EQ(0.5, result(1, 1));
-    EXPECT_EQ(168, result(2, 0));
-    EXPECT_EQ(4, result(2, 1));
+    EXPECT_EQ(result(0, 0), 85);
+    EXPECT_EQ(result(0, 1), 2);
+    EXPECT_EQ(result(1, 0), 0);
+    EXPECT_EQ(result(1, 1), 0.5);
+    EXPECT_EQ(result(2, 0), 168);
+    EXPECT_EQ(result(2, 1), 4);
 }
 
-template <class Matrix>
-void MatricesGTest::testBigMatrixMultiplication() {
-    Matrix mat = Matrix::adjacencyMatrix(graph);
-    Matrix result = mat * mat;
-    ASSERT_EQ(mat.numberOfRows(), result.numberOfRows());
-    ASSERT_EQ(mat.numberOfColumns(), result.numberOfColumns());
-}
-
-template <class Matrix>
-void MatricesGTest::testAdjacencyMatrix() {
+TYPED_TEST(MatricesGTest, testAdjacencyMatrix) {
     Graph G(6);
     G.addEdge(0, 0);
     G.addEdge(0, 1);
@@ -1043,31 +839,32 @@ void MatricesGTest::testAdjacencyMatrix() {
     G.addEdge(3, 4);
     G.addEdge(3, 5);
 
+    using Matrix = typename TestFixture::Matrix;
     Matrix mat = Matrix::adjacencyMatrix(G);
 
     // first row
-    EXPECT_EQ(1, mat(0, 0));
-    EXPECT_EQ(1, mat(0, 1));
-    EXPECT_EQ(0, mat(0, 2));
-    EXPECT_EQ(0, mat(0, 3));
-    EXPECT_EQ(1, mat(0, 4));
-    EXPECT_EQ(0, mat(0, 5));
+    EXPECT_EQ(mat(0, 0), 1);
+    EXPECT_EQ(mat(0, 1), 1);
+    EXPECT_EQ(mat(0, 2), 0);
+    EXPECT_EQ(mat(0, 3), 0);
+    EXPECT_EQ(mat(0, 4), 1);
+    EXPECT_EQ(mat(0, 5), 0);
 
     // third row
-    EXPECT_EQ(0, mat(2, 0));
-    EXPECT_EQ(1, mat(2, 1));
-    EXPECT_EQ(0, mat(2, 2));
-    EXPECT_EQ(1, mat(2, 3));
-    EXPECT_EQ(0, mat(2, 4));
-    EXPECT_EQ(0, mat(2, 5));
+    EXPECT_EQ(mat(2, 0), 0);
+    EXPECT_EQ(mat(2, 1), 1);
+    EXPECT_EQ(mat(2, 2), 0);
+    EXPECT_EQ(mat(2, 3), 1);
+    EXPECT_EQ(mat(2, 4), 0);
+    EXPECT_EQ(mat(2, 5), 0);
 
     // fifth row
-    EXPECT_EQ(1, mat(4, 0));
-    EXPECT_EQ(1, mat(4, 1));
-    EXPECT_EQ(0, mat(4, 2));
-    EXPECT_EQ(1, mat(4, 3));
-    EXPECT_EQ(0, mat(4, 4));
-    EXPECT_EQ(0, mat(4, 5));
+    EXPECT_EQ(mat(4, 0), 1);
+    EXPECT_EQ(mat(4, 1), 1);
+    EXPECT_EQ(mat(4, 2), 0);
+    EXPECT_EQ(mat(4, 3), 1);
+    EXPECT_EQ(mat(4, 4), 0);
+    EXPECT_EQ(mat(4, 5), 0);
 
     // directed, weighted G
     Graph dGraph(4, true, true);
@@ -1080,11 +877,11 @@ void MatricesGTest::testAdjacencyMatrix() {
     ASSERT_EQ(dGraph.numberOfNodes(), mat.numberOfRows());
     ASSERT_EQ(dGraph.numberOfNodes(), mat.numberOfColumns());
 
-    EXPECT_EQ(2, mat(0, 1));
-    EXPECT_EQ(0, mat(1, 0));
-    EXPECT_EQ(42, mat(0, 0));
-    EXPECT_EQ(-3, mat(2, 3));
-    EXPECT_EQ(5, mat(3, 2));
+    EXPECT_EQ(mat(0, 1), 2);
+    EXPECT_EQ(mat(1, 0), 0);
+    EXPECT_EQ(mat(0, 0), 42);
+    EXPECT_EQ(mat(2, 3), -3);
+    EXPECT_EQ(mat(3, 2), 5);
 
     // read lesmis G
     METISGraphReader graphReader;
@@ -1098,35 +895,36 @@ void MatricesGTest::testAdjacencyMatrix() {
             if (G.hasEdge(u, v)) {
                 EXPECT_EQ(G.weight(u, v), mat(u, v));
             } else {
-                EXPECT_EQ(0.0, mat(u, v));
+                EXPECT_EQ(mat(u, v), 0.0);
             }
         });
     });
 }
 
-template <class Matrix>
-void MatricesGTest::testDiagonalMatrix() {
+TYPED_TEST(MatricesGTest, testDiagonalMatrix) {
     Vector diagonal = {1, 0, 4, -1};
-    Matrix mat = Matrix::diagonalMatrix(diagonal);
-    EXPECT_EQ(4u, mat.numberOfRows());
-    EXPECT_EQ(4u, mat.numberOfColumns());
 
-    EXPECT_EQ(1, mat(0, 0));
-    EXPECT_EQ(0, mat(1, 1));
-    EXPECT_EQ(4, mat(2, 2));
-    EXPECT_EQ(-1, mat(3, 3));
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = Matrix::diagonalMatrix(diagonal);
+
+    EXPECT_EQ(mat.numberOfRows(), 4);
+    EXPECT_EQ(mat.numberOfColumns(), 4);
+
+    EXPECT_EQ(mat(0, 0), 1);
+    EXPECT_EQ(mat(1, 1), 0);
+    EXPECT_EQ(mat(2, 2), 4);
+    EXPECT_EQ(mat(3, 3), -1);
 
     for (index i = 0; i < mat.numberOfRows(); ++i) {
         for (index j = 0; j < mat.numberOfColumns(); ++j) {
             if (i != j) {
-                EXPECT_EQ(0, mat(i, j));
+                EXPECT_EQ(mat(i, j), 0);
             }
         }
     }
 }
 
-template <class Matrix>
-void MatricesGTest::testIncidenceMatrix() {
+TYPED_TEST(MatricesGTest, testIncidenceMatrix) {
     Graph G = Graph(5, true);
     G.addEdge(0, 1, 4.0);
     G.addEdge(0, 2, 9.0);
@@ -1137,33 +935,34 @@ void MatricesGTest::testIncidenceMatrix() {
 
     G.indexEdges();
 
+    using Matrix = typename TestFixture::Matrix;
     Matrix mat = Matrix::incidenceMatrix(G);
     ASSERT_EQ(G.numberOfNodes(), mat.numberOfRows());
     ASSERT_EQ(G.numberOfEdges(), mat.numberOfColumns());
 
-    EXPECT_EQ(std::sqrt(G.weight(0, 1)), mat(0, 0));
-    EXPECT_EQ(-std::sqrt(G.weight(0, 1)), mat(1, 0));
+    EXPECT_EQ(mat(0, 0), std::sqrt(G.weight(0, 1)));
+    EXPECT_EQ(mat(1, 0), -std::sqrt(G.weight(0, 1)));
     for (uint64_t i = 2; i < mat.numberOfRows(); ++i) {
-        EXPECT_EQ(0.0, mat(i, 0));
+        EXPECT_EQ(mat(i, 0), 0.0);
     }
 
-    EXPECT_EQ(-std::sqrt(G.weight(0, 2)), mat(2, 1));
+    EXPECT_EQ(mat(2, 1), -std::sqrt(G.weight(0, 2)));
 
-    EXPECT_EQ(-std::sqrt(G.weight(0, 3)), mat(3, 2));
-    EXPECT_EQ(-std::sqrt(G.weight(2, 3)), mat(3, 3));
+    EXPECT_EQ(mat(3, 2), -std::sqrt(G.weight(0, 3)));
+    EXPECT_EQ(mat(3, 3), -std::sqrt(G.weight(2, 3)));
 
     for (uint64_t i = 0; i < mat.numberOfRows(); ++i) {
-        EXPECT_EQ(0.0, mat(i, 5));
+        EXPECT_EQ(mat(i, 5), 0.0);
     }
 
     Vector row0 = mat.row(0);
     ASSERT_EQ(row0.getDimension(), mat.numberOfColumns());
 
-    EXPECT_EQ(std::sqrt(G.weight(0, 1)), row0[0]);
-    EXPECT_EQ(std::sqrt(G.weight(0, 2)), row0[1]);
-    EXPECT_EQ(std::sqrt(G.weight(0, 3)), row0[2]);
+    EXPECT_EQ(row0[0], std::sqrt(G.weight(0, 1)));
+    EXPECT_EQ(row0[1], std::sqrt(G.weight(0, 2)));
+    EXPECT_EQ(row0[2], std::sqrt(G.weight(0, 3)));
     for (uint64_t j = 3; j < row0.getDimension(); ++j) {
-        EXPECT_EQ(0.0, row0[j]);
+        EXPECT_EQ(row0[j], 0.0);
     }
 
     for (uint64_t j = 0; j < 5; ++j) {
@@ -1175,14 +974,14 @@ void MatricesGTest::testIncidenceMatrix() {
             sum += column[i];
         }
 
-        EXPECT_EQ(0.0, sum);
+        EXPECT_EQ(sum, 0.0);
     }
 
     Vector column5 = mat.column(5);
     ASSERT_EQ(column5.getDimension(), mat.numberOfRows());
 
     for (uint64_t i = 0; i < column5.getDimension(); ++i) {
-        EXPECT_EQ(0.0, column5[i]);
+        EXPECT_EQ(column5[i], 0.0);
     }
 
     Vector v = {12, 3, 9, 28, 0, -1};
@@ -1190,186 +989,165 @@ void MatricesGTest::testIncidenceMatrix() {
     Vector result = mat * v;
     ASSERT_EQ(result.getDimension(), mat.numberOfRows());
 
-    EXPECT_EQ(69, result[0]);
-    EXPECT_EQ(-24, result[1]);
-    EXPECT_EQ(19, result[2]);
-    EXPECT_EQ(-64, result[3]);
-    EXPECT_EQ(0, result[4]);
+    EXPECT_EQ(result[0], 69);
+    EXPECT_EQ(result[1], -24);
+    EXPECT_EQ(result[2], 19);
+    EXPECT_EQ(result[3], -64);
+    EXPECT_EQ(result[4], 0);
 }
 
-template <class Matrix>
-void MatricesGTest::testLaplacianOfGraph() {
-    METISGraphReader graphReader;
-    Matrix mat = Matrix::laplacianMatrix(graph);
+TYPED_TEST(MatricesGTest, testLaplacianOfGraph) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = Matrix::laplacianMatrix(this->graph);
+
     EXPECT_TRUE(MatrixTools::isLaplacian(mat));
 
-    mat = Matrix::laplacianMatrix(graphReader.read("input/power.graph"));
+    mat = Matrix::laplacianMatrix(METISGraphReader{}.read("input/power.graph"));
     EXPECT_TRUE(MatrixTools::isLaplacian(mat));
 }
 
-TEST_F(MatricesGTest, testDimension) {
-    testDimension<DynamicMatrix>();
-    testDimension<CSRMatrix>();
-    testDimension<DenseMatrix>();
+TYPED_TEST(MatricesGTest, testForElementsInRow) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = this->get4x4Matrix();
+    count nnz = 0;
+
+    for (index row = 0; row < 4; ++row)
+        mat.forElementsInRow(row, [&](index col, double value) {
+            EXPECT_EQ(mat(row, col), value);
+            if (value != mat.getZero())
+                ++nnz;
+        });
+
+    EXPECT_EQ(nnz, mat.nnz());
 }
 
-TEST_F(MatricesGTest, testMatrixToGraph) {
-    testMatrixToGraph<DynamicMatrix>();
-    testMatrixToGraph<CSRMatrix>();
+TYPED_TEST(MatricesGTest, testForNonZeroElementsInRow) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = this->get4x4Matrix();
+    count nnz = 0;
+
+    for (index row = 0; row < 4; ++row)
+        mat.forNonZeroElementsInRow(row, [&](index col, double value) {
+            EXPECT_EQ(mat(row, col), value);
+            ++nnz;
+        });
+
+    EXPECT_EQ(nnz, mat.nnz());
 }
 
-TEST_F(MatricesGTest, testNNZInRow) {
-    testNNZInRow<DynamicMatrix>();
-    testNNZInRow<CSRMatrix>();
-    testNNZInRow<DenseMatrix>();
+TYPED_TEST(MatricesGTest, testParallelForElementsInRow) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = this->get4x4Matrix();
+    std::atomic<count> nnz{0};
+
+    for (index row = 0; row < 4; ++row)
+        mat.parallelForElementsInRow(row, [&](index col, double value) {
+            EXPECT_EQ(mat(row, col), value);
+            if (value != mat.getZero()) {
+                nnz.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+
+    EXPECT_EQ(mat.nnz(), nnz.load(std::memory_order_relaxed));
 }
 
-TEST_F(MatricesGTest, testRowAndColumnAccess) {
-    testRowAndColumnAccess<DynamicMatrix>();
-    testRowAndColumnAccess<CSRMatrix>();
-    testRowAndColumnAccess<DenseMatrix>();
+TYPED_TEST(MatricesGTest, testForElementsInRowOrder) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = this->get4x4Matrix();
+    count nnz = 0;
+
+    mat.forElementsInRowOrder([&](index row, index col, double value) {
+        EXPECT_EQ(mat(row, col), value);
+        if (value != mat.getZero())
+            ++nnz;
+    });
+
+    EXPECT_EQ(nnz, mat.nnz());
 }
 
-TEST_F(MatricesGTest, testDiagonalVector) {
-    testDiagonalVector<DynamicMatrix>();
-    testDiagonalVector<CSRMatrix>();
-    testDiagonalVector<DenseMatrix>();
+TYPED_TEST(MatricesGTest, testParallelForNonZeroElementsInRow) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = this->get4x4Matrix();
+    std::atomic<count> nnz{0};
+
+    for (index row = 0; row < 4; ++row)
+        mat.parallelForNonZeroElementsInRow(row, [&](index col, double value) {
+            EXPECT_EQ(mat(row, col), value);
+            nnz.fetch_add(1, std::memory_order_relaxed);
+        });
+
+    EXPECT_EQ(nnz.load(std::memory_order_relaxed), mat.nnz());
 }
 
-TEST_F(MatricesGTest, testTranspose) {
-    testTranspose<DynamicMatrix>();
-    testTranspose<CSRMatrix>();
-    testTranspose<DenseMatrix>();
+TYPED_TEST(MatricesGTest, testParallelForElementsInRowOrder) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = this->get4x4Matrix();
+    std::atomic<count> nnz{0};
+
+    mat.parallelForElementsInRowOrder([&](index row, index col, double value) {
+        EXPECT_EQ(mat(row, col), value);
+        if (value != mat.getZero())
+            nnz.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    EXPECT_EQ(nnz.load(std::memory_order_relaxed), mat.nnz());
 }
 
-TEST_F(MatricesGTest, testExtract) {
-    testExtract<DynamicMatrix>();
-    testExtract<CSRMatrix>();
+TYPED_TEST(MatricesGTest, testForNonZeroElementsInRowOrder) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = this->get4x4Matrix();
+    count nnz = 0;
+
+    mat.forNonZeroElementsInRowOrder([&](index row, index col, double value) {
+        EXPECT_EQ(mat(row, col), value);
+        ++nnz;
+    });
+
+    EXPECT_EQ(nnz, mat.nnz());
 }
 
-TEST_F(MatricesGTest, testAssign) {
-    testAssign<DynamicMatrix>();
-    testAssign<CSRMatrix>();
-    testAssign<DenseMatrix>();
+TYPED_TEST(MatricesGTest, testParallelForNonZeroElementsInRowOrder) {
+    using Matrix = typename TestFixture::Matrix;
+    Matrix mat = this->get4x4Matrix();
+    std::atomic<count> nnz{0};
+
+    mat.parallelForNonZeroElementsInRowOrder([&](index row, index col, double value) {
+        EXPECT_EQ(mat(row, col), value);
+        nnz.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    EXPECT_EQ(nnz.load(std::memory_order_relaxed), mat.nnz());
 }
 
-TEST_F(MatricesGTest, testApply) {
-    testApply<DynamicMatrix>();
-    testApply<CSRMatrix>();
+TYPED_TEST(MatricesGTest, testBigMatrixMultiplication) {
+    using Matrix = typename TestFixture::Matrix;
+    if (std::is_same<Matrix, DenseMatrix>::value) {
+        GTEST_SKIP() << "Skipping big matrix multiplication test for DenseMatrix.";
+    }
+
+    Matrix mat = Matrix::adjacencyMatrix(this->graph);
+    Matrix result = mat * mat;
+    EXPECT_EQ(mat.numberOfRows(), result.numberOfRows());
+    EXPECT_EQ(mat.numberOfColumns(), result.numberOfColumns());
 }
 
-TEST_F(MatricesGTest, testMatrixAddition) {
-    testMatrixAddition<DynamicMatrix>();
-    testMatrixAddition<CSRMatrix>();
-    testMatrixAddition<DenseMatrix>();
+TYPED_TEST(MatricesGTest, testMatrixToGraph) {
+    using Matrix = typename TestFixture::Matrix;
+
+    Matrix mat = Matrix::adjacencyMatrix(METISGraphReader{}.read("input/power.graph"));
+    Graph G = MatrixTools::matrixToGraph(mat);
+
+    EXPECT_EQ(G.numberOfNodes(), 4941);
+    EXPECT_EQ(G.numberOfEdges(), 6594);
 }
 
-TEST_F(MatricesGTest, testMatrixSubtraction) {
-    testMatrixSubtraction<DynamicMatrix>();
-    testMatrixSubtraction<CSRMatrix>();
-    testMatrixSubtraction<DenseMatrix>();
-}
+} // namespace
 
-TEST_F(MatricesGTest, testScalarMultiplication) {
-    testScalarMultiplication<DynamicMatrix>();
-    testScalarMultiplication<CSRMatrix>();
-    testScalarMultiplication<DenseMatrix>();
-}
+namespace {
 
-TEST_F(MatricesGTest, testMatrixDivisionOperator) {
-    testMatrixDivisionOperator<DynamicMatrix>();
-    testMatrixDivisionOperator<CSRMatrix>();
-    testMatrixDivisionOperator<DenseMatrix>();
-}
+using CSRMatrixGTest = testing::Test;
 
-TEST_F(MatricesGTest, testMatrixVectorProduct) {
-    testMatrixVectorProduct<DynamicMatrix>();
-    testMatrixVectorProduct<CSRMatrix>();
-    testMatrixVectorProduct<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testMatrixMultiplication) {
-    testMatrixMultiplication<DynamicMatrix>();
-    testMatrixMultiplication<CSRMatrix>();
-    testMatrixMultiplication<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testBigMatrixMultiplcation) {
-    testBigMatrixMultiplication<DynamicMatrix>();
-    testBigMatrixMultiplication<CSRMatrix>();
-}
-
-TEST_F(MatricesGTest, testAdjacencyMatrixOfGraph) {
-    testAdjacencyMatrix<DynamicMatrix>();
-    testAdjacencyMatrix<CSRMatrix>();
-    testAdjacencyMatrix<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testDiagonalMatrix) {
-    testDiagonalMatrix<DynamicMatrix>();
-    testDiagonalMatrix<CSRMatrix>();
-    testDiagonalMatrix<CSRMatrix>();
-}
-
-TEST_F(MatricesGTest, testIncidenceMatrix) {
-    testIncidenceMatrix<DynamicMatrix>();
-    testIncidenceMatrix<CSRMatrix>();
-    testIncidenceMatrix<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testLaplacianMatrixOfGraph) {
-    testLaplacianOfGraph<DynamicMatrix>();
-    testLaplacianOfGraph<CSRMatrix>();
-    testLaplacianOfGraph<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testForElementsInRow) {
-    testForElementsInRow<DynamicMatrix>();
-    testForElementsInRow<CSRMatrix>();
-    testForElementsInRow<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testParallelForElementsInRow) {
-    testParallelForElementsInRow<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testForNonZeroElementsInRow) {
-    testForNonZeroElementsInRow<DynamicMatrix>();
-    testForNonZeroElementsInRow<CSRMatrix>();
-    testForNonZeroElementsInRow<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testParallelForNonZeroElementsInRow) {
-    testParallelForNonZeroElementsInRow<CSRMatrix>();
-    testParallelForNonZeroElementsInRow<DynamicMatrix>();
-    testParallelForNonZeroElementsInRow<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testForElementsInRowOrder) {
-    testForElementsInRowOrder<DenseMatrix>();
-    testForElementsInRowOrder<DynamicMatrix>();
-    testForElementsInRowOrder<CSRMatrix>();
-}
-
-TEST_F(MatricesGTest, testParallelForElementsInRowOrder) {
-    testParallelForElementsInRowOrder<DenseMatrix>();
-    testParallelForElementsInRowOrder<CSRMatrix>();
-    testParallelForElementsInRowOrder<DynamicMatrix>();
-}
-
-TEST_F(MatricesGTest, testForNonZeroElementsInRowOrder) {
-    testForNonZeroElementsInRowOrder<DynamicMatrix>();
-    testForNonZeroElementsInRowOrder<CSRMatrix>();
-    testForNonZeroElementsInRowOrder<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testParallelForNonZeroElementsInRowOrder) {
-    testParallelForNonZeroElementsInRowOrder<DynamicMatrix>();
-    testParallelForNonZeroElementsInRowOrder<CSRMatrix>();
-    testParallelForNonZeroElementsInRowOrder<DenseMatrix>();
-}
-
-TEST_F(MatricesGTest, testCSRMatrixSort) {
+TEST_F(CSRMatrixGTest, testCSRMatrixSort) {
     /* 1 0 0 0
      * 2 3 0 0
      * 0 4 5 6
@@ -1382,4 +1160,6 @@ TEST_F(MatricesGTest, testCSRMatrixSort) {
     CSRGeneralMatrix<double> csr(4, 4, triplets);
     csr.sort();
 }
-} /* namespace NetworKit */
+
+} // namespace
+} // namespace NetworKit


### PR DESCRIPTION
The first commit adds missing matrix functions and tests:
- For CSRMatrix: functions for iterating over all elements of the matrix, including zeros.
- For DenseMatrix: functions to compute the adjacency, Laplacian, and incidence matrix of a graph and a diagonal matrix.
- For DynamcMatrix: functions to iterate over the (non-zero) elements.
In this way, all matrix classes offer the same set of APIs.

The second commit refactors the unit tests for matrices. It defines a typed test suite (see https://google.github.io/googletest/advanced.html#typed-tests) that performs the unit tests on all the matrix types. This is much more convenient than defining a templated unit test (as we were doing before) because:
- Failures much are easier to track: if a test fails, the type is reported in the logs.
- Tests are more concise (the new version has 220 fewer lines of code).

Other minor changes:
- Avoid Yoda conditions in tests https://en.wikipedia.org/wiki/Yoda_conditions
- Replace `ASSERT_` with `EXPECT_` where it is reasonable to do so (https://google.github.io/googletest/primer.html#assertions)