### PR TITLE
CI: fix Windows build and update CI + build settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,14 @@ env:
 
 jobs:
   macos-build-latest-version-apple-clang:
-    name: "macOS ${{ matrix.os }} (apple-clang, CPython 3.12): ${{ matrix.build-configuration }}"
+    name: "macOS ${{ matrix.os }} ${{ startsWith(matrix.os, '14') && ', arm64' || '' }} (apple-clang, CPython 3.12): ${{ matrix.build-configuration }}"
     runs-on: macos-${{ matrix.os }}
     env:
       CC: cc
       CXX: c++
     strategy:
       matrix:
-        os: ['13']
+        os: ['13', '14'] # For macos-14, the default image is arm based. So 13 = x86_64, 14 = arm64
         build-configuration: ['full', 'full (native)']
     steps:
       - name: Install prerequisites
@@ -138,23 +138,18 @@ jobs:
     runs-on: macos-${{ matrix.os }}
     strategy:
       matrix:
-        os: ['13']
-        compiler: ['clang-17', 'gcc-13']
+        os: ['14'] # llvm and gcc are only tested on arm based machines
+        compiler: ['llvm-17', 'gcc-12']
     steps:
       - name: Install prerequisites
         run: |
-          brew install libomp
           brew install ninja
       - name: Install compiler llvm
-        if: matrix.compiler == 'clang-17'
+        if: matrix.compiler == 'llvm-17'
         run: |
+          brew install libomp
           brew reinstall llvm@17
           brew link --overwrite llvm@17
-      - name: Install compiler gcc
-        if: matrix.compiler == 'gcc-13'
-        run: |
-          brew reinstall gcc@13
-          brew link --overwrite gcc@13
       - name: Checkout networkit
         uses: actions/checkout@v4
         with:
@@ -163,11 +158,11 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
         shell: bash
         env:
-          CC: ${{ matrix.compiler == 'clang-16' && '/usr/local/opt/llvm@17/bin/clang' || 'gcc-13' }}
-          CXX: ${{ matrix.compiler == 'clang-16' && '/usr/local/opt/llvm@17/bin/clang++' || 'g++-13' }}
+          CC: ${{ matrix.compiler == 'llvm-17' && '/opt/homebrew/opt/llvm/bin/clang' || 'gcc-12' }}
+          CXX: ${{ matrix.compiler == 'llvm-17' && '/opt/homebrew/opt/llvm/bin/clang++' || 'g++-12' }}
 
   linux-build-latest:
-    name: "Linux (gcc-12${{ startsWith(matrix.build-configuration, 'full') && ', CPython 3.12' || '' }}): ${{ matrix.build-configuration }}"
+    name: "Linux (gcc-13${{ startsWith(matrix.build-configuration, 'full') && ', CPython 3.12' || '' }}): ${{ matrix.build-configuration }}"
     runs-on: ubuntu-22.04
     env:
       CC: gcc-13
@@ -209,14 +204,14 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        compiler: ['clang-17']
+        compiler: ['llvm-18']
     steps:
       - name: Install prerequisites
         run:  |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-17 main" | sudo tee /etc/apt/sources.list.d/llvm17.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-18 main" | sudo tee /etc/apt/sources.list.d/llvm18.list
           sudo apt-get update
-          sudo apt-get install clang-17 libomp-17-dev ninja-build
+          sudo apt-get install clang-18 libomp-18-dev ninja-build
       - name: Checkout networkit
         uses: actions/checkout@v4
         with:
@@ -230,8 +225,8 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
         shell: bash
         env:
-          CC: clang-17
-          CXX: clang++-17
+          CC: clang-18
+          CXX: clang++-18
 
   linux-pep-518-install:
     name: "Linux: Release build using pyproject.toml"
@@ -286,7 +281,7 @@ jobs:
           CXX: ${{ matrix.compiler == 'gcc-8' && 'g++-8' || 'clang++-7' }}
 
   linux-build-clang-tidy:
-    name: "Linux (clang-16): clang-tidy"
+    name: "Linux (llvm-17): clang-tidy"
     runs-on: ubuntu-20.04
     env:
       CC: clang-17
