### PR TITLE
Lamg: parallel solve for multiple components

### DIFF
--- a/include/networkit/numerics/ConjugateGradient.hpp
+++ b/include/networkit/numerics/ConjugateGradient.hpp
@@ -49,7 +49,7 @@ public:
      * does not run for more than @a status.max_iters iterations.
      */
     SolverStatus solve(const Vector &rhs, Vector &result, count maxConvergenceTime = 5 * 60 * 1000,
-                       count maxIterations = std::numeric_limits<count>::max()) override;
+                       count maxIterations = std::numeric_limits<count>::max()) const override;
 
     /**
      * Solves the linear systems in parallel.
@@ -60,7 +60,7 @@ public:
      */
     void parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
                        count maxConvergenceTime = 5 * 60 * 1000,
-                       count maxIterations = std::numeric_limits<count>::max()) override;
+                       count maxIterations = std::numeric_limits<count>::max()) const override;
 
     /**
      * Abstract parallel solve function that computes and processes results using @a resultProcessor
@@ -103,7 +103,7 @@ private:
 
 template <class Matrix, class Preconditioner>
 SolverStatus ConjugateGradient<Matrix, Preconditioner>::solve(const Vector &rhs, Vector &result,
-                                                              count, count maxIterations) {
+                                                              count, count maxIterations) const {
     assert(matrix.numberOfRows() == rhs.getDimension());
 
     // Absolute residual to achieve
@@ -149,7 +149,7 @@ template <class Matrix, class Preconditioner>
 void ConjugateGradient<Matrix, Preconditioner>::parallelSolve(const std::vector<Vector> &rhs,
                                                               std::vector<Vector> &results,
                                                               count maxConvergenceTime,
-                                                              count maxIterations) {
+                                                              count maxIterations) const {
 #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(rhs.size()); ++i) {
         this->solve(rhs[i], results[i], maxConvergenceTime, maxIterations);

--- a/include/networkit/numerics/ConjugateGradient.hpp
+++ b/include/networkit/numerics/ConjugateGradient.hpp
@@ -58,9 +58,10 @@ public:
      * @param maxConvergenceTime
      * @param maxIterations
      */
-    void parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
-                       count maxConvergenceTime = 5 * 60 * 1000,
-                       count maxIterations = std::numeric_limits<count>::max()) const override;
+    std::vector<SolverStatus>
+    parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
+                  count maxConvergenceTime = 5 * 60 * 1000,
+                  count maxIterations = std::numeric_limits<count>::max()) const override;
 
     /**
      * Abstract parallel solve function that computes and processes results using @a resultProcessor
@@ -146,14 +147,15 @@ SolverStatus ConjugateGradient<Matrix, Preconditioner>::solve(const Vector &rhs,
 }
 
 template <class Matrix, class Preconditioner>
-void ConjugateGradient<Matrix, Preconditioner>::parallelSolve(const std::vector<Vector> &rhs,
-                                                              std::vector<Vector> &results,
-                                                              count maxConvergenceTime,
-                                                              count maxIterations) const {
+std::vector<SolverStatus> ConjugateGradient<Matrix, Preconditioner>::parallelSolve(
+    const std::vector<Vector> &rhs, std::vector<Vector> &results, count maxConvergenceTime,
+    count maxIterations) const {
+    std::vector<SolverStatus> stati(rhs.size());
 #pragma omp parallel for
     for (omp_index i = 0; i < static_cast<omp_index>(rhs.size()); ++i) {
-        this->solve(rhs[i], results[i], maxConvergenceTime, maxIterations);
+        stati[i] = this->solve(rhs[i], results[i], maxConvergenceTime, maxIterations);
     }
+    return stati;
 }
 
 } /* namespace NetworKit */

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -169,7 +169,8 @@ public:
      * @param maxConvergenceTime
      * @param maxIterations
      */
-    void parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
+    std::vector<SolverStatus>
+    parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
                        count maxConvergenceTime = 5 * 60 * 1000,
                        count maxIterations = std::numeric_limits<count>::max()) const override;
 

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -65,12 +65,24 @@ public:
      * Compute the multigrid hierarchy for the given Laplacian matrix @a laplacianMatrix.
      * @param laplacianMatrix
      * @note This method also works for disconnected graphs. If you know that the graph is
-     * connected, if is faster to use @ref setupConnected instead.
+     * connected, it is faster to use @ref setupConnected instead.
      */
     void setup(const Matrix &laplacianMatrix) override;
 
     /**
-     * Compute the multigrid hierarchy for te given Laplacian matrix @a laplacianMatrix.
+     * Compute the multigrid hierarchy for the given Laplacian matrix @a laplacianMatrix that
+     * corresponds to the graph @a G using the existing component decomposition @a decomp.
+     * @param laplacianMatrix
+     * @param decomp ComponentDecomposition that corresponds to the graph of the @a laplacianMatrix
+     * @note This setup method allows you to skip some computation in the general setup method. You
+     * can provide your own graph and decomposition via this method to prevent duplicate
+     * computation. Note that the output is undefined if the three parameters do not correspond the
+     * the same graph.
+     */
+    void setup(const Matrix &laplacianMatrix, const Graph &G, const ComponentDecomposition &decomp);
+
+    /**
+     * Compute the multigrid hierarchy for the given Laplacian matrix @a laplacianMatrix.
      * @param laplacianMatrix
      * @note The graph has to be connected for this method to work. Otherwise the output is
      * undefined.
@@ -170,6 +182,12 @@ void Lamg<Matrix>::setupConnected(const Matrix &laplacianMatrix) {
     this->laplacianMatrix = laplacianMatrix;
     initializeForOneComponent();
     numComponents = 1;
+}
+
+template <class Matrix>
+void Lamg<Matrix>::setup(const Matrix &laplacianMatrix, const Graph &G,
+                         const ComponentDecomposition &decomp) {
+    this->setup(laplacianMatrix);
 }
 
 template <class Matrix>

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -185,6 +185,7 @@ public:
      * @param maxIterations
      * @note If the solver does not support parallelism during solves, this function falls back to
      * solving the systems sequentially.
+     * @note The @a rhsLoader and @a resultProcessor are called from multiple threads in parallel.
      */
     template <typename RHSLoader, typename ResultProcessor>
     void parallelSolve(const RHSLoader &rhsLoader, const ResultProcessor &resultProcessor,

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -101,7 +101,7 @@ public:
      * residual.
      */
     SolverStatus solve(const Vector &rhs, Vector &result, count maxConvergenceTime = 5 * 60 * 1000,
-                       count maxIterations = std::numeric_limits<count>::max()) override;
+                       count maxIterations = std::numeric_limits<count>::max()) const override;
 
     /**
      * Compute the @a results for the matrix currently setup and the right-hand sides @a rhs.
@@ -114,7 +114,7 @@ public:
      */
     void parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
                        count maxConvergenceTime = 5 * 60 * 1000,
