### PR TITLE
Bug fix/csr matrix set value binary search bug

### DIFF
--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -64,8 +64,8 @@ public:
      * @param isSorted If the matrix representation should uses sorted vectors.
      */
     CSRGeneralMatrix(count nRows, count nCols, ValueType zero = 0)
-        : rowIdx(nRows + 1), columnIdx(0), nonZeros(0), nRows(nRows), nCols(nCols),
-          isSorted(true), zero(zero) {}
+        : rowIdx(nRows + 1), columnIdx(0), nonZeros(0), nRows(nRows), nCols(nCols), isSorted(true),
+          zero(zero) {}
 
     /**
      * Constructs the @a dimension x @a dimension Matrix from the elements at
@@ -286,7 +286,7 @@ public:
 
         index colIdx = none;
 
-        if (! isSorted) {
+        if (!isSorted) {
             for (index k = rowIdx[i]; k < rowIdx[i + 1]; ++k) {
                 if (columnIdx[k] == j) {
                     colIdx = k;
@@ -298,7 +298,7 @@ public:
             colIdx = static_cast<index>(it - columnIdx.begin());
         }
 
-        if (! isSorted) {
+        if (!isSorted) {
             if (colIdx != none) {
                 if (value != zero) { // update existing value
                     nonZeros[colIdx] = value;
@@ -390,9 +390,7 @@ public:
     /**
      * Make the matrix use an unsorted representation.
      */
-    void makeUnsorted() {
-        isSorted = false;
-    }
+    void makeUnsorted() { isSorted = false; }
 
     /**
      * @return Row @a i of this matrix as vector.

--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -50,7 +50,6 @@ public:
      * Constructs the CSRGeneralMatrix with size @a dimension x @a dimension.
      * @param dimension Defines how many rows and columns this matrix has.
      * @param zero The zero element (default = 0).
-     * @param isSorted If the matrix representation should uses sorted vectors.
      */
     CSRGeneralMatrix(count dimension, ValueType zero = 0)
         : rowIdx(dimension + 1), columnIdx(0), nonZeros(0), nRows(dimension), nCols(dimension),
@@ -61,7 +60,6 @@ public:
      * @param nRows Number of rows.
      * @param nCols Number of columns.
      * @param zero The zero element (default = 0).
-     * @param isSorted If the matrix representation should uses sorted vectors.
      */
     CSRGeneralMatrix(count nRows, count nCols, ValueType zero = 0)
         : rowIdx(nRows + 1), columnIdx(0), nonZeros(0), nRows(nRows), nCols(nCols), isSorted(true),

--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -286,7 +286,7 @@ public:
 
         index colIdx = none;
 
