### PR TITLE
Lamg solver: support solving systems with more than one component in parallel

### DIFF
--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -64,12 +64,24 @@ public:
      * Compute the multigrid hierarchy for the given Laplacian matrix @a laplacianMatrix.
      * @param laplacianMatrix
      * @note This method also works for disconnected graphs. If you know that the graph is
-     * connected, if is faster to use @ref setupConnected instead.
+     * connected, it is faster to use @ref setupConnected instead.
      */
     void setup(const Matrix &laplacianMatrix) override;
 
     /**
-     * Compute the multigrid hierarchy for te given Laplacian matrix @a laplacianMatrix.
+     * Compute the multigrid hierarchy for the given Laplacian matrix @a laplacianMatrix that
+     * corresponds to the graph @a G using the existing component decomposition @a decomp.
+     * @param laplacianMatrix
+     * @param decomp ComponentDecomposition that corresponds to the graph of the @a laplacianMatrix
+     * @note This setup method allows you to skip some computation in the general setup method. You
+     * can provide your own graph and decomposition via this method to prevent duplicate
+     * computation. Note that the output is undefined if the three parameters do not correspond the
+     * the same graph.
+     */
+    void setup(const Matrix &laplacianMatrix, const Graph &G, const ComponentDecomposition &decomp);
+
+    /**
+     * Compute the multigrid hierarchy for the given Laplacian matrix @a laplacianMatrix.
      * @param laplacianMatrix
      * @note The graph has to be connected for this method to work. Otherwise the output is
      * undefined.
@@ -169,6 +181,12 @@ void Lamg<Matrix>::setupConnected(const Matrix &laplacianMatrix) {
     this->laplacianMatrix = laplacianMatrix;
     initializeForOneComponent();
     numComponents = 1;
+}
+
+template <class Matrix>
+void Lamg<Matrix>::setup(const Matrix &laplacianMatrix, const Graph &G,
+                         const ComponentDecomposition &decomp) {
+    this->setup(laplacianMatrix);
 }
 
 template <class Matrix>

--- a/networkit/cpp/numerics/test/CMakeLists.txt
+++ b/networkit/cpp/numerics/test/CMakeLists.txt
@@ -1,3 +1,4 @@
 networkit_add_test(numerics GaussSeidelRelaxationGTest algebraic graph)
-networkit_add_test(numerics LAMGGTest algebraic auxiliary components io)
+networkit_add_test(numerics LAMGGTest algebraic auxiliary components)
+networkit_add_test(numerics LAMGSolverGTest algebraic auxiliary components io)
 

--- a/networkit/cpp/numerics/test/LAMGGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGGTest.cpp
@@ -9,113 +9,212 @@
 
 #include <networkit/algebraic/CSRMatrix.hpp>
 #include <networkit/algebraic/Vector.hpp>
-#include <networkit/auxiliary/Timer.hpp>
 #include <networkit/components/ConnectedComponents.hpp>
-#include <networkit/generators/BarabasiAlbertGenerator.hpp>
 #include <networkit/graph/Graph.hpp>
-#include <networkit/io/LineFileReader.hpp>
-#include <networkit/io/METISGraphReader.hpp>
-#include <networkit/io/METISGraphWriter.hpp>
-#include <networkit/numerics/GaussSeidelRelaxation.hpp>
-#include <networkit/numerics/LAMG/MultiLevelSetup.hpp>
-#include <networkit/numerics/LAMG/SolverLamg.hpp>
-#include <networkit/structures/Partition.hpp>
+#include <networkit/numerics/LAMG/Lamg.hpp>
 
 namespace NetworKit {
 
-class LAMGGTest : public testing::Test {
-protected:
-    const std::vector<std::string> GRAPH_INSTANCES = {"input/jazz.graph", "input/power.graph"};
+// list of variants:
+// - solver: solve, parallelSolve
+// - setup: connected, not connected, not connected with partition
+// - components: one component, multiple components
+// - parallelism: single thread, multiple threads
 
-    Vector randZeroSum(const Graph &graph, size_t seed) const;
-    Vector randVector(count dimension) const;
+class LAMGGTest
+    // params: Solver, Setup, Components, Parallelism
+    : public testing::TestWithParam<
+          std::tuple<std::string, std::string, std::string, std::string>> {
+protected:
+    // returns a graph and a vector of RHS, solution pairs s.t. L*solution = RHS for all entries
+    std::tuple<Graph, std::vector<Vector>, std::vector<Vector>> testData() const;
 };
 
-TEST_F(LAMGGTest, testSmallGraphs) {
-    METISGraphReader reader;
-    GaussSeidelRelaxation<CSRMatrix> gaussSmoother, smoother;
-    MultiLevelSetup<CSRMatrix> setup(gaussSmoother);
-    Aux::Timer timer;
-    for (index i = 0; i < GRAPH_INSTANCES.size(); ++i) {
-        std::string graph = GRAPH_INSTANCES[i];
-        Graph G = reader.read(graph);
-        ConnectedComponents con(G);
-        con.run();
-        Partition comps = con.getPartition();
-        if (comps.numberOfSubsets() > 1) { // disconnected graphs are currently not supported
-            continue;
-        }
+INSTANTIATE_TEST_SUITE_P(
+    LAMGGTest, LAMGGTest,
+    testing::Combine(testing::Values("solve", "parallelSolve", "loaderSolve"),
+                     testing::Values("connected", "disconnected", "disconnectedWithPartition"),
+                     testing::Values("one", "two"), testing::Values("single", "four")));
 
-        LevelHierarchy<CSRMatrix> hierarchy;
-        timer.start();
-        setup.setup(G, hierarchy);
-        SolverLamg<CSRMatrix> solver(hierarchy, smoother);
-        timer.stop();
-        DEBUG("setup time\t ", timer.elapsedMilliseconds());
-
-        Vector b(G.numberOfNodes());
-        Vector x(G.numberOfNodes());
-
-        b = randZeroSum(G, 12345);
-        x = randVector(G.numberOfNodes());
-
-        LAMGSolverStatus status;
-        // needed for getting a relative residual <= 1e-6
-        status.desiredResidualReduction =
-            1e-6 * b.length() / (hierarchy.at(0).getLaplacian() * x - b).length();
-
-        Vector result = x;
-        DEBUG("Solving equation system - Gauss-Seidel");
-        timer.start();
-        solver.solve(result, b, status);
-        timer.stop();
-
-        EXPECT_TRUE(status.converged);
-
-        DEBUG("solve time\t ", timer.elapsedMilliseconds());
-        DEBUG("final residual = ", status.residual);
-        DEBUG("numIters = ", status.numIters);
-        DEBUG("DONE");
+// Temporary function
+inline std::ostream &operator<<(std::ostream &os, const CSRMatrix &M) {
+    for (index i = 0; i < M.numberOfRows(); i++) {
+        for (index j = 0; j < M.numberOfColumns(); j++)
+            os << M(i, j) << ", ";
+        os << std::endl;
     }
+    return os;
 }
 
-Vector LAMGGTest::randVector(count dimension) const {
-    Vector randVector(dimension);
-    for (index i = 0; i < dimension; ++i) {
-        randVector[i] = 2.0 * Aux::Random::probability() - 1.0;
+inline std::ostream &operator<<(std::ostream &os, const Vector &vec) {
+    os << "[";
+    for (index i = 0; i < vec.getDimension(); i++) {
+        if (i != 0)
+            os << ", ";
+        os << vec[i];
     }
-
-    // introduce bias
-    for (index i = 0; i < dimension; ++i) {
-        randVector[i] = randVector[i] * randVector[i];
-    }
-
-    return randVector;
+    os << "]";
+    return os;
 }
 
-Vector LAMGGTest::randZeroSum(const Graph &G, size_t seed) const {
-    std::mt19937 rand(seed);
-    auto rand_value = std::uniform_real_distribution<double>(-1.0, 1.0);
-    ConnectedComponents con(G);
-    count n = G.numberOfNodes();
-    con.run();
-    Partition comps = con.getPartition();
+inline bool vector_almost_equal(const Vector &lhs, const Vector &rhs) {
+    if (lhs.getDimension() != rhs.getDimension())
+        return false;
+    for (size_t i = 0; i < lhs.getDimension(); ++i) {
+        if (std::abs(lhs[i] - rhs[i]) > 1e-4)
+            return false;
+    }
+    return true;
+}
 
-    /* Fill each component randomly such that its sum is 0 */
-    Vector b(n, 0.0);
+std::tuple<Graph, std::vector<Vector>, std::vector<Vector>> LAMGGTest::testData() const {
+    auto [solveFn, setupFn, components, parallelism] = GetParam();
 
-    for (int id : comps.getSubsetIds()) {
-        auto indexes = comps.getMembers(id);
-        assert(!indexes.empty());
-        double sum = 0.0;
-        for (auto entry : indexes) {
-            b[entry] = rand_value(rand);
-            sum += b[entry];
-        }
-        b[*indexes.begin()] -= sum;
+    Graph G(6);
+    std::vector<Vector> rhss;
+    std::vector<Vector> solutions;
+    if (components == "one") {
+        /*
+        0 - 1 - 2
+        |       |
+        3 - 4 - 5
+
+        L:
+         2 -1  0 -1  0  0
+        -1  2 -1  0  0  0
+         0 -1  2  0  0 -1
+        -1  0  0  2 -1  0
+         0  0  0 -1  2 -1
+         0  0 -1  0 -1  2
+        */
+
+        G.addEdge(0, 1);
+        G.addEdge(0, 3);
+        G.addEdge(1, 2);
+        G.addEdge(2, 5);
+        G.addEdge(3, 4);
+        G.addEdge(4, 5);
+
+        // rhs, solution
+        rhss = {
+            {-4, 0, -2, 2, 0, 4},
+            {-8, 2, 10, 14, -8, -10},
+        };
+        solutions = {
+            {-2.5, -1.5, -0.5, 0.5, 1.5, 2.5},
+            {-0.5, 2.5, 3.5, 4.5, -4.5, -5.5},
+        };
+
+        return {G, rhss, solutions};
     }
 
-    return b;
+    if (components == "two") {
+        /*
+       0 - 1 - 2
+
+       3 - 4 - 5
+
+       L:
+        1 -1  0  0  0  0
+       -1  2 -1  0  0  0
+        0 -1  1  0  0  0
+        0  0  0  1 -1  0
+        0  0  0 -1  2 -1
+        0  0  0  0 -1  1
+       */
+
+        G.addEdge(0, 1);
+        G.addEdge(1, 2);
+        G.addEdge(3, 4);
+        G.addEdge(4, 5);
+
+        // rhs, solution
+        rhss = {
+            {-1, 3, -2, -1, -3, 4},
+            {0, 0, 0, -1, -3, 4},
+            {-1, 3, -2, 0, 0, 0},
+            {-10, 0, 10, 16, -6, -10},
+        };
+        solutions = {
+            {0, 1, -1, -2, -1, 3},
+            {0, 0, 0, -2, -1, 3},
+            {0, 1, -1, 0, 0, 0},
+            {-10, 0, 10, 14, -2, -12},
+        };
+
+        return {G, rhss, solutions};
+    }
+    throw std::logic_error("unknown number of components.");
+}
+
+TEST_P(LAMGGTest, testLamgVariants) {
+    auto [solveFn, setupFn, components, parallelism] = GetParam();
+
+    if (parallelism == "single")
+        omp_set_num_threads(1);
+    else if (parallelism == "four")
+        omp_set_num_threads(4);
+    else
+        throw std::logic_error("unhandled variant!");
+
+    // skip combinations that do not work
+    if (setupFn == "connected" && components != "one")
+        return;
+
+    auto [G, rhss, solutions] = testData();
+
+    auto L = CSRMatrix::laplacianMatrix(G);
+
+    Lamg<CSRMatrix> lamg;
+
+    ParallelConnectedComponents pcc(G);
+    pcc.run();
+
+    if (setupFn == "connected")
+        lamg.setupConnected(L);
+    else if (setupFn == "disconnected")
+        lamg.setup(L);
+    else if (setupFn == "disconnectedWithPartition")
+        lamg.setup(L, G, pcc);
+    else
+        throw std::logic_error("unhandled variant!");
+
+    // for loader solve variant
+    const auto rhsLoader = [&rhss](count i, Vector &rhs) -> Vector & {
+        rhs = rhss[i];
+        return rhs;
+    };
+
+    const auto resultProcessor = [&solutions](count i, const Vector &result) {
+        EXPECT_TRUE(vector_almost_equal(result, solutions[i]))
+            << "Lamg result: " << result << "gt: " << solutions[i];
+    };
+
+    if (solveFn == "solve") {
+        for (size_t i = 0; i < rhss.size(); ++i) {
+            const auto &rhs = rhss[i];
+            const auto &gt = solutions[i];
+
+            Vector result(rhs.getDimension());
+
+            lamg.solve(rhs, result);
+
+            EXPECT_TRUE(vector_almost_equal(result, gt))
+                << "Lamg result: " << result << "gt: " << gt;
+        }
+    } else if (solveFn == "parallelSolve") {
+        std::vector<Vector> results(rhss.size(), Vector(6));
+        lamg.parallelSolve(rhss, results);
+        for (size_t i = 0; i < rhss.size(); ++i) {
+            const auto &gt = solutions[i];
+            const auto &result = results[i];
+            EXPECT_TRUE(vector_almost_equal(result, gt))
+                << "Lamg result: " << result << "gt: " << gt;
+        }
+    } else if (solveFn == "loaderSolve")
+        lamg.parallelSolve(rhsLoader, resultProcessor, {rhss.size(), L.numberOfColumns()});
+    else
+        throw std::logic_error("unhandled variant!");
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/numerics/test/LAMGSolverGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGSolverGTest.cpp
@@ -1,0 +1,122 @@
+/*
+ * LAMGGTest.cpp
+ *
+ *  Created on: 20.11.2014
+ *      Author: Michael
+ */
+
+#include <gtest/gtest.h>
+
+#include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/algebraic/Vector.hpp>
+#include <networkit/auxiliary/Timer.hpp>
+#include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/generators/BarabasiAlbertGenerator.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/io/LineFileReader.hpp>
+#include <networkit/io/METISGraphReader.hpp>
+#include <networkit/io/METISGraphWriter.hpp>
+#include <networkit/numerics/GaussSeidelRelaxation.hpp>
+#include <networkit/numerics/LAMG/Lamg.hpp>
+#include <networkit/numerics/LAMG/MultiLevelSetup.hpp>
+#include <networkit/numerics/LAMG/SolverLamg.hpp>
+#include <networkit/structures/Partition.hpp>
+
+namespace NetworKit {
+
+class LAMGSolverGTest : public testing::Test {
+protected:
+    const std::vector<std::string> GRAPH_INSTANCES = {"input/jazz.graph", "input/power.graph"};
+
+    Vector randZeroSum(const Graph &graph, size_t seed) const;
+    Vector randVector(count dimension) const;
+};
+
+TEST_F(LAMGSolverGTest, testSmallGraphs) {
+    METISGraphReader reader;
+    GaussSeidelRelaxation<CSRMatrix> gaussSmoother, smoother;
+    MultiLevelSetup<CSRMatrix> setup(gaussSmoother);
+    Aux::Timer timer;
+    for (index i = 0; i < GRAPH_INSTANCES.size(); ++i) {
+        std::string graph = GRAPH_INSTANCES[i];
+        Graph G = reader.read(graph);
+        ConnectedComponents con(G);
+        con.run();
+        Partition comps = con.getPartition();
+        if (comps.numberOfSubsets() > 1) { // disconnected graphs are currently not supported
+            continue;
+        }
+
+        LevelHierarchy<CSRMatrix> hierarchy;
+        timer.start();
+        setup.setup(G, hierarchy);
+        SolverLamg<CSRMatrix> solver(hierarchy, smoother);
+        timer.stop();
+        DEBUG("setup time\t ", timer.elapsedMilliseconds());
+
+        Vector b(G.numberOfNodes());
+        Vector x(G.numberOfNodes());
+
+        b = randZeroSum(G, 12345);
+        x = randVector(G.numberOfNodes());
+
+        LAMGSolverStatus status;
+        // needed for getting a relative residual <= 1e-6
+        status.desiredResidualReduction =
+            1e-6 * b.length() / (hierarchy.at(0).getLaplacian() * x - b).length();
+
+        Vector result = x;
+        DEBUG("Solving equation system - Gauss-Seidel");
+        timer.start();
+        solver.solve(result, b, status);
+        timer.stop();
+
+        EXPECT_TRUE(status.converged);
+
+        DEBUG("solve time\t ", timer.elapsedMilliseconds());
+        DEBUG("final residual = ", status.residual);
+        DEBUG("numIters = ", status.numIters);
+        DEBUG("DONE");
+    }
+}
+
+Vector LAMGSolverGTest::randVector(count dimension) const {
+    Vector randVector(dimension);
+    for (index i = 0; i < dimension; ++i) {
+        randVector[i] = 2.0 * Aux::Random::probability() - 1.0;
+    }
+
+    // introduce bias
+    for (index i = 0; i < dimension; ++i) {
+        randVector[i] = randVector[i] * randVector[i];
+    }
+
+    return randVector;
+}
+
+Vector LAMGSolverGTest::randZeroSum(const Graph &G, size_t seed) const {
+    std::mt19937 rand(seed);
+    auto rand_value = std::uniform_real_distribution<double>(-1.0, 1.0);
+    ConnectedComponents con(G);
+    count n = G.numberOfNodes();
+    con.run();
+    Partition comps = con.getPartition();
+
+    /* Fill each component randomly such that its sum is 0 */
+    Vector b(n, 0.0);
+
+    for (int id : comps.getSubsetIds()) {
+        auto indexes = comps.getMembers(id);
+        assert(!indexes.empty());
+        double sum = 0.0;
+        for (auto entry : indexes) {
+            b[entry] = rand_value(rand);
+            sum += b[entry];
+        }
+        b[*indexes.begin()] -= sum;
+    }
+
+    return b;
+}
+
+} /* namespace NetworKit */


### PR DESCRIPTION
This PR adds support to the Lamg solver to deal with multi-component systems in parallel. 

Todos:
- [x] adds tests
- [] add new setup function
- [] investigate if other setup functions are useful
- [] add support for parallelSolve
- [] benchmarks