### PR TITLE
New feature: convert networkx attributes to networkit attributes

### DIFF
--- a/.github/workflows/scripts/core_sanitizers_coverage.sh
+++ b/.github/workflows/scripts/core_sanitizers_coverage.sh
@@ -2,7 +2,7 @@
 
 python3 -m venv pyenv && . pyenv/bin/activate
 pip3 install --upgrade pip
-pip3 install coveralls cython gcovr matplotlib requests setuptools tabulate numpy
+pip3 install coveralls cython gcovr matplotlib requests setuptools tabulate numpy networkx
 
 mkdir core_build && cd "$_"
 export CPU_COUNT=$(python3 $GITHUB_WORKSPACE/.github/workflows/scripts/get_core_count.py)

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -581,6 +581,36 @@ public:
         return edgeAttributes().attach<std::string>(name);
     }
 
+    auto getNodeIntAttribute(const std::string &name) {
+        nodeAttributes().theGraph = this;
+        return nodeAttributes().get<int>(name);
+    }
+
+    auto getEdgeIntAttribute(const std::string &name) {
+        edgeAttributes().theGraph = this;
+        return edgeAttributes().get<int>(name);
+    }
+
+    auto getNodeDoubleAttribute(const std::string &name) {
+        nodeAttributes().theGraph = this;
+        return nodeAttributes().get<double>(name);
+    }
+
+    auto getEdgeDoubleAttribute(const std::string &name) {
+        edgeAttributes().theGraph = this;
+        return edgeAttributes().get<double>(name);
+    }
+
+    auto getNodeStringAttribute(const std::string &name) {
+        nodeAttributes().theGraph = this;
+        return nodeAttributes().get<std::string>(name);
+    }
+
+    auto getEdgeStringAttribute(const std::string &name) {
+        edgeAttributes().theGraph = this;
+        return edgeAttributes().get<std::string>(name);
+    }
+
     void detachNodeAttribute(std::string const &name) {
         nodeAttributes().theGraph = this;
         nodeAttributes().detach(name);

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1725,7 +1725,7 @@ public:
         forNodesWhile([&] { return !found; },
                       [&](node u) {
                           forNeighborsOf(u, [&](node v) {
-                              if (v < u)
+                              if (!this->isDirected() && v < u)
                                   return;
                               auto uvId = edgeId(u, v);
                               if (uvId == id) {

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -1929,10 +1929,14 @@ TEST_P(GraphGTest, testEdgeIndexResolver) {
     G.addEdge(5, 6);
     G.addEdge(2, 2);
 
+    if (G.isDirected())
+        G.addEdge(3, 2);
+
     std::map<std::pair<node, node>, edgeid> expectedEdges;
     expectedEdges[std::make_pair(0, 0)] = 0;
     expectedEdges[std::make_pair(5, 6)] = 1;
     expectedEdges[std::make_pair(2, 2)] = 2;
+    expectedEdges[std::make_pair(3, 2)] = 3;
 
     G.forEdges([&](node, node, edgeid eid) {
         auto edge = G.edgeById(eid);

--- a/networkit/graph.pxd
+++ b/networkit/graph.pxd
@@ -90,10 +90,16 @@ cdef extern from "<networkit/graph/Graph.hpp>":
 		_NodeIntAttribute attachNodeIntAttribute(string) except +
 		_NodeDoubleAttribute attachNodeDoubleAttribute(string) except +
 		_NodeStringAttribute attachNodeStringAttribute(string) except +
+		_NodeIntAttribute getNodeIntAttribute(string) except +
+		_NodeDoubleAttribute getNodeDoubleAttribute(string) except +
+		_NodeStringAttribute getNodeStringAttribute(string) except +
 		void detachNodeAttribute(string) except +
 		_EdgeIntAttribute attachEdgeIntAttribute(string) except +
 		_EdgeDoubleAttribute attachEdgeDoubleAttribute(string) except +
 		_EdgeStringAttribute attachEdgeStringAttribute(string) except +
+		_EdgeIntAttribute getEdgeIntAttribute(string) except +
+		_EdgeDoubleAttribute getEdgeDoubleAttribute(string) except +
+		_EdgeStringAttribute getEdgeStringAttribute(string) except +
 		void detachEdgeAttribute(string) except +
 
 cdef extern from "<networkit/graph/Graph.hpp>":

--- a/networkit/graph.pyx
+++ b/networkit/graph.pyx
@@ -989,6 +989,42 @@ cdef class Graph:
 		elif ofType == str:
 			return NodeAttribute(NodeStringAttribute().setThis(self._this.attachNodeStringAttribute(stdstring(name)), &self._this), str)
 
+	def getNodeAttribute(self, name, ofType):
+		"""
+		getNodeAttribute(name, ofType)
+
+		Gets a node attribute that is already attached to the graph and returns it.
+
+		.. code-block::
+			
+			A = G.getNodeAttribute("attributeIdentifier", ofType)
+
+		Notes
+		-----
+		Using node attributes is in experimental state. The API may change in future updates.
+
+		Parameters
+		----------
+		name   : str
+			Name for this attribute
+		ofType : type
+			Type of the attribute (either int, float, or str)
+
+		Returns
+		-------
+		networkit.graph.NodeAttribute
+			The resulting node attribute container.
+		"""
+		if not isinstance(name, str):
+			raise Exception("Attribute name has to be a string")
+
+		if ofType == int:
+			return NodeAttribute(NodeIntAttribute().setThis(self._this.getNodeIntAttribute(stdstring(name)), &self._this), int)
+		elif ofType == float:
+			return NodeAttribute(NodeDoubleAttribute().setThis(self._this.getNodeDoubleAttribute(stdstring(name)), &self._this), float)
+		elif ofType == str:
+			return NodeAttribute(NodeStringAttribute().setThis(self._this.getNodeStringAttribute(stdstring(name)), &self._this), str)
+
 	def detachNodeAttribute(self, name):
 		"""
 		detachNodeAttribute(name)
@@ -1053,6 +1089,43 @@ cdef class Graph:
 			return EdgeAttribute(EdgeDoubleAttribute().setThis(self._this.attachEdgeDoubleAttribute(stdstring(name)), &self._this), float)
 		elif ofType == str:
 			return EdgeAttribute(EdgeStringAttribute().setThis(self._this.attachEdgeStringAttribute(stdstring(name)), &self._this), str)
+
+	
+	def getEdgeAttribute(self, name, ofType):
+		"""
+		getEdgeAttribute(name, ofType)
+
+		Gets an edge attribute that is already attached to the graph and returns it.
+
+		.. code-block::
+	
+			A = G.getEdgeAttribute("attributeIdentifier", ofType)
+
+		Notes
+		-----
+		Using edge attributes is in experimental state. The API may change in future updates.
+
+		Parameters
+		----------
+		name   : str
+			Name for this attribute
+		ofType : type
+			Type of the attribute (either int, float, or str)
+
+		Returns
+		-------
+		networkit.graph.EdgeAttribute
+			The resulting edge attribute container.
+		"""
+		if not isinstance(name, str):
+			raise Exception("Attribute name has to be a string")
+
+		if ofType == int:
+			return EdgeAttribute(EdgeIntAttribute().setThis(self._this.getEdgeIntAttribute(stdstring(name)), &self._this), int)
+		elif ofType == float:
+			return EdgeAttribute(EdgeDoubleAttribute().setThis(self._this.getEdgeDoubleAttribute(stdstring(name)), &self._this), float)
+		elif ofType == str:
+			return EdgeAttribute(EdgeStringAttribute().setThis(self._this.getEdgeStringAttribute(stdstring(name)), &self._this), str)
 
 	def detachEdgeAttribute(self, name):
 		"""

--- a/networkit/graph.pyx
+++ b/networkit/graph.pyx
@@ -1202,7 +1202,6 @@ cdef class NodeIntAttribute:
 
 	cdef setThis(self, _NodeIntAttribute& other, _Graph* G):
 		self._this.swap(other)
-		self._G = G
 		return self
 
 	def __getitem__(self, node):
@@ -1247,7 +1246,6 @@ cdef class NodeIntAttribute:
 cdef class NodeDoubleAttribute:
 	cdef setThis(self, _NodeDoubleAttribute& other, _Graph* G):
 		self._this.swap(other)
-		self._G = G
 		return self
 
 	def __getitem__(self, node):
@@ -1291,7 +1289,6 @@ cdef class NodeStringAttribute:
 
 	cdef setThis(self, _NodeStringAttribute& other, _Graph* G):
 		self._this.swap(other)
-		self._G = G
 		return self
 
 	def getName(self):
@@ -1399,7 +1396,6 @@ cdef class EdgeIntAttribute:
 
 	cdef setThis(self, _EdgeIntAttribute& other, _Graph* G):
 		self._this.swap(other)
-		self._G = G
 		return self
 
 	def __getitem__(self, edgeIdORnodePair):
@@ -1457,7 +1453,6 @@ cdef class EdgeIntAttribute:
 cdef class EdgeDoubleAttribute:
 	cdef setThis(self, _EdgeDoubleAttribute& other, _Graph* G):
 		self._this.swap(other)
-		self._G = G
 		return self
 
 	def __getitem__(self, edgeIdORnodePair):
@@ -1515,7 +1510,6 @@ cdef class EdgeStringAttribute:
 
 	cdef setThis(self, _EdgeStringAttribute& other, _Graph* G):
 		self._this.swap(other)
-		self._G = G
 		return self
 
 	def __getitem__(self, edgeIdORnodePair):

--- a/networkit/nxadapter.py
+++ b/networkit/nxadapter.py
@@ -1,6 +1,7 @@
 """
 This module handles compatibility between NetworKit and NetworkX
 """
+from typing import Union
 
 # local imports
 from . import graph
@@ -8,53 +9,144 @@ import warnings
 from .support import MissingDependencyError
 
 # non standard library modules / external
+import numpy as np
+
 try:
-	import networkx as nx
+    import networkx as nx
 except ImportError:
-	have_nx = False
+    have_nx = False
 else:
-	have_nx = True
+    have_nx = True
 
 ########  CONVERSION ########
 
-def nx2nk(nxG, weightAttr=None):
-	"""
-	nx2nk(nxG, weightAttr=None)
 
-	Convert a networkx.Graph to a networkit.Graph.
+def _inferType(attr: object) -> Union[int, float, str, None]:
+    """
+    Infer the type of an attribute.
+    Integer types are mapped to int,
+    Floating point types are mapped to float,
+    str is mapped to str,
+    any other type is mapped to None.
+    """
+    if np.issubdtype(type(attr), np.integer):
+        return int
+    if np.issubdtype(type(attr), np.floating):
+        return float
+    if type(attr) == str:
+        return str
+    return None
 
-	Parameters
-	----------
-	nxG : networkx.Graph
-		The input networkx graph.
-	weightAttr : str, optional
-		The edge attribute which should be treated as the edge weight. Default: None
-	"""
 
-	if not have_nx:
-		raise MissingDependencyError("networkx")
-	# map networkx node ids to consecutive numerical node ids
-	idmap = dict((id, u) for (id, u) in zip(nxG.nodes(), range(nxG.number_of_nodes())))
-	z = max(idmap.values()) + 1
-	# print("z = {0}".format(z))
+def nx2nk(
+    nxG: Union[nx.Graph, nx.DiGraph], weightAttr: str = None, data: bool = False
+) -> graph.Graph:
+    """
+    nx2nk(nxG, weightAttr=None)
 
-	if weightAttr is not None:
-		nkG = graph.Graph(z, weighted=True, directed=nxG.is_directed())
-		for (u_, v_) in nxG.edges():
-			u, v = idmap[u_], idmap[v_]
-			w = nxG[u_][v_][weightAttr]
-			nkG.addEdge(u, v, w)
-	else:
-		nkG = graph.Graph(z, directed=nxG.is_directed())
-		for (u_, v_) in nxG.edges():
-			u, v = idmap[u_], idmap[v_]
-			assert (u < z)
-			assert (v < z)
-			nkG.addEdge(u, v)
+    Convert a networkx.Graph to a networkit.Graph.
+    If data is true, try to convert networkx.Graph data to networkit.Graph attributes.
+    Note that there are limitations to this conversion: networkit only supports int, float, and str attribute types.
+    Other types will be converted into their string representation.
+    Attribute keys are always converted to strings.
 
-	assert (nkG.numberOfNodes() == nxG.number_of_nodes())
-	assert (nkG.numberOfEdges() == nxG.number_of_edges())
-	return nkG
+    Parameters
+    ----------
+    nxG : networkx.Graph
+            The input networkx graph.
+    weightAttr : str, optional
+            The edge attribute which should be treated as the edge weight. Default: None
+    data : bool, optional
+            If true, convert networkx.Graph data into networkit.Graph attributes. Default: False
+    """
+
+    if not have_nx:
+        raise MissingDependencyError("networkx")
+    # map networkx node ids to consecutive numerical node ids
+    idmap = dict((id, u) for (id, u) in zip(nxG.nodes(), range(nxG.number_of_nodes())))
+    z = max(idmap.values()) + 1
+    # print("z = {0}".format(z))
+
+    if weightAttr is not None:
+        nkG = graph.Graph(z, weighted=True, directed=nxG.is_directed())
+        for u_, v_ in nxG.edges():
+            u, v = idmap[u_], idmap[v_]
+            w = nxG[u_][v_][weightAttr]
+            nkG.addEdge(u, v, w)
+    else:
+        nkG = graph.Graph(z, directed=nxG.is_directed())
+        for u_, v_ in nxG.edges():
+            u, v = idmap[u_], idmap[v_]
+            assert u < z
+            assert v < z
+            nkG.addEdge(u, v)
+
+    assert nkG.numberOfNodes() == nxG.number_of_nodes()
+    assert nkG.numberOfEdges() == nxG.number_of_edges()
+
+    # convert data
+    if data:
+        # node attributes
+        for node, attributes in nxG.nodes(data=True):
+            # when we see a new attr, create/attach to graph. otherwise add to existing (get by name). if type is not compatible, raise exception. type is inferred from the first occurence.
+            for key, value in attributes.items():
+                valueType = _inferType(value)
+                try:
+                    attribute = nkG.getNodeAttribute(str(key), valueType or str)
+                except RuntimeError:  # attribute does not exist or is of different type
+                    try:
+                        attribute = nkG.attachNodeAttribute(str(key), valueType or str)
+                        if valueType is None:
+                            print(
+                                f"Info: the node attribute {key} has been converted to its string representation."
+                            )
+                    except (
+                        RuntimeError
+                    ):  # attribute exists (with different type because of previous logic)
+                        raise RuntimeError(
+                            f"Node attribute {key} has multiple data types which is not supported in networkit."
+                        )
+
+                if valueType is int:
+                    attribute[idmap[node]] = int(value)
+                elif valueType is float:
+                    attribute[idmap[node]] = float(value)
+                else:
+                    attribute[idmap[node]] = str(value)
+
+        # edge attributes
+        nkG.indexEdges()
+        for u, v, attributes in nxG.edges(data=True):
+            # when we see a new attr, create/attach to graph. otherwise add to existing (get by name). if type is not compatible, raise exception. type is inferred from the first occurence.
+            for key, value in attributes.items():
+                if key == weightAttr:
+                    continue
+                valueType = _inferType(value)
+                try:
+                    attribute = nkG.getEdgeAttribute(str(key), valueType or str)
+                except RuntimeError:  # attribute does not exist or is of different type
+                    try:
+                        attribute = nkG.attachEdgeAttribute(str(key), valueType or str)
+                        if valueType is None:
+                            print(
+                                f"Info: the edge attribute {key} has been converted to its string representation."
+                            )
+                    except (
+                        RuntimeError
+                    ):  # attribute exists (with different type because of previous logic)
+                        raise RuntimeError(
+                            f"Edge attribute {key} has multiple data types which is not supported in networkit."
+                        )
+
+                if valueType is int:
+                    attribute[idmap[u], idmap[v]] = int(value)
+                elif valueType is float:
+                    attribute[idmap[u], idmap[v]] = float(value)
+                else:
+                    attribute[idmap[u], idmap[v]] = str(value)
+
+    return nkG
+
 
 def nk2nx(nkG):
 	""" 

--- a/networkit/nxadapter.py
+++ b/networkit/nxadapter.py
@@ -5,7 +5,7 @@ from typing import Union, Mapping
 
 # local imports
 from . import graph
-import warnings
+from warnings import warn
 from .support import MissingDependencyError
 
 # non standard library modules / external
@@ -107,7 +107,7 @@ def nx2nk(
                     try:
                         attribute = nkG.attachNodeAttribute(str(key), valueType or str)
                         if valueType is None:
-                            print(
+                            warn(
                                 f"Info: the node attribute {key} has been converted to its string representation."
                             )
                     except (
@@ -142,7 +142,7 @@ def nx2nk(
                     try:
                         attribute = nkG.attachEdgeAttribute(str(key), valueType or str)
                         if valueType is None:
-                            print(
+                            warn(
                                 f"Info: the edge attribute {key} has been converted to its string representation."
                             )
                     except (

--- a/networkit/nxadapter.py
+++ b/networkit/nxadapter.py
@@ -40,9 +40,9 @@ def _inferType(attr: object) -> Union[int, float, str, None]:
 
 def nx2nk(
     nxG: Union[nx.Graph, nx.DiGraph],
-    weightAttr: str = None,
+    weightAttr: Union[str, None] = None,
     data: bool = False,
-    typeMap: Mapping[str, type] = None,
+    typeMap: Union[Mapping[str, type], None] = None,
 ) -> graph.Graph:
     """
     nx2nk(nxG, weightAttr=None)

--- a/networkit/nxadapter.py
+++ b/networkit/nxadapter.py
@@ -96,7 +96,11 @@ def nx2nk(
         for node, attributes in nxG.nodes(data=True):
             # when we see a new attr, create/attach to graph. otherwise add to existing (get by name). if type is not compatible, raise exception. type is inferred from the first occurence.
             for key, value in attributes.items():
-                valueType = typeMap[key] if str(key) in typeMap else _inferType(value)
+                valueType = (
+                    typeMap.get(key, _inferType(value))
+                    if typeMap
+                    else _inferType(value)
+                )
                 try:
                     attribute = nkG.getNodeAttribute(str(key), valueType or str)
                 except RuntimeError:  # attribute does not exist or is of different type
@@ -127,7 +131,11 @@ def nx2nk(
             for key, value in attributes.items():
                 if key == weightAttr:
                     continue
-                valueType = typeMap[key] if str(key) in typeMap else _inferType(value)
+                valueType = (
+                    typeMap.get(key, _inferType(value))
+                    if typeMap
+                    else _inferType(value)
+                )
                 try:
                     attribute = nkG.getEdgeAttribute(str(key), valueType or str)
                 except RuntimeError:  # attribute does not exist or is of different type

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -395,6 +395,44 @@ class TestGraph(unittest.TestCase):
 			G.detachEdgeAttribute("attribute")
 			G.detachEdgeAttribute("attributeRead")
 
+	def testEdgeAttributeGet(self):
+		G = nk.Graph(5)
+		G.indexEdges()
+
+		G.addEdge(0, 1)
+		G.addEdge(0, 2)
+		G.addEdge(1, 3)
+		G.addEdge(2, 4)
+
+		for attType in [int, float, str]:
+			attVals = [attType(u+v) for u,v in G.iterEdges()]
+
+			attrs = G.attachEdgeAttribute("attribute", attType)
+			for u,v in G.iterEdges():
+				attrs[u,v] = attVals[u]
+			
+			attrsGet = G.getEdgeAttribute("attribute", attType)
+			for u,v in G.iterEdges():
+				self.assertEqual(attrs[u,v], attrsGet[u,v])
+
+			G.detachEdgeAttribute("attribute")
+
+	def testNodeAttributeReadWrite(self):
+		G = nk.Graph(5)
+
+		for attType in [int, float, str]:
+			attVals = [attType(u) for u in G.iterNodes()]
+
+			attrs = G.attachNodeAttribute("attribute", attType)
+			for u in G.iterNodes():
+				attrs[u] = attVals[u]
+
+			attrsGet = G.getNodeAttribute("attribute", attType)
+			for u in G.iterNodes():
+				self.assertEqual(attrs[u], attrsGet[u])
+
+			G.detachNodeAttribute("attribute")
+
 	def testRandomEdgesReproducibility(self):
 		numSamples = 10
 		numSeeds = 3

--- a/networkit/test/test_nxadapter.py
+++ b/networkit/test/test_nxadapter.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+import unittest
+import unittest.mock
+import io
+import networkit as nk
+import networkx as nx
+
+from typing import Union, List
+
+
+class TestNXAdapter(unittest.TestCase):
+    def toyNxgraph(
+        self, directed: bool, data: List[str]
+    ) -> Union[nx.Graph, nx.DiGraph]:
+        nxGraph = nx.Graph()
+
+        # 0 - 'a'
+        # |    |
+        # 3    2
+        nxGraph.add_edge(0, "a")
+        nxGraph.add_edge(0, 3)
+        nxGraph.add_edge("a", 2)
+
+        if "weight" in data:
+            nxGraph[0]["a"]["weight"] = 2
+            nxGraph[0][3]["weight"] = 4
+            nxGraph["a"][2]["weight"] = -6
+
+        # int attribute
+        if "intEdgeAttr" in data:
+            nxGraph[0]["a"]["intEdgeAttr"] = 1
+            nxGraph[0][3]["intEdgeAttr"] = 2
+            nxGraph["a"][2]["intEdgeAttr"] = -3
+
+        if "intNodeAttr" in data:
+            nxGraph.nodes[0]["intNodeAttr"] = 4
+            nxGraph.nodes["a"]["intNodeAttr"] = 5
+            nxGraph.nodes[2]["intNodeAttr"] = 6
+            nxGraph.nodes[3]["intNodeAttr"] = 7
+
+        # float attribute
+        if "floatEdgeAttr" in data:
+            nxGraph[0]["a"]["floatEdgeAttr"] = 1.2
+            nxGraph[0][3]["floatEdgeAttr"] = 2.3
+            nxGraph["a"][2]["floatEdgeAttr"] = -3.1
+
+        if "floatNodeAttr" in data:
+            nxGraph.nodes[0]["floatNodeAttr"] = 4.7
+            nxGraph.nodes["a"]["floatNodeAttr"] = 5.6
+            nxGraph.nodes[2]["floatNodeAttr"] = 6.5
+            nxGraph.nodes[3]["floatNodeAttr"] = 7.4
+
+        # str attribute
+        if "strEdgeAttr" in data:
+            nxGraph[0]["a"]["strEdgeAttr"] = "0a"
+            nxGraph[0][3]["strEdgeAttr"] = "03"
+            nxGraph["a"][2]["strEdgeAttr"] = "a2"
+
+        if "strNodeAttr" in data:
+            nxGraph.nodes[0]["strNodeAttr"] = "n0"
+            nxGraph.nodes["a"]["strNodeAttr"] = "na"
+            nxGraph.nodes[2]["strNodeAttr"] = "n2"
+            nxGraph.nodes[3]["strNodeAttr"] = "n3"
+
+        # complex attribute: tuple
+        if "complexEdgeAttr" in data:
+            nxGraph[0]["a"]["complexEdgeAttr"] = (0, "a", "0a")
+            nxGraph[0][3]["complexEdgeAttr"] = (0, 3, "03")
+            nxGraph["a"][2]["complexEdgeAttr"] = ("a", 2, "a2")
+
+        if "complexNodeAttr" in data:
+            nxGraph.nodes[0]["complexNodeAttr"] = (0, "0")
+            nxGraph.nodes["a"]["complexNodeAttr"] = ("a", "a")
+            nxGraph.nodes[2]["complexNodeAttr"] = (2, "2")
+            nxGraph.nodes[3]["complexNodeAttr"] = (3, "3")
+
+        if directed:
+            nxGraph = nxGraph.to_directed()
+            nxGraph.add_edge(3, 2)
+
+            if "weight" in data:
+                nxGraph[3][2]["weight"] = -5
+            if "intEdgeAttr" in data:
+                nxGraph[3][2]["intEdgeAttr"] = -1
+            if "floatEdgeAttr" in data:
+                nxGraph[3][2]["floatEdgeAttr"] = -1.2
+            if "strEdgeAttr" in data:
+                nxGraph[3][2]["strEdgeAttr"] = "32"
+            if "complexEdgeAttr" in data:
+                nxGraph[3][2]["complexEdgeAttr"] = (3, 2, "32")
+
+        return nxGraph
+
+    def test_nx2nk_weight_undirected(self):
+        nxG = self.toyNxgraph(directed=False, data=["weight"])
+        nkG = nk.nxadapter.nx2nk(nxG, weightAttr="weight", data=False)
+
+        self.assertEqual(nkG.numberOfNodes(), 4)
+        self.assertEqual(nkG.numberOfEdges(), 3)
+
+        self.assertEqual(nkG.weight(0, 1), 2)
+        self.assertEqual(nkG.weight(0, 2), 4)
+        self.assertEqual(nkG.weight(1, 3), -6)
+
+    def test_nx2nk_weight_directed(self):
+        nxG = self.toyNxgraph(directed=True, data=["weight"])
+        nkG = nk.nxadapter.nx2nk(nxG, weightAttr="weight", data=False)
+
+        self.assertEqual(nkG.numberOfNodes(), 4)
+        self.assertEqual(nkG.numberOfEdges(), 7)
+
+        self.assertEqual(nkG.weight(0, 1), 2)
+        self.assertEqual(nkG.weight(0, 2), 4)
+        self.assertEqual(nkG.weight(1, 3), -6)
+        self.assertEqual(nkG.weight(1, 0), 2)
+        self.assertEqual(nkG.weight(2, 0), 4)
+        self.assertEqual(nkG.weight(3, 1), -6)
+        self.assertEqual(nkG.weight(2, 3), -5)
+
+    @unittest.mock.patch("sys.stdout")
+    def test_nx2nk_int_undirected(self, mock_stdout):
+        nxG = self.toyNxgraph(directed=False, data=["intEdgeAttr", "intNodeAttr"])
+        nkG = nk.nxadapter.nx2nk(nxG, data=True)
+
+        edgeAttr = nkG.getEdgeAttribute("intEdgeAttr", int)
+        self.assertEqual(edgeAttr[0, 1], 1)
+        self.assertEqual(edgeAttr[0, 2], 2)
+        self.assertEqual(edgeAttr[1, 3], -3)
+
+        nodeAttr = nkG.getNodeAttribute("intNodeAttr", int)
+        self.assertEqual(nodeAttr[0], 4)
+        self.assertEqual(nodeAttr[1], 5)
+        self.assertEqual(nodeAttr[3], 6)
+        self.assertEqual(nodeAttr[2], 7)
+
+        mock_stdout.write.assert_not_called()
+
+    @unittest.mock.patch("sys.stdout")
+    def test_nx2nk_int_directed(self, mock_stdout):
+        nxG = self.toyNxgraph(directed=True, data=["intEdgeAttr"])
+        nkG = nk.nxadapter.nx2nk(nxG, data=True)
+
+        edgeAttr = nkG.getEdgeAttribute("intEdgeAttr", int)
+        self.assertEqual(edgeAttr[0, 1], 1)
+        self.assertEqual(edgeAttr[0, 2], 2)
+        self.assertEqual(edgeAttr[1, 3], -3)
+        self.assertEqual(edgeAttr[1, 0], 1)
+        self.assertEqual(edgeAttr[2, 0], 2)
+        self.assertEqual(edgeAttr[3, 1], -3)
+        self.assertEqual(edgeAttr[2, 3], -1)
+
+        mock_stdout.write.assert_not_called()
+
+    @unittest.mock.patch("sys.stdout")
+    def test_nx2nk_float_undirected(self, mock_stdout):
+        nxG = self.toyNxgraph(directed=False, data=["floatEdgeAttr", "floatNodeAttr"])
+        nkG = nk.nxadapter.nx2nk(nxG, data=True)
+
+        edgeAttr = nkG.getEdgeAttribute("floatEdgeAttr", float)
+        self.assertEqual(edgeAttr[0, 1], 1.2)
+        self.assertEqual(edgeAttr[0, 2], 2.3)
+        self.assertEqual(edgeAttr[1, 3], -3.1)
+
+        nodeAttr = nkG.getNodeAttribute("floatNodeAttr", float)
+        self.assertEqual(nodeAttr[0], 4.7)
+        self.assertEqual(nodeAttr[1], 5.6)
+        self.assertEqual(nodeAttr[3], 6.5)
+        self.assertEqual(nodeAttr[2], 7.4)
+
+        mock_stdout.write.assert_not_called()
+
+    @unittest.mock.patch("sys.stdout")
+    def test_nx2nk_float_directed(self, mock_stdout):
+        nxG = self.toyNxgraph(directed=True, data=["floatEdgeAttr"])
+        nkG = nk.nxadapter.nx2nk(nxG, data=True)
+
+        edgeAttr = nkG.getEdgeAttribute("floatEdgeAttr", float)
+        self.assertEqual(edgeAttr[0, 1], 1.2)
+        self.assertEqual(edgeAttr[0, 2], 2.3)
+        self.assertEqual(edgeAttr[1, 3], -3.1)
+        self.assertEqual(edgeAttr[1, 0], 1.2)
+        self.assertEqual(edgeAttr[2, 0], 2.3)
+        self.assertEqual(edgeAttr[3, 1], -3.1)
+        self.assertEqual(edgeAttr[2, 3], -1.2)
+
+        mock_stdout.write.assert_not_called()
+
+    @unittest.mock.patch("sys.stdout")
+    def test_nx2nk_str_undirected(self, mock_stdout):
+        nxG = self.toyNxgraph(directed=False, data=["strEdgeAttr", "strNodeAttr"])
+        nkG = nk.nxadapter.nx2nk(nxG, data=True)
+
+        edgeAttr = nkG.getEdgeAttribute("strEdgeAttr", str)
+        self.assertEqual(edgeAttr[0, 1], "0a")
+        self.assertEqual(edgeAttr[0, 2], "03")
+        self.assertEqual(edgeAttr[1, 3], "a2")
+
+        nodeAttr = nkG.getNodeAttribute("strNodeAttr", str)
+        self.assertEqual(nodeAttr[0], "n0")
+        self.assertEqual(nodeAttr[1], "na")
+        self.assertEqual(nodeAttr[3], "n2")
+        self.assertEqual(nodeAttr[2], "n3")
+
+        mock_stdout.write.assert_not_called()
+
+    @unittest.mock.patch("sys.stdout")
+    def test_nx2nk_str_directed(self, mock_stdout):
+        nxG = self.toyNxgraph(directed=True, data=["strEdgeAttr"])
+        nkG = nk.nxadapter.nx2nk(nxG, data=True)
+
+        edgeAttr = nkG.getEdgeAttribute("strEdgeAttr", str)
+        self.assertEqual(edgeAttr[0, 1], "0a")
+        self.assertEqual(edgeAttr[0, 2], "03")
+        self.assertEqual(edgeAttr[1, 3], "a2")
+        self.assertEqual(edgeAttr[1, 0], "0a")
+        self.assertEqual(edgeAttr[2, 0], "03")
+        self.assertEqual(edgeAttr[3, 1], "a2")
+        self.assertEqual(edgeAttr[2, 3], "32")
+
+        mock_stdout.write.assert_not_called()
+
+    @unittest.mock.patch("sys.stdout")
+    def test_nx2nk_complex_undirected(self, mock_stdout):
+        nxG = self.toyNxgraph(
+            directed=False, data=["complexEdgeAttr", "complexNodeAttr"]
+        )
+        nkG = nk.nxadapter.nx2nk(nxG, data=True)
+
+        edgeAttr = nkG.getEdgeAttribute("complexEdgeAttr", str)
+        self.assertEqual(edgeAttr[0, 1], "(0, 'a', '0a')")
+        self.assertEqual(edgeAttr[0, 2], "(0, 3, '03')")
+        self.assertEqual(edgeAttr[1, 3], "('a', 2, 'a2')")
+
+        nodeAttr = nkG.getNodeAttribute("complexNodeAttr", str)
+        self.assertEqual(nodeAttr[0], "(0, '0')")
+        self.assertEqual(nodeAttr[1], "('a', 'a')")
+        self.assertEqual(nodeAttr[3], "(2, '2')")
+        self.assertEqual(nodeAttr[2], "(3, '3')")
+
+        mock_stdout.write.assert_has_calls(
+            [
+                unittest.mock.call(
+                    "Info: the node attribute complexNodeAttr has been converted to its string representation."
+                ),
+                unittest.mock.call(
+                    "Info: the edge attribute complexEdgeAttr has been converted to its string representation."
+                ),
+            ],
+            any_order=True,
+        )
+
+    @unittest.mock.patch("sys.stdout")
+    def test_nx2nk_complex_directed(self, mock_stdout):
+        nxG = self.toyNxgraph(directed=True, data=["complexEdgeAttr"])
+        nkG = nk.nxadapter.nx2nk(nxG, data=True)
+
+        edgeAttr = nkG.getEdgeAttribute("complexEdgeAttr", str)
+        self.assertEqual(edgeAttr[0, 1], "(0, 'a', '0a')")
+        self.assertEqual(edgeAttr[0, 2], "(0, 3, '03')")
+        self.assertEqual(edgeAttr[1, 3], "('a', 2, 'a2')")
+        self.assertEqual(edgeAttr[1, 0], "(0, 'a', '0a')")
+        self.assertEqual(edgeAttr[2, 0], "(0, 3, '03')")
+        self.assertEqual(edgeAttr[3, 1], "('a', 2, 'a2')")
+        self.assertEqual(edgeAttr[2, 3], "(3, 2, '32'")
+
+        mock_stdout.write.assert_has_calls(
+            [
+                unittest.mock.call(
+                    "Info: the node attribute complexNodeAttr has been converted to its string representation."
+                ),
+                unittest.mock.call(
+                    "Info: the edge attribute complexEdgeAttr has been converted to its string representation."
+                ),
+            ],
+            any_order=True,
+        )
+
+    def test_nx2nk(self):
+        nkG = nk.Graph(3)
+        nkG.addEdge(0, 1)
+        nkG.addEdge(0, 2)
+
+        nxG = nk.nxadapter.nk2nx(nkG)
+
+        self.assertEqual(len(nxG.edges()), 2)
+        self.assertEqual(len(nxG.nodes()), 3)
+
+
+# @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
+
+if __name__ == "__main__":
+    # TestNXAdapter().test_nx2nk_int_directed()
+    unittest.main()

--- a/networkit/test/test_nxadapter.py
+++ b/networkit/test/test_nxadapter.py
@@ -261,13 +261,10 @@ class TestNXAdapter(unittest.TestCase):
         self.assertEqual(edgeAttr[1, 0], "(0, 'a', '0a')")
         self.assertEqual(edgeAttr[2, 0], "(0, 3, '03')")
         self.assertEqual(edgeAttr[3, 1], "('a', 2, 'a2')")
-        self.assertEqual(edgeAttr[2, 3], "(3, 2, '32'")
+        self.assertEqual(edgeAttr[2, 3], "(3, 2, '32')")
 
         mock_stdout.write.assert_has_calls(
             [
-                unittest.mock.call(
-                    "Info: the node attribute complexNodeAttr has been converted to its string representation."
-                ),
                 unittest.mock.call(
                     "Info: the edge attribute complexEdgeAttr has been converted to its string representation."
                 ),
@@ -285,9 +282,24 @@ class TestNXAdapter(unittest.TestCase):
         self.assertEqual(len(nxG.edges()), 2)
         self.assertEqual(len(nxG.nodes()), 3)
 
+    @unittest.mock.patch("sys.stdout")
+    def test_nx2nk_custom_typemap(self, mock_stdout):
+        nxG = self.toyNxgraph(directed=False, data=["intEdgeAttr", "intNodeAttr"])
+        nkG = nk.nxadapter.nx2nk(nxG, data=True, typeMap={"intEdgeAttr": int})
 
-# @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
+        edgeAttr = nkG.getEdgeAttribute("intEdgeAttr", int)
+        self.assertEqual(edgeAttr[0, 1], 1)
+        self.assertEqual(edgeAttr[0, 2], 2)
+        self.assertEqual(edgeAttr[1, 3], -3)
+
+        nodeAttr = nkG.getNodeAttribute("intNodeAttr", int)
+        self.assertEqual(nodeAttr[0], 4)
+        self.assertEqual(nodeAttr[1], 5)
+        self.assertEqual(nodeAttr[3], 6)
+        self.assertEqual(nodeAttr[2], 7)
+
+        mock_stdout.write.assert_not_called()
+
 
 if __name__ == "__main__":
-    # TestNXAdapter().test_nx2nk_int_directed()
     unittest.main()


### PR DESCRIPTION
Adds support for node and edge attributes to the networkx -> networkit graph conversion function.
Additionally, adds python bindings for the attribute getter functions.

This PR is not complete yet. The code should be finished (imo), but there is a weird error when accessing edge attributes of directed graphs. I think this problem is not related to the new code in this PR, but more investigation is necessary.