### PR TITLE
Fix clang-format configuration file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -60,7 +60,6 @@ ForEachMacros:
     - BOOST_FOREACH
 IncludeBlocks: Preserve
 IncludeCategories:
-IncludeCategories:
   - Regex: '^<networkit/'
     Priority: 4
   - Regex: '^<(tlx|googletest|ttmath)/'


### PR DESCRIPTION
Running clang-format does not work for me because of the duplicate `IncludeCategories`.