### PR TITLE
Fix GTest: make algebraicDistanceGTest deterministic

### DIFF
--- a/networkit/cpp/distance/test/DistanceGTest.cpp
+++ b/networkit/cpp/distance/test/DistanceGTest.cpp
@@ -195,6 +195,7 @@ TEST_P(DistanceGTest, testAdamicAdar) {
 }
 
 TEST_P(DistanceGTest, testAlgebraicDistance) {
+    Aux::Random::setSeed(42, false);
     auto G = generateERGraph(500, 0.03);
     G.indexEdges();
 


### PR DESCRIPTION
The CI fails occasionally because of this test (i.e.: https://github.com/networkit/networkit/actions/runs/8687798112/job/23822052569?pr=1207)