-        if (!sorted()) {
+        if (! isSorted) {
             for (index k = rowIdx[i]; k < rowIdx[i + 1]; ++k) {
                 if (columnIdx[k] == j) {
                     colIdx = k;
@@ -298,7 +298,7 @@ public:
             colIdx = static_cast<index>(it - columnIdx.begin());
         }
 
-        if (!sorted()) {
+        if (! isSorted) {
             if (colIdx != none) {
                 if (value != zero) { // update existing value
                     nonZeros[colIdx] = value;
@@ -316,7 +316,7 @@ public:
 
                 // update rowIdx
                 for (index k = i + 1; k < rowIdx.size(); ++k) {
-                    rowIdx[k]++;
+                    ++rowIdx[k];
                 }
             }
         } else {
@@ -337,7 +337,7 @@ public:
 
                 // update rowIdx
                 for (index k = i + 1; k < rowIdx.size(); ++k) {
-                    rowIdx[k]++;
+                    ++rowIdx[k];
                 }
             }
         }

--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -44,20 +44,19 @@ class CSRGeneralMatrix {
     /**
      * Binary search the sorted columnIdx vector between [@a left, @a right]
      * for column @a j.
-     * If @a j is not present, the index that is immediately left of the place
-     * where @a j would be is returned.
+     * If @a j is not present, non is returned
      * @param left
      * @param right
      * @param j
-     * @return The position of column @a j in columnIdx or the element immediately
-     * to the left of the place where @a j would be.
+     * @return The position of column @a j in columnIdx or none if @a j is not present.
      */
     index binarySearchColumns(index left, index right, index j) const {
         assert(sorted());
-        const auto it = std::lower_bound(columnIdx.begin() + left, columnIdx.begin() + right, j);
+        const auto it = std::lower_bound(columnIdx.begin() + left, columnIdx.begin() + right, j,
+                                         [](index i, index value) { return i > value; });
         if (it == columnIdx.end() || *it != j)
             return none;
-        return it - columnIdx.begin();
+        return std::distance(columnIdx.begin(), it);
     }
 
 public:
@@ -280,7 +279,7 @@ public:
                 }
             }
         } else {
-            index colIdx = binarySearchColumns(rowIdx[i], rowIdx[i + 1] - 1, j);
+            index colIdx = binarySearchColumns(rowIdx[i], rowIdx[i + 1], j);
             if (colIdx != none && rowIdx[i] <= colIdx && columnIdx[colIdx] == j) {
                 value = nonZeros[colIdx];
             }
@@ -308,7 +307,7 @@ public:
                 }
             }
         } else {
-            colIdx = binarySearchColumns(rowIdx[i], rowIdx[i + 1] - 1, j);
+            colIdx = binarySearchColumns(rowIdx[i], rowIdx[i + 1], j);
         }
 
         if (colIdx != none && colIdx >= rowIdx[i]

--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -64,8 +64,8 @@ public:
      * @param isSorted If the matrix representation should uses sorted vectors.
      */
     CSRGeneralMatrix(count nRows, count nCols, ValueType zero = 0, bool isSorted = true)
-        : rowIdx(nRows + 1), columnIdx(0), nonZeros(0), nRows(nRows), nCols(nCols), isSorted(isSorted),
-          zero(zero) {}
+        : rowIdx(nRows + 1), columnIdx(0), nonZeros(0), nRows(nRows), nCols(nCols),
+          isSorted(isSorted), zero(zero) {}
 
     /**
      * Constructs the @a dimension x @a dimension Matrix from the elements at
@@ -263,7 +263,8 @@ public:
                 }
             }
         } else {
-            auto it = std::lower_bound(columnIdx.begin() + rowIdx[i], columnIdx.begin() + rowIdx[i + 1], j);
+            auto it = std::lower_bound(columnIdx.begin() + rowIdx[i],
+                                       columnIdx.begin() + rowIdx[i + 1], j);
             auto colIdx = it - columnIdx.begin();
 
             if (*it == j && rowIdx[i] <= colIdx && rowIdx[i + 1] > colIdx) {
@@ -292,7 +293,8 @@ public:
                 }
             }
         } else {
-            auto it = std::lower_bound(columnIdx.begin() + rowIdx[i], columnIdx.begin() + rowIdx[i + 1], j);
+            auto it = std::lower_bound(columnIdx.begin() + rowIdx[i],
+                                       columnIdx.begin() + rowIdx[i + 1], j);
             colIdx = it - columnIdx.begin();
         }
 

--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -52,9 +52,9 @@ public:
      * @param zero The zero element (default = 0).
      * @param isSorted If the matrix representation should uses sorted vectors.
      */
-    CSRGeneralMatrix(count dimension, ValueType zero = 0, bool isSorted = true)
+    CSRGeneralMatrix(count dimension, ValueType zero = 0)
         : rowIdx(dimension + 1), columnIdx(0), nonZeros(0), nRows(dimension), nCols(dimension),
-          isSorted(isSorted), zero(zero) {}
+          isSorted(true), zero(zero) {}
 
     /**
      * Constructs the CSRGeneralMatrix with size @a nRows x @a nCols.
@@ -63,9 +63,9 @@ public:
      * @param zero The zero element (default = 0).
      * @param isSorted If the matrix representation should uses sorted vectors.
      */
-    CSRGeneralMatrix(count nRows, count nCols, ValueType zero = 0, bool isSorted = true)
+    CSRGeneralMatrix(count nRows, count nCols, ValueType zero = 0)
         : rowIdx(nRows + 1), columnIdx(0), nonZeros(0), nRows(nRows), nCols(nCols),
-          isSorted(isSorted), zero(zero) {}
+          isSorted(true), zero(zero) {}
 
     /**
      * Constructs the @a dimension x @a dimension Matrix from the elements at
@@ -386,6 +386,13 @@ public:
      * @return True if the matrix is sorted, otherwise false.
      */
     bool sorted() const noexcept { return isSorted; }
+
+    /**
+     * Make the matrix use an unsorted representation.
+     */
+    void makeUnsorted() {
+        isSorted = false;
+    }
 
     /**
      * @return Row @a i of this matrix as vector.

--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -265,7 +265,7 @@ public:
         } else {
             auto it = std::lower_bound(columnIdx.begin() + rowIdx[i],
                                        columnIdx.begin() + rowIdx[i + 1], j);
-            auto colIdx = it - columnIdx.begin();
+            index colIdx = static_cast<index>(it - columnIdx.begin());
 
             if (*it == j && rowIdx[i] <= colIdx && rowIdx[i + 1] > colIdx) {
                 value = nonZeros[colIdx];
@@ -295,12 +295,12 @@ public:
         } else {
             auto it = std::lower_bound(columnIdx.begin() + rowIdx[i],
                                        columnIdx.begin() + rowIdx[i + 1], j);
-            colIdx = it - columnIdx.begin();
+            colIdx = static_cast<index>(it - columnIdx.begin());
         }
 
         if (!sorted()) {
             if (colIdx != none) {
-                if (nonZeros[colIdx] != zero) { // update existing value
+                if (value != zero) { // update existing value
                     nonZeros[colIdx] = value;
                 } else { // remove value if set to zero
                     columnIdx.erase(columnIdx.begin() + colIdx);
@@ -321,7 +321,7 @@ public:
             }
         } else {
             if (colIdx < rowIdx[i + 1] && columnIdx[colIdx] == j) {
-                if (nonZeros[colIdx] != zero) { // update existing value
+                if (value != zero) { // update existing value
                     nonZeros[colIdx] = value;
                 } else { // remove value if set to zero
                     columnIdx.erase(columnIdx.begin() + colIdx);

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -1384,6 +1384,48 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValue) {
     ASSERT_EQ(A(0,1), -1);
     ASSERT_EQ(A(1,0), -1);
     ASSERT_EQ(A(1,1), 1);
+
+    /* 0 0.5 0 -1.2
+     * 0  0 -2  0
+     * 0  0  0 0.6
+     * 0  0  0 0.5
+     * */
+
+    CSRMatrix B(4);
+
+    B.setValue(0, 1, 0.5);
+    B.setValue(0, 3, -1.2);
+    B.setValue(1, 2, -2);
+    B.setValue(2, 3, 0.6);
+    B.setValue(3, 3, 0.5);
+
+    ASSERT_TRUE(B.sorted());
+
+    ASSERT_EQ(B(0, 1), 0.5);
+    ASSERT_EQ(B(0, 3), -1.2);
+    ASSERT_EQ(B(1, 2), -2);
+    ASSERT_EQ(B(2, 3), 0.6);
+    ASSERT_EQ(B(3, 3), 0.5);
+
+    CSRMatrix C(4);
+
+    C.setValue(1, 0, 1);
+    C.setValue(1, 1, 2);
+    C.setValue(1, 2, 3);
+    C.setValue(1, 3, 4);
+    C.setValue(3, 3, 5);
+    C.setValue(2, 3, 6);
+    C.setValue(0, 3, 7);
+
+    ASSERT_TRUE(C.sorted());
+
+    ASSERT_EQ(C(1, 0), 1);
+    ASSERT_EQ(C(1, 1), 2);
+    ASSERT_EQ(C(1, 2), 3);
+    ASSERT_EQ(C(1, 3), 4);
+    ASSERT_EQ(C(3, 3), 5);
+    ASSERT_EQ(C(2, 3), 6);
+    ASSERT_EQ(C(0, 3), 7);
 }
 
 } // namespace

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -1380,7 +1380,7 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueSorted) {
     A.setValue(0, 2, 1);
     A.setValue(1, 2, -1);
 
-    ASSERT_TRUE(A.sorted());
+    EXPECT_TRUE(A.sorted());
 
     EXPECT_EQ(A(0, 0), 1);
     EXPECT_EQ(A(0, 1), -1);
@@ -1403,7 +1403,7 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueSorted) {
     B.setValue(2, 3, 0.6);
     B.setValue(3, 3, 0.5);
 
-    ASSERT_TRUE(B.sorted());
+    EXPECT_TRUE(B.sorted());
 
     EXPECT_EQ(B(0, 1), 0.5);
     EXPECT_EQ(B(0, 3), -1.2);
@@ -1422,7 +1422,7 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueSorted) {
     C.setValue(0, 3, 7);
     C.setValue(0, 2, 0);
 
-    ASSERT_TRUE(C.sorted());
+    EXPECT_TRUE(C.sorted());
 
     EXPECT_EQ(C(1, 0), 1);
     EXPECT_EQ(C(1, 1), 2);
@@ -1460,7 +1460,7 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
     A.setValue(0, 2, 1);
     A.setValue(1, 2, -1);
 
-    ASSERT_FALSE(A.sorted());
+    EXPECT_FALSE(A.sorted());
 
     EXPECT_EQ(A(0, 0), 1);
     EXPECT_EQ(A(0, 1), -1);
@@ -1483,7 +1483,7 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
     B.setValue(2, 3, 0.6);
     B.setValue(3, 3, 0.5);
 
-    ASSERT_FALSE(B.sorted());
+    EXPECT_FALSE(B.sorted());
 
     EXPECT_EQ(B(0, 1), 0.5);
     EXPECT_EQ(B(0, 3), -1.2);
@@ -1502,7 +1502,7 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
     C.setValue(0, 3, 7);
     C.setValue(0, 2, 0);
 
-    ASSERT_FALSE(C.sorted());
+    EXPECT_FALSE(C.sorted());
 
     EXPECT_EQ(C(1, 0), 1);
     EXPECT_EQ(C(1, 1), 2);

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -1372,7 +1372,7 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueSorted) {
      * -1 1 -1
      */
 
-    CSRMatrix A(2, 3, 0, true);
+    CSRMatrix A(2, 3, 0);
     A.setValue(0, 0, 1);
     A.setValue(0, 1, -1);
     A.setValue(1, 0, -1);
@@ -1452,7 +1452,9 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
      * -1 1 -1
      */
 
-    CSRMatrix A(2, 3, 0, false);
+    CSRMatrix A(2, 3, 0);
+    A.makeUnsorted();
+
     A.setValue(0, 0, 1);
     A.setValue(0, 1, -1);
     A.setValue(1, 0, -1);
@@ -1475,7 +1477,8 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
      * 0  0  0 0.5
      * */
 
-    CSRMatrix B(4, 0, false);
+    CSRMatrix B(4, 0.0);
+    B.makeUnsorted();
 
     B.setValue(0, 1, 0.5);
     B.setValue(0, 3, -1.2);
@@ -1491,7 +1494,8 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
     EXPECT_EQ(B(2, 3), 0.6);
     EXPECT_EQ(B(3, 3), 0.5);
 
-    CSRMatrix C(4, 0, false);
+    CSRMatrix C(4, 0.0);
+    C.makeUnsorted();
 
     C.setValue(1, 0, 1);
     C.setValue(1, 3, 4);
@@ -1512,6 +1516,100 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
     EXPECT_EQ(C(2, 3), 6);
     EXPECT_EQ(C(0, 3), 7);
     EXPECT_EQ(C(0, 2), 0);
+
+    C.setValue(1, 0, 0);
+    C.setValue(1, 3, 0);
+    C.setValue(2, 3, 0);
+
+    EXPECT_EQ(C(1, 0), 0);
+    EXPECT_EQ(C(1, 1), 2);
+    EXPECT_EQ(C(1, 2), 3);
+    EXPECT_EQ(C(1, 3), 0);
+    EXPECT_EQ(C(3, 3), 5);
+    EXPECT_EQ(C(2, 3), 0);
+    EXPECT_EQ(C(0, 3), 7);
+    EXPECT_EQ(C(0, 2), 0);
+}
+
+TEST_F(CSRMatrixGTest, testCSRMatrixSetValueMakeUnsorted) {
+    /* 1 -1 1
+     * -1 1 -1
+     */
+
+    CSRMatrix A(2, 3, 0);
+    A.setValue(0, 0, 1);
+    A.setValue(0, 1, -1);
+    A.setValue(1, 0, -1);
+    A.setValue(1, 1, 1);
+    A.setValue(0, 2, 1);
+    A.setValue(1, 2, -1);
+
+    EXPECT_TRUE(A.sorted());
+
+    EXPECT_EQ(A(0, 0), 1);
+    EXPECT_EQ(A(0, 1), -1);
+    EXPECT_EQ(A(1, 0), -1);
+    EXPECT_EQ(A(1, 1), 1);
+    EXPECT_EQ(A(0, 2), 1);
+    EXPECT_EQ(A(1, 2), -1);
+
+    A.makeUnsorted();
+    EXPECT_FALSE(A.sorted());
+
+    EXPECT_EQ(A(0, 0), 1);
+    EXPECT_EQ(A(0, 1), -1);
+    EXPECT_EQ(A(1, 0), -1);
+    EXPECT_EQ(A(1, 1), 1);
+    EXPECT_EQ(A(0, 2), 1);
+    EXPECT_EQ(A(1, 2), -1);
+
+    /* 0 0.5 0 -1.2
+     * 0  0 -2  0
+     * 0  0  0 0.6
+     * 0  0  0 0.5
+     * */
+
+    CSRMatrix B(4, 0.0);
+    B.makeUnsorted();
+
+    B.setValue(0, 1, 0.5);
+    B.setValue(0, 3, -1.2);
+    B.setValue(1, 2, -2);
+    B.setValue(2, 3, 0.6);
+    B.setValue(3, 3, 0.5);
+
+    EXPECT_FALSE(B.sorted());
+
+    EXPECT_EQ(B(0, 1), 0.5);
+    EXPECT_EQ(B(0, 3), -1.2);
+    EXPECT_EQ(B(1, 2), -2);
+    EXPECT_EQ(B(2, 3), 0.6);
+    EXPECT_EQ(B(3, 3), 0.5);
+
+    CSRMatrix C(4, 0.0);
+
+    C.setValue(1, 0, 1);
+    C.setValue(1, 3, 4);
+    C.setValue(1, 1, 2);
+    C.setValue(1, 2, 3);
+    C.setValue(3, 3, 5);
+    C.setValue(2, 3, 6);
+    C.setValue(0, 3, 7);
+    C.setValue(0, 2, 0);
+
+    EXPECT_TRUE(C.sorted());
+
+    EXPECT_EQ(C(1, 0), 1);
+    EXPECT_EQ(C(1, 1), 2);
+    EXPECT_EQ(C(1, 2), 3);
+    EXPECT_EQ(C(1, 3), 4);
+    EXPECT_EQ(C(3, 3), 5);
+    EXPECT_EQ(C(2, 3), 6);
+    EXPECT_EQ(C(0, 3), 7);
+    EXPECT_EQ(C(0, 2), 0);
+
+    C.makeUnsorted();
+    EXPECT_FALSE(C.sorted());
 
     C.setValue(1, 0, 0);
     C.setValue(1, 3, 0);

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -1367,23 +1367,27 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSort) {
     csr.sort();
 }
 
