### PR TITLE
Feature/girgs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "extlibs/ttmath"]
 	path = extlibs/ttmath
 	url = https://github.com/networkit/ttmath
+[submodule "extlibs/girgs"]
+	path = extlibs/girgs
+	url = git@github.com:chistopher/girgs.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,18 @@ else()
 endif()
 
 ################################################################################
+# Use girgs as a CMake submodule
+if(EXISTS "${PROJECT_SOURCE_DIR}/extlibs/girgs/CMakeLists.txt")
+	option(BUILD_SHARED_LIBS	""	OFF)
+	option(OPTION_BUILD_CLI		""	OFF)
+	add_subdirectory(extlibs/girgs EXCLUDE_FROM_ALL)
+else()
+	message(FATAL_ERROR
+			"Missing GIRGs library in extlibs/girgs "
+			"Please run `git submodule update --init` to fetch the submodule.")
+endif()
+
+################################################################################
 # NETWORKIT MODULES
 if(NETWORKIT_BUILD_CORE AND NETWORKIT_MONOLITH)
 
@@ -263,7 +275,7 @@ if(NETWORKIT_BUILD_CORE AND NETWORKIT_MONOLITH)
 		target_include_directories(networkit_state BEFORE PUBLIC "${PROJECT_SOURCE_DIR}/include")
 	endif()
 
-	target_link_libraries(networkit PRIVATE OpenMP::OpenMP_CXX PUBLIC tlx)
+	target_link_libraries(networkit PRIVATE OpenMP::OpenMP_CXX girgs::girgs PUBLIC tlx)
 
 	set_target_properties(networkit PROPERTIES
 			CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
@@ -388,7 +400,7 @@ function(networkit_add_module modname)
 			COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"
 			LINK_FLAGS "${NETWORKIT_LINK_FLAGS}")
 
-		target_link_libraries(${MODULE_TARGET} PRIVATE OpenMP::OpenMP_CXX PUBLIC tlx)
+		target_link_libraries(${MODULE_TARGET} PRIVATE OpenMP::OpenMP_CXX girgs::girgs PUBLIC tlx)
 		target_include_directories(${MODULE_TARGET} BEFORE PUBLIC "${PROJECT_SOURCE_DIR}/include")
 		target_include_directories(${MODULE_TARGET} PUBLIC "${PROJECT_SOURCE_DIR}/extlibs/ttmath/")
 

--- a/include/networkit/generators/GeometricInhomogeneousGenerator.hpp
+++ b/include/networkit/generators/GeometricInhomogeneousGenerator.hpp
@@ -1,0 +1,42 @@
+/*
+ * GeometricInhomogeneousGenerator.hpp
+ *
+ *  Created on: 26.10.2023
+ *      Author: Christopher Weyand, Manuel Penschuck <networkit@manuel.jetzt>
+ */
+
+#ifndef GEOMETRICINHOMOGENEOUS_H_
+#define GEOMETRICINHOMOGENEOUS_H_
+
+#include <networkit/generators/StaticGraphGenerator.hpp>
+
+namespace NetworKit {
+
+class GeometricInhomogeneousGenerator: public StaticGraphGenerator {
+public:
+    /**
+     * @param[in] n Number of nodes
+     * @param[in] avgDegree The desired average degree with 0 < avgDegree < n-1
+     * @param[in] powerlawExp Target exponent of power-law distribution with powerlawExp > 2.0
+     * @param[in] temperature Temperature adds noise to the instance with 0 <= T <= 1
+     * @param[in] dimension Dimension of the underlying geometry with 1 <= dimension <= 5
+     */
+    GeometricInhomogeneousGenerator(count n, double avgDegree, double powerlawExp=3, double temperature=0.0, unsigned dim=1);
+
+    // Add virtual destructor
+    virtual ~GeometricInhomogeneousGenerator() = default;
+
+    /// @return Graph to be generated according to parameters specified in constructor
+    Graph generate() override;
+
+private:
+    count n;
+    double avgDegree;
+    double powerlawExp;
+    double alpha;
+    unsigned dim;
+};
+
+} // NetworKit
+
+#endif // GEOMETRICINHOMOGENEOUS_H_