-                       count maxIterations = std::numeric_limits<count>::max()) override;
+                       count maxIterations = std::numeric_limits<count>::max()) const override;
 
     /**
      * Abstract parallel solve function that computes and processes results using @a resultProcessor
@@ -132,7 +132,7 @@ public:
     template <typename RHSLoader, typename ResultProcessor>
     void parallelSolve(const RHSLoader &rhsLoader, const ResultProcessor &resultProcessor,
                        std::pair<count, count> rhsSize, count maxConvergenceTime = 5 * 60 * 1000,
-                       count maxIterations = std::numeric_limits<count>::max()) {
+                       count maxIterations = std::numeric_limits<count>::max()) const {
         if (numComponents == 1) {
             const index numThreads = omp_get_max_threads();
             if (compSolvers.size() != numThreads) {
@@ -247,7 +247,7 @@ void Lamg<Matrix>::setup(const Matrix &laplacianMatrix) {
 
 template <class Matrix>
 SolverStatus Lamg<Matrix>::solve(const Vector &rhs, Vector &result, count maxConvergenceTime,
-                                 count maxIterations) {
+                                 count maxIterations) const {
     if (!validSetup || result.getDimension() != laplacianMatrix.numberOfColumns()
         || rhs.getDimension() != laplacianMatrix.numberOfRows()) {
         throw std::runtime_error("No or wrong matrix is setup for given vectors.");
@@ -302,7 +302,7 @@ SolverStatus Lamg<Matrix>::solve(const Vector &rhs, Vector &result, count maxCon
 
 template <class Matrix>
 void Lamg<Matrix>::parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
-                                 count maxConvergenceTime, count maxIterations) {
+                                 count maxConvergenceTime, count maxIterations) const {
     if (numComponents == 1) {
         assert(rhs.size() == results.size());
         const index numThreads = omp_get_max_threads();

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -398,9 +398,9 @@ SolverStatus Lamg<Matrix>::solve(const Vector &rhs, Vector &result, count maxCon
             }
 
             double resReduction = this->tolerance * rhsVectors[0][i].length()
-                / (compHierarchies[i].at(0).getLaplacian() * initialVectors[0][i]
+                                  / (compHierarchies[i].at(0).getLaplacian() * initialVectors[0][i]
                                      - rhsVectors[0][i])
-                      .length();
+                                        .length();
             compStati[0][i].desiredResidualReduction =
                 resReduction * components[i].size() / laplacianMatrix.numberOfRows();
             compStati[0][i].maxIters = maxIterations;

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -451,6 +451,10 @@ Lamg<Matrix>::parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> 
     return stati;
 }
 
+extern template class Lamg<CSRMatrix>;
+extern template class Lamg<DenseMatrix>;
+extern template class Lamg<DynamicMatrix>;
+
 } /* namespace NetworKit */
 
 #endif // NETWORKIT_NUMERICS_LAMG_LAMG_HPP_

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -205,7 +205,7 @@ public:
         std::vector<Vector> RHSs(numThreads, Vector(m));
 
 #pragma omp parallel for