-TEST_F(CSRMatrixGTest, testCSRMatrixSetValue) {
-    /* 1 -1
-     * -1 1
+TEST_F(CSRMatrixGTest, testCSRMatrixSetValueSorted) {
+    /* 1 -1 1
+     * -1 1 -1
      */
 
-    CSRMatrix A(2);
+    CSRMatrix A(2, 3, 0, true);
     A.setValue(0, 0, 1);
     A.setValue(0, 1, -1);
     A.setValue(1, 0, -1);
     A.setValue(1, 1, 1);
+    A.setValue(0, 2, 1);
+    A.setValue(1, 2, -1);
 
     ASSERT_TRUE(A.sorted());
 
-    ASSERT_EQ(A(0,0), 1);
-    ASSERT_EQ(A(0,1), -1);
-    ASSERT_EQ(A(1,0), -1);
-    ASSERT_EQ(A(1,1), 1);
+    ASSERT_EQ(A(0, 0), 1);
+    ASSERT_EQ(A(0, 1), -1);
+    ASSERT_EQ(A(1, 0), -1);
+    ASSERT_EQ(A(1, 1), 1);
+    ASSERT_EQ(A(0, 2), 1);
+    ASSERT_EQ(A(1, 2), -1);
 
     /* 0 0.5 0 -1.2
      * 0  0 -2  0
@@ -1410,12 +1414,13 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValue) {
     CSRMatrix C(4);
 
     C.setValue(1, 0, 1);
+    C.setValue(1, 3, 4);
     C.setValue(1, 1, 2);
     C.setValue(1, 2, 3);
-    C.setValue(1, 3, 4);
     C.setValue(3, 3, 5);
     C.setValue(2, 3, 6);
     C.setValue(0, 3, 7);
+    C.setValue(0, 2, 0);
 
     ASSERT_TRUE(C.sorted());
 
@@ -1426,6 +1431,100 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValue) {
     ASSERT_EQ(C(3, 3), 5);
     ASSERT_EQ(C(2, 3), 6);
     ASSERT_EQ(C(0, 3), 7);
+    ASSERT_EQ(C(0, 2), 0);
+
+    C.setValue(1, 0, 0);
+    C.setValue(1, 3, 0);
+    C.setValue(2, 3, 0);
+
+    ASSERT_EQ(C(1, 0), 0);
+    ASSERT_EQ(C(1, 1), 2);
+    ASSERT_EQ(C(1, 2), 3);
+    ASSERT_EQ(C(1, 3), 0);
+    ASSERT_EQ(C(3, 3), 5);
+    ASSERT_EQ(C(2, 3), 0);
+    ASSERT_EQ(C(0, 3), 7);
+    ASSERT_EQ(C(0, 2), 0);
+}
+
+TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
+    /* 1 -1 1
+     * -1 1 -1
+     */
+
+    CSRMatrix A(2, 3, 0, false);
+    A.setValue(0, 0, 1);
+    A.setValue(0, 1, -1);
+    A.setValue(1, 0, -1);
+    A.setValue(1, 1, 1);
+    A.setValue(0, 2, 1);
+    A.setValue(1, 2, -1);
+
+    ASSERT_FALSE(A.sorted());
+
+    ASSERT_EQ(A(0, 0), 1);
+    ASSERT_EQ(A(0, 1), -1);
+    ASSERT_EQ(A(1, 0), -1);
+    ASSERT_EQ(A(1, 1), 1);
+    ASSERT_EQ(A(0, 2), 1);
+    ASSERT_EQ(A(1, 2), -1);
+
+    /* 0 0.5 0 -1.2
+     * 0  0 -2  0
+     * 0  0  0 0.6
+     * 0  0  0 0.5
+     * */
+
+    CSRMatrix B(4, 0, false);
+
+    B.setValue(0, 1, 0.5);
+    B.setValue(0, 3, -1.2);
+    B.setValue(1, 2, -2);
+    B.setValue(2, 3, 0.6);
+    B.setValue(3, 3, 0.5);
+
+    ASSERT_FALSE(B.sorted());
+
+    ASSERT_EQ(B(0, 1), 0.5);
+    ASSERT_EQ(B(0, 3), -1.2);
+    ASSERT_EQ(B(1, 2), -2);
+    ASSERT_EQ(B(2, 3), 0.6);
+    ASSERT_EQ(B(3, 3), 0.5);
+
+    CSRMatrix C(4, 0, false);
+
+    C.setValue(1, 0, 1);
+    C.setValue(1, 3, 4);
+    C.setValue(1, 1, 2);
+    C.setValue(1, 2, 3);
+    C.setValue(3, 3, 5);
+    C.setValue(2, 3, 6);
+    C.setValue(0, 3, 7);
+    C.setValue(0, 2, 0);
+
+    ASSERT_FALSE(C.sorted());
+
+    ASSERT_EQ(C(1, 0), 1);
+    ASSERT_EQ(C(1, 1), 2);
+    ASSERT_EQ(C(1, 2), 3);
+    ASSERT_EQ(C(1, 3), 4);
+    ASSERT_EQ(C(3, 3), 5);
+    ASSERT_EQ(C(2, 3), 6);
+    ASSERT_EQ(C(0, 3), 7);
+    ASSERT_EQ(C(0, 2), 0);
+
+    C.setValue(1, 0, 0);
+    C.setValue(1, 3, 0);
+    C.setValue(2, 3, 0);
+
+    ASSERT_EQ(C(1, 0), 0);
+    ASSERT_EQ(C(1, 1), 2);
+    ASSERT_EQ(C(1, 2), 3);
+    ASSERT_EQ(C(1, 3), 0);
+    ASSERT_EQ(C(3, 3), 5);
+    ASSERT_EQ(C(2, 3), 0);
+    ASSERT_EQ(C(0, 3), 7);
+    ASSERT_EQ(C(0, 2), 0);
 }
 
 } // namespace

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -1367,5 +1367,24 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSort) {
     csr.sort();
 }
 
