### PR TITLE
Restore original removeEdge API.

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1979,22 +1979,12 @@ public:
      */
     bool addPartialOutEdge(Unsafe, node u, node v, edgeweight ew = defaultEdgeWeight,
                            uint64_t index = 0, bool checkForMultiEdges = false);
-
     /**
      * Removes the undirected edge {@a u,@a v}.
      * @param u Endpoint of edge.
      * @param v Endpoint of edge.
-     * @param maintainSortedEdges If set to true, the ingoing and outgoing adjacency vectors will
-     * automatically be updated to maintain a sorting (if it existed before) by performing up to n-1
-     * swaps. If the user plans to remove multiple edges, better set it to false and call
-     * sortEdges() afterwards to avoid redundant swaps. Default = false.
-     * @param maintainCompactEdgeIDs If set to true, the EdgeIDs will automatically be adjusted,
-     * so that no gaps in between IDs exist. If the user plans to remove multiple edges, better set
-     * it to false and call indexEdges(force=true) afterwards to avoid redundant re-indexing.
-     * Default = false.
      */
-    void removeEdge(node u, node v, bool maintainSortedEdges = false,
-                    bool maintainCompactEdgeIDs = false);
+    void removeEdge(node u, node v);
 
     /**
      * Removes all the edges in the graph.
@@ -2503,6 +2493,18 @@ public:
      */
     template <typename L>
     double parallelSumForEdges(L handle) const;
+
+    // If set to true, the ingoing and outgoing adjacency vectors will
+    // automatically be updated to maintain a sorting (if it existed before) by
+    // performing up to n-1 swaps. If the user plans to remove multiple edges,
+    // better set it to false and call sortEdges() afterwards to avoid
+    // redundant swaps. Default = false.
+    bool maintainEdgesSorted = false;
+    // If set to true, the EdgeIDs will automatically be adjusted, so that no
+    // gaps in between IDs exist. If the user plans to remove multiple edges,
+    // better set it to false and call indexEdges(force=true) afterwards to
+    // avoid redundant re-indexing.
+    bool maintainCompactEdgeIDs = false;
 };
 
 /* NODE ITERATORS */

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -2242,19 +2242,21 @@ TEST_P(GraphGTest, testSortEdges) {
 }
 
 TEST_P(GraphGTest, testEdgeIdsSortingAfterRemove) {
-    constexpr node n = 100;
+    const node n = 100;
 
     Aux::Random::setSeed(42, true);
-    auto G = createGraph(n, 10 * n);
+    Graph G = createGraph(n, 10 * n);
     G.sortEdges();
     G.indexEdges();
-    auto original = G;
+    Graph original = G;
+
+    G.maintainEdgesSorted = true;
 
     // remove edges
     while (2 * G.numberOfEdges() > original.numberOfEdges()) {
         const auto e = GraphTools::randomEdge(G, false);
-        G.removeEdge(e.first, e.second, true, false); // with sorting after each removal
-        original.removeEdge(e.first, e.second);       // without sorting
+        G.removeEdge(e.first, e.second);        // with sorting after each removal
+        original.removeEdge(e.first, e.second); // without sorting
     }
 
     original.sortEdges(); // calling sort only once
@@ -2299,19 +2301,21 @@ TEST_P(GraphGTest, testEdgeIdsSortingAfterRemove) {
 }
 
 TEST_P(GraphGTest, testEdgeIdsConsistencyAfterRemove) {
-    constexpr node n = 100;
+    const node n = 100;
 
     Aux::Random::setSeed(42, true);
-    auto G = createGraph(n, 10 * n);
+    Graph G = createGraph(n, 10 * n);
     G.sortEdges();
     G.indexEdges();
-    auto original = G;
+    Graph original = G;
+
+    G.maintainCompactEdgeIDs = true;
 
     // remove edges
     while (2 * G.numberOfEdges() > original.numberOfEdges()) {
         const auto e = GraphTools::randomEdge(G, false);
-        G.removeEdge(e.first, e.second, false, true); // re-indexing after each removal
-        original.removeEdge(e.first, e.second);       // not re-indexing
+        G.removeEdge(e.first, e.second);        // re-indexing after each removal
+        original.removeEdge(e.first, e.second); // not re-indexing
     }
 
     original.indexEdges(true); // re-indexing only once


### PR DESCRIPTION
The two boolean parameters introduced to `removeEdge` in #1127 should be removed because we are assuming that the users are familiar with the internal implementation of Graph and know how `sortEdges` and `indexEdges` work. `removeEdge` should be kept as simple as it was and the additional complexity of dealing with sorted edges or indexed edges should be moved elsewhere.

I suggest that we introduce two new public member variables in Graph so that:
- advanced users that want to keep the edges/edge ids sorted can do so,
- we don't complicate NetworKit APIs.