@@ -468,9 +463,9 @@ jobs:
       - name: Install prerequisites
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-17 main" | sudo tee /etc/apt/sources.list.d/llvm17.list
+          echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-18 main" | sudo tee /etc/apt/sources.list.d/llvm18.list
           sudo apt-get update
-          sudo apt-get install clang-format-17 python3-yaml
+          sudo apt-get install clang-format-18 python3-yaml
       - name: Checkout networkit
         uses: actions/checkout@v4
         with:
@@ -480,4 +475,4 @@ jobs:
           set -e
           ./check_code.sh -v
         env:
-          NETWORKIT_OVERRIDE_CLANG_FORMAT: "clang-format-17"
+          NETWORKIT_OVERRIDE_CLANG_FORMAT: "clang-format-18"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
 	endif()
 
 elseif (MSVC)
-	set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} /DNETWORKIT_OMP2 /MP /DNETWORKIT_WINDOWS")
+	set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} /DNETWORKIT_OMP2 /MP /DNETWORKIT_WINDOWS /permissive-")
 
 	# TTMath requires running an ASM for MSVC which we disable here at the cost of worse performance
 	set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} /DTTMATH_NOASM=1")

--- a/include/networkit/generators/ErdosRenyiEnumerator.hpp
+++ b/include/networkit/generators/ErdosRenyiEnumerator.hpp
@@ -299,14 +299,14 @@ private:
 
     // SFINAE to allow using functors with and without thread id as parameter
     template <typename Handle>
-    auto callHandle(Handle h, unsigned tid, node u, node v) const
-        -> decltype(h(0u, node{0}, node{0})) {
+    auto callHandle(Handle h, unsigned tid, node u,
+                    node v) const -> decltype(h(0u, node{0}, node{0})) {
         return h(tid, u, v);
     }
 
     template <typename Handle>
-    auto callHandle(Handle h, unsigned /*tid*/, node u, node v) const
-        -> decltype(h(node{0}, node{0})) {
+    auto callHandle(Handle h, unsigned /*tid*/, node u,
+                    node v) const -> decltype(h(node{0}, node{0})) {
         return h(u, v);
     }
 };

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -277,7 +277,7 @@ private:
     private:
         using Base<NodeOrEdge>::theGraph;
         std::vector<T> values; // the real attribute storage
-    };                         // class AttributeStorage<NodeOrEdge, Base, T>
+    }; // class AttributeStorage<NodeOrEdge, Base, T>
 
     template <typename NodeOrEdge, typename T>
     class Attribute {
@@ -781,8 +781,8 @@ private:
                                   typename Aux::FunctionTraits<F>::template arg<2>::type>::value
                   && std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<3>::type>::
                       value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid id) const
-        -> decltype(f(u, v, ew, id)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew,
+                    edgeid id) const -> decltype(f(u, v, ew, id)) {
         return f(u, v, ew, id);
     }
 
@@ -814,8 +814,8 @@ private:
                   (Aux::FunctionTraits<F>::arity >= 2)
                   && std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<
                                                   2>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid /*id*/) const
-        -> decltype(f(u, v, ew)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew,
+                    edgeid /*id*/) const -> decltype(f(u, v, ew)) {
         return f(u, v, ew);
     }
 
@@ -828,8 +828,8 @@ private:
                            (Aux::FunctionTraits<F>::arity >= 1)
                            && std::is_same<node, typename Aux::FunctionTraits<F>::template arg<
                                                      1>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/, edgeid /*id*/) const
-        -> decltype(f(u, v)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/,
+                    edgeid /*id*/) const -> decltype(f(u, v)) {
         return f(u, v);
     }
 

--- a/include/networkit/layout/LayoutAlgorithm.hpp
+++ b/include/networkit/layout/LayoutAlgorithm.hpp
@@ -24,7 +24,7 @@ public:
     LayoutAlgorithm(const Graph &G)
         : G(G){
 
-        };
+          };
 
     virtual void run() = 0;
 

