### PR TITLE
Slightly improve the performance of the HyperbolicGenerator

### DIFF
--- a/include/networkit/geometric/HyperbolicSpace.hpp
+++ b/include/networkit/geometric/HyperbolicSpace.hpp
@@ -47,6 +47,30 @@ public:
                            double maxPhi, double minR, double maxR, double alpha);
 
     /**
+     * @param angles empty vector to hold angular coordinates of generated points
+     * @param radii empty vector to hold radial coordinates of generated points
+     * @param R radius of the hyperbolic disk
+     * @param alpha dispersion parameter for the node positions
+     *
+     * Fill preallocated vectors with randomly sampled points in native coordinates
+     * The points are sorted by angle
+     */
+    static void fillPointsSorted(vector<double> &angles, vector<double> &radii, double R,
+                                 double alpha);
+
+    /**
+     * @param angles empty vector to hold angular coordinates of generated points
+     * @param radii empty vector to hold radial coordinates of generated points
+     * @param stretch multiplier for the radius of the hyperbolic disk
+     * @param alpha dispersion parameter for the node positions
+     *
+     * Fill preallocated vectors with randomly sampled points in native coordinates
+     * The points are sorted by angle
+     */
+    static void fillPointsSorted(vector<double> &angles, vector<double> &radii, double minPhi,
+                                 double maxPhi, double minR, double maxR, double alpha);
+
+    /**
      * @param firstangle angular coordinate of the first point
      * @param firstR radial coordinate of the first point
      * @param secondangle angular coordinate of the second point

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1808,6 +1808,7 @@ TEST_F(CentralityGTest, testApproxElectricalCloseness) {
         Aux::Random::setSeed(seed, true);
         auto G = HyperbolicGenerator(n, 10, 3).generate();
         G = ConnectedComponents::extractLargestConnectedComponent(G, true);
+        auto n = G.numberOfNodes();
 
         // Create a biconnected component with size 2.
         G.addNodes(2);

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1808,12 +1808,12 @@ TEST_F(CentralityGTest, testApproxElectricalCloseness) {
         Aux::Random::setSeed(seed, true);
         auto G = HyperbolicGenerator(n, 10, 3).generate();
         G = ConnectedComponents::extractLargestConnectedComponent(G, true);
-        auto n = G.numberOfNodes();
+        auto new_n = G.numberOfNodes();
 
         // Create a biconnected component with size 2.
         G.addNodes(2);
-        G.addEdge(n - 1, n);
-        G.addEdge(n, n + 1);
+        G.addEdge(new_n - 1, new_n);
+        G.addEdge(new_n, new_n + 1);
 
         ApproxElectricalCloseness apx(G);
         apx.run();

--- a/networkit/cpp/generators/HyperbolicGenerator.cpp
+++ b/networkit/cpp/generators/HyperbolicGenerator.cpp
@@ -75,29 +75,10 @@ Graph HyperbolicGenerator::generate(count n, double R, double alpha, double T) {
     vector<double> radii(n);
 
     // sample points randomly
-    HyperbolicSpace::fillPoints(angles, radii, R, alpha);
-    vector<index> permutation(n);
-
-    index p = 0;
-    std::generate(permutation.begin(), permutation.end(), [&p]() { return p++; });
-
-    // can probably be parallelized easily, but doesn't bring much benefit
-    Aux::Parallel::sort(
-        permutation.begin(), permutation.end(), [&angles, &radii](index i, index j) {
-            return angles[i] < angles[j] || (angles[i] == angles[j] && radii[i] < radii[j]);
-        });
-
-    vector<double> anglecopy(n);
-    vector<double> radiicopy(n);
-
-#pragma omp parallel for
-    for (omp_index j = 0; j < static_cast<omp_index>(n); j++) {
-        anglecopy[j] = angles[permutation[j]];
-        radiicopy[j] = radii[permutation[j]];
-    }
+    HyperbolicSpace::fillPointsSorted(angles, radii, R, alpha);
 
     INFO("Generated Points");
-    return generate(anglecopy, radiicopy, R, T);
+    return generate(angles, radii, R, T);
 }
 
 Graph HyperbolicGenerator::generateCold(const vector<double> &angles, const vector<double> &radii,

--- a/networkit/cpp/geometric/HyperbolicSpace.cpp
+++ b/networkit/cpp/geometric/HyperbolicSpace.cpp
@@ -135,7 +135,6 @@ void HyperbolicSpace::fillPointsSorted(vector<double> &angles, vector<double> &r
     }
 }
 
-
 Point2DWithIndex<double> HyperbolicSpace::polarToCartesian(double phi, double r) {
     return Point2DWithIndex<double>(r * std::cos(phi), r * std::sin(phi));
 }


### PR DESCRIPTION
The past implementation generated random numbers and sorted them seperately.

I replaced this with an algorithm that directly generates sorted random numbers (Program 1 from this 1980 paper: [Generating Sorted Lists of Random Numbers](https://dl.acm.org/doi/10.1145/355900.355907)).

I tested the performance of this change using the following configuration:
```
	HyperbolicGenerator gen{20000000};
	auto graph = gen.generate();
```
Here are some numbers:
​ | before | after
--- | --- | ----
Total Runtime | 14.9 s | 12.9 s
Point generation runtime | 3.1 s | 1.3 s

Memory usage should also be a bit lower, because I removed the permutation and copy vectors.

Also note that the `fillPointsSorted` is basically a copy of the `fillPoints` functions. I kept the old `fillPoints` function because it is still being used by the DynamicHyperbolicGenerator and I didn't want to mess with that.