-        for (int i = 0; i < n; ++i) {
+        for (omp_index i = 0; i < static_cast<omp_index>(n); ++i) {
             const index threadId = omp_get_thread_num();
 
             const Vector &rhs = rhsLoader(i, RHSs[threadId]);
@@ -443,7 +443,7 @@ Lamg<Matrix>::parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> 
     std::vector<SolverStatus> stati(rhs.size());
 
 #pragma omp parallel for
-    for (int i = 0; i < rhs.size(); ++i) {
+    for (omp_index i = 0; i < static_cast<omp_index>(rhs.size()); ++i) {
         const index threadId = omp_get_thread_num();
         stati[i] = solveThread(rhs[i], results[i], maxConvergenceTime, maxIterations, threadId);
     }

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -205,7 +205,7 @@ public:
         std::vector<Vector> RHSs(numThreads, Vector(m));
 
 #pragma omp parallel for
-        for (index i = 0; i < n; ++i) {
+        for (int i = 0; i < n; ++i) {
             const index threadId = omp_get_thread_num();
 
             const Vector &rhs = rhsLoader(i, RHSs[threadId]);
@@ -443,7 +443,7 @@ Lamg<Matrix>::parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> 
     std::vector<SolverStatus> stati(rhs.size());
 
 #pragma omp parallel for
-    for (index i = 0; i < rhs.size(); ++i) {
+    for (int i = 0; i < rhs.size(); ++i) {
         const index threadId = omp_get_thread_num();
         stati[i] = solveThread(rhs[i], results[i], maxConvergenceTime, maxIterations, threadId);
     }

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -234,7 +234,7 @@ void Lamg<Matrix>::initializeInternalDatastructures() const {
     compStati.resize(omp_get_max_threads());
 
 #pragma omp parallel for
-    for (index thread = 0; thread < omp_get_max_threads(); ++thread) {
+    for (int thread = 0; thread < omp_get_max_threads(); ++thread) {
         // resize inner vectors
         initialVectors[thread].resize(numComponents);
         rhsVectors[thread].resize(numComponents);
@@ -427,7 +427,6 @@ void Lamg<Matrix>::parallelSolve(const std::vector<Vector> &rhs, std::vector<Vec
                                  count maxConvergenceTime, count maxIterations) const {
     if (numComponents == 1) {
         assert(rhs.size() == results.size());
-        const index numThreads = omp_get_max_threads();
 
 #pragma omp parallel for
         for (omp_index i = 0; i < static_cast<omp_index>(rhs.size()); ++i) {

--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -369,6 +369,12 @@ void Lamg<Matrix>::setup(const Matrix &laplacianMatrix) {
 template <class Matrix>
 SolverStatus Lamg<Matrix>::solveThread(const Vector &rhs, Vector &result, count maxConvergenceTime,
                                        count maxIterations, const index threadId) const {
+    if (!validSetup)
+        throw std::runtime_error("LAMG is not properly setup!");
+    if (result.getDimension() != laplacianMatrix.numberOfColumns()
+        || rhs.getDimension() != laplacianMatrix.numberOfRows()) {
+        throw std::runtime_error("Wrong matrix dimensions for given vectors.");
+    }
     SolverStatus status;
 
     if (numComponents == 1) {
@@ -427,11 +433,6 @@ SolverStatus Lamg<Matrix>::solveThread(const Vector &rhs, Vector &result, count 
 template <class Matrix>
 SolverStatus Lamg<Matrix>::solve(const Vector &rhs, Vector &result, count maxConvergenceTime,
                                  count maxIterations) const {
-    if (!validSetup || result.getDimension() != laplacianMatrix.numberOfColumns()
-        || rhs.getDimension() != laplacianMatrix.numberOfRows()) {
-        throw std::runtime_error("No or wrong matrix is setup for given vectors.");
-    }
-
     return solveThread(rhs, result, maxConvergenceTime, maxIterations, 0);
 }
 

--- a/include/networkit/numerics/LAMG/SolverLamg.hpp
+++ b/include/networkit/numerics/LAMG/SolverLamg.hpp
@@ -36,7 +36,7 @@ struct LAMGSolverStatus {
     count numIters = 0; // number of iterations needed during solve phase
     double residual = std::numeric_limits<double>::infinity(); // absolute final residual
     bool converged = false;                                    // flag of conversion status
-    std::vector<double> residualHistory; // history of absolute residuals
+    std::vector<double> residualHistory;                       // history of absolute residuals
 };
 
 /**

--- a/include/networkit/numerics/LAMG/SolverLamg.hpp
+++ b/include/networkit/numerics/LAMG/SolverLamg.hpp
@@ -33,9 +33,9 @@ struct LAMGSolverStatus {
     count numPostSmoothIters = 2; // number of post smoothing iterations
 
     // out
-    count numIters;                      // number of iterations needed during solve phase
-    double residual;                     // absolute final residual
-    bool converged;                      // flag of conversion status
+    count numIters = 0; // number of iterations needed during solve phase
+    double residual = std::numeric_limits<double>::infinity(); // absolute final residual
+    bool converged = false;                                    // flag of conversion status
     std::vector<double> residualHistory; // history of absolute residuals
 };
 

--- a/include/networkit/numerics/LinearSolver.hpp
+++ b/include/networkit/numerics/LinearSolver.hpp
@@ -139,11 +139,11 @@ template <class Matrix>
 std::vector<SolverStatus>
 LinearSolver<Matrix>::parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
                                     count maxConvergenceTime, count maxIterations) const {
-    std::vector<SolverStatus> stati(rhs.size());
+    std::vector<SolverStatus> stats(rhs.size());
     for (index i = 0; i < rhs.size(); ++i) {
-        stati[i] = solve(rhs[i], results[i], maxConvergenceTime, maxIterations);
+        stats[i] = solve(rhs[i], results[i], maxConvergenceTime, maxIterations);
     }
-    return stati;
+    return stats;
 }
 
 } /* namespace NetworKit */

--- a/include/networkit/numerics/LinearSolver.hpp
+++ b/include/networkit/numerics/LinearSolver.hpp
@@ -78,7 +78,7 @@ public:
      */
     virtual SolverStatus solve(const Vector &rhs, Vector &result,
                                count maxConvergenceTime = 5 * 60 * 1000,
-                               count maxIterations = std::numeric_limits<count>::max()) = 0;
+                               count maxIterations = std::numeric_limits<count>::max()) const = 0;
 
     /**
      * Abstract parallel solve function that computes the @a results for the matrix currently setup
@@ -93,7 +93,7 @@ public:
      */
     virtual void parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
                                count maxConvergenceTime = 5 * 60 * 1000,
-                               count maxIterations = std::numeric_limits<count>::max());
+                               count maxIterations = std::numeric_limits<count>::max()) const;
 
     /**
      * Abstract parallel solve function that computes and processes results using @a resultProcessor
@@ -111,7 +111,7 @@ public:
     template <typename RHSLoader, typename ResultProcessor>
     void parallelSolve(const RHSLoader &rhsLoader, const ResultProcessor &resultProcessor,
                        std::pair<count, count> rhsSize, count maxConvergenceTime = 5 * 60 * 1000,
-                       count maxIterations = std::numeric_limits<count>::max()) {
+                       count maxIterations = std::numeric_limits<count>::max()) const {
         count n = rhsSize.first;
         count m = rhsSize.second;
         Vector rhs(m);
@@ -136,7 +136,7 @@ void LinearSolver<Matrix>::setupConnected(const Graph &graph) {
 template <class Matrix>
 void LinearSolver<Matrix>::parallelSolve(const std::vector<Vector> &rhs,
                                          std::vector<Vector> &results, count maxConvergenceTime,
-                                         count maxIterations) {
+                                         count maxIterations) const {
     for (index i = 0; i < rhs.size(); ++i) {
         solve(rhs[i], results[i], maxConvergenceTime, maxIterations);
     }

--- a/include/networkit/numerics/LinearSolver.hpp
+++ b/include/networkit/numerics/LinearSolver.hpp
@@ -88,12 +88,14 @@ public:
      * @param results
      * @param maxConvergenceTime
      * @param maxIterations
+     * @return A vector of @ref SolverStatus objects for each right hand side.
      * @note If the solver does not support parallelism during solves, this function falls back to
      * solving the systems sequentially.
      */
-    virtual void parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
-                               count maxConvergenceTime = 5 * 60 * 1000,
-                               count maxIterations = std::numeric_limits<count>::max()) const;
+    virtual std::vector<SolverStatus>
+    parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
+                  count maxConvergenceTime = 5 * 60 * 1000,
+                  count maxIterations = std::numeric_limits<count>::max()) const;
 
     /**
      * Abstract parallel solve function that computes and processes results using @a resultProcessor
@@ -134,12 +136,14 @@ void LinearSolver<Matrix>::setupConnected(const Graph &graph) {
 }
 
 template <class Matrix>
-void LinearSolver<Matrix>::parallelSolve(const std::vector<Vector> &rhs,
-                                         std::vector<Vector> &results, count maxConvergenceTime,
-                                         count maxIterations) const {
+std::vector<SolverStatus>
+LinearSolver<Matrix>::parallelSolve(const std::vector<Vector> &rhs, std::vector<Vector> &results,
+                                    count maxConvergenceTime, count maxIterations) const {
+    std::vector<SolverStatus> stati(rhs.size());
     for (index i = 0; i < rhs.size(); ++i) {
-        solve(rhs[i], results[i], maxConvergenceTime, maxIterations);
+        stati[i] = solve(rhs[i], results[i], maxConvergenceTime, maxIterations);
     }
+    return stati;
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/numerics/CMakeLists.txt
+++ b/networkit/cpp/numerics/CMakeLists.txt
@@ -2,6 +2,7 @@ networkit_add_module(numerics
     MultiLevelSetup.cpp
     LevelHierarchy.cpp
     SolverLamg.cpp
+    Lamg.cpp
 )
 
 networkit_module_link_modules(numerics

--- a/networkit/cpp/numerics/Lamg.cpp
+++ b/networkit/cpp/numerics/Lamg.cpp
@@ -1,0 +1,15 @@
+/*
+ * Lamg.cpp
+ *
+ *  Created on: 02.05.2024
+ */
+
+#include <networkit/numerics/LAMG/Lamg.hpp>
+
+namespace NetworKit {
+
+template class Lamg<CSRMatrix>;
+template class Lamg<DenseMatrix>;
+template class Lamg<DynamicMatrix>;
+
+} // namespace NetworKit

--- a/networkit/cpp/numerics/test/CMakeLists.txt
+++ b/networkit/cpp/numerics/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 networkit_add_test(numerics GaussSeidelRelaxationGTest algebraic graph)
 networkit_add_test(numerics LAMGGTest algebraic auxiliary components)
-networkit_add_test(numerics LAMGSolverGTest algebraic auxiliary components io)
+networkit_add_test(numerics SolverLamgGTest algebraic auxiliary components io)
 

--- a/networkit/cpp/numerics/test/CMakeLists.txt
+++ b/networkit/cpp/numerics/test/CMakeLists.txt
@@ -1,3 +1,4 @@
 networkit_add_test(numerics GaussSeidelRelaxationGTest algebraic graph)
-networkit_add_test(numerics LAMGGTest algebraic auxiliary components io)
+networkit_add_test(numerics LAMGGTest algebraic auxiliary components)
+networkit_add_test(numerics LAMGSolverGTest algebraic auxiliary components io)
 

--- a/networkit/cpp/numerics/test/LAMGGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGGTest.cpp
@@ -192,14 +192,14 @@ TEST_P(LAMGGTest, testLamgVariants) {
         throw std::logic_error("unhandled variant!");
 
     // for loader solve variant
-    count numLoaderCalls = 0;
+    std::atomic<int> numLoaderCalls = 0;
     const auto rhsLoader = [&rhss, &numLoaderCalls](count i, Vector &rhs) -> Vector & {
         rhs = rhss[i];
         ++numLoaderCalls;
         return rhs;
     };
 
-    count numProcessorCalls = 0;
+    std::atomic<int> numProcessorCalls = 0;
     const auto resultProcessor = [&](count i, const Vector &result) {
         EXPECT_TRUE(vector_almost_equal(L * result, rhss[i]))
             << "Lamg result: " << result << "\nL * result: " << L * result << "\nrhs: " << rhss[i];

--- a/networkit/cpp/numerics/test/LAMGGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGGTest.cpp
@@ -9,113 +9,212 @@
 
 #include <networkit/algebraic/CSRMatrix.hpp>
 #include <networkit/algebraic/Vector.hpp>
-#include <networkit/auxiliary/Timer.hpp>
 #include <networkit/components/ConnectedComponents.hpp>
-#include <networkit/generators/BarabasiAlbertGenerator.hpp>
 #include <networkit/graph/Graph.hpp>
-#include <networkit/io/LineFileReader.hpp>
-#include <networkit/io/METISGraphReader.hpp>
-#include <networkit/io/METISGraphWriter.hpp>
-#include <networkit/numerics/GaussSeidelRelaxation.hpp>
-#include <networkit/numerics/LAMG/MultiLevelSetup.hpp>
-#include <networkit/numerics/LAMG/SolverLamg.hpp>
-#include <networkit/structures/Partition.hpp>
+#include <networkit/numerics/LAMG/Lamg.hpp>
 
 namespace NetworKit {
 
-class LAMGGTest : public testing::Test {
-protected:
-    const std::vector<std::string> GRAPH_INSTANCES = {"input/jazz.graph", "input/power.graph"};
+// list of variants:
+// - solver: solve, parallelSolve
+// - setup: connected, not connected, not connected with partition
+// - components: one component, multiple components
+// - parallelism: single thread, multiple threads
 
-    Vector randZeroSum(const Graph &graph, size_t seed) const;
-    Vector randVector(count dimension) const;
+class LAMGGTest
+    // params: Solver, Setup, Components, Parallelism
+    : public testing::TestWithParam<
+          std::tuple<std::string, std::string, std::string, std::string>> {
+protected:
+    // returns a graph and a vector of RHS, solution pairs s.t. L*solution = RHS for all entries
+    std::tuple<Graph, std::vector<Vector>, std::vector<Vector>> testData() const;
 };
 
-TEST_F(LAMGGTest, testSmallGraphs) {
-    METISGraphReader reader;
-    GaussSeidelRelaxation<CSRMatrix> gaussSmoother, smoother;
-    MultiLevelSetup<CSRMatrix> setup(gaussSmoother);
-    Aux::Timer timer;
-    for (index i = 0; i < GRAPH_INSTANCES.size(); ++i) {
-        std::string graph = GRAPH_INSTANCES[i];
-        Graph G = reader.read(graph);
-        ConnectedComponents con(G);
-        con.run();
-        Partition comps = con.getPartition();
-        if (comps.numberOfSubsets() > 1) { // disconnected graphs are currently not supported
-            continue;
-        }
+INSTANTIATE_TEST_SUITE_P(
+    LAMGGTest, LAMGGTest,
+    testing::Combine(testing::Values("solve", "parallelSolve", "loaderSolve"),
+                     testing::Values("connected", "disconnected", "disconnectedWithPartition"),
+                     testing::Values("one", "two"), testing::Values("single", "four")));
 
-        LevelHierarchy<CSRMatrix> hierarchy;
-        timer.start();
-        setup.setup(G, hierarchy);
-        SolverLamg<CSRMatrix> solver(hierarchy, smoother);
-        timer.stop();
-        DEBUG("setup time\t ", timer.elapsedMilliseconds());
-
-        Vector b(G.numberOfNodes());
-        Vector x(G.numberOfNodes());
-
-        b = randZeroSum(G, 12345);
-        x = randVector(G.numberOfNodes());
-
-        LAMGSolverStatus status;
-        // needed for getting a relative residual <= 1e-6
-        status.desiredResidualReduction =
-            1e-6 * b.length() / (hierarchy.at(0).getLaplacian() * x - b).length();
-
-        Vector result = x;
-        DEBUG("Solving equation system - Gauss-Seidel");
-        timer.start();
-        solver.solve(result, b, status);
-        timer.stop();
-
-        EXPECT_TRUE(status.converged);
-
-        DEBUG("solve time\t ", timer.elapsedMilliseconds());
-        DEBUG("final residual = ", status.residual);
-        DEBUG("numIters = ", status.numIters);
-        DEBUG("DONE");
+// Temporary function
+inline std::ostream &operator<<(std::ostream &os, const CSRMatrix &M) {
+    for (index i = 0; i < M.numberOfRows(); i++) {
+        for (index j = 0; j < M.numberOfColumns(); j++)
+            os << M(i, j) << ", ";
+        os << std::endl;
     }
+    return os;
 }
 
-Vector LAMGGTest::randVector(count dimension) const {
-    Vector randVector(dimension);
-    for (index i = 0; i < dimension; ++i) {
-        randVector[i] = 2.0 * Aux::Random::probability() - 1.0;
+inline std::ostream &operator<<(std::ostream &os, const Vector &vec) {
+    os << "[";
+    for (index i = 0; i < vec.getDimension(); i++) {
+        if (i != 0)
+            os << ", ";
+        os << vec[i];
     }
-
-    // introduce bias
-    for (index i = 0; i < dimension; ++i) {
-        randVector[i] = randVector[i] * randVector[i];
-    }
-
-    return randVector;
+    os << "]";
+    return os;
 }
 
-Vector LAMGGTest::randZeroSum(const Graph &G, size_t seed) const {
-    std::mt19937 rand(seed);
-    auto rand_value = std::uniform_real_distribution<double>(-1.0, 1.0);
-    ConnectedComponents con(G);
-    count n = G.numberOfNodes();
-    con.run();
-    Partition comps = con.getPartition();
+inline bool vector_almost_equal(const Vector &lhs, const Vector &rhs) {
+    if (lhs.getDimension() != rhs.getDimension())
+        return false;
+    for (size_t i = 0; i < lhs.getDimension(); ++i) {
+        if (std::abs(lhs[i] - rhs[i]) > 1e-4)
+            return false;
+    }
+    return true;
+}
 
-    /* Fill each component randomly such that its sum is 0 */
-    Vector b(n, 0.0);
+std::tuple<Graph, std::vector<Vector>, std::vector<Vector>> LAMGGTest::testData() const {
+    auto [solveFn, setupFn, components, parallelism] = GetParam();
 
-    for (int id : comps.getSubsetIds()) {
-        auto indexes = comps.getMembers(id);
-        assert(!indexes.empty());
-        double sum = 0.0;
-        for (auto entry : indexes) {
-            b[entry] = rand_value(rand);
-            sum += b[entry];
-        }
-        b[*indexes.begin()] -= sum;
+    Graph G(6);
+    std::vector<Vector> rhss;
+    std::vector<Vector> solutions;
+    if (components == "one") {
+        /*
+        0 - 1 - 2
+        |       |
+        3 - 4 - 5
+
+        L:
+         2 -1  0 -1  0  0
+        -1  2 -1  0  0  0
+         0 -1  2  0  0 -1
+        -1  0  0  2 -1  0
+         0  0  0 -1  2 -1
+         0  0 -1  0 -1  2
+        */
+
+        G.addEdge(0, 1);
+        G.addEdge(0, 3);
+        G.addEdge(1, 2);
+        G.addEdge(2, 5);
+        G.addEdge(3, 4);
+        G.addEdge(4, 5);
+
+        // rhs, solution
+        rhss = {
+            {-4, 0, -2, 2, 0, 4},
+            {-8, 2, 10, 14, -8, -10},
+        };
+        solutions = {
+            {-2.5, -1.5, -0.5, 0.5, 1.5, 2.5},
+            {-0.5, 2.5, 3.5, 4.5, -4.5, -5.5},
+        };
+
+        return {G, rhss, solutions};
     }
 
-    return b;
+    if (components == "two") {
+        /*
+       0 - 1 - 2
+
+       3 - 4 - 5
+
+       L:
+        1 -1  0  0  0  0
+       -1  2 -1  0  0  0
+        0 -1  1  0  0  0
+        0  0  0  1 -1  0
+        0  0  0 -1  2 -1
+        0  0  0  0 -1  1
+       */
+
+        G.addEdge(0, 1);
+        G.addEdge(1, 2);
+        G.addEdge(3, 4);
+        G.addEdge(4, 5);
+
+        // rhs, solution
+        rhss = {
+            {-1, 3, -2, -1, -3, 4},
+            {0, 0, 0, -1, -3, 4},
+            {-1, 3, -2, 0, 0, 0},
+            {-10, 0, 10, 16, -6, -10},
+        };
+        solutions = {
+            {0, 1, -1, -2, -1, 3},
+            {0, 0, 0, -2, -1, 3},
+            {0, 1, -1, 0, 0, 0},
+            {-10, 0, 10, 14, -2, -12},
+        };
+
+        return {G, rhss, solutions};
+    }
+    throw std::logic_error("unknown number of components.");
+}
+
+TEST_P(LAMGGTest, testLamgVariants) {
+    auto [solveFn, setupFn, components, parallelism] = GetParam();
+
+    if (parallelism == "single")
+        omp_set_num_threads(1);
+    else if (parallelism == "four")
+        omp_set_num_threads(4);
+    else
+        throw std::logic_error("unhandled variant!");
+
+    // skip combinations that do not work
+    if (setupFn == "connected" && components != "one")
+        return;
+
+    auto [G, rhss, solutions] = testData();
+
+    auto L = CSRMatrix::laplacianMatrix(G);
+
+    Lamg<CSRMatrix> lamg;
+
+    ParallelConnectedComponents pcc(G);
+    pcc.run();
+
+    if (setupFn == "connected")
+        lamg.setupConnected(L);
+    else if (setupFn == "disconnected")
+        lamg.setup(L);
+    else if (setupFn == "disconnectedWithPartition")
+        lamg.setup(L, G, pcc);
+    else
+        throw std::logic_error("unhandled variant!");
+
+    // for loader solve variant
+    const auto rhsLoader = [&rhss](count i, Vector &rhs) -> Vector & {
+        rhs = rhss[i];
+        return rhs;
+    };
+
+    const auto resultProcessor = [&solutions](count i, const Vector &result) {
+        EXPECT_TRUE(vector_almost_equal(result, solutions[i]))
+            << "Lamg result: " << result << "gt: " << solutions[i];
+    };
+
+    if (solveFn == "solve") {
+        for (size_t i = 0; i < rhss.size(); ++i) {
+            const auto &rhs = rhss[i];
+            const auto &gt = solutions[i];
+
+            Vector result(rhs.getDimension());
+
+            lamg.solve(rhs, result);
+
+            EXPECT_TRUE(vector_almost_equal(result, gt))
+                << "Lamg result: " << result << "gt: " << gt;
+        }
+    } else if (solveFn == "parallelSolve") {
+        std::vector<Vector> results(rhss.size(), Vector(6));
+        lamg.parallelSolve(rhss, results);
+        for (size_t i = 0; i < rhss.size(); ++i) {
+            const auto &gt = solutions[i];
+            const auto &result = results[i];
+            EXPECT_TRUE(vector_almost_equal(result, gt))
+                << "Lamg result: " << result << "gt: " << gt;
+        }
+    } else if (solveFn == "loaderSolve")
+        lamg.parallelSolve(rhsLoader, resultProcessor, {rhss.size(), L.numberOfColumns()});
+    else
+        throw std::logic_error("unhandled variant!");
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/numerics/test/LAMGGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGGTest.cpp
@@ -164,7 +164,10 @@ TEST_P(LAMGGTest, testLamgVariants) {
     if (setupFn == "setupConnected" && components != "one")
         return;
 
-    auto [G, rhss] = testData();
+    // auto [G, rhss] = testData();
+    auto data = testData();
+    auto G = std::get<0>(data);
+    auto rhss = std::get<1>(data);
 
     auto L = CSRMatrix::laplacianMatrix(G);
 

--- a/networkit/cpp/numerics/test/LAMGGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGGTest.cpp
@@ -192,8 +192,10 @@ TEST_P(LAMGGTest, testLamgVariants) {
         throw std::logic_error("unhandled variant!");
 
     // for loader solve variant
-    const auto rhsLoader = [&rhss](count i, Vector &rhs) -> Vector & {
+    count numLoaderCalls = 0;
+    const auto rhsLoader = [&rhss, &numLoaderCalls](count i, Vector &rhs) -> Vector & {
         rhs = rhss[i];
+        ++numLoaderCalls;
         return rhs;
     };
 
@@ -227,6 +229,7 @@ TEST_P(LAMGGTest, testLamgVariants) {
     } else if (solveFn == "loaderSolve") {
         lamg.parallelSolve(rhsLoader, resultProcessor, {rhss.size(), L.numberOfColumns()});
         EXPECT_EQ(numProcessorCalls, rhss.size());
+        EXPECT_EQ(numLoaderCalls, rhss.size());
     } else
         throw std::logic_error("unhandled variant!");
 }

--- a/networkit/cpp/numerics/test/LAMGGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGGTest.cpp
@@ -28,6 +28,8 @@ class LAMGGTest
 protected:
     // returns a graph and a vector of RHSs
     std::tuple<Graph, std::vector<Vector>> testData() const;
+    template <class Matrix>
+    void runTest();
 };
 
 INSTANTIATE_TEST_SUITE_P(LAMGGTest, LAMGGTest,
@@ -150,7 +152,18 @@ std::tuple<Graph, std::vector<Vector>> LAMGGTest::testData() const {
     throw std::logic_error("unknown number of components.");
 }
 
-TEST_P(LAMGGTest, testLamgVariants) {
+TEST_P(LAMGGTest, testLamgCSRMatrixVariants) {
+    runTest<CSRMatrix>();
+}
+TEST_P(LAMGGTest, testLamgDenseMatrixVariants) {
+    runTest<DenseMatrix>();
+}
+TEST_P(LAMGGTest, testLamgDynamicMatrixVariants) {
+    runTest<DynamicMatrix>();
+}
+
+template <class Matrix>
+void LAMGGTest::runTest() {
     auto [solveFn, setupFn, components, parallelism] = GetParam();
 
     if (parallelism == "single")
@@ -169,9 +182,9 @@ TEST_P(LAMGGTest, testLamgVariants) {
     auto G = std::get<0>(data);
     auto rhss = std::get<1>(data);
 
-    auto L = CSRMatrix::laplacianMatrix(G);
+    auto L = Matrix::laplacianMatrix(G);
 
-    Lamg<CSRMatrix> lamg;
+    Lamg<Matrix> lamg;
 
     ParallelConnectedComponents pcc(G);
     pcc.run();

--- a/networkit/cpp/numerics/test/LAMGGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGGTest.cpp
@@ -185,9 +185,11 @@ TEST_P(LAMGGTest, testLamgVariants) {
         return rhs;
     };
 
-    const auto resultProcessor = [&solutions](count i, const Vector &result) {
+    count numProcessorCalls = 0;
+    const auto resultProcessor = [&solutions, &numProcessorCalls](count i, const Vector &result) {
         EXPECT_TRUE(vector_almost_equal(result, solutions[i]))
             << "Lamg result: " << result << "gt: " << solutions[i];
+        ++numProcessorCalls;
     };
 
     if (solveFn == "solve") {
@@ -211,9 +213,10 @@ TEST_P(LAMGGTest, testLamgVariants) {
             EXPECT_TRUE(vector_almost_equal(result, gt))
                 << "Lamg result: " << result << "gt: " << gt;
         }
-    } else if (solveFn == "loaderSolve")
+    } else if (solveFn == "loaderSolve") {
         lamg.parallelSolve(rhsLoader, resultProcessor, {rhss.size(), L.numberOfColumns()});
-    else
+        EXPECT_EQ(numProcessorCalls, rhss.size());
+    } else
         throw std::logic_error("unhandled variant!");
 }
 

--- a/networkit/cpp/numerics/test/LAMGGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGGTest.cpp
@@ -40,27 +40,6 @@ INSTANTIATE_TEST_SUITE_P(LAMGGTest, LAMGGTest,
                                           testing::Values("one", "two"),
                                           testing::Values("single", "four")));
 
-// print functions for test debugging / output
-inline std::ostream &operator<<(std::ostream &os, const CSRMatrix &M) {
-    for (index i = 0; i < M.numberOfRows(); i++) {
-        for (index j = 0; j < M.numberOfColumns(); j++)
-            os << M(i, j) << ", ";
-        os << std::endl;
-    }
-    return os;
-}
-
-inline std::ostream &operator<<(std::ostream &os, const Vector &vec) {
-    os << "[";
-    for (index i = 0; i < vec.getDimension(); i++) {
-        if (i != 0)
-            os << ", ";
-        os << vec[i];
-    }
-    os << "]";
-    return os;
-}
-
 inline bool vector_almost_equal(const Vector &lhs, const Vector &rhs) {
     if (lhs.getDimension() != rhs.getDimension())
         return false;

--- a/networkit/cpp/numerics/test/LAMGSolverGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGSolverGTest.cpp
@@ -1,0 +1,122 @@
+/*
+ * LAMGGTest.cpp
+ *
+ *  Created on: 20.11.2014
+ *      Author: Michael
+ */
+
+#include <gtest/gtest.h>
+
+#include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/algebraic/Vector.hpp>
+#include <networkit/auxiliary/Timer.hpp>
+#include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/generators/BarabasiAlbertGenerator.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/io/LineFileReader.hpp>
+#include <networkit/io/METISGraphReader.hpp>
+#include <networkit/io/METISGraphWriter.hpp>
+#include <networkit/numerics/GaussSeidelRelaxation.hpp>
+#include <networkit/numerics/LAMG/Lamg.hpp>
+#include <networkit/numerics/LAMG/MultiLevelSetup.hpp>
+#include <networkit/numerics/LAMG/SolverLamg.hpp>
+#include <networkit/structures/Partition.hpp>
+
+namespace NetworKit {
+
+class LAMGSolverGTest : public testing::Test {
+protected:
+    const std::vector<std::string> GRAPH_INSTANCES = {"input/jazz.graph", "input/power.graph"};
+
+    Vector randZeroSum(const Graph &graph, size_t seed) const;
+    Vector randVector(count dimension) const;
+};
+
+TEST_F(LAMGSolverGTest, testSmallGraphs) {
+    METISGraphReader reader;
+    GaussSeidelRelaxation<CSRMatrix> gaussSmoother, smoother;
+    MultiLevelSetup<CSRMatrix> setup(gaussSmoother);
+    Aux::Timer timer;
+    for (index i = 0; i < GRAPH_INSTANCES.size(); ++i) {
+        std::string graph = GRAPH_INSTANCES[i];
+        Graph G = reader.read(graph);
+        ConnectedComponents con(G);
+        con.run();
+        Partition comps = con.getPartition();
+        if (comps.numberOfSubsets() > 1) { // disconnected graphs are currently not supported
+            continue;
+        }
+
+        LevelHierarchy<CSRMatrix> hierarchy;
+        timer.start();
+        setup.setup(G, hierarchy);
+        SolverLamg<CSRMatrix> solver(hierarchy, smoother);
+        timer.stop();
+        DEBUG("setup time\t ", timer.elapsedMilliseconds());
+
+        Vector b(G.numberOfNodes());
+        Vector x(G.numberOfNodes());
+
+        b = randZeroSum(G, 12345);
+        x = randVector(G.numberOfNodes());
+
+        LAMGSolverStatus status;
+        // needed for getting a relative residual <= 1e-6
+        status.desiredResidualReduction =
+            1e-6 * b.length() / (hierarchy.at(0).getLaplacian() * x - b).length();
+
+        Vector result = x;
+        DEBUG("Solving equation system - Gauss-Seidel");
+        timer.start();
+        solver.solve(result, b, status);
+        timer.stop();
+
+        EXPECT_TRUE(status.converged);
+
+        DEBUG("solve time\t ", timer.elapsedMilliseconds());
+        DEBUG("final residual = ", status.residual);
+        DEBUG("numIters = ", status.numIters);
+        DEBUG("DONE");
+    }
+}
+
+Vector LAMGSolverGTest::randVector(count dimension) const {
+    Vector randVector(dimension);
+    for (index i = 0; i < dimension; ++i) {
+        randVector[i] = 2.0 * Aux::Random::probability() - 1.0;
+    }
+
+    // introduce bias
+    for (index i = 0; i < dimension; ++i) {
+        randVector[i] = randVector[i] * randVector[i];
+    }
+
+    return randVector;
+}
+
+Vector LAMGSolverGTest::randZeroSum(const Graph &G, size_t seed) const {
+    std::mt19937 rand(seed);
+    auto rand_value = std::uniform_real_distribution<double>(-1.0, 1.0);
+    ConnectedComponents con(G);
+    count n = G.numberOfNodes();
+    con.run();
+    Partition comps = con.getPartition();
+
+    /* Fill each component randomly such that its sum is 0 */
+    Vector b(n, 0.0);
+
+    for (int id : comps.getSubsetIds()) {
+        auto indexes = comps.getMembers(id);
+        assert(!indexes.empty());
+        double sum = 0.0;
+        for (auto entry : indexes) {
+            b[entry] = rand_value(rand);
+            sum += b[entry];
+        }
+        b[*indexes.begin()] -= sum;
+    }
+
+    return b;
+}
+
+} /* namespace NetworKit */

--- a/networkit/cpp/numerics/test/SolverLamgGTest.cpp
+++ b/networkit/cpp/numerics/test/SolverLamgGTest.cpp
@@ -1,5 +1,5 @@
 /*
- * LAMGGTest.cpp
+ * SolverLamgGTest.cpp
  *
  *  Created on: 20.11.2014
  *      Author: Michael
@@ -24,7 +24,7 @@
 
 namespace NetworKit {
 
-class LAMGSolverGTest : public testing::Test {
+class SolverLamgGTest : public testing::Test {
 protected:
     const std::vector<std::string> GRAPH_INSTANCES = {"input/jazz.graph", "input/power.graph"};
 
@@ -32,7 +32,7 @@ protected:
     Vector randVector(count dimension) const;
 };
 
-TEST_F(LAMGSolverGTest, testSmallGraphs) {
+TEST_F(SolverLamgGTest, testSmallGraphs) {
     METISGraphReader reader;
     GaussSeidelRelaxation<CSRMatrix> gaussSmoother, smoother;
     MultiLevelSetup<CSRMatrix> setup(gaussSmoother);
@@ -80,7 +80,7 @@ TEST_F(LAMGSolverGTest, testSmallGraphs) {
     }
 }
 
-Vector LAMGSolverGTest::randVector(count dimension) const {
+Vector SolverLamgGTest::randVector(count dimension) const {
     Vector randVector(dimension);
     for (index i = 0; i < dimension; ++i) {
         randVector[i] = 2.0 * Aux::Random::probability() - 1.0;
@@ -94,7 +94,7 @@ Vector LAMGSolverGTest::randVector(count dimension) const {
     return randVector;
 }
 
-Vector LAMGSolverGTest::randZeroSum(const Graph &G, size_t seed) const {
+Vector SolverLamgGTest::randZeroSum(const Graph &G, size_t seed) const {
     std::mt19937 rand(seed);
     auto rand_value = std::uniform_real_distribution<double>(-1.0, 1.0);
     ConnectedComponents con(G);

--- a/networkit/cpp/viz/test/CMakeLists.txt
+++ b/networkit/cpp/viz/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 networkit_add_test(viz MaxentStressGTest
-    auxiliary clique community components graph io sparsification)
+    auxiliary clique community components graph io numerics sparsification)
 networkit_add_test(viz OctreeGTest
     algebraic auxiliary)
 networkit_add_test(viz VizGTest


### PR DESCRIPTION
This PR adds support to the Lamg solver to deal with multi-component systems in parallel.
Related issue: #1167

Todos:
- [x] add tests
- [x] make code more const correct
- [x] rework setup functions
- [x] add support for parallelSolve
- [x] benchmarks


Note that this PR depends on #1210 and #1214 which should be merged first. (currently all commits from #1210 are listed here as well, but this PR is only for changes in LAMG.hpp and tests)