### PR TITLE
pyproject.toml: Add wheel as requirement and pin stable versions of cython, setuptools.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.1
         env:
-          CIBW_BEFORE_BUILD: pip install cython
+          CIBW_BEFORE_BUILD: pip install "cython==0.29.*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs }}
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
@@ -71,7 +71,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.1
         env:
-          CIBW_BEFORE_BUILD: pip install cython
+          CIBW_BEFORE_BUILD: pip install "cython==0.29.*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs }}
           CIBW_BUILD: ${{ github.ref == 'refs/heads/master' && 'cp39-* cp310-*' || 'cp310-*' }}
@@ -104,7 +104,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_BEFORE_BUILD: 
-            pip install cython &&
+            pip install "cython==0.29.*" &&
             brew install libomp ninja
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs }}
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
@@ -146,7 +146,7 @@ jobs:
   #       uses: pypa/cibuildwheel@v2.1.1
   #       env:
   #         CIBW_BEFORE_BUILD: 
-  #           pip install cython &&
+  #           pip install "cython==0.29.*" &&
   #           brew install libomp ninja &&
   #           pip install --pre -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
   #         CIBW_ENVIRONMENT: CXX=c++ NETWORKIT_OSX_CROSSBUILD=ON
@@ -188,7 +188,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.1
         env:
-          CIBW_BEFORE_BUILD: pip install cython ipython
+          CIBW_BEFORE_BUILD: pip install "cython==0.29.*" ipython
           CIBW_ARCHS: "AMD64"
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
           CIBW_SKIP: pp*
@@ -222,7 +222,7 @@ jobs:
           python-version: '3.10'
       - name: Create sdist source
         run: |
-          pip install cython
+          pip install "cython==0.29.*"
           python3 setup.py build_ext
           python3 setup.py sdist
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,7 @@ jobs:
           cd ../..
           python -m venv pyenv
           . ./pyenv/Scripts/activate
-          pip install cython ipython jupyter ipywidgets==7.7.1 jupyterlab-widgets==1.1.1
+          pip install "cython==0.29.*" ipython jupyter ipywidgets==7.7.1 jupyterlab-widgets==1.1.1
           mkdir build && cd build
           cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DNETWORKIT_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DNETWORKIT_CXX_STANDARD=${{ env.CXX_STANDARD }} -DNETWORKIT_WARNINGS=ON -DNETWORKIT_WARNINGS_AS_ERRORS=ON -DNETWORKIT_EXT_TLX=${{ env.TLX_PATH_WIN }} -DNETWORKIT_NATIVE=${{ env.NATIVE }} ..
           ninja

--- a/.github/workflows/scripts/documentation.sh
+++ b/.github/workflows/scripts/documentation.sh
@@ -6,7 +6,7 @@ python3 -m venv pyenv && . pyenv/bin/activate
 pip3 install --upgrade pip
  
 # cython is required because git does not contain _NetworKit.
-pip3 install cython
+pip3 install 'cython==0.29.*'
 
 # Several modules are required to build the documentation.
 pip3 install 'Jinja2<3.1.0' sphinx sphinx_bootstrap_theme numpydoc exhale nbsphinx breathe

--- a/.github/workflows/scripts/full.sh
+++ b/.github/workflows/scripts/full.sh
@@ -8,7 +8,7 @@ cmake --version
 
 python3 -m venv pyenv && . pyenv/bin/activate
 pip3 install --upgrade pip
-pip3 install cython ipython jupyter
+pip3 install 'cython==0.29.*' ipython jupyter
 
 # Build tlx
 cd tlx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ changelog = "https://github.com/networkit/networkit/blob/master/CHANGES.md"
 
 [build-system]
 requires = [
-  "cython",
-  "setuptools"
+  "cython ~= 0.29.0",
+  "setuptools ~= 58.0",
+  "wheel"
 ]


### PR DESCRIPTION
This PR fixes invalid C++ code, which the recently released version of Cython (3.0.0) produces (see: #1106). Until this is fixed, the previously stable 0.29.X version is used.

Furthermore, wheel is added as build requirement in order to create wheels when doing non-editable install via pip.