### PR TITLE
Use string_view instead of const string&.

### DIFF
--- a/include/networkit/auxiliary/Log.hpp
+++ b/include/networkit/auxiliary/Log.hpp
@@ -3,6 +3,7 @@
 
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include <networkit/auxiliary/StringBuilder.hpp>
 
@@ -78,7 +79,7 @@ enum class LogLevel {
  * Accept loglevel as string and set.
  * @param logLevel as string
  */
-void setLogLevel(const std::string &logLevel);
+void setLogLevel(std::string_view logLevel);
 
 /**
  * @return current loglevel as string
@@ -86,7 +87,7 @@ void setLogLevel(const std::string &logLevel);
 std::string getLogLevel();
 
 namespace Impl {
-void log(const Location &loc, LogLevel p, const std::string &msg);
+void log(const Location &loc, LogLevel p, std::string_view msg);
 } // namespace Impl
 
 ///! Returns true iff logging at the provided level is currently activated
@@ -103,7 +104,7 @@ void log(const Location &loc, LogLevel p, const T &...args) {
 }
 
 template <typename... T>
-void logF(const Location &loc, LogLevel p, const std::string &format, const T &...args) {
+void logF(const Location &loc, LogLevel p, std::string_view format, const T &...args) {
     if (!isLogLevelEnabled(p))
         return;
 

--- a/include/networkit/auxiliary/StringBuilder.hpp
+++ b/include/networkit/auxiliary/StringBuilder.hpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -22,10 +23,10 @@ template <typename... T>
 std::ostream &printToStream(std::ostream &stream, const T &...args);
 
 template <typename... T>
-std::string toStringF(const std::string &format, const T &...args);
+std::string toStringF(std::string_view format, const T &...args);
 
 template <typename... T>
-std::ostream &printToStreamF(std::ostream &stream, const std::string &format, const T &...args);
+std::ostream &printToStreamF(std::ostream &stream, std::string_view format, const T &...args);
 
 // Implementation
 /////////////////
@@ -99,14 +100,14 @@ void printToStream(std::ostream &stream, const T &arg, const Args &...args) {
     printToStream(stream, args...);
 }
 
-inline std::tuple<std::string::const_iterator, bool>
-printFormatPartToStream(std::ostream &stream, std::string::const_iterator begin,
-                        std::string::const_iterator end);
+inline std::tuple<std::string_view::const_iterator, bool>
+printFormatPartToStream(std::ostream &stream, std::string_view::const_iterator begin,
+                        std::string_view::const_iterator end);
 
-inline void printToStreamF(std::ostream &stream, std::string::const_iterator format_begin,
-                           std::string::const_iterator format_end) {
+inline void printToStreamF(std::ostream &stream, std::string_view::const_iterator format_begin,
+                           std::string_view::const_iterator format_end) {
     bool printArgument;
-    using iterator = std::string::const_iterator;
+    using iterator = std::string_view::const_iterator;
     iterator it;
     std::tie(it, printArgument) = printFormatPartToStream(stream, format_begin, format_end);
     if (printArgument) {
@@ -114,10 +115,11 @@ inline void printToStreamF(std::ostream &stream, std::string::const_iterator for
     }
 }
 template <typename T, typename... Args>
-void printToStreamF(std::ostream &stream, std::string::const_iterator format_begin,
-                    std::string::const_iterator format_end, const T &arg, const Args &...args) {
+void printToStreamF(std::ostream &stream, std::string_view::const_iterator format_begin,
+                    std::string_view::const_iterator format_end, const T &arg,
+                    const Args &...args) {
     bool printArgument;
-    using iterator = std::string::const_iterator;
+    using iterator = std::string_view::const_iterator;
     iterator it;
     std::tie(it, printArgument) = printFormatPartToStream(stream, format_begin, format_end);
     if (printArgument) {
@@ -136,9 +138,9 @@ void printToStreamF(std::ostream &stream, std::string::const_iterator format_beg
  * @returns The iterator that points one after the last consumed
  * character and whether a further argument should be printed.
  */
-inline auto printFormatPartToStream(std::ostream &stream, std::string::const_iterator begin,
-                                    std::string::const_iterator end)
-    -> std::tuple<std::string::const_iterator, bool> {
+inline auto printFormatPartToStream(std::ostream &stream, std::string_view::const_iterator begin,
+                                    std::string_view::const_iterator end)
+    -> std::tuple<std::string_view::const_iterator, bool> {
     auto it = begin;
     while (it != end) {
         auto nextPercent = std::find(it, end, '%');
@@ -303,14 +305,14 @@ std::ostream &printToStream(std::ostream &stream, const T &...args) {
 }
 
 template <typename... T>
-std::string toStringF(const std::string &format, const T &...args) {
+std::string toStringF(std::string_view format, const T &...args) {
     std::stringstream stream;
     printToStreamF(stream, format, args...);
     return stream.str();
 }
 
 template <typename... T>
-std::ostream &printToStreamF(std::ostream &stream, const std::string &format, const T &...args) {
+std::ostream &printToStreamF(std::ostream &stream, std::string_view format, const T &...args) {
     Impl::printToStreamF(stream, format.begin(), format.end(), args...);
     return stream;
 }

--- a/networkit/cpp/auxiliary/Log.cpp
+++ b/networkit/cpp/auxiliary/Log.cpp
@@ -6,6 +6,8 @@
 #include <ios>
 #include <iostream>
 #include <mutex>
+#include <string>
+#include <string_view>
 
 #include <networkit/GlobalState.hpp>
 #include <networkit/auxiliary/Log.hpp>
@@ -13,7 +15,7 @@
 namespace Aux {
 namespace Log {
 
-void setLogLevel(const std::string &logLevel) {
+void setLogLevel(std::string_view logLevel) {
     if (logLevel == "TRACE") {
         NetworKit::GlobalState::setLogLevel(LogLevel::TRACE);
     } else if (logLevel == "DEBUG") {
@@ -114,7 +116,7 @@ std::tuple<std::string, std::string> getTerminalFormat(LogLevel p) {
 
 static void logToTerminal(const Location &loc, LogLevel p,
                           const std::chrono::time_point<std::chrono::system_clock> &timePoint,
-                          const std::string &msg) {
+                          std::string_view msg) {
     std::stringstream stream;
 
     if (NetworKit::GlobalState::getPrintTime()) {
@@ -149,7 +151,7 @@ static void logToTerminal(const Location &loc, LogLevel p,
 
 static void logToFile(const Location &loc, LogLevel p,
                       const std::chrono::time_point<std::chrono::system_clock> &timePoint,
-                      const std::string &msg) {
+                      std::string_view msg) {
     if (!NetworKit::GlobalState::getLogFileIsOpen()) {
         return;
     }
@@ -175,7 +177,7 @@ static void logToFile(const Location &loc, LogLevel p,
 
 namespace Impl {
 
-void log(const Location &loc, LogLevel p, const std::string &msg) {
+void log(const Location &loc, LogLevel p, std::string_view msg) {
     auto time = std::chrono::system_clock::now();
 
     logToTerminal(loc, p, time, msg);


### PR DESCRIPTION
As done in #1134, I found other places in `Log` where we can replace `const std::string&` with `std::string_view`.