### PR TITLE
Improve LAMG helper classes

### DIFF
--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -14,6 +14,7 @@
 #include <networkit/algebraic/MatrixTools.hpp>
 #include <networkit/components/ParallelConnectedComponents.hpp>
 #include <networkit/numerics/GaussSeidelRelaxation.hpp>
+#include <networkit/numerics/LAMG/LevelHierarchy.hpp>
 #include <networkit/numerics/LAMG/MultiLevelSetup.hpp>
 #include <networkit/numerics/LAMG/SolverLamg.hpp>
 #include <networkit/numerics/LinearSolver.hpp>

--- a/include/networkit/numerics/LAMG/LevelHierarchy.hpp
+++ b/include/networkit/numerics/LAMG/LevelHierarchy.hpp
@@ -40,7 +40,7 @@ public:
                              const std::vector<EliminationStage<Matrix>> &coarseningStages);
     void addAggregationLevel(const Matrix &A, const Matrix &P, const Matrix &R);
     void setLastAsCoarsest();
-    inline DenseMatrix &getCoarseMatrix() { return coarseLUMatrix; }
+    inline const DenseMatrix &getCoarseMatrix() const { return coarseLUMatrix; }
 
     inline count size() const {
         return levelType.size() + 1; // elimination + aggregation levels + finestLevel
@@ -48,7 +48,8 @@ public:
 
     LevelType getType(index levelIdx) const;
     Level<Matrix> &at(index levelIdx);
-    double cycleIndex(index levelIdx);
+    const Level<Matrix> &at(index levelIdx) const;
+    double cycleIndex(index levelIdx) const;
 };
 
 template <class Matrix>
@@ -118,7 +119,24 @@ Level<Matrix> &LevelHierarchy<Matrix>::at(index levelIdx) {
 }
 
 template <class Matrix>
-double LevelHierarchy<Matrix>::cycleIndex(index levelIdx) {
+const Level<Matrix> &LevelHierarchy<Matrix>::at(index levelIdx) const {
+    assert(levelIdx < this->size());
+
+    if (levelIdx == 0) { // finest level
+        return finestLevel;
+    } else {
+        levelIdx--;
+    }
+
+    if (levelType[levelIdx] == ELIMINATION) {
+        return eliminationLevels[levelIndex[levelIdx]];
+    } else {
+        return aggregationLevels[levelIndex[levelIdx]];
+    }
+}
+
+template <class Matrix>
+double LevelHierarchy<Matrix>::cycleIndex(index levelIdx) const {
     double gamma = 1.0;
     if (getType(levelIdx + 1) != ELIMINATION) {
         const double finestNumEdges = finestLevel.getLaplacian().nnz();

--- a/include/networkit/numerics/LAMG/LevelHierarchy.hpp
+++ b/include/networkit/numerics/LAMG/LevelHierarchy.hpp
@@ -8,7 +8,9 @@
 #ifndef NETWORKIT_NUMERICS_LAMG_LEVEL_HIERARCHY_HPP_
 #define NETWORKIT_NUMERICS_LAMG_LEVEL_HIERARCHY_HPP_
 
+#include <networkit/algebraic/CSRMatrix.hpp>
 #include <networkit/algebraic/DenseMatrix.hpp>
+#include <networkit/algebraic/DynamicMatrix.hpp>
 #include <networkit/numerics/LAMG/LAMGSettings.hpp>
 #include <networkit/numerics/LAMG/Level/Level.hpp>
 #include <networkit/numerics/LAMG/Level/LevelAggregation.hpp>
@@ -153,6 +155,10 @@ double LevelHierarchy<Matrix>::cycleIndex(index levelIdx) const {
 
     return gamma;
 }
+
+extern template class LevelHierarchy<CSRMatrix>;
+extern template class LevelHierarchy<DenseMatrix>;
+extern template class LevelHierarchy<DynamicMatrix>;
 
 } /* namespace NetworKit */
 

--- a/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
+++ b/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
@@ -830,7 +830,7 @@ void MultiLevelSetup<Matrix>::galerkinOperator(const Matrix &P, const Matrix &A,
         spa.increaseRow();
     }
 
-    B = CSRMatrix(P.numberOfColumns(), P.numberOfColumns(), triplets);
+    B = Matrix(P.numberOfColumns(), P.numberOfColumns(), triplets);
 }
 
 template <>

--- a/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
+++ b/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
@@ -222,13 +222,12 @@ public:
      * @param matrix Laplcian matrix.
      * @param hierarchy[out] The constructed hierarchy.
      */
-    void setup(const Matrix &matrix, LevelHierarchy<Matrix> &hierarchy) const;
+    void setup(Matrix matrix, LevelHierarchy<Matrix> &hierarchy) const;
 };
 
 template <class Matrix>
