### PR TITLE
Fix clang-tidy errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,18 +267,18 @@ jobs:
           CXX: ${{ matrix.compiler == 'gcc-8' && 'g++-8' || 'clang++-7' }}
 
   linux-build-clang-tidy:
-    name: "Linux (clang-15): clang-tidy"
+    name: "Linux (clang-16): clang-tidy"
     runs-on: ubuntu-20.04
     env:
-      CC: clang
-      CXX: clang++
+      CC: clang-16
+      CXX: clang++-16
     steps:
       - name: Install prerequisites
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-15 main" | sudo tee /etc/apt/sources.list.d/llvm13.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-16 main" | sudo tee /etc/apt/sources.list.d/llvm13.list
           sudo apt-get update
-          sudo apt-get install libomp-15-dev clang-15 clang-tidy-15 ninja-build
+          sudo apt-get install libomp-16-dev clang-16 clang-tidy-16 ninja-build
       - name: Checkout networkit
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/scripts/clang_tidy.sh
+++ b/.github/workflows/scripts/clang_tidy.sh
@@ -3,9 +3,9 @@ set -e
 set -o pipefail
 
 sudo rm -rf /usr/local/clang-*
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 9999
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 9999
-sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 9999
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 9999
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 9999
+sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-16 9999
 $CXX --version
 clang-tidy --version
 mkdir debug_test && cd "$_"

--- a/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
@@ -182,7 +182,7 @@ void ApproxElectricalCloseness::computeNodeSequence() {
     // of them arbitrarily select one of them.
     std::queue<std::pair<node, index>> q;
     const auto &rootComps = bcc.getComponentsOfNode(root);
-    q.push({root, *(rootComps.begin())});
+    q.emplace(root, *(rootComps.begin()));
 
     topOrder.reserve(bcc.numberOfComponents());
     topOrder.insert(topOrder.begin(), rootComps.begin(), rootComps.end());
@@ -210,7 +210,7 @@ void ApproxElectricalCloseness::computeNodeSequence() {
                         topOrder.push_back(vComponentIndex);
                     }
                 }
-                q.push({v, *(vComps.begin())});
+                q.emplace(v, *(vComps.begin()));
                 status[v] = NodeStatus::VISITED;
             }
         });
@@ -414,7 +414,7 @@ void ApproxElectricalCloseness::dfsUST() {
     const auto &siblingPtr = ustSiblingPtrGlobal[omp_get_thread_num()];
 
     std::stack<std::pair<node, node>> stack;
-    stack.push({root, childPtr[root]});
+    stack.emplace(root, childPtr[root]);
 
     count timestamp = 0;
     do {
@@ -428,7 +428,7 @@ void ApproxElectricalCloseness::dfsUST() {
         } else {
             stack.top().second = siblingPtr[v];
             tVisit[v] = ++timestamp;
-            stack.push({v, childPtr[v]});
+            stack.emplace(v, childPtr[v]);
             assert(parentGlobal[omp_get_thread_num()][v] == u);
         }
     } while (!stack.empty());

--- a/networkit/cpp/centrality/DynBetweenness.cpp
+++ b/networkit/cpp/centrality/DynBetweenness.cpp
@@ -107,7 +107,7 @@ void DynBetweenness::increaseScore(std::vector<bool> &affected, node y, PrioQ &Q
                 }
                 if (!visited[w] && !affected[w] && w != y) {
                     TRACE("Inserting node ", w, " with new priority ", distances[w][y]);
-                    Q.push(std::make_pair(diameter + 1.0 - distances[w][y], w));
+                    Q.emplace(diameter + 1.0 - distances[w][y], w);
                     visited[w] = true;
                 }
             }
@@ -141,7 +141,7 @@ void DynBetweenness::decreaseScore(std::vector<bool> &affected, node y, PrioQ &Q
                 }
                 if (!visited[w] && !affected[w] && w != y) {
                     TRACE("Inserting node ", w, " with old priority ", distancesOld[w][y]);
-                    Q.push(std::make_pair(diameter + 1.0 - distancesOld[w][y], w));
+                    Q.emplace(diameter + 1.0 - distancesOld[w][y], w);
                     visited[w] = true;
                 }
             }
