### PR TITLE
graphio: add function to guess file format

### DIFF
--- a/networkit/graphio.pyx
+++ b/networkit/graphio.pyx
@@ -1106,12 +1106,17 @@ def guessFileFormat(filepath: str) -> Format:
 	guessFileFormat(filepath)
 
 	Guesses the graph file format using heuristics. May fail and throw an IOException.
+	
+	The running time of this function depends on the file format: 
+	Guessing Binary formats and structured text (GEXF, GraphML, GraphViz, GML, KONECT, MatrixMarket) takes constant time.
+	If the format is EdgeList, METIS or SNAP, running time is linear in the file size.
+
 	Returns networkit.graphio.Format
 
 	Parameters
 	----------
-	filepath : string
-		graph file
+	filepath : str
+		Input file path.
 	"""
 	# first, check for binary formats: look at magic bytes
 
@@ -1184,7 +1189,7 @@ def guessFileFormat(filepath: str) -> Format:
 			# snap check: keep verifying line format while the file could be a snap file
 			# check that all lines have format \d+ \d+ (or are empty lines)
 			if snapFound:
-					match = re.match(r'(^\d+\s\d+$)|(^\s*$)', line)
+					match = re.match(r'(^\d+\s\d+\s*$)|(^\s*$)', line)
 					if not match:
 						snapFound = False
 			

--- a/networkit/graphio.pyx
+++ b/networkit/graphio.pyx
@@ -1234,7 +1234,7 @@ def guessFileFormat(filepath: str) -> Format:
 		guess = Format.SNAP
 	
 	if metisFound and guess: # file could be both metis and edge list
-		raise IOError("guessing failed: file could be METIS or edge list!")
+		raise IOError("Format guessing failed: file could be METIS or edge list!")
 	
 	if guess:
 		return guess
@@ -1242,7 +1242,7 @@ def guessFileFormat(filepath: str) -> Format:
 		return Format.METIS
 	
 	# if none match, raise error
-	raise IOError("format guessing failed: no type found")
+	raise IOError("Format guessing failed: no type found")
 	
 
 def readGraph(path, fileformat=None, *kargs, **kwargs):

--- a/networkit/graphio.pyx
+++ b/networkit/graphio.pyx
@@ -1027,6 +1027,7 @@ class Format(__AutoNumber):
 	- networkit.graphio.Format.METIS
 	- networkit.graphio.Format.NetworkitBinary
 	- networkit.graphio.Format.SNAP
+	- networkit.graphio.Format.MatrixMarket
 	
 	"""
 	SNAP = ()
@@ -1048,6 +1049,7 @@ class Format(__AutoNumber):
 	MAT = ()
 	ThrillBinary = ()
 	NetworkitBinary = ()
+	MatrixMarket = ()
 
 # reading
 
@@ -1143,6 +1145,10 @@ def guessFileFormat(filepath: str) -> Format:
 		# KONECT - has comments with % sign, starts with % FORMAT WEIGHTS
 		if re.match(r'^%\s((asym)|(sym)|(bip))\s((unweighted)|(positive)|(posweighted)|(signed)|(multisigned)|(weighted)|(multiweighted)|(dynamic)|(multiposweighted))$', firstline.lower()):
 			return Format.KONECT
+		
+		# MatrixMarket - has specific first line. Specification defines the first line as "%%MatrixMarket [...]", but some files use a single % instead. We accept both.
+		if re.match(r'%+MatrixMarket', firstline):
+			return Format.MatrixMarket
 
 	# if none match, read all lines of the file and guess the format out of METIS, SNAP, EdgeList variants
 	# types:
@@ -1210,7 +1216,7 @@ def guessFileFormat(filepath: str) -> Format:
 
 	# finally, guess type
 	guess = None
-	if commentPrefix:	# for edge list, expect a comment prefix
+	if commentPrefix == '#':	# for edge list, expect comment prefix '#' (otherwise, custom handling is required)
 		if minId == 0:	# could extend this to set the correct minId, but for now just pick one of the nk.Format enums
 			if separator == '\t':
 				guess = Format.EdgeListTabZero

--- a/networkit/test/test_graphio.py
+++ b/networkit/test/test_graphio.py
@@ -93,6 +93,20 @@ class TestGEXFIO(unittest.TestCase):
 			else:
 				G1 = nk.graphio.readGraph(filename, format, *kargs)
 			self.checkStatic(G, G1)
+	
+	def testGuessFormat(self):
+		instances = [
+			("airfoil1.graph", nk.Format.METIS),
+			("comments.edgelist", nk.Format.EdgeListTabOne),
+			("dynamicTest.gexf", nk.Format.GEXF),
+			("foodweb-baydry.konect", nk.Format.KONECT),
+			("foodweb-baydry.networkit", nk.Format.NetworkitBinary),
+			("jazz2_directed.gml", nk.Format.GML),
+		]
+
+		for (file, expected_result) in instances:
+			guess = nk.graphio.guessFileFormat(f"input/{file}")
+			self.assertEqual(guess, expected_result)
 
 
 if __name__ == "__main__":

--- a/networkit/test/test_graphio.py
+++ b/networkit/test/test_graphio.py
@@ -72,7 +72,7 @@ class TestGEXFIO(unittest.TestCase):
 		G = nk.generators.ErdosRenyiGenerator(100, 0.1).generate()
 		someFailed = False
 
-		excluded_formats = set([nk.Format.KONECT, nk.Format.DOT, nk.Format.GraphViz, nk.Format.SNAP])
+		excluded_formats = set([nk.Format.KONECT, nk.Format.DOT, nk.Format.GraphViz, nk.Format.SNAP, nk.Format.MatrixMarket])
 
 		for format in nk.Format:
 			if format in excluded_formats:
@@ -102,6 +102,7 @@ class TestGEXFIO(unittest.TestCase):
 			("foodweb-baydry.konect", nk.Format.KONECT),
 			("foodweb-baydry.networkit", nk.Format.NetworkitBinary),
 			("jazz2_directed.gml", nk.Format.GML),
+			("chesapeake.mtx", nk.Format.MatrixMarket),
 		]
 
 		for (file, expected_result) in instances:


### PR DESCRIPTION
This PR adds a new `guessFileFormat` function to the `graphio` module (python). This function is used to guess the file format when `graphio.readGraph(path, fileformat)` is called with `fileformat=None` - which is now the default value for the `fileformat` parameter. Guessing may fail and raise an exception (in which case one needs to provide the format manually as before). 

The guessing strategies are quite simple and will probably fail for some cases where the format is actually rather easy to guess, but for now it works for the most common file structures and types (see tests). We can improve this function when new ideas/problems arise.

Direct use:
```py
>>> import networkit as nk
>>> nk.graphio.guessFileFormat("input/airfoil1.graph")
<Format.METIS: 6>
```
With `readGraph`:
```py
>>> import networkit as nk
>>> nk.readGraph("input/airfoil1.graph")
<networkit.graph.Graph object at 0x7fa2a591c570>
```


One problem which is unfixable is that a file can be both in METIS and EdgeList format, e.g.
```
3 3
1 2
0 2
0 1
```
Depending on the format, this is either a 3 or 4 node graph. When this case is detected, an error is raised and the format has to be provided manually.