### PR TITLE
vizbridges: edge scores with default dict

### DIFF
--- a/networkit/test/test_vizbridges.py
+++ b/networkit/test/test_vizbridges.py
@@ -145,6 +145,24 @@ class TestVizbridges(unittest.TestCase):
                     edgeScores=scores,
                 )
 
+    def testVizEdgeScoresDefaultdictOneEntry(self):
+        for dim, directed, weighted in zip(
+            vizbridges.Dimension, [True, False], [True, False]
+        ):
+            with self.subTest(dim=dim, directed=directed, weighted=weighted):
+                G = self.getSmallGraph(weighted, directed)
+                G.indexEdges()
+                scores = defaultdict(lambda: 0)
+                # create incomplete defaultdict
+                for u, v in G.iterEdges():
+                    scores[u, v] = 1
+                    break
+                vizbridges.widgetFromGraph(
+                    G,
+                    dimension=dim,
+                    edgeScores=scores,
+                )
+
     def testVizEdgePalette(self):
         for dim, directed, weighted in zip(
             vizbridges.Dimension, [True, False], [True, False]


### PR DESCRIPTION
This PR adds a new (failing) test for the case where an incomplete defaultdict is provided to the `widgetFromGraph` function and fixes the problem. 

The previous implementation used `dict.get()` which always returns `None` if the value is not in the dict - even when a default factory is available (we misread the documentation). Now, we use `[]` to access values, which does use the default factory if available.