@@ -179,7 +179,7 @@ void DynBetweenness::update(GraphEvent event) {
         INFO("Phase 1. distances[", u, "][", v, "] = ", distances[u][v], ", and G.weight", u, ", ",
              v, " = ", G.weight(u, v));
         distances[u][v] = weightuv;
-        modified.push(std::make_pair(u, v));
+        modified.emplace(u, v);
         sigma[u][v] = 1;
         visited[u] = true;
         if (!G.isDirected()) {
@@ -225,8 +225,8 @@ void DynBetweenness::update(GraphEvent event) {
                 n_sources[y] = n_sources[Pred[y]];
                 visited[y] = true;
                 // since u is not in source, we insert it now
-                Qnew.push(std::make_pair(diameter + 1.0 - distances[u][y], u));
-                Qold.push(std::make_pair(diameter + 1.0 - distancesOld[u][y], u));
+                Qnew.emplace(diameter + 1.0 - distances[u][y], u);
+                Qold.emplace(diameter + 1.0 - distancesOld[u][y], u);
                 for (count c = 0; c < n_sources[y]; c++) {
                     node s = source_nodes[c];
                     if (s != u) {
@@ -239,27 +239,27 @@ void DynBetweenness::update(GraphEvent event) {
                             distances[y][s] = distances[s][y];
                             sigma[y][s] = sigma[s][y];
                         }
-                        modified.push(std::make_pair(s, y));
+                        modified.emplace(s, y);
                         affected[s] = true;
                         TRACE("Node ", y, ", Inserting node ", s, " with new priority ",
                               diameter + 1 - distances[s][y]);
                         TRACE("Node ", y, ", Inserting node ", s, " with old priority ",
                               diameter + 1 - distancesOld[s][y]);
-                        Qnew.push(std::make_pair(diameter + 1 - distances[s][y], s));
-                        Qold.push(std::make_pair(diameter + 1 - distancesOld[s][y], s));
+                        Qnew.emplace(diameter + 1 - distances[s][y], s);
+                        Qold.emplace(diameter + 1 - distancesOld[s][y], s);
                     } else if (distances[s][y] == distances[s][u] + weightuv + distances[v][y]) {
                         sigma[s][y] += sigma[s][u] * sigma[v][y];
                         if (!G.isDirected()) {
                             sigma[y][s] = sigma[s][y];
                         }
-                        modified.push(std::make_pair(s, y));
+                        modified.emplace(s, y);
                         affected[s] = true;
                         TRACE("Node ", y, ", Inserting node ", s, " with new priority ",
                               diameter + 1 - distances[s][y]);
                         TRACE("Node ", y, ", Inserting node ", s, " with old priority ",
                               diameter + 1 - distancesOld[s][y]);
-                        Qnew.push(std::make_pair(diameter + 1.0 - distances[s][y], s));
-                        Qold.push(std::make_pair(diameter + 1.0 - distancesOld[s][y], s));
+                        Qnew.emplace(diameter + 1.0 - distances[s][y], s);
+                        Qold.emplace(diameter + 1.0 - distancesOld[s][y], s);
                     } else if (distances[s][y] < distances[s][u] + weightuv + distances[v][y]) {
                         std::swap(source_nodes[c], source_nodes[n_sources[y] - 1]);
                         c--;
@@ -296,7 +296,7 @@ void DynBetweenness::update(GraphEvent event) {
                         }
                         stack.push(w);
                         enqueued[w] = true;
-                        modified.push(std::make_pair(u, w));
+                        modified.emplace(u, w);
                         Pred[w] = y;
                     }
                 });

--- a/networkit/cpp/components/StronglyConnectedComponents.cpp
+++ b/networkit/cpp/components/StronglyConnectedComponents.cpp
@@ -52,7 +52,7 @@ void StronglyConnectedComponents::run() {
         ++curDepth;
         stack.emplace_back(v);
         onStack[v] = 1;
-        dfsStack.push({v, G->neighborRange(v).begin()});
+        dfsStack.emplace(v, G->neighborRange(v).begin());
     };
 
     auto strongConnect = [&](const node u) -> void {

--- a/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
+++ b/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
@@ -122,7 +122,7 @@ void DynamicHyperbolicGenerator::recomputeBands() {
         for (index i = 0; i < nodeCount; i++) {
             double alias = permutation[i];
             if (radii[alias] >= bandRadii[j] && radii[alias] <= bandRadii[j + 1]) {
-                bands[j].push_back(Point2DWithIndex<double>(angles[alias], radii[alias], alias));
+                bands[j].emplace_back(angles[alias], radii[alias], alias);
                 bandAngles[j].push_back(angles[alias]);
             }
         }

--- a/networkit/cpp/generators/HavelHakimiGenerator.cpp
+++ b/networkit/cpp/generators/HavelHakimiGenerator.cpp
@@ -37,7 +37,7 @@ Graph HavelHakimiGenerator::generate() {
     // put nodes in appropriate lists
     Buckets nodesByDeficit(numDegVals);
     for (node v = 0; v < n; v++) {
-        nodesByDeficit[seq[v]].push_front(std::make_pair(seq[v], v));
+        nodesByDeficit[seq[v]].emplace_front(seq[v], v);
     }
 
     index maxDeficit = numDegVals - 1;

--- a/networkit/cpp/generators/HyperbolicGenerator.cpp
+++ b/networkit/cpp/generators/HyperbolicGenerator.cpp
@@ -130,7 +130,7 @@ Graph HyperbolicGenerator::generateCold(const vector<double> &angles, const vect
         for (index i = 0; i < n; i++) {
             double alias = permutation[i];
             if (radii[alias] >= bandRadii[j] && radii[alias] <= bandRadii[j + 1]) {
-                bands[j].push_back(Point2DWithIndex<double>(angles[alias], radii[alias], alias));
+                bands[j].emplace_back(angles[alias], radii[alias], alias);
             }
         }
     }

--- a/networkit/cpp/generators/MocnikGenerator.cpp
+++ b/networkit/cpp/generators/MocnikGenerator.cpp
@@ -282,7 +282,7 @@ void MocnikGenerator::addEdgesToGraph(Graph &G, count n, double k, double relati
                 for (node &j : getNodes(s, x)) {
                     d = dist(nodePositions[i], nodePositions[j]);
                     if (d <= kdMin && i != j) {
-                        edges[cell].push_back(std::make_tuple(i, j, d));
+                        edges[cell].emplace_back(i, j, d);
                     }
                 }
             }

--- a/networkit/cpp/generators/PubWebGenerator.cpp
+++ b/networkit/cpp/generators/PubWebGenerator.cpp
@@ -62,7 +62,7 @@ void PubWebGenerator::determineNeighbors(Graph &g) {
 
             if (isInRange(sqrDist)) {
                 edge e = std::make_pair(std::min(u, v), std::max(u, v));
-                pq.push(std::make_pair(-sqrDist, e));
+                pq.emplace(-sqrDist, e);
             }
         });
 

--- a/networkit/cpp/randomization/CurveballImpl.cpp
+++ b/networkit/cpp/randomization/CurveballImpl.cpp
@@ -105,7 +105,7 @@ nodepair_vector CurveballAdjacencyList::getEdges() const {
     edges.reserve(degreeCount);
     for (node nodeid = 0; nodeid < static_cast<node>(offsets.size()); nodeid++) {
         for (auto it = cbegin(nodeid); it != cend(nodeid); it++) {
-            edges.push_back(std::make_pair(nodeid, *it));
+            edges.emplace_back(nodeid, *it);
         }
     }
 

--- a/networkit/cpp/sparsification/SimmelianScore.cpp
+++ b/networkit/cpp/sparsification/SimmelianScore.cpp
@@ -22,7 +22,7 @@ SimmelianScore::getRankedNeighborhood(const Graph &g, const std::vector<count> &
         // Sort ego's alters from strongly to weakly tied.
         g.forNeighborsOf(u, [&](node, node v, edgeid eid) {
             count triangleCount = std::round(triangles[eid]);
-            neighbors[u].push_back(RankedEdge(u, v, triangleCount));
+            neighbors[u].emplace_back(u, v, triangleCount);
         });
         std::sort(neighbors[u].begin(), neighbors[u].end());
 


### PR DESCRIPTION
Building NetworKit with:

```
cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_STANDARD=17 -DNETWORKIT_CLANG_TIDY=ON
```

fails because of `modernize-use-emplace`. Shouldn't these error be caught by our CI?