+TEST_F(CSRMatrixGTest, testCSRMatrixSetValue) {
+    /* 1 -1
+     * -1 1
+     */
+
+    CSRMatrix A(2);
+    A.setValue(0, 0, 1);
+    A.setValue(0, 1, -1);
+    A.setValue(1, 0, -1);
+    A.setValue(1, 1, 1);
+
+    ASSERT_TRUE(A.sorted());
+
+    ASSERT_EQ(A(0,0), 1);
+    ASSERT_EQ(A(0,1), -1);
+    ASSERT_EQ(A(1,0), -1);
+    ASSERT_EQ(A(1,1), 1);
+}
+
 } // namespace
 } // namespace NetworKit

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -1382,12 +1382,12 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueSorted) {
 
     ASSERT_TRUE(A.sorted());
 
-    ASSERT_EQ(A(0, 0), 1);
-    ASSERT_EQ(A(0, 1), -1);
-    ASSERT_EQ(A(1, 0), -1);
-    ASSERT_EQ(A(1, 1), 1);
-    ASSERT_EQ(A(0, 2), 1);
-    ASSERT_EQ(A(1, 2), -1);
+    EXPECT_EQ(A(0, 0), 1);
+    EXPECT_EQ(A(0, 1), -1);
+    EXPECT_EQ(A(1, 0), -1);
+    EXPECT_EQ(A(1, 1), 1);
+    EXPECT_EQ(A(0, 2), 1);
+    EXPECT_EQ(A(1, 2), -1);
 
     /* 0 0.5 0 -1.2
      * 0  0 -2  0
@@ -1405,11 +1405,11 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueSorted) {
 
     ASSERT_TRUE(B.sorted());
 
-    ASSERT_EQ(B(0, 1), 0.5);
-    ASSERT_EQ(B(0, 3), -1.2);
-    ASSERT_EQ(B(1, 2), -2);
-    ASSERT_EQ(B(2, 3), 0.6);
-    ASSERT_EQ(B(3, 3), 0.5);
+    EXPECT_EQ(B(0, 1), 0.5);
+    EXPECT_EQ(B(0, 3), -1.2);
+    EXPECT_EQ(B(1, 2), -2);
+    EXPECT_EQ(B(2, 3), 0.6);
+    EXPECT_EQ(B(3, 3), 0.5);
 
     CSRMatrix C(4);
 
@@ -1424,27 +1424,27 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueSorted) {
 
     ASSERT_TRUE(C.sorted());
 
-    ASSERT_EQ(C(1, 0), 1);
-    ASSERT_EQ(C(1, 1), 2);
-    ASSERT_EQ(C(1, 2), 3);
-    ASSERT_EQ(C(1, 3), 4);
-    ASSERT_EQ(C(3, 3), 5);
-    ASSERT_EQ(C(2, 3), 6);
-    ASSERT_EQ(C(0, 3), 7);
-    ASSERT_EQ(C(0, 2), 0);
+    EXPECT_EQ(C(1, 0), 1);
+    EXPECT_EQ(C(1, 1), 2);
+    EXPECT_EQ(C(1, 2), 3);
+    EXPECT_EQ(C(1, 3), 4);
+    EXPECT_EQ(C(3, 3), 5);
+    EXPECT_EQ(C(2, 3), 6);
+    EXPECT_EQ(C(0, 3), 7);
+    EXPECT_EQ(C(0, 2), 0);
 
     C.setValue(1, 0, 0);
     C.setValue(1, 3, 0);
     C.setValue(2, 3, 0);
 
-    ASSERT_EQ(C(1, 0), 0);
-    ASSERT_EQ(C(1, 1), 2);
-    ASSERT_EQ(C(1, 2), 3);
-    ASSERT_EQ(C(1, 3), 0);
-    ASSERT_EQ(C(3, 3), 5);
-    ASSERT_EQ(C(2, 3), 0);
-    ASSERT_EQ(C(0, 3), 7);
-    ASSERT_EQ(C(0, 2), 0);
+    EXPECT_EQ(C(1, 0), 0);
+    EXPECT_EQ(C(1, 1), 2);
+    EXPECT_EQ(C(1, 2), 3);
+    EXPECT_EQ(C(1, 3), 0);
+    EXPECT_EQ(C(3, 3), 5);
+    EXPECT_EQ(C(2, 3), 0);
+    EXPECT_EQ(C(0, 3), 7);
+    EXPECT_EQ(C(0, 2), 0);
 }
 
 TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
@@ -1462,12 +1462,12 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
 
     ASSERT_FALSE(A.sorted());
 
-    ASSERT_EQ(A(0, 0), 1);
-    ASSERT_EQ(A(0, 1), -1);
-    ASSERT_EQ(A(1, 0), -1);
-    ASSERT_EQ(A(1, 1), 1);
-    ASSERT_EQ(A(0, 2), 1);
-    ASSERT_EQ(A(1, 2), -1);
+    EXPECT_EQ(A(0, 0), 1);
+    EXPECT_EQ(A(0, 1), -1);
+    EXPECT_EQ(A(1, 0), -1);
+    EXPECT_EQ(A(1, 1), 1);
+    EXPECT_EQ(A(0, 2), 1);
+    EXPECT_EQ(A(1, 2), -1);
 
     /* 0 0.5 0 -1.2
      * 0  0 -2  0
@@ -1485,11 +1485,11 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
 
     ASSERT_FALSE(B.sorted());
 
-    ASSERT_EQ(B(0, 1), 0.5);
-    ASSERT_EQ(B(0, 3), -1.2);
-    ASSERT_EQ(B(1, 2), -2);
-    ASSERT_EQ(B(2, 3), 0.6);
-    ASSERT_EQ(B(3, 3), 0.5);
+    EXPECT_EQ(B(0, 1), 0.5);
+    EXPECT_EQ(B(0, 3), -1.2);
+    EXPECT_EQ(B(1, 2), -2);
+    EXPECT_EQ(B(2, 3), 0.6);
+    EXPECT_EQ(B(3, 3), 0.5);
 
     CSRMatrix C(4, 0, false);
 
@@ -1504,27 +1504,27 @@ TEST_F(CSRMatrixGTest, testCSRMatrixSetValueUnsorted) {
 
     ASSERT_FALSE(C.sorted());
 
-    ASSERT_EQ(C(1, 0), 1);
-    ASSERT_EQ(C(1, 1), 2);
-    ASSERT_EQ(C(1, 2), 3);
-    ASSERT_EQ(C(1, 3), 4);
-    ASSERT_EQ(C(3, 3), 5);
-    ASSERT_EQ(C(2, 3), 6);
-    ASSERT_EQ(C(0, 3), 7);
-    ASSERT_EQ(C(0, 2), 0);
+    EXPECT_EQ(C(1, 0), 1);
+    EXPECT_EQ(C(1, 1), 2);
+    EXPECT_EQ(C(1, 2), 3);
+    EXPECT_EQ(C(1, 3), 4);
+    EXPECT_EQ(C(3, 3), 5);
+    EXPECT_EQ(C(2, 3), 6);
+    EXPECT_EQ(C(0, 3), 7);
+    EXPECT_EQ(C(0, 2), 0);
 
     C.setValue(1, 0, 0);
     C.setValue(1, 3, 0);
     C.setValue(2, 3, 0);
 
-    ASSERT_EQ(C(1, 0), 0);
-    ASSERT_EQ(C(1, 1), 2);
-    ASSERT_EQ(C(1, 2), 3);
-    ASSERT_EQ(C(1, 3), 0);
-    ASSERT_EQ(C(3, 3), 5);
-    ASSERT_EQ(C(2, 3), 0);
-    ASSERT_EQ(C(0, 3), 7);
-    ASSERT_EQ(C(0, 2), 0);
+    EXPECT_EQ(C(1, 0), 0);
+    EXPECT_EQ(C(1, 1), 2);
+    EXPECT_EQ(C(1, 2), 3);
+    EXPECT_EQ(C(1, 3), 0);
+    EXPECT_EQ(C(3, 3), 5);
+    EXPECT_EQ(C(2, 3), 0);
+    EXPECT_EQ(C(0, 3), 7);
+    EXPECT_EQ(C(0, 2), 0);
 }
 
 } // namespace


### PR DESCRIPTION
A bug in the binary search of GeneralCSRMatrix caused the collumn index array to be not sorted, if setValue operations are made in the wrong order. An example can be seen in #1104. The binary search function has been replaced at the appropriate places, now allowing setValue operations in any order, while keeping the values sorted. A test has been added to check this behavior for the example from #1104 and two other matrices.