### PR TITLE
fix string attribute read

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -498,7 +498,12 @@ private:
             std::string line;
             while (std::getline(in, line)) {
                 std::istringstream istring(line);
-                istring >> n >> v;
+                if constexpr (std::is_same_v<T, std::string>) {
+                    istring >> n >> std::ws;
+                    std::getline(istring, v);
+                } else {
+                    istring >> n >> v;
+                }
                 set(n, v);
             }
         }


### PR DESCRIPTION
fixes #1187 for std::string (note: this implementation still does not support strings that contain `\n`!)

vector types are not supported yet; this will require more complex changes (like adding a serialization library).
Fixing the string bug is higher priority though, because string attributes are available in python as well, while vector types are not.