--- a/networkit/cpp/centrality/GroupClosenessGrowShrink.cpp
+++ b/networkit/cpp/centrality/GroupClosenessGrowShrink.cpp
@@ -15,15 +15,18 @@ GroupClosenessGrowShrink::GroupClosenessGrowShrink(const Graph &G, const std::ve
                                                    bool extended, count insertions,
                                                    count maxIterations)
     : G(&G),
-      weightedImpl{G.isWeighted() ? std::make_unique<
-                       GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<edgeweight>>(
-                       G, group, extended, insertions, maxIterations)
-                                  : nullptr},
-      unweightedImpl{G.isWeighted()
-                         ? nullptr
-                         : std::make_unique<
-                             GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<count>>(
-                             G, group, extended, insertions, maxIterations)} {}
+      weightedImpl{
+          G.isWeighted()
+              ? std::make_unique<
+                    GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<edgeweight>>(
+                    G, group, extended, insertions, maxIterations)
+              : nullptr},
+      unweightedImpl{
+          G.isWeighted()
+              ? nullptr
+              : std::make_unique<
+                    GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<count>>(
+                    G, group, extended, insertions, maxIterations)} {}
 
 GroupClosenessGrowShrink::~GroupClosenessGrowShrink() = default;
 

--- a/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
@@ -21,8 +21,8 @@ namespace NetworKit {
 NeighborhoodFunctionHeuristic::NeighborhoodFunctionHeuristic(const Graph &G, count nSamples,
                                                              SelectionStrategy strategy)
     : Algorithm(), G(&G),
-      nSamples(!nSamples ? (count)std::ceil(
-                   std::max((double)0.15f * G.numberOfNodes(), std::sqrt(G.numberOfEdges())))
+      nSamples(!nSamples ? (count)std::ceil(std::max((double)0.15f * G.numberOfNodes(),
+                                                     std::sqrt(G.numberOfEdges())))
                          : nSamples),
       strategy(strategy) {
 

--- a/networkit/cpp/generators/test/GeneratorsGTest.cpp
+++ b/networkit/cpp/generators/test/GeneratorsGTest.cpp
@@ -936,9 +936,8 @@ TEST_F(GeneratorsGTest, testStaticDegreeSequenceGenerator) {
     for (int iter = 0; iter < 100; ++iter) {
         const auto n = distr_num_nodes(prng);
         std::vector<count> seq(n);
-        std::generate(seq.begin(), seq.end(), [&] {
-            return std::uniform_int_distribution<count>{0, n - 1}(prng);
-        });
+        std::generate(seq.begin(), seq.end(),
+                      [&] { return std::uniform_int_distribution<count>{0, n - 1}(prng); });
 
         HavelHakimiGenerator gen(seq, true);
         const auto isRealizable = gen.isRealizable();

--- a/networkit/cpp/geometric/test/GeometricGTest.cpp
+++ b/networkit/cpp/geometric/test/GeometricGTest.cpp
@@ -78,9 +78,9 @@ TEST_F(GeometricGTest, testEuclideanCircleConsistency) {
         Point2DWithIndex<double> counterPointInside =
             HyperbolicSpace::polarToCartesian(mirrorangle, mirrorradiusInside);
         EXPECT_LE(HyperbolicSpace::poincareMetric(cartesianPoint, counterPointInside), R)
-            << "(" << cartesianPoint.getX() << ", " << cartesianPoint.getY() << ")"
-            << " and (" << counterPointInside.getX() << ", " << counterPointInside.getY() << ")"
-            << " are " << HyperbolicSpace::poincareMetric(cartesianPoint, counterPointInside)
+            << "(" << cartesianPoint.getX() << ", " << cartesianPoint.getY() << ")" << " and ("
+            << counterPointInside.getX() << ", " << counterPointInside.getY() << ")" << " are "
+            << HyperbolicSpace::poincareMetric(cartesianPoint, counterPointInside)
             << " apart from each other, which is more than " << R << ".";
 
         double mirrorradiusOutside = std::abs(r_e - euRadius) + epsilon;

--- a/networkit/cpp/io/test/IOBenchmark.cpp
+++ b/networkit/cpp/io/test/IOBenchmark.cpp
@@ -75,11 +75,7 @@ void IOBenchmark::convertToHeatMap(std::vector<bool> &infected, std::vector<doub
     file.open(filename.c_str());
 
     // write column labels
-    file << "x"
-         << "\t"
-         << "y"
-         << "\t"
-         << "label" << std::endl;
+    file << "x" << "\t" << "y" << "\t" << "label" << std::endl;
 
     // write heat map
     for (index i = 0; i < infectedByRegion.size(); i++) {

--- a/networkit/cpp/matching/Matching.cpp
+++ b/networkit/cpp/matching/Matching.cpp
@@ -104,4 +104,4 @@ std::vector<node> Matching::getVector() const {
 }
 
 } // namespace NetworKit
-  /* namespace NetworKit */
+/* namespace NetworKit */

--- a/networkit/cpp/scd/LocalDegreeDirectedGraph.hpp
+++ b/networkit/cpp/scd/LocalDegreeDirectedGraph.hpp
@@ -211,8 +211,7 @@ public:
      */
     template <typename F>
     void forTrianglesOf(node u, F callback) {
-        forTrianglesOf(
-            u, [](node, edgeweight) {}, callback);
+        forTrianglesOf(u, [](node, edgeweight) {}, callback);
     }
 
     /**

--- a/networkit/cpp/scd/LocalTightnessExpansion.cpp
+++ b/networkit/cpp/scd/LocalTightnessExpansion.cpp
@@ -66,7 +66,7 @@ private:
 public:
     LocalGraph(const Graph &g, NodeAddedCallbackType nodeAddedCallback)
         : LocalDegreeDirectedGraph<is_weighted, InnerNodeAddedCallback<NodeAddedCallbackType>>(
-            g, InnerNodeAddedCallback<NodeAddedCallbackType>{nodeAddedCallback, triangleSum}) {
+              g, InnerNodeAddedCallback<NodeAddedCallbackType>{nodeAddedCallback, triangleSum}) {
         if (g.isWeighted() != is_weighted) {
             throw std::runtime_error("Error, weighted/unweighted status of input graph does not "
                                      "match is_weighted template parameter");

--- a/networkit/cpp/viz/MaxentStress.cpp
+++ b/networkit/cpp/viz/MaxentStress.cpp
@@ -504,9 +504,8 @@ void MaxentStress::computeKnownDistances(const count k, const GraphDistance grap
     case EDGE_WEIGHT:
         // add edges to known distances
         G->parallelForNodes([&](node u) {
-            G->forNeighborsOf(u, [&](node v, edgeweight w) {
-                knownDistances[u].push_back({v, w});
-            });
+            G->forNeighborsOf(u,
+                              [&](node v, edgeweight w) { knownDistances[u].push_back({v, w}); });
             // add k-neighborhood
             if (k > 1) { // 1-neighborhood are adjacent vertices that are already added above
                 addKNeighborhoodOfVertex(u, k);

--- a/networkit/cpp/viz/test/VizGTest.cpp
+++ b/networkit/cpp/viz/test/VizGTest.cpp
@@ -33,9 +33,8 @@ TEST_F(VizGTest, testPostscriptWriterOnRandomGraph) {
     std::vector<Point2D> coordinates(G.upperNodeIdBound());
 
     // create coordinates
-    G.forNodes([&](node u) {
-        coordinates[u] = {Aux::Random::probability(), Aux::Random::probability()};
-    });
+    G.forNodes(
+        [&](node u) { coordinates[u] = {Aux::Random::probability(), Aux::Random::probability()}; });
 
     // write graph to file
     std::string path = "output/testGraph.eps";


### PR DESCRIPTION
Notes: 

- GCC is not updated to 13.X for macOS, since the compiler is currently broken when working with `libomp` on CI (not reproducible locally).
- clang-tidy is not updated to 18.X. This is out of scope for this PR, due to non-minor refactoring.
- The `-permissive` flag is added for MSVC builds, since when building with Visual Studio, the flag is enabled by default. This marks nonconforming code (related to MSVC + a CPP-standard).