--- a/networkit/cpp/generators/CMakeLists.txt
+++ b/networkit/cpp/generators/CMakeLists.txt
@@ -13,6 +13,7 @@ networkit_add_module(generators
     DynamicPubWebGenerator.cpp
     EdgeSwitchingMarkovChainGenerator.cpp
     ErdosRenyiGenerator.cpp
+    GeometricInhomogeneousGenerator.cpp
     HavelHakimiGenerator.cpp
     HyperbolicGenerator.cpp
     LFRGenerator.cpp

--- a/networkit/cpp/generators/GeometricInhomogeneousGenerator.cpp
+++ b/networkit/cpp/generators/GeometricInhomogeneousGenerator.cpp
@@ -1,0 +1,55 @@
+/*
+ * GeometricInhomogeneousGenerator.cpp
+ *
+ *  Created on: 26.10.2023
+ *      Author: Christopher Weyand, Manuel Penschuck <networkit@manuel.jetzt>
+ */
+
+#include <limits>
+
+#include <girgs/Generator.h>
+
+#include <networkit/generators/GeometricInhomogeneousGenerator.hpp>
+#include <networkit/auxiliary/Random.hpp>
+
+namespace NetworKit {
+
+GeometricInhomogeneousGenerator::GeometricInhomogeneousGenerator(count n, double avgDegree, double exp, double temperature, unsigned dim)
+    : n(n), avgDegree(avgDegree), powerlawExp(exp), dim(dim) {
+    if (n >= static_cast<count>(std::numeric_limits<int>::max()))
+        throw std::runtime_error("Support only INT_MAX nodes");
+
+    if (avgDegree > n-1)
+        throw std::runtime_error("Average degree is at most n-1");
+
+    if (exp <= 2.0)
+        throw std::runtime_error("Power law exponent must be > 2");
+
+    if (temperature < 0 || temperature > 1)
+        throw std::runtime_error("Temperature T has to satiesfy 0 <= T <= 1");
+    alpha = temperature <= 0.0 ? std::numeric_limits<double>::infinity() : 1/temperature;
+
+    if (!(1 <= dim && dim <= 5))
+        throw std::runtime_error("Support only 1 to 5 dimensions");
+}
+
+Graph GeometricInhomogeneousGenerator::generate() {
+    auto& gen = Aux::Random::getURNG();
+
+    // generate inputs
+    auto positions = girgs::generatePositions(static_cast<int>(n), dim, gen());
+    auto weights = girgs::generateWeights(static_cast<int>(n), powerlawExp, gen());
+    girgs::scaleWeights(weights, avgDegree, dim, alpha);
+
+    // gerenate edge list
+    auto edges = girgs::generateEdges(weights, positions, alpha, gen());
+
+    // convert to networkit Graph
+    Graph G(n);
+    for(auto [u,v] : edges) 
+        G.addEdge(u,v);
+
+    return G;
+}
+
+} // NetworKit

--- a/networkit/generators.pyx
+++ b/networkit/generators.pyx
@@ -335,6 +335,36 @@ cdef class ErdosRenyiGenerator(StaticGraphGenerator):
 			p = (2 * m) / (scale * n * (n-1))
 		return cls(scale * n, p)
 
+cdef extern from "<networkit/generators/GeometricInhomogeneousGenerator.hpp>":
+	cdef cppclass _GeometricInhomogeneousGenerator "NetworKit::GeometricInhomogeneousGenerator"(_StaticGraphGenerator):
+		_GeometricInhomogeneousGenerator(count n, double avgDegree, double powerlawExp, double temperature, unsigned dim) except +
+
+cdef class GeometricInhomogeneousGenerator(StaticGraphGenerator):
+	"""
+	GeometricInhomogeneousGenerator(count numNodes, double avgDegree, double powerlawExp, double temperature, unsigned dimensions)
+
+	Creates a Geometric Inhomogeneous Random Graph by first samling n random points in a d-dimension space
+	and then connecting them according to their weights and distances. It implements the generator of
+	Blaesius et al. "Efficiently Generating Geometric Inhomogeneous and Hyperbolic Random Graphs" [https://arxiv.org/abs/1905.06706]
+
+
+	Parameters
+	----------
+	numNodes : count
+		Number of nodes n in the graph.
+	avgDegree : double
+		Desired average degree -- will be met only in expection, though variance is quite small.
+	powerlawExp : double
+		Exponenent of the powerlaw degree distribution with powerlawExp > 2
+	temperature : double
+		Temperature adds noise to the instance with 0 <= T <= 1
+	dimensions : unsigned
+		Number of dimensions in the underlying geometric with 1 <= dimensions <= 5
+	"""
+
+	def __cinit__(self, numNodes, avgDegree, powerlawExp = 3, temperature = 0, dimensions = 1):
+		self._this = new _GeometricInhomogeneousGenerator(numNodes, avgDegree, powerlawExp, temperature, dimensions)
+
 cdef extern from "<networkit/generators/DorogovtsevMendesGenerator.hpp>":
 
 	cdef cppclass _DorogovtsevMendesGenerator "NetworKit::DorogovtsevMendesGenerator"(_StaticGraphGenerator):


### PR DESCRIPTION
I tried to add a  generator for [GIRGs](https://doi.org/10.1017/nws.2022.32).
In contrast to #320, this PR is just a wrapper around our [implementation](https://github.com/chistopher/girgs) and I tried to keep the code complexity as low as possible. 
The GIRGs repo is added as a git submodule and builds a static library.
Networkit or its components link against it but do not expose it further.

There still remain some issues that I don't like and I would greatly appreciate your input.
- in a non-monolith build, all components link against GIRGs although only the generators module needs it
- GIRGs enables `-Wswitch-default` warnings that trigger a lot here. I can remove this from the public interface of GIRGs if desired.
- the algorithm does not catch SIGINT. Since the implementation is very fast, we could catch SIGINT in the wrapper and just ignore it to prevent an interactive python shell from exiting.