-void MultiLevelSetup<Matrix>::setup(const Matrix &matrix, LevelHierarchy<Matrix> &hierarchy) const {
-    CSRMatrix A = matrix;
-    setupForMatrix(A, hierarchy);
+void MultiLevelSetup<Matrix>::setup(Matrix matrix, LevelHierarchy<Matrix> &hierarchy) const {
+    setupForMatrix(matrix, hierarchy);
 }
 
 template <class Matrix>
@@ -835,11 +834,10 @@ void MultiLevelSetup<Matrix>::galerkinOperator(const Matrix &P, const Matrix &A,
 }
 
 template <>
-inline void MultiLevelSetup<CSRMatrix>::setup(const CSRMatrix &matrix,
+inline void MultiLevelSetup<CSRMatrix>::setup(CSRMatrix matrix,
                                               LevelHierarchy<CSRMatrix> &hierarchy) const {
-    CSRMatrix A = matrix;
-    A.sort();
-    setupForMatrix(A, hierarchy);
+    matrix.sort();
+    setupForMatrix(matrix, hierarchy);
 }
 
 template <>

--- a/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
+++ b/include/networkit/numerics/LAMG/MultiLevelSetup.hpp
@@ -9,6 +9,8 @@
 #define NETWORKIT_NUMERICS_LAMG_MULTI_LEVEL_SETUP_HPP_
 
 #include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/algebraic/DenseMatrix.hpp>
+#include <networkit/algebraic/DynamicMatrix.hpp>
 #include <networkit/numerics/LAMG/LevelHierarchy.hpp>
 #include <networkit/numerics/Smoother.hpp>
 
@@ -1080,6 +1082,10 @@ inline void MultiLevelSetup<CSRMatrix>::coarseningAggregation(CSRMatrix &matrix,
 
     hierarchy.addAggregationLevel(matrix, P, R);
 }
+
+extern template class MultiLevelSetup<CSRMatrix>;
+extern template class MultiLevelSetup<DenseMatrix>;
+extern template class MultiLevelSetup<DynamicMatrix>;
 
 } /* namespace NetworKit */
 

--- a/include/networkit/numerics/LAMG/SolverLamg.hpp
+++ b/include/networkit/numerics/LAMG/SolverLamg.hpp
@@ -46,7 +46,7 @@ struct LAMGSolverStatus {
 template <class Matrix>
 class SolverLamg {
 private:
-    LevelHierarchy<Matrix> &hierarchy;
+    const LevelHierarchy<Matrix> &hierarchy;
     const Smoother<Matrix> &smoother;
 
     // data structures for iterate recombination
@@ -64,7 +64,7 @@ private:
     void multigridCycle(index level, Vector &xf, const Vector &bf);
     void saveIterate(index level, const Vector &x, const Vector &r);
     void clearHistory(index level);
-    void minRes(index level, Vector &x, const Vector &r);
+    void minRes(index level, Vector &x, const Vector &r) const;
 
 public:
     /**
@@ -73,7 +73,7 @@ public:
      * @param hierarchy Reference to the LevelHierarchy constructed by MultiLevelSetup.
      * @param smoother Reference to a smoother.
      */
-    SolverLamg(LevelHierarchy<Matrix> &hierarchy, const Smoother<Matrix> &smoother)
+    SolverLamg(const LevelHierarchy<Matrix> &hierarchy, const Smoother<Matrix> &smoother)
         : hierarchy(hierarchy), smoother(smoother),
           bStages(hierarchy.size(), std::vector<Vector>()) {}
 
@@ -134,7 +134,7 @@ void SolverLamg<Matrix>::solve(Vector &x, const Vector &b, LAMGSolverStatus &sta
 }
 
 template <class Matrix>
-void SolverLamg<Matrix>::solveCycle(Vector &x, const Vector &b, int finest,
+void SolverLamg<Matrix>::solveCycle(Vector &x, const Vector &b, const int finest,
                                     LAMGSolverStatus &status) {
     Aux::Timer timer;
     timer.start();
@@ -187,7 +187,7 @@ void SolverLamg<Matrix>::solveCycle(Vector &x, const Vector &b, int finest,
 }
 
 template <class Matrix>
-void SolverLamg<Matrix>::cycle(Vector &x, const Vector &b, int finest, int coarsest,
+void SolverLamg<Matrix>::cycle(Vector &x, const Vector &b, const int finest, const int coarsest,
                                std::vector<count> &numVisits, std::vector<Vector> &X,
                                std::vector<Vector> &B, const LAMGSolverStatus &status) {
     std::fill(numVisits.begin(), numVisits.end(), 0);
@@ -291,7 +291,7 @@ void SolverLamg<Matrix>::cycle(Vector &x, const Vector &b, int finest, int coars
 }
 
 template <class Matrix>
-void SolverLamg<Matrix>::saveIterate(index level, const Vector &x, const Vector &r) {
+void SolverLamg<Matrix>::saveIterate(const index level, const Vector &x, const Vector &r) {
     // update latest pointer
     index i = latestIterate[level];
     latestIterate[level] = (i + 1) % MAX_COMBINED_ITERATES;
@@ -307,13 +307,13 @@ void SolverLamg<Matrix>::saveIterate(index level, const Vector &x, const Vector 
 }
 
 template <class Matrix>
-void SolverLamg<Matrix>::clearHistory(index level) {
+void SolverLamg<Matrix>::clearHistory(const index level) {
     latestIterate[level] = 0;
     numActiveIterates[level] = 0;
 }
 
 template <class Matrix>
-void SolverLamg<Matrix>::minRes(index level, Vector &x, const Vector &r) {
+void SolverLamg<Matrix>::minRes(const index level, Vector &x, const Vector &r) const {
     if (numActiveIterates[level] > 0) {
         count n = numActiveIterates[level];
 

--- a/include/networkit/numerics/LAMG/SolverLamg.hpp
+++ b/include/networkit/numerics/LAMG/SolverLamg.hpp
@@ -61,7 +61,6 @@ private:
     void solveCycle(Vector &x, const Vector &b, int finest, LAMGSolverStatus &status);
     void cycle(Vector &x, const Vector &b, int finest, int coarsest, std::vector<count> &numVisits,
                std::vector<Vector> &X, std::vector<Vector> &B, const LAMGSolverStatus &status);
-    void multigridCycle(index level, Vector &xf, const Vector &bf);
     void saveIterate(index level, const Vector &x, const Vector &r);
     void clearHistory(index level);
     void minRes(index level, Vector &x, const Vector &r) const;

--- a/include/networkit/numerics/LAMG/SolverLamg.hpp
+++ b/include/networkit/numerics/LAMG/SolverLamg.hpp
@@ -311,10 +311,6 @@ void SolverLamg<Matrix>::clearHistory(const index level) {
     numActiveIterates[level] = 0;
 }
 
-extern template class SolverLamg<CSRMatrix>;
-extern template class SolverLamg<DenseMatrix>;
-extern template class SolverLamg<DynamicMatrix>;
-
 } /* namespace NetworKit */
 
 #endif // NETWORKIT_NUMERICS_LAMG_SOLVER_LAMG_HPP_

--- a/networkit/cpp/algebraic/test/CMakeLists.txt
+++ b/networkit/cpp/algebraic/test/CMakeLists.txt
@@ -11,7 +11,7 @@ networkit_add_test(algebraic AlgebraicPageRankGTest
     algebraic auxiliary centrality io)
 
 networkit_add_test(algebraic AlgebraicSpanningEdgeCentralityGTest
-    algebraic centrality io)
+    algebraic centrality io numerics)
 
 networkit_add_test(algebraic AlgebraicTriangleCountingGTest
     algebraic auxiliary centrality io)

--- a/networkit/cpp/centrality/test/CMakeLists.txt
+++ b/networkit/cpp/centrality/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 networkit_add_test(centrality ApproxBetweennessGTest
     distance generators)
 networkit_add_test(centrality CentralityGTest
-    auxiliary generators io structures)
+    auxiliary generators io numerics structures)
 networkit_add_test(centrality DynBetweennessGTest
     auxiliary generators graph io)
 networkit_add_test(centrality SpanningEdgeCentralityGTest
-    graph io)
+    graph io numerics)
 networkit_add_test(centrality TopClosenessGTest
     generators graph io)
 

--- a/networkit/cpp/distance/test/CMakeLists.txt
+++ b/networkit/cpp/distance/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 networkit_add_test(distance APSPGTest
     auxiliary dyn_distance generators io)
 networkit_add_test(distance CommuteTimeDistanceGTest
-    centrality graph io)
+    centrality graph io numerics)
 networkit_add_test(distance DistanceGTest
     dyn_distance generators io)
 networkit_add_test(distance GraphDistanceGTest

--- a/networkit/cpp/numerics/CMakeLists.txt
+++ b/networkit/cpp/numerics/CMakeLists.txt
@@ -1,4 +1,9 @@
-networkit_add_module(numerics)
+networkit_add_module(numerics
+    MultiLevelSetup.cpp
+)
+
+networkit_module_link_modules(numerics
+    algebraic)
 
 add_subdirectory(test)
 

--- a/networkit/cpp/numerics/CMakeLists.txt
+++ b/networkit/cpp/numerics/CMakeLists.txt
@@ -1,6 +1,7 @@
 networkit_add_module(numerics
     MultiLevelSetup.cpp
     LevelHierarchy.cpp
+    SolverLamg.cpp
 )
 
 networkit_module_link_modules(numerics

--- a/networkit/cpp/numerics/CMakeLists.txt
+++ b/networkit/cpp/numerics/CMakeLists.txt
@@ -1,5 +1,6 @@
 networkit_add_module(numerics
     MultiLevelSetup.cpp
+    LevelHierarchy.cpp
 )
 
 networkit_module_link_modules(numerics

--- a/networkit/cpp/numerics/LevelHierarchy.cpp
+++ b/networkit/cpp/numerics/LevelHierarchy.cpp
@@ -1,7 +1,8 @@
 /*
  * LevelHierarchy.cpp
  *
- *  Created on: 23.04.2024
+ *  Created on: 23.04.2024 
+ *      Author: Lukas
  */
 
 #include <networkit/numerics/LAMG/LevelHierarchy.hpp>

--- a/networkit/cpp/numerics/LevelHierarchy.cpp
+++ b/networkit/cpp/numerics/LevelHierarchy.cpp
@@ -1,7 +1,7 @@
 /*
  * LevelHierarchy.cpp
  *
- *  Created on: 23.04.2024 
+ *  Created on: 23.04.2024
  *      Author: Lukas
  */
 

--- a/networkit/cpp/numerics/LevelHierarchy.cpp
+++ b/networkit/cpp/numerics/LevelHierarchy.cpp
@@ -1,0 +1,15 @@
+/*
+ * LevelHierarchy.cpp
+ *
+ *  Created on: 23.04.2024
+ */
+
+#include <networkit/numerics/LAMG/LevelHierarchy.hpp>
+
+namespace NetworKit {
+
+template class LevelHierarchy<CSRMatrix>;
+template class LevelHierarchy<DenseMatrix>;
+template class LevelHierarchy<DynamicMatrix>;
+
+} // namespace NetworKit

--- a/networkit/cpp/numerics/MultiLevelSetup.cpp
+++ b/networkit/cpp/numerics/MultiLevelSetup.cpp
@@ -1,0 +1,15 @@
+/*
+ * MultiLevelSetup.cpp
+ *
+ *  Created on: 23.04.2024
+ */
+
+#include <networkit/numerics/LAMG/MultiLevelSetup.hpp>
+
+namespace NetworKit {
+
+template class MultiLevelSetup<CSRMatrix>;
+template class MultiLevelSetup<DenseMatrix>;
+template class MultiLevelSetup<DynamicMatrix>;
+
+} // namespace NetworKit

--- a/networkit/cpp/numerics/MultiLevelSetup.cpp
+++ b/networkit/cpp/numerics/MultiLevelSetup.cpp
@@ -2,6 +2,7 @@
  * MultiLevelSetup.cpp
  *
  *  Created on: 23.04.2024
+ *      Author: Lukas
  */
 
 #include <networkit/numerics/LAMG/MultiLevelSetup.hpp>

--- a/networkit/cpp/numerics/SolverLamg.cpp
+++ b/networkit/cpp/numerics/SolverLamg.cpp
@@ -1,0 +1,140 @@
+/*
+ * SolverLamg.cpp
+ *
+ *  Created on: 02.05.2024
+ */
+
+#include <networkit/numerics/LAMG/SolverLamg.hpp>
+
+namespace NetworKit {
+
+template class SolverLamg<CSRMatrix>;
+template class SolverLamg<DenseMatrix>;
+template class SolverLamg<DynamicMatrix>;
+
+template <>
+void SolverLamg<CSRMatrix>::minRes(const index level, Vector &x, const Vector &r) const {
+    if (numActiveIterates[level] > 0) {
+        count n = numActiveIterates[level];
+
+        std::vector<index> ARowIdx(r.getDimension() + 1);
+        std::vector<index> ERowIdx(r.getDimension() + 1);
+
+#pragma omp parallel for
+        for (omp_index i = 0; i < static_cast<omp_index>(r.getDimension()); ++i) {
+            for (index k = 0; k < n; ++k) {
+                double AEvalue = r[i] - rHistory[level][k][i];
+                if (std::fabs(AEvalue) > 1e-25) {
+                    ++ARowIdx[i + 1];
+                }
+
+                double Eval = history[level][k][i] - x[i];
+                if (std::fabs(Eval) > 1e-25) {
+                    ++ERowIdx[i + 1];
+                }
+            }
+        }
+
+        for (index i = 0; i < r.getDimension(); ++i) {
+            ARowIdx[i + 1] += ARowIdx[i];
+            ERowIdx[i + 1] += ERowIdx[i];
+        }
+
+        std::vector<index> AColumnIdx(ARowIdx[r.getDimension()]);
+        std::vector<double> ANonZeros(ARowIdx[r.getDimension()]);
+
+        std::vector<index> EColumnIdx(ERowIdx[r.getDimension()]);
+        std::vector<double> ENonZeros(ERowIdx[r.getDimension()]);
+
+#pragma omp parallel for
+        for (omp_index i = 0; i < static_cast<omp_index>(r.getDimension()); ++i) {
+            for (index k = 0, aIdx = ARowIdx[i], eIdx = ERowIdx[i]; k < n; ++k) {
+                double AEvalue = r[i] - rHistory[level][k][i];
+                if (std::fabs(AEvalue) > 1e-25) {
+                    AColumnIdx[aIdx] = k;
+                    ANonZeros[aIdx] = AEvalue;
+                    ++aIdx;
+                }
+
+                double Eval = history[level][k][i] - x[i];
+                if (std::fabs(Eval) > 1e-25) {
+                    EColumnIdx[eIdx] = k;
+                    ENonZeros[eIdx] = Eval;
+                    ++eIdx;
+                }
+            }
+        }
+
+        CSRMatrix AE(r.getDimension(), n, ARowIdx, AColumnIdx, ANonZeros, 0.0, true);
+        CSRMatrix E(r.getDimension(), n, ERowIdx, EColumnIdx, ENonZeros, 0.0, true);
+
+        Vector alpha = smoother.relax(CSRMatrix::mTmMultiply(AE, AE), CSRMatrix::mTvMultiply(AE, r),
+                                      Vector(n, 0.0), 10);
+        x += E * alpha;
+    }
+}
+
+template <>
+void SolverLamg<DynamicMatrix>::minRes(const index level, Vector &x, const Vector &r) const {
+    if (numActiveIterates[level] > 0) {
+        count n = numActiveIterates[level];
+
+        DynamicMatrix AE(r.getDimension(), n);
+        DynamicMatrix E(r.getDimension(), n);
+
+#pragma omp parallel for
+        for (omp_index i = 0; i < static_cast<omp_index>(r.getDimension());
+             ++i) {                                            // iterate rows of A and E: 0 to r
+            for (index k = 0; k < n; ++k) {                    // iterate columns: 0 to n
+                double AEvalue = r[i] - rHistory[level][k][i]; // value at (i,k)
+                if (std::fabs(AEvalue)
+                    > 1e-25) { // if there is a value, increase row count of row i+1 by 1
+                    AE.setValue(i, k, AEvalue);
+                }
+
+                double Eval = history[level][k][i] - x[i];
+                if (std::fabs(Eval) > 1e-25) {
+                    E.setValue(i, k, Eval);
+                }
+            }
+        }
+
+        Vector alpha = smoother.relax(DynamicMatrix::mTmMultiply(AE, AE),
+                                      DynamicMatrix::mTvMultiply(AE, r), Vector(n, 0.0), 10);
+        x += E * alpha;
+    }
+}
+
+template <>
+void SolverLamg<DenseMatrix>::minRes(const index level, Vector &x, const Vector &r) const {
+    if (numActiveIterates[level] > 0) {
+        count n = numActiveIterates[level];
+
+        DenseMatrix AE(r.getDimension(), n);
+        DenseMatrix E(r.getDimension(), n);
+
+#pragma omp parallel for
+        for (omp_index i = 0; i < static_cast<omp_index>(r.getDimension());
+             ++i) {                                            // iterate rows of A and E: 0 to r
+            for (index k = 0; k < n; ++k) {                    // iterate columns: 0 to n
+                double AEvalue = r[i] - rHistory[level][k][i]; // value at (i,k)
+                if (std::fabs(AEvalue)
+                    > 1e-25) { // if there is a value, increase row count of row i+1 by 1
+                    AE.setValue(i, k, AEvalue);
+                }
+
+                double Eval = history[level][k][i] - x[i];
+                if (std::fabs(Eval) > 1e-25) {
+                    E.setValue(i, k, Eval);
+                }
+            }
+        }
+
+        DenseMatrix AEtransposed = AE.transpose();
+
+        Vector alpha = smoother.relax(AEtransposed * AE, AEtransposed * r, Vector(n, 0.0), 10);
+        x += E * alpha;
+    }
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/numerics/SolverLamg.cpp
+++ b/networkit/cpp/numerics/SolverLamg.cpp
@@ -2,6 +2,7 @@
  * SolverLamg.cpp
  *
  *  Created on: 02.05.2024
+ *      Author: Lukas
  */
 
 #include <networkit/numerics/LAMG/SolverLamg.hpp>

--- a/networkit/cpp/numerics/SolverLamg.cpp
+++ b/networkit/cpp/numerics/SolverLamg.cpp
@@ -8,10 +8,6 @@
 
 namespace NetworKit {
 
-template class SolverLamg<CSRMatrix>;
-template class SolverLamg<DenseMatrix>;
-template class SolverLamg<DynamicMatrix>;
-
 template <>
 void SolverLamg<CSRMatrix>::minRes(const index level, Vector &x, const Vector &r) const {
     if (numActiveIterates[level] > 0) {
@@ -136,5 +132,9 @@ void SolverLamg<DenseMatrix>::minRes(const index level, Vector &x, const Vector 
         x += E * alpha;
     }
 }
+
+template class SolverLamg<CSRMatrix>;
+template class SolverLamg<DenseMatrix>;
+template class SolverLamg<DynamicMatrix>;
 
 } // namespace NetworKit

--- a/networkit/cpp/viz/CMakeLists.txt
+++ b/networkit/cpp/viz/CMakeLists.txt
@@ -5,6 +5,6 @@ networkit_add_module(viz
     )
 
 networkit_module_link_modules(viz
-    algebraic auxiliary coarsening community components distance graph io structures)
+    algebraic auxiliary coarsening community components distance graph io numerics structures)
 
 add_subdirectory(test)


### PR DESCRIPTION
Various small changes to the LAMG helper classes to improve readability, performance, and allow use in `const` contexts. Also fixes a few problems such that the template `Matrix` can now be any of our matrix classes - and now uses explicit template instantiation to verfiy this.