### PR TITLE
Graph: Seperate core functions from common API

### DIFF
--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -130,7 +130,7 @@ public:
 private:
     using Base<NodeOrEdge, GraphType>::theGraph;
     std::vector<T> values; // the real attribute storage
-}; // class AttributeStorage<NodeOrEdge, Base, T>
+};                         // class AttributeStorage<NodeOrEdge, Base, T>
 
 template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
 class Attribute {

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -12,7 +12,15 @@
 #ifndef NETWORKIT_GRAPH_ATTRIBUTES_HPP_
 #define NETWORKIT_GRAPH_ATTRIBUTES_HPP_
 
-#include <networkit/graph/Graph.hpp>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <typeindex>
+#include <unordered_map>
+#include <vector>
+
+#include <networkit/Globals.hpp>
+#include <networkit/auxiliary/Log.hpp>
 
 namespace NetworKit {
 
@@ -130,7 +138,7 @@ public:
 private:
     using Base<NodeOrEdge, GraphType>::theGraph;
     std::vector<T> values; // the real attribute storage
-};                         // class AttributeStorage<NodeOrEdge, Base, T>
+}; // class AttributeStorage<NodeOrEdge, Base, T>
 
 template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
 class Attribute {

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -138,7 +138,7 @@ public:
 private:
     using Base<NodeOrEdge, GraphType>::theGraph;
     std::vector<T> values; // the real attribute storage
-}; // class AttributeStorage<NodeOrEdge, Base, T>
+};                         // class AttributeStorage<NodeOrEdge, Base, T>
 
 template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
 class Attribute {
@@ -454,4 +454,4 @@ public:
 
 } // namespace NetworKit
 
-#endif //
+#endif // NETWORKIT_GRAPH_ATTRIBUTES_HPP_

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -1,0 +1,449 @@
+/*
+ * Attributes.hpp
+ *
+ *  Created on: 14.05.2024
+ *      Author: Klaus Ahrens
+ *              Eugenio Angriman
+ *              Lukas Berner
+ *              Fabian Brandt-Tumescheit
+ *              Alexander van der Grinten
+ */
+
+#ifndef NETWORKIT_GRAPH_ATTRIBUTES_HPP_
+#define NETWORKIT_GRAPH_ATTRIBUTES_HPP_
+
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+// base class for all node (and edge) attribute
+// storages with attribute type info
+// independent of the attribute type, holds bookkeeping info only:
+// - attribute name
+// - type info of derived (real storage holding) classes
+// - which indices are valid
+// - number of valid indices
+// - the associated graph (who knows, which nodes/edges exist)
+// - the validity of the whole storage (initially true, false after detach)
+// all indexed accesses by NetworKit::index: synonym both for node and edgeid
+
+template <typename NodeOrEdge, typename GraphType>
+class AttributeStorageBase { // alias ASB
+public:
+    AttributeStorageBase(const GraphType *graph, std::string name, std::type_index type)
+        : name{std::move(name)}, type{type}, theGraph{graph}, validStorage{true} {
+        checkPremise(); // node for PerNode, theGraph.hasEdgeIds() for PerEdges
+    }
+
+    void invalidateStorage() { validStorage = false; }
+
+    const std::string &getName() const noexcept { return name; }
+
+    std::type_index getType() const noexcept { return type; }
+
+    bool isValid(index n) const noexcept { return n < valid.size() && valid[n]; }
+
+    // Called by Graph when node/edgeid n is deleted.
+    void invalidate(index n) {
+        if (isValid(n)) {
+            valid[n] = false;
+            --validElements;
+        }
+    }
+
+protected:
+    void markValid(index n) {
+        indexOK(n); // specialized for node/edgeid
+        if (n >= valid.size())
+            valid.resize(n + 1);
+        if (!valid[n]) {
+            valid[n] = true;
+            ++validElements;
+        }
+    }
+
+    void checkIndex(index n) const {
+        indexOK(n);
+        if (!isValid(n)) {
+            throw std::runtime_error("Invalid attribute value");
+        }
+    }
+
+private:
+    std::string name;
+    std::type_index type;
+    std::vector<bool> valid; // For each node/edgeid: whether attribute is set or not.
+
+protected:
+    void indexOK(index n) const;
+    void checkPremise() const;
+    index validElements = 0;
+    const GraphType *theGraph;
+    bool validStorage; // Validity of the whole storage
+
+}; // class AttributeStorageBase
+
+template <typename NodeOrEdge, typename GraphType>
+using ASB = AttributeStorageBase<NodeOrEdge, GraphType>;
+
+template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
+class Attribute;
+
+template <typename NodeOrEdge, typename GraphType, template <typename, typename> class Base,
+          typename T>
+class AttributeStorage : public Base<NodeOrEdge, GraphType> {
+public:
+    AttributeStorage(const GraphType *theGraph, std::string name)
+        : Base<NodeOrEdge, GraphType>{theGraph, std::move(name), typeid(T)} {}
+
+    void resize(index i) {
+        if (i >= values.size())
+            values.resize(i + 1);
+    }
+
+    auto size() const noexcept { return this->validElements; }
+
+    void set(index i, T &&v) {
+        this->markValid(i);
+        resize(i);
+        values[i] = std::move(v);
+    }
+
+    // instead of returning an std::optional (C++17) we provide these
+    // C++14 options
+    // (1) throw an exception when invalid:
+    T get(index i) const { // may throw
+        this->checkIndex(i);
+        return values[i];
+    }
+
+    // (2) give default value when invalid:
+    T get(index i, T defaultT) const noexcept {
+        if (i >= values.size() || !this->isValid(i))
+            return defaultT;
+        return values[i];
+    }
+
+    friend Attribute<NodeOrEdge, GraphType, T, true>;
+    friend Attribute<NodeOrEdge, GraphType, T, false>;
+
+private:
+    using Base<NodeOrEdge, GraphType>::theGraph;
+    std::vector<T> values; // the real attribute storage
+}; // class AttributeStorage<NodeOrEdge, Base, T>
+
+template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
+class Attribute {
+public:
+    using AttributeStorage_type =
+        std::conditional_t<isConst, const AttributeStorage<NodeOrEdge, GraphType, ASB, T>,
+                           AttributeStorage<NodeOrEdge, GraphType, ASB, T>>;
+    class Iterator {
+    public:
+        // The value type of the attribute. Returned by
+        // operator*().
+        using value_type = T;
+
+        // Reference to the value_type, required by STL.
+        using reference = std::conditional_t<isConst, const value_type &, value_type &>;
+
+        // Pointer to the value_type, required by STL.
+        using pointer = std::conditional_t<isConst, const value_type *, value_type *>;
+
+        // STL iterator category.
+        using iterator_category = std::forward_iterator_tag;
+
+        // Signed integer type of the result of subtracting two pointers,
+        // required by STL.
+        using difference_type = ptrdiff_t;
+
+        Iterator() : storage{nullptr}, idx{0} {}
+        Iterator(AttributeStorage_type *storage) : storage{storage}, idx{0} {
+            if (storage) {
+                nextValid();
+            }
+        }
+
+        Iterator &nextValid() {
+            while (storage && !storage->isValid(idx)) {
+                if (idx >= storage->values.size()) {
+                    storage = nullptr;
+                    return *this;
+                }
+                ++idx;
+            }
+            return *this;
+        }
+
+        Iterator &operator++() {
+            if (!storage) {
+                throw std::runtime_error("Invalid attribute iterator");
+            }
+            ++idx;
+            return nextValid();
+        }
+
+        auto operator*() const {
+            if (!storage) {
+                throw std::runtime_error("Invalid attribute iterator");
+            }
+            return std::make_pair(idx, storage->values[idx]);
+        }
+
+        bool operator==(Iterator const &iter) const noexcept {
+            if (storage == nullptr && iter.storage == nullptr) {
+                return true;
+            }
+            return storage == iter.storage && idx == iter.idx;
+        }
+
+        bool operator!=(Iterator const &iter) const noexcept { return !(*this == iter); }
+
+    private:
+        AttributeStorage_type *storage;
+        index idx;
+    }; // class Iterator
+
+private:
+    class IndexProxy {
+        // a helper class for distinguished read and write on an indexed
+        // attribute
+        // operator[] on an attribute yields an IndexProxy holding
+        // location and index of access
+        //    - casting an IndexProxy to the attribute type reads the value
+        //    - assigning to it (operator=) writes the value
+    public:
+        IndexProxy(AttributeStorage_type *storage, index idx) : storage{storage}, idx{idx} {}
+
+        // reading at idx
+        operator T() const {
+            storage->checkIndex(idx);
+            return storage->values[idx];
+        }
+
+        // writing at idx
+        template <bool ic = isConst>
+        std::enable_if_t<!ic, T> &operator=(T &&other) {
+            storage->set(idx, std::move(other));
+            return storage->values[idx];
+        }
+
+    private:
+        AttributeStorage_type *storage;
+        index idx;
+    }; // class IndexProxy
+public:
+    explicit Attribute(std::shared_ptr<AttributeStorage_type> ownedStorage = nullptr)
+        : ownedStorage{ownedStorage}, valid{ownedStorage != nullptr} {}
+
+    Attribute(Attribute const &other) : ownedStorage{other.ownedStorage}, valid{other.valid} {}
+
+    template <bool ic = isConst, std::enable_if_t<ic, int> = 0>
+    Attribute(Attribute<NodeOrEdge, GraphType, T, false> const &other)
+        : ownedStorage{other.ownedStorage}, valid{other.valid} {}
+
+    Attribute &operator=(Attribute other) {
+        this->swap(other);
+        return *this;
+    }
+
+    void swap(Attribute &other) {
+        std::swap(ownedStorage, other.ownedStorage);
+        std::swap(valid, other.valid);
+    }
+
+    Attribute(Attribute &&other) noexcept
+        : ownedStorage{std::move(other.ownedStorage)}, valid{other.valid} {
+        other.valid = false;
+    }
+
+    template <bool ic = isConst, std::enable_if_t<ic, int> = 0>
+    Attribute(Attribute<NodeOrEdge, GraphType, T, false> &&other) noexcept
+        : ownedStorage{std::move(other.ownedStorage)}, valid{other.valid} {
+        other.valid = false;
+    }
+
+    auto begin() const {
+        checkAttribute();
+        return Iterator(ownedStorage.get()).nextValid();
+    }
+
+    auto end() const { return Iterator(nullptr); }
+
+    auto size() const noexcept { return ownedStorage->size(); }
+
+    template <bool ic = isConst>
+    std::enable_if_t<!ic> set(index i, T v) {
+        checkAttribute();
+        ownedStorage->set(i, std::move(v));
+    }
+
+    template <bool ic = isConst>
+    std::enable_if_t<!ic> set2(node u, node v, T t) {
+        static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
+        set(ownedStorage->theGraph->edgeId(u, v), t);
+    }
+
+    auto get(index i) const {
+        checkAttribute();
+        return ownedStorage->get(i);
+    }
+
+    auto get2(node u, node v) const {
+        static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
+        return get(ownedStorage->theGraph->edgeId(u, v));
+    }
+
+    auto get(index i, T defaultT) const {
+        checkAttribute();
+        return ownedStorage->get(i, defaultT);
+    }
+
+    auto get2(node u, node v, T defaultT) const {
+        static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
+        return get(ownedStorage->theGraph->edgeId(u, v), defaultT);
+    }
+
+    IndexProxy operator[](index i) const {
+        checkAttribute();
+        return IndexProxy(ownedStorage.get(), i);
+    }
+
+    IndexProxy operator()(node u, node v) const {
+        static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
+        checkAttribute();
+        return IndexProxy(ownedStorage.get(), ownedStorage->theGraph->edgeId(u, v));
+    }
+
+    void checkAttribute() const {
+        if (!ownedStorage->validStorage)
+            throw std::runtime_error("Invalid attribute");
+    }
+
+    auto getName() const {
+        checkAttribute();
+        return ownedStorage->getName();
+    }
+
+    void write(std::string const &filename) const {
+        std::ofstream out(filename);
+        if (!out)
+            ERROR("cannot open ", filename, " for writing");
+
+        for (auto it = begin(); it != end(); ++it) {
+            auto pair = *it;
+            auto n = pair.first;  // node/edgeid
+            auto v = pair.second; // value
+            out << n << "\t" << v << "\n";
+        }
+        out.close();
+    }
+
+    template <bool ic = isConst>
+    std::enable_if_t<!ic> read(const std::string &filename) {
+        std::ifstream in(filename);
+        if (!in) {
+            ERROR("cannot open ", filename, " for reading");
+        }
+        index n; // node/edgeid
+        T v;     // value
+        std::string line;
+        while (std::getline(in, line)) {
+            std::istringstream istring(line);
+            if constexpr (std::is_same_v<T, std::string>) {
+                istring >> n >> std::ws;
+                std::getline(istring, v);
+            } else {
+                istring >> n >> v;
+            }
+            set(n, v);
+        }
+    }
+
+private:
+    std::shared_ptr<AttributeStorage_type> ownedStorage;
+    bool valid;
+}; // class Attribute
+
+template <typename NodeOrEdge, typename GraphType>
+class AttributeMap {
+    friend GraphType;
+    const GraphType *theGraph;
+
+public:
+    std::unordered_map<std::string, std::shared_ptr<ASB<NodeOrEdge, GraphType>>> attrMap;
+
+    AttributeMap(const GraphType *g) : theGraph{g} {}
+
+    auto find(std::string const &name) {
+        auto it = attrMap.find(name);
+        if (it == attrMap.end()) {
+            throw std::runtime_error("No such attribute");
+        }
+        return it;
+    }
+
+    auto find(std::string const &name) const {
+        auto it = attrMap.find(name);
+        if (it == attrMap.end()) {
+            throw std::runtime_error("No such attribute");
+        }
+        return it;
+    }
+
+    template <typename T>
+    auto attach(const std::string &name) {
+        auto ownedPtr = std::make_shared<AttributeStorage<NodeOrEdge, GraphType, ASB, T>>(
+            theGraph, std::string{name});
+        auto insertResult = attrMap.emplace(ownedPtr->getName(), ownedPtr);
+        auto success = insertResult.second;
+        if (!success) {
+            throw std::runtime_error("Attribute with same name already exists");
+        }
+        return Attribute<NodeOrEdge, GraphType, T, false>{ownedPtr};
+    }
+
+    void detach(const std::string &name) {
+        auto it = find(name);
+        auto storage = it->second.get();
+        storage->invalidateStorage();
+        it->second.reset();
+        attrMap.erase(name);
+    }
+
+    template <typename T>
+    auto get(const std::string &name) {
+        auto it = find(name);
+        if (it->second.get()->getType() != typeid(T))
+            throw std::runtime_error("Type mismatch in Attributes().get()");
+        return Attribute<NodeOrEdge, GraphType, T, false>{
+            std::static_pointer_cast<AttributeStorage<NodeOrEdge, GraphType, ASB, T>>(it->second)};
+    }
+
+    template <typename T>
+    auto get(const std::string &name) const {
+        auto it = find(name);
+        if (it->second.get()->getType() != typeid(T))
+            throw std::runtime_error("Type mismatch in Attributes().get()");
+        return Attribute<NodeOrEdge, GraphType, T, true>{
+            std::static_pointer_cast<const AttributeStorage<NodeOrEdge, GraphType, ASB, T>>(
+                it->second)};
+    }
+
+}; // class AttributeMap
+
+/// @private
+class PerNode {
+public:
+    static constexpr bool edges = false;
+};
+
+/// @private
+class PerEdge {
+public:
+    static constexpr bool edges = true;
+};
+
+} // namespace NetworKit
+
+#endif //

--- a/include/networkit/graph/EdgeIterators.hpp
+++ b/include/networkit/graph/EdgeIterators.hpp
@@ -171,4 +171,4 @@ public:
 
 } // namespace NetworKit
 
-#endif //
+#endif // NETWORKIT_GRAPH_EDGE_ITERATORS_HPP_

--- a/include/networkit/graph/EdgeIterators.hpp
+++ b/include/networkit/graph/EdgeIterators.hpp
@@ -1,0 +1,205 @@
+/*
+ * EdgeIterators.hpp
+ *
+ *  Created on: 14.05.2024
+ */
+
+#ifndef NETWORKIT_GRAPH_EDGE_ITERATORS_HPP_
+#define NETWORKIT_GRAPH_EDGE_ITERATORS_HPP_
+
+#include <networkit/Globals.hpp>
+#include <networkit/graph/NodeIterators.hpp>
+
+namespace NetworKit {
+
+struct Edge {
+    node u, v;
+
+    Edge() : u(none), v(none) {}
+
+    Edge(node _u, node _v, bool sorted = false) {
+        u = sorted ? std::min(_u, _v) : _u;
+        v = sorted ? std::max(_u, _v) : _v;
+    }
+};
+
+/**
+ * A weighted edge used for the graph constructor with
+ * initializer list syntax.
+ */
+struct WeightedEdge : Edge {
+    edgeweight weight;
+
+    // Needed by cython
+    WeightedEdge() : Edge(), weight(std::numeric_limits<edgeweight>::max()) {}
+
+    WeightedEdge(node u, node v, edgeweight w) : Edge(u, v), weight(w) {}
+};
+
+struct WeightedEdgeWithId : WeightedEdge {
+    edgeid eid;
+
+    WeightedEdgeWithId(node u, node v, edgeweight w, edgeid eid)
+        : WeightedEdge(u, v, w), eid(eid) {}
+};
+
+template <typename GraphType>
+class EdgeIteratorBase {
+
+protected:
+    const GraphType *G;
+    NodeIteratorBase<GraphType> nodeIter;
+    index i;
+
+public:
+    EdgeIteratorBase(const GraphType *G, NodeIteratorBase<GraphType> nodeIter)
+        : G(G), nodeIter(nodeIter), i(index{0}) {
+        if (nodeIter != G->nodeRange().end() && !G->degree(*nodeIter)) {
+            nextEdge();
+        }
+    }
+
+    /**
+     * @brief WARNING: This constructor is required for Python and should not be used as the
+     * iterator is not initialized.
+     */
+    EdgeIteratorBase() : G(nullptr) {}
+
+    virtual ~EdgeIteratorBase() = default;
+
+    // A valid edge might be defined differently for different graph types
+    bool validEdge() const noexcept;
+
+    void nextEdge() {
+        do {
+            if (++i >= G->degree(*nodeIter)) {
+                i = 0;
+                do {
+                    assert(nodeIter != G->nodeRange().end());
+                    ++nodeIter;
+                    if (nodeIter == G->nodeRange().end()) {
+                        return;
+                    }
+                } while (!G->degree(*nodeIter));
+            }
+        } while (!validEdge());
+    }
+
+    void prevEdge() {
+        do {
+            if (!i) {
+                do {
+                    assert(nodeIter != G->nodeRange().begin());
+                    --nodeIter;
+                } while (!G->degree(*nodeIter));
+
+                i = G->degree(*nodeIter);
+            }
+            --i;
+        } while (!validEdge());
+    }
+
+    bool operator==(const EdgeIteratorBase &rhs) const noexcept {
+        return nodeIter == rhs.nodeIter && i == rhs.i;
+    }
+
+    bool operator!=(const EdgeIteratorBase &rhs) const noexcept { return !(*this == rhs); }
+};
+
+template <typename GraphType>
+using EIB = EdgeIteratorBase<GraphType>;
+
+/**
+ * Class to iterate over the edges of the graph. If the graph is undirected, operator*()
+ * returns the edges (u, v) s.t. u <= v.
+ */
+template <typename GraphType, typename EdgeType>
+class EdgeTypeIterator : public EdgeIteratorBase<GraphType> {
+
+public:
+    // The value type of the edges (i.e. a pair). Returned by operator*().
+    using value_type = EdgeType;
+
+    // Reference to the value_type, required by STL.
+    using reference = value_type &;
+
+    // Pointer to the value_type, required by STL.
+    using pointer = value_type *;
+
+    // STL iterator category.
+    using iterator_category = std::forward_iterator_tag;
+
+    // Signed integer type of the result of subtracting two pointers,
+    // required by STL.
+    using difference_type = ptrdiff_t;
+
+    // Own type.
+    using self = EdgeTypeIterator;
+
+    EdgeTypeIterator(const GraphType *G, NodeIteratorBase<GraphType> nodeIter)
+        : EdgeIteratorBase<GraphType>(G, nodeIter) {}
+
+    EdgeTypeIterator() : EdgeIteratorBase<GraphType>() {}
+
+    bool operator==(const EdgeTypeIterator &rhs) const noexcept {
+        return this->EdgeIteratorBase<GraphType>::operator==(
+            static_cast<EdgeIteratorBase<GraphType>>(rhs));
+    }
+
+    bool operator!=(const EdgeTypeIterator &rhs) const noexcept { return !(*this == rhs); }
+
+    // The returned edge depends on both the type of edge and graph
+    EdgeType operator*() const noexcept;
+
+    EdgeTypeIterator &operator++() {
+        EdgeIteratorBase<GraphType>::nextEdge();
+        return *this;
+    }
+
+    EdgeTypeIterator operator++(int) {
+        const auto tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+    EdgeTypeIterator operator--() {
+        EdgeIteratorBase<GraphType>::prevEdge();
+        return *this;
+    }
+
+    EdgeTypeIterator operator--(int) {
+        const auto tmp = *this;
+        --(*this);
+        return tmp;
+    }
+};
+
+/**
+ * Wrapper class to iterate over a range of the edges of a graph.
+ */
+template <typename GraphType, typename EdgeType>
+class EdgeTypeRange {
+
+    const GraphType *G;
+
+public:
+    EdgeTypeRange(const GraphType &G) : G(&G) {}
+
+    EdgeTypeRange() : G(nullptr) {};
+
+    ~EdgeTypeRange() = default;
+
+    EdgeTypeIterator<GraphType, EdgeType> begin() const {
+        assert(G);
+        return EdgeTypeIterator<GraphType, EdgeType>(G, G->nodeRange().begin());
+    }
+
+    EdgeTypeIterator<GraphType, EdgeType> end() const {
+        assert(G);
+        return EdgeTypeIterator<GraphType, EdgeType>(G, G->nodeRange().end());
+    }
+};
+
+} // namespace NetworKit
+
+#endif //

--- a/include/networkit/graph/EdgeIterators.hpp
+++ b/include/networkit/graph/EdgeIterators.hpp
@@ -12,37 +12,6 @@
 
 namespace NetworKit {
 
-struct Edge {
-    node u, v;
-
-    Edge() : u(none), v(none) {}
-
-    Edge(node _u, node _v, bool sorted = false) {
-        u = sorted ? std::min(_u, _v) : _u;
-        v = sorted ? std::max(_u, _v) : _v;
-    }
-};
-
-/**
- * A weighted edge used for the graph constructor with
- * initializer list syntax.
- */
-struct WeightedEdge : Edge {
-    edgeweight weight;
-
-    // Needed by cython
-    WeightedEdge() : Edge(), weight(std::numeric_limits<edgeweight>::max()) {}
-
-    WeightedEdge(node u, node v, edgeweight w) : Edge(u, v), weight(w) {}
-};
-
-struct WeightedEdgeWithId : WeightedEdge {
-    edgeid eid;
-
-    WeightedEdgeWithId(node u, node v, edgeweight w, edgeid eid)
-        : WeightedEdge(u, v, w), eid(eid) {}
-};
-
 template <typename GraphType>
 class EdgeIteratorBase {
 

--- a/include/networkit/graph/EdgeIterators.hpp
+++ b/include/networkit/graph/EdgeIterators.hpp
@@ -154,7 +154,7 @@ class EdgeTypeRange {
 public:
     EdgeTypeRange(const GraphType &G) : G(&G) {}
 
-    EdgeTypeRange() : G(nullptr) {};
+    EdgeTypeRange() : G(nullptr){};
 
     ~EdgeTypeRange() = default;
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -33,6 +33,7 @@
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/graph/Attributes.hpp>
+#include <networkit/graph/NodeIterators.hpp>
 
 #include <tlx/define/deprecated.hpp>
 
@@ -522,111 +523,10 @@ private:
     }
 
 public:
-    /**
-     * Class to iterate over the nodes of a graph.
-     */
-    class NodeIterator {
-
-        const Graph *G;
-        node u;
-
-    public:
-        // The value type of the nodes (i.e. nodes). Returned by
-        // operator*().
-        using value_type = node;
-
-        // Reference to the value_type, required by STL.
-        using reference = value_type &;
-
-        // Pointer to the value_type, required by STL.
-        using pointer = value_type *;
-
-        // STL iterator category.
-        using iterator_category = std::forward_iterator_tag;
-
-        // Signed integer type of the result of subtracting two pointers,
-        // required by STL.
-        using difference_type = ptrdiff_t;
-
-        // Own type.
-        using self = NodeIterator;
-
-        NodeIterator(const Graph *G, node u) : G(G), u(u) {
-            if (!G->hasNode(u) && u < G->upperNodeIdBound()) {
-                ++(*this);
-            }
-        }
-
-        /**
-         * @brief WARNING: This constructor is required for Python and should not be used as the
-         * iterator is not initialized.
-         */
-        NodeIterator() : G(nullptr) {}
-
-        ~NodeIterator() = default;
-
-        NodeIterator &operator++() {
-            assert(u < G->upperNodeIdBound());
-            do {
-                ++u;
-            } while (!(G->hasNode(u) || u >= G->upperNodeIdBound()));
-            return *this;
-        }
-
-        NodeIterator operator++(int) {
-            const auto tmp = *this;
-            ++(*this);
-            return tmp;
-        }
-
-        NodeIterator operator--() {
-            assert(u);
-            do {
-                --u;
-            } while (!G->hasNode(u));
-            return *this;
-        }
-
-        NodeIterator operator--(int) {
-            const auto tmp = *this;
-            --(*this);
-            return tmp;
-        }
-
-        bool operator==(const NodeIterator &rhs) const noexcept { return u == rhs.u; }
-
-        bool operator!=(const NodeIterator &rhs) const noexcept { return !(*this == rhs); }
-
-        node operator*() const noexcept {
-            assert(u < G->upperNodeIdBound());
-            return u;
-        }
-    };
-
-    /**
-     * Wrapper class to iterate over a range of the nodes of a graph.
-     */
-    class NodeRange {
-
-        const Graph *G;
-
-    public:
-        NodeRange(const Graph &G) : G(&G) {}
-
-        NodeRange() : G(nullptr) {};
-
-        ~NodeRange() = default;
-
-        NodeIterator begin() const noexcept {
-            assert(G);
-            return NodeIterator(G, node{0});
-        }
-
-        NodeIterator end() const noexcept {
-            assert(G);
-            return NodeIterator(G, G->upperNodeIdBound());
-        }
-    };
+    // For support of legacy API: NetworKit::Graph::NodeIterator
+    using NodeIterator = NodeIteratorBase<Graph>;
+    // For support of legacy API: NetworKit::Graph::NodeRange
+    using NodeRange = NodeRangeBase<Graph>;
 
     // Necessary for friendship with EdgeIteratorBase.
     class EdgeIterator;

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -432,8 +432,8 @@ private:
                                   typename Aux::FunctionTraits<F>::template arg<2>::type>::value
                   && std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<3>::type>::
                       value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew,
-                    edgeid id) const -> decltype(f(u, v, ew, id)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid id) const
+        -> decltype(f(u, v, ew, id)) {
         return f(u, v, ew, id);
     }
 
@@ -465,8 +465,8 @@ private:
                   (Aux::FunctionTraits<F>::arity >= 2)
                   && std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<
                                                   2>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew,
-                    edgeid /*id*/) const -> decltype(f(u, v, ew)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid /*id*/) const
+        -> decltype(f(u, v, ew)) {
         return f(u, v, ew);
     }
 
@@ -479,8 +479,8 @@ private:
                            (Aux::FunctionTraits<F>::arity >= 1)
                            && std::is_same<node, typename Aux::FunctionTraits<F>::template arg<
                                                      1>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/,
-                    edgeid /*id*/) const -> decltype(f(u, v)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/, edgeid /*id*/) const
+        -> decltype(f(u, v)) {
         return f(u, v);
     }
 
@@ -556,7 +556,7 @@ public:
     public:
         NeighborRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborRange() : G(nullptr) {};
+        NeighborRange() : G(nullptr){};
 
         NeighborIterator begin() const {
             assert(G);
@@ -588,7 +588,7 @@ public:
     public:
         NeighborWeightRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborWeightRange() : G(nullptr) {};
+        NeighborWeightRange() : G(nullptr){};
 
         NeighborWeightIterator begin() const {
             assert(G);

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -41,6 +41,37 @@
 
 namespace NetworKit {
 
+struct Edge {
+    node u, v;
+
+    Edge() : u(none), v(none) {}
+
+    Edge(node _u, node _v, bool sorted = false) {
+        u = sorted ? std::min(_u, _v) : _u;
+        v = sorted ? std::max(_u, _v) : _v;
+    }
+};
+
+/**
+ * A weighted edge used for the graph constructor with
+ * initializer list syntax.
+ */
+struct WeightedEdge : Edge {
+    edgeweight weight;
+
+    // Needed by cython
+    WeightedEdge() : Edge(), weight(std::numeric_limits<edgeweight>::max()) {}
+
+    WeightedEdge(node u, node v, edgeweight w) : Edge(u, v), weight(w) {}
+};
+
+struct WeightedEdgeWithId : WeightedEdge {
+    edgeid eid;
+
+    WeightedEdgeWithId(node u, node v, edgeweight w, edgeid eid)
+        : WeightedEdge(u, v, w), eid(eid) {}
+};
+
 inline bool operator==(const Edge &e1, const Edge &e2) {
     return e1.u == e2.u && e1.v == e2.v;
 }

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -432,8 +432,8 @@ private:
                                   typename Aux::FunctionTraits<F>::template arg<2>::type>::value
                   && std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<3>::type>::
                       value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid id) const
-        -> decltype(f(u, v, ew, id)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew,
+                    edgeid id) const -> decltype(f(u, v, ew, id)) {
         return f(u, v, ew, id);
     }
 
@@ -465,8 +465,8 @@ private:
                   (Aux::FunctionTraits<F>::arity >= 2)
                   && std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<
                                                   2>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid /*id*/) const
-        -> decltype(f(u, v, ew)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew,
+                    edgeid /*id*/) const -> decltype(f(u, v, ew)) {
         return f(u, v, ew);
     }
 
@@ -479,8 +479,8 @@ private:
                            (Aux::FunctionTraits<F>::arity >= 1)
                            && std::is_same<node, typename Aux::FunctionTraits<F>::template arg<
                                                      1>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/, edgeid /*id*/) const
-        -> decltype(f(u, v)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/,
+                    edgeid /*id*/) const -> decltype(f(u, v)) {
         return f(u, v);
     }
 
@@ -540,9 +540,10 @@ public:
     using EdgeWeightRange = EdgeTypeRange<Graph, WeightedEdge>;
 
     // For support of API: NetworKit::Graph::NeighborIterator;
-    using NeighborIterator = NeighborIteratorBase;
+    using NeighborIterator = NeighborIteratorBase<std::vector<node>>;
     // For support of API: NetworKit::Graph::NeighborIterator;
-    using NeighborWeightIterator = NeighborWeightIteratorBase;
+    using NeighborWeightIterator =
+        NeighborWeightIteratorBase<std::vector<node>, std::vector<edgeweight>>;
 
     /**
      * Wrapper class to iterate over a range of the neighbors of a node within
@@ -556,7 +557,7 @@ public:
     public:
         NeighborRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborRange() : G(nullptr){};
+        NeighborRange() : G(nullptr) {};
 
         NeighborIterator begin() const {
             assert(G);
@@ -588,7 +589,7 @@ public:
     public:
         NeighborWeightRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborWeightRange() : G(nullptr){};
+        NeighborWeightRange() : G(nullptr) {};
 
         NeighborWeightIterator begin() const {
             assert(G);

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -32,6 +32,7 @@
 #include <networkit/auxiliary/FunctionTraits.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
+#include <networkit/graph/Attributes.hpp>
 
 #include <tlx/define/deprecated.hpp>
 
@@ -156,431 +157,8 @@ class Graph final {
     std::vector<std::vector<edgeid>> outEdgeIds;
 
 private:
-    // base class for all node (and edge) attribute
-    // storages with attribute type info
-    // independent of the attribute type, holds bookkeeping info only:
-    // - attribute name
-    // - type info of derived (real storage holding) classes
-    // - which indices are valid
-    // - number of valid indices
-    // - the associated graph (who knows, which nodes/edges exist)
-    // - the validity of the whole storage (initially true, false after detach)
-    // all indexed accesses by NetworKit::index: synonym both for node and edgeid
-
-    class PerNode {
-    public:
-        static constexpr bool edges = false;
-    };
-    class PerEdge {
-    public:
-        static constexpr bool edges = true;
-    };
-
-    template <typename NodeOrEdge>
-    class AttributeStorageBase { // alias ASB
-    public:
-        AttributeStorageBase(const Graph *graph, std::string name, std::type_index type)
-            : name{std::move(name)}, type{type}, theGraph{graph}, validStorage{true} {
-            checkPremise(); // node for PerNode, theGraph.hasEdgeIds() for PerEdges
-        }
-
-        void invalidateStorage() { validStorage = false; }
-
-        const std::string &getName() const noexcept { return name; }
-
-        std::type_index getType() const noexcept { return type; }
-
-        bool isValid(index n) const noexcept { return n < valid.size() && valid[n]; }
-
-        // Called by Graph when node/edgeid n is deleted.
-        void invalidate(index n) {
-            if (isValid(n)) {
-                valid[n] = false;
-                --validElements;
-            }
-        }
-
-    protected:
-        void markValid(index n) {
-            indexOK(n); // specialized for node/edgeid
-            if (n >= valid.size())
-                valid.resize(n + 1);
-            if (!valid[n]) {
-                valid[n] = true;
-                ++validElements;
-            }
-        }
-
-        void checkIndex(index n) const {
-            indexOK(n);
-            if (!isValid(n)) {
-                throw std::runtime_error("Invalid attribute value");
-            }
-        }
-
-    private:
-        std::string name;
-        std::type_index type;
-        std::vector<bool> valid; // For each node/edgeid: whether attribute is set or not.
-
-    protected:
-        void indexOK(index n) const;
-        void checkPremise() const;
-        index validElements = 0;
-        const Graph *theGraph;
-        bool validStorage; // Validity of the whole storage
-
-    }; // class AttributeStorageBase
-
-    template <typename NodeOrEdge>
-    using ASB = AttributeStorageBase<NodeOrEdge>;
-
-    template <typename NodeOrEdge, typename T, bool isConst>
-    class Attribute;
-
-    template <typename NodeOrEdge, template <typename> class Base, typename T>
-    class AttributeStorage : public Base<NodeOrEdge> {
-    public:
-        AttributeStorage(const Graph *theGraph, std::string name)
-            : Base<NodeOrEdge>{theGraph, std::move(name), typeid(T)} {}
-
-        void resize(index i) {
-            if (i >= values.size())
-                values.resize(i + 1);
-        }
-
-        auto size() const noexcept { return this->validElements; }
-
-        void set(index i, T &&v) {
-            this->markValid(i);
-            resize(i);
-            values[i] = std::move(v);
-        }
-
-        // instead of returning an std::optional (C++17) we provide these
-        // C++14 options
-        // (1) throw an exception when invalid:
-        T get(index i) const { // may throw
-            this->checkIndex(i);
-            return values[i];
-        }
-
-        // (2) give default value when invalid:
-        T get(index i, T defaultT) const noexcept {
-            if (i >= values.size() || !this->isValid(i))
-                return defaultT;
-            return values[i];
-        }
-
-        friend Attribute<NodeOrEdge, T, true>;
-        friend Attribute<NodeOrEdge, T, false>;
-
-    private:
-        using Base<NodeOrEdge>::theGraph;
-        std::vector<T> values; // the real attribute storage
-    };                         // class AttributeStorage<NodeOrEdge, Base, T>
-
-    template <typename NodeOrEdge, typename T, bool isConst>
-    class Attribute {
-    public:
-        using AttributeStorage_type =
-            std::conditional_t<isConst, const AttributeStorage<NodeOrEdge, ASB, T>,
-                               AttributeStorage<NodeOrEdge, ASB, T>>;
-        class Iterator {
-        public:
-            // The value type of the attribute. Returned by
-            // operator*().
-            using value_type = T;
-
-            // Reference to the value_type, required by STL.
-            using reference = std::conditional_t<isConst, const value_type &, value_type &>;
-
-            // Pointer to the value_type, required by STL.
-            using pointer = std::conditional_t<isConst, const value_type *, value_type *>;
-
-            // STL iterator category.
-            using iterator_category = std::forward_iterator_tag;
-
-            // Signed integer type of the result of subtracting two pointers,
-            // required by STL.
-            using difference_type = ptrdiff_t;
-
-            Iterator() : storage{nullptr}, idx{0} {}
-            Iterator(AttributeStorage_type *storage) : storage{storage}, idx{0} {
-                if (storage) {
-                    nextValid();
-                }
-            }
-
-            Iterator &nextValid() {
-                while (storage && !storage->isValid(idx)) {
-                    if (idx >= storage->values.size()) {
-                        storage = nullptr;
-                        return *this;
-                    }
-                    ++idx;
-                }
-                return *this;
-            }
-
-            Iterator &operator++() {
-                if (!storage) {
-                    throw std::runtime_error("Invalid attribute iterator");
-                }
-                ++idx;
-                return nextValid();
-            }
-
-            auto operator*() const {
-                if (!storage) {
-                    throw std::runtime_error("Invalid attribute iterator");
-                }
-                return std::make_pair(idx, storage->values[idx]);
-            }
-
-            bool operator==(Iterator const &iter) const noexcept {
-                if (storage == nullptr && iter.storage == nullptr) {
-                    return true;
-                }
-                return storage == iter.storage && idx == iter.idx;
-            }
-
-            bool operator!=(Iterator const &iter) const noexcept { return !(*this == iter); }
-
-        private:
-            AttributeStorage_type *storage;
-            index idx;
-        }; // class Iterator
-
-    private:
-        class IndexProxy {
-            // a helper class for distinguished read and write on an indexed
-            // attribute
-            // operator[] on an attribute yields an IndexProxy holding
-            // location and index of access
-            //    - casting an IndexProxy to the attribute type reads the value
-            //    - assigning to it (operator=) writes the value
-        public:
-            IndexProxy(AttributeStorage_type *storage, index idx) : storage{storage}, idx{idx} {}
-
-            // reading at idx
-            operator T() const {
-                storage->checkIndex(idx);
-                return storage->values[idx];
-            }
-
-            // writing at idx
-            template <bool ic = isConst>
-            std::enable_if_t<!ic, T> &operator=(T &&other) {
-                storage->set(idx, std::move(other));
-                return storage->values[idx];
-            }
-
-        private:
-            AttributeStorage_type *storage;
-            index idx;
-        }; // class IndexProxy
-    public:
-        explicit Attribute(std::shared_ptr<AttributeStorage_type> ownedStorage = nullptr)
-            : ownedStorage{ownedStorage}, valid{ownedStorage != nullptr} {}
-
-        Attribute(Attribute const &other) : ownedStorage{other.ownedStorage}, valid{other.valid} {}
-
-        template <bool ic = isConst, std::enable_if_t<ic, int> = 0>
-        Attribute(Attribute<NodeOrEdge, T, false> const &other)
-            : ownedStorage{other.ownedStorage}, valid{other.valid} {}
-
-        Attribute &operator=(Attribute other) {
-            this->swap(other);
-            return *this;
-        }
-
-        void swap(Attribute &other) {
-            std::swap(ownedStorage, other.ownedStorage);
-            std::swap(valid, other.valid);
-        }
-
-        Attribute(Attribute &&other) noexcept
-            : ownedStorage{std::move(other.ownedStorage)}, valid{other.valid} {
-            other.valid = false;
-        }
-
-        template <bool ic = isConst, std::enable_if_t<ic, int> = 0>
-        Attribute(Attribute<NodeOrEdge, T, false> &&other) noexcept
-            : ownedStorage{std::move(other.ownedStorage)}, valid{other.valid} {
-            other.valid = false;
-        }
-
-        auto begin() const {
-            checkAttribute();
-            return Iterator(ownedStorage.get()).nextValid();
-        }
-
-        auto end() const { return Iterator(nullptr); }
-
-        auto size() const noexcept { return ownedStorage->size(); }
-
-        template <bool ic = isConst>
-        std::enable_if_t<!ic> set(index i, T v) {
-            checkAttribute();
-            ownedStorage->set(i, std::move(v));
-        }
-
-        template <bool ic = isConst>
-        std::enable_if_t<!ic> set2(node u, node v, T t) {
-            static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
-            set(ownedStorage->theGraph->edgeId(u, v), t);
-        }
-
-        auto get(index i) const {
-            checkAttribute();
-            return ownedStorage->get(i);
-        }
-
-        auto get2(node u, node v) const {
-            static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
-            return get(ownedStorage->theGraph->edgeId(u, v));
-        }
-
-        auto get(index i, T defaultT) const {
-            checkAttribute();
-            return ownedStorage->get(i, defaultT);
-        }
-
-        auto get2(node u, node v, T defaultT) const {
-            static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
-            return get(ownedStorage->theGraph->edgeId(u, v), defaultT);
-        }
-
-        IndexProxy operator[](index i) const {
-            checkAttribute();
-            return IndexProxy(ownedStorage.get(), i);
-        }
-
-        IndexProxy operator()(node u, node v) const {
-            static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
-            checkAttribute();
-            return IndexProxy(ownedStorage.get(), ownedStorage->theGraph->edgeId(u, v));
-        }
-
-        void checkAttribute() const {
-            if (!ownedStorage->validStorage)
-                throw std::runtime_error("Invalid attribute");
-        }
-
-        auto getName() const {
-            checkAttribute();
-            return ownedStorage->getName();
-        }
-
-        void write(std::string const &filename) const {
-            std::ofstream out(filename);
-            if (!out)
-                ERROR("cannot open ", filename, " for writing");
-
-            for (auto it = begin(); it != end(); ++it) {
-                auto pair = *it;
-                auto n = pair.first;  // node/edgeid
-                auto v = pair.second; // value
-                out << n << "\t" << v << "\n";
-            }
-            out.close();
-        }
-
-        template <bool ic = isConst>
-        std::enable_if_t<!ic> read(const std::string &filename) {
-            std::ifstream in(filename);
-            if (!in) {
-                ERROR("cannot open ", filename, " for reading");
-            }
-            index n; // node/edgeid
-            T v;     // value
-            std::string line;
-            while (std::getline(in, line)) {
-                std::istringstream istring(line);
-                if constexpr (std::is_same_v<T, std::string>) {
-                    istring >> n >> std::ws;
-                    std::getline(istring, v);
-                } else {
-                    istring >> n >> v;
-                }
-                set(n, v);
-            }
-        }
-
-    private:
-        std::shared_ptr<AttributeStorage_type> ownedStorage;
-        bool valid;
-    }; // class Attribute
-
-    template <typename NodeOrEdge>
-    class AttributeMap {
-        friend Graph;
-        const Graph *theGraph;
-
-    public:
-        std::unordered_map<std::string, std::shared_ptr<ASB<NodeOrEdge>>> attrMap;
-
-        AttributeMap(const Graph *g) : theGraph{g} {}
-
-        auto find(std::string const &name) {
-            auto it = attrMap.find(name);
-            if (it == attrMap.end()) {
-                throw std::runtime_error("No such attribute");
-            }
-            return it;
-        }
-
-        auto find(std::string const &name) const {
-            auto it = attrMap.find(name);
-            if (it == attrMap.end()) {
-                throw std::runtime_error("No such attribute");
-            }
-            return it;
-        }
-
-        template <typename T>
-        auto attach(const std::string &name) {
-            auto ownedPtr =
-                std::make_shared<AttributeStorage<NodeOrEdge, ASB, T>>(theGraph, std::string{name});
-            auto insertResult = attrMap.emplace(ownedPtr->getName(), ownedPtr);
-            auto success = insertResult.second;
-            if (!success) {
-                throw std::runtime_error("Attribute with same name already exists");
-            }
-            return Attribute<NodeOrEdge, T, false>{ownedPtr};
-        }
-
-        void detach(const std::string &name) {
-            auto it = find(name);
-            auto storage = it->second.get();
-            storage->invalidateStorage();
-            it->second.reset();
-            attrMap.erase(name);
-        }
-
-        template <typename T>
-        auto get(const std::string &name) {
-            auto it = find(name);
-            if (it->second.get()->getType() != typeid(T))
-                throw std::runtime_error("Type mismatch in Attributes().get()");
-            return Attribute<NodeOrEdge, T, false>{
-                std::static_pointer_cast<AttributeStorage<NodeOrEdge, ASB, T>>(it->second)};
-        }
-
-        template <typename T>
-        auto get(const std::string &name) const {
-            auto it = find(name);
-            if (it->second.get()->getType() != typeid(T))
-                throw std::runtime_error("Type mismatch in Attributes().get()");
-            return Attribute<NodeOrEdge, T, true>{
-                std::static_pointer_cast<const AttributeStorage<NodeOrEdge, ASB, T>>(it->second)};
-        }
-
-    }; // class AttributeMap
-
-    AttributeMap<PerNode> nodeAttributeMap;
-    AttributeMap<PerEdge> edgeAttributeMap;
+    AttributeMap<PerNode, Graph> nodeAttributeMap;
+    AttributeMap<PerEdge, Graph> edgeAttributeMap;
 
 public:
     auto &nodeAttributes() noexcept { return nodeAttributeMap; }
@@ -661,13 +239,13 @@ public:
         edgeAttributes().detach(name);
     }
 
-    using NodeIntAttribute = Attribute<PerNode, int, false>;
-    using NodeDoubleAttribute = Attribute<PerNode, double, false>;
-    using NodeStringAttribute = Attribute<PerNode, std::string, false>;
+    using NodeIntAttribute = Attribute<PerNode, Graph, int, false>;
+    using NodeDoubleAttribute = Attribute<PerNode, Graph, double, false>;
+    using NodeStringAttribute = Attribute<PerNode, Graph, std::string, false>;
 
-    using EdgeIntAttribute = Attribute<PerEdge, int, false>;
-    using EdgeDoubleAttribute = Attribute<PerEdge, double, false>;
-    using EdgeStringAttribute = Attribute<PerEdge, std::string, false>;
+    using EdgeIntAttribute = Attribute<PerEdge, Graph, int, false>;
+    using EdgeDoubleAttribute = Attribute<PerEdge, Graph, double, false>;
+    using EdgeStringAttribute = Attribute<PerEdge, Graph, std::string, false>;
 
 private:
     /**
@@ -851,8 +429,8 @@ private:
                                   typename Aux::FunctionTraits<F>::template arg<2>::type>::value
                   && std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<3>::type>::
                       value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid id) const
-        -> decltype(f(u, v, ew, id)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew,
+                    edgeid id) const -> decltype(f(u, v, ew, id)) {
         return f(u, v, ew, id);
     }
 
@@ -884,8 +462,8 @@ private:
                   (Aux::FunctionTraits<F>::arity >= 2)
                   && std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<
                                                   2>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid /*id*/) const
-        -> decltype(f(u, v, ew)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew,
+                    edgeid /*id*/) const -> decltype(f(u, v, ew)) {
         return f(u, v, ew);
     }
 
@@ -898,8 +476,8 @@ private:
                            (Aux::FunctionTraits<F>::arity >= 1)
                            && std::is_same<node, typename Aux::FunctionTraits<F>::template arg<
                                                      1>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/, edgeid /*id*/) const
-        -> decltype(f(u, v)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/,
+                    edgeid /*id*/) const -> decltype(f(u, v)) {
         return f(u, v);
     }
 
@@ -1035,7 +613,7 @@ public:
     public:
         NodeRange(const Graph &G) : G(&G) {}
 
-        NodeRange() : G(nullptr){};
+        NodeRange() : G(nullptr) {};
 
         ~NodeRange() = default;
 
@@ -1260,7 +838,7 @@ public:
     public:
         EdgeRange(const Graph &G) : G(&G) {}
 
-        EdgeRange() : G(nullptr){};
+        EdgeRange() : G(nullptr) {};
 
         ~EdgeRange() = default;
 
@@ -1285,7 +863,7 @@ public:
     public:
         EdgeWeightRange(const Graph &G) : G(&G) {}
 
-        EdgeWeightRange() : G(nullptr){};
+        EdgeWeightRange() : G(nullptr) {};
 
         ~EdgeWeightRange() = default;
 
@@ -1450,7 +1028,7 @@ public:
     public:
         NeighborRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborRange() : G(nullptr){};
+        NeighborRange() : G(nullptr) {};
 
         NeighborIterator begin() const {
             assert(G);
@@ -1482,7 +1060,7 @@ public:
     public:
         NeighborWeightRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborWeightRange() : G(nullptr){};
+        NeighborWeightRange() : G(nullptr) {};
 
         NeighborWeightIterator begin() const {
             assert(G);

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -34,6 +34,7 @@
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/graph/Attributes.hpp>
 #include <networkit/graph/EdgeIterators.hpp>
+#include <networkit/graph/NeighborIterators.hpp>
 #include <networkit/graph/NodeIterators.hpp>
 
 #include <tlx/define/deprecated.hpp>
@@ -498,152 +499,19 @@ public:
     // For support of API: NetworKit::Graph::NodeRange
     using NodeRange = NodeRangeBase<Graph>;
 
-    // // For support of API: NetworKit::Graph:EdgeIterator
+    // For support of API: NetworKit::Graph:EdgeIterator
     using EdgeIterator = EdgeTypeIterator<Graph, Edge>;
-    // // For support of API: NetworKit::Graph:EdgeWeightIterator
+    // For support of API: NetworKit::Graph:EdgeWeightIterator
     using EdgeWeightIterator = EdgeTypeIterator<Graph, WeightedEdge>;
-    // // For support of API: NetworKit::Graph:EdgeRange
+    // For support of API: NetworKit::Graph:EdgeRange
     using EdgeRange = EdgeTypeRange<Graph, Edge>;
-    // // For support of API: NetworKit::Graph:EdgeWeightRange
+    // For support of API: NetworKit::Graph:EdgeWeightRange
     using EdgeWeightRange = EdgeTypeRange<Graph, WeightedEdge>;
 
-    /**
-     * Class to iterate over the in/out neighbors of a node.
-     */
-    class NeighborIterator {
-
-        std::vector<node>::const_iterator nIter;
-
-    public:
-        // The value type of the neighbors (i.e. nodes). Returned by
-        // operator*().
-        using value_type = node;
-
-        // Reference to the value_type, required by STL.
-        using reference = value_type &;
-
-        // Pointer to the value_type, required by STL.
-        using pointer = value_type *;
-
-        // STL iterator category.
-        using iterator_category = std::forward_iterator_tag;
-
-        // Signed integer type of the result of subtracting two pointers,
-        // required by STL.
-        using difference_type = ptrdiff_t;
-
-        // Own type.
-        using self = NeighborIterator;
-
-        NeighborIterator(std::vector<node>::const_iterator nodesIter) : nIter(nodesIter) {}
-
-        /**
-         * @brief WARNING: This contructor is required for Python and should not be used as the
-         * iterator is not initialized.
-         */
-        NeighborIterator() {}
-
-        NeighborIterator &operator++() {
-            ++nIter;
-            return *this;
-        }
-
-        NeighborIterator operator++(int) {
-            const auto tmp = *this;
-            ++nIter;
-            return tmp;
-        }
-
-        NeighborIterator operator--() {
-            const auto tmp = *this;
-            --nIter;
-            return tmp;
-        }
-
-        NeighborIterator operator--(int) {
-            --nIter;
-            return *this;
-        }
-
-        bool operator==(const NeighborIterator &rhs) const { return nIter == rhs.nIter; }
-
-        bool operator!=(const NeighborIterator &rhs) const { return !(nIter == rhs.nIter); }
-
-        node operator*() const { return *nIter; }
-    };
-
-    /**
-     * Class to iterate over the in/out neighbors of a node including the edge
-     * weights. Values are std::pair<node, edgeweight>.
-     */
-    class NeighborWeightIterator {
-
-        std::vector<node>::const_iterator nIter;
-        std::vector<edgeweight>::const_iterator wIter;
-
-    public:
-        // The value type of the neighbors (i.e. nodes). Returned by
-        // operator*().
-        using value_type = std::pair<node, edgeweight>;
-
-        // Reference to the value_type, required by STL.
-        using reference = value_type &;
-
-        // Pointer to the value_type, required by STL.
-        using pointer = value_type *;
-
-        // STL iterator category.
-        using iterator_category = std::forward_iterator_tag;
-
-        // Signed integer type of the result of subtracting two pointers,
-        // required by STL.
-        using difference_type = ptrdiff_t;
-
-        // Own type.
-        using self = NeighborWeightIterator;
-
-        NeighborWeightIterator(std::vector<node>::const_iterator nodesIter,
-                               std::vector<edgeweight>::const_iterator weightIter)
-            : nIter(nodesIter), wIter(weightIter) {}
-
-        /**
-         * @brief WARNING: This contructor is required for Python and should not be used as the
-         * iterator is not initialized.
-         */
-        NeighborWeightIterator() {}
-
-        NeighborWeightIterator &operator++() {
-            ++nIter;
-            ++wIter;
-            return *this;
-        }
-
-        NeighborWeightIterator operator++(int) {
-            const auto tmp = *this;
-            ++(*this);
-            return tmp;
-        }
-
-        NeighborWeightIterator operator--() {
-            --nIter;
-            --wIter;
-            return *this;
-        }
-
-        NeighborWeightIterator operator--(int) {
-            const auto tmp = *this;
-            --(*this);
-            return tmp;
-        }
-
-        bool operator==(const NeighborWeightIterator &rhs) const {
-            return nIter == rhs.nIter && wIter == rhs.wIter;
-        }
-
-        bool operator!=(const NeighborWeightIterator &rhs) const { return !(*this == rhs); }
-
-        std::pair<node, edgeweight> operator*() const { return std::make_pair(*nIter, *wIter); }
-    };
+    // For support of API: NetworKit::Graph::NeighborIterator;
+    using NeighborIterator = NeighborIteratorBase;
+    // For support of API: NetworKit::Graph::NeighborIterator;
+    using NeighborWeightIterator = NeighborWeightIteratorBase;
 
     /**
      * Wrapper class to iterate over a range of the neighbors of a node within

--- a/include/networkit/graph/NeighborIterators.hpp
+++ b/include/networkit/graph/NeighborIterators.hpp
@@ -152,4 +152,4 @@ public:
 
 } // namespace NetworKit
 
-#endif //
+#endif // NETWORKIT_GRAPH_NEIGHBOR_ITERATORS_HPP_

--- a/include/networkit/graph/NeighborIterators.hpp
+++ b/include/networkit/graph/NeighborIterators.hpp
@@ -1,0 +1,155 @@
+/*
+ * EdgeIterators.hpp
+ *
+ *  Created on: 14.05.2024
+ */
+
+#ifndef NETWORKIT_GRAPH_NEIGHBOR_ITERATORS_HPP_
+#define NETWORKIT_GRAPH_NEIGHBOR_ITERATORS_HPP_
+
+#include <networkit/Globals.hpp>
+#include <networkit/graph/NodeIterators.hpp>
+
+namespace NetworKit {
+
+/**
+ * Class to iterate over the in/out neighbors of a node.
+ */
+class NeighborIteratorBase {
+
+    std::vector<node>::const_iterator nIter;
+
+public:
+    // The value type of the neighbors (i.e. nodes). Returned by
+    // operator*().
+    using value_type = node;
+
+    // Reference to the value_type, required by STL.
+    using reference = value_type &;
+
+    // Pointer to the value_type, required by STL.
+    using pointer = value_type *;
+
+    // STL iterator category.
+    using iterator_category = std::forward_iterator_tag;
+
+    // Signed integer type of the result of subtracting two pointers,
+    // required by STL.
+    using difference_type = ptrdiff_t;
+
+    // Own type.
+    using self = NeighborIteratorBase;
+
+    NeighborIteratorBase(std::vector<node>::const_iterator nodesIter) : nIter(nodesIter) {}
+
+    /**
+     * @brief WARNING: This contructor is required for Python and should not be used as the
+     * iterator is not initialized.
+     */
+    NeighborIteratorBase() {}
+
+    NeighborIteratorBase &operator++() {
+        ++nIter;
+        return *this;
+    }
+
+    NeighborIteratorBase operator++(int) {
+        const auto tmp = *this;
+        ++nIter;
+        return tmp;
+    }
+
+    NeighborIteratorBase operator--() {
+        const auto tmp = *this;
+        --nIter;
+        return tmp;
+    }
+
+    NeighborIteratorBase operator--(int) {
+        --nIter;
+        return *this;
+    }
+
+    bool operator==(const NeighborIteratorBase &rhs) const { return nIter == rhs.nIter; }
+
+    bool operator!=(const NeighborIteratorBase &rhs) const { return !(nIter == rhs.nIter); }
+
+    node operator*() const { return *nIter; }
+};
+
+/**
+ * Class to iterate over the in/out neighbors of a node including the edge
+ * weights. Values are std::pair<node, edgeweight>.
+ */
+class NeighborWeightIteratorBase {
+
+    std::vector<node>::const_iterator nIter;
+    std::vector<edgeweight>::const_iterator wIter;
+
+public:
+    // The value type of the neighbors (i.e. nodes). Returned by
+    // operator*().
+    using value_type = std::pair<node, edgeweight>;
+
+    // Reference to the value_type, required by STL.
+    using reference = value_type &;
+
+    // Pointer to the value_type, required by STL.
+    using pointer = value_type *;
+
+    // STL iterator category.
+    using iterator_category = std::forward_iterator_tag;
+
+    // Signed integer type of the result of subtracting two pointers,
+    // required by STL.
+    using difference_type = ptrdiff_t;
+
+    // Own type.
+    using self = NeighborWeightIteratorBase;
+
+    NeighborWeightIteratorBase(std::vector<node>::const_iterator nodesIter,
+                               std::vector<edgeweight>::const_iterator weightIter)
+        : nIter(nodesIter), wIter(weightIter) {}
+
+    /**
+     * @brief WARNING: This contructor is required for Python and should not be used as the
+     * iterator is not initialized.
+     */
+    NeighborWeightIteratorBase() {}
+
+    NeighborWeightIteratorBase &operator++() {
+        ++nIter;
+        ++wIter;
+        return *this;
+    }
+
+    NeighborWeightIteratorBase operator++(int) {
+        const auto tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+    NeighborWeightIteratorBase operator--() {
+        --nIter;
+        --wIter;
+        return *this;
+    }
+
+    NeighborWeightIteratorBase operator--(int) {
+        const auto tmp = *this;
+        --(*this);
+        return tmp;
+    }
+
+    bool operator==(const NeighborWeightIteratorBase &rhs) const {
+        return nIter == rhs.nIter && wIter == rhs.wIter;
+    }
+
+    bool operator!=(const NeighborWeightIteratorBase &rhs) const { return !(*this == rhs); }
+
+    std::pair<node, edgeweight> operator*() const { return std::make_pair(*nIter, *wIter); }
+};
+
+} // namespace NetworKit
+
+#endif //

--- a/include/networkit/graph/NeighborIterators.hpp
+++ b/include/networkit/graph/NeighborIterators.hpp
@@ -15,14 +15,15 @@ namespace NetworKit {
 /**
  * Class to iterate over the in/out neighbors of a node.
  */
+template <typename containerType>
 class NeighborIteratorBase {
 
-    std::vector<node>::const_iterator nIter;
+    typename containerType::const_iterator elementIter;
 
 public:
     // The value type of the neighbors (i.e. nodes). Returned by
     // operator*().
-    using value_type = node;
+    using value_type = typename containerType::value_type;
 
     // Reference to the value_type, required by STL.
     using reference = value_type &;
@@ -40,7 +41,8 @@ public:
     // Own type.
     using self = NeighborIteratorBase;
 
-    NeighborIteratorBase(std::vector<node>::const_iterator nodesIter) : nIter(nodesIter) {}
+    NeighborIteratorBase(typename containerType::const_iterator elementIter)
+        : elementIter(elementIter) {}
 
     /**
      * @brief WARNING: This contructor is required for Python and should not be used as the
@@ -49,47 +51,53 @@ public:
     NeighborIteratorBase() {}
 
     NeighborIteratorBase &operator++() {
-        ++nIter;
+        ++elementIter;
         return *this;
     }
 
     NeighborIteratorBase operator++(int) {
         const auto tmp = *this;
-        ++nIter;
+        ++elementIter;
         return tmp;
     }
 
     NeighborIteratorBase operator--() {
         const auto tmp = *this;
-        --nIter;
+        --elementIter;
         return tmp;
     }
 
     NeighborIteratorBase operator--(int) {
-        --nIter;
+        --elementIter;
         return *this;
     }
 
-    bool operator==(const NeighborIteratorBase &rhs) const { return nIter == rhs.nIter; }
+    bool operator==(const NeighborIteratorBase &rhs) const {
+        return elementIter == rhs.elementIter;
+    }
 
-    bool operator!=(const NeighborIteratorBase &rhs) const { return !(nIter == rhs.nIter); }
+    bool operator!=(const NeighborIteratorBase &rhs) const {
+        return !(elementIter == rhs.elementIter);
+    }
 
-    node operator*() const { return *nIter; }
+    value_type operator*() const { return *elementIter; }
 };
 
 /**
  * Class to iterate over the in/out neighbors of a node including the edge
  * weights. Values are std::pair<node, edgeweight>.
  */
+template <typename containerType, typename weightContainerType>
 class NeighborWeightIteratorBase {
 
-    std::vector<node>::const_iterator nIter;
-    std::vector<edgeweight>::const_iterator wIter;
+    typename containerType::const_iterator elementIter;
+    typename weightContainerType::const_iterator weightIter;
 
 public:
     // The value type of the neighbors (i.e. nodes). Returned by
     // operator*().
-    using value_type = std::pair<node, edgeweight>;
+    using value_type =
+        std::pair<typename containerType::value_type, typename weightContainerType::value_type>;
 
     // Reference to the value_type, required by STL.
     using reference = value_type &;
@@ -107,9 +115,9 @@ public:
     // Own type.
     using self = NeighborWeightIteratorBase;
 
-    NeighborWeightIteratorBase(std::vector<node>::const_iterator nodesIter,
-                               std::vector<edgeweight>::const_iterator weightIter)
-        : nIter(nodesIter), wIter(weightIter) {}
+    NeighborWeightIteratorBase(typename containerType::const_iterator elementIter,
+                               typename weightContainerType::const_iterator weightIter)
+        : elementIter(elementIter), weightIter(weightIter) {}
 
     /**
      * @brief WARNING: This contructor is required for Python and should not be used as the
@@ -118,8 +126,8 @@ public:
     NeighborWeightIteratorBase() {}
 
     NeighborWeightIteratorBase &operator++() {
-        ++nIter;
-        ++wIter;
+        ++elementIter;
+        ++weightIter;
         return *this;
     }
 
@@ -130,8 +138,8 @@ public:
     }
 
     NeighborWeightIteratorBase operator--() {
-        --nIter;
-        --wIter;
+        --elementIter;
+        --weightIter;
         return *this;
     }
 
@@ -142,12 +150,15 @@ public:
     }
 
     bool operator==(const NeighborWeightIteratorBase &rhs) const {
-        return nIter == rhs.nIter && wIter == rhs.wIter;
+        return elementIter == rhs.elementIter && weightIter == rhs.weightIter;
     }
 
     bool operator!=(const NeighborWeightIteratorBase &rhs) const { return !(*this == rhs); }
 
-    std::pair<node, edgeweight> operator*() const { return std::make_pair(*nIter, *wIter); }
+    std::pair<typename containerType::value_type, typename weightContainerType::value_type>
+    operator*() const {
+        return std::make_pair(*elementIter, *weightIter);
+    }
 };
 
 } // namespace NetworKit

--- a/include/networkit/graph/NodeIterators.hpp
+++ b/include/networkit/graph/NodeIterators.hpp
@@ -1,0 +1,124 @@
+/*
+ * NodeIterators.hpp
+ *
+ *  Created on: 14.05.2024
+ */
+
+#ifndef NETWORKIT_GRAPH_NODE_ITERATORS_HPP_
+#define NETWORKIT_GRAPH_NODE_ITERATORS_HPP_
+
+#include <networkit/Globals.hpp>
+
+namespace NetworKit {
+
+/**
+ * Class to iterate over the nodes of a graph.
+ */
+template <typename GraphType>
+class NodeIteratorBase {
+
+    const GraphType *G;
+    node u;
+
+public:
+    // The value type of the nodes (i.e. nodes). Returned by
+    // operator*().
+    using value_type = node;
+
+    // Reference to the value_type, required by STL.
+    using reference = value_type &;
+
+    // Pointer to the value_type, required by STL.
+    using pointer = value_type *;
+
+    // STL iterator category.
+    using iterator_category = std::forward_iterator_tag;
+
+    // Signed integer type of the result of subtracting two pointers,
+    // required by STL.
+    using difference_type = ptrdiff_t;
+
+    // Own type.
+    using self = NodeIteratorBase;
+
+    NodeIteratorBase(const GraphType *G, node u) : G(G), u(u) {
+        if (!G->hasNode(u) && u < G->upperNodeIdBound()) {
+            ++(*this);
+        }
+    }
+
+    /**
+     * @brief WARNING: This constructor is required for Python and should not be used as the
+     * iterator is not initialized.
+     */
+    NodeIteratorBase() : G(nullptr) {}
+
+    ~NodeIteratorBase() = default;
+
+    NodeIteratorBase &operator++() {
+        assert(u < G->upperNodeIdBound());
+        do {
+            ++u;
+        } while (!(G->hasNode(u) || u >= G->upperNodeIdBound()));
+        return *this;
+    }
+
+    NodeIteratorBase operator++(int) {
+        const auto tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+    NodeIteratorBase operator--() {
+        assert(u);
+        do {
+            --u;
+        } while (!G->hasNode(u));
+        return *this;
+    }
+
+    NodeIteratorBase operator--(int) {
+        const auto tmp = *this;
+        --(*this);
+        return tmp;
+    }
+
+    bool operator==(const NodeIteratorBase &rhs) const noexcept { return u == rhs.u; }
+
+    bool operator!=(const NodeIteratorBase &rhs) const noexcept { return !(*this == rhs); }
+
+    node operator*() const noexcept {
+        assert(u < G->upperNodeIdBound());
+        return u;
+    }
+};
+
+/**
+ * Wrapper class to iterate over a range of the nodes of a graph.
+ */
+template <typename GraphType>
+class NodeRangeBase {
+
+    const GraphType *G;
+
+public:
+    NodeRangeBase(const GraphType &G) : G(&G) {}
+
+    NodeRangeBase() : G(nullptr) {};
+
+    ~NodeRangeBase() = default;
+
+    NodeIteratorBase<GraphType> begin() const noexcept {
+        assert(G);
+        return NodeIteratorBase(G, node{0});
+    }
+
+    NodeIteratorBase<GraphType> end() const noexcept {
+        assert(G);
+        return NodeIteratorBase(G, G->upperNodeIdBound());
+    }
+};
+
+} // namespace NetworKit
+
+#endif //

--- a/include/networkit/graph/NodeIterators.hpp
+++ b/include/networkit/graph/NodeIterators.hpp
@@ -104,7 +104,7 @@ class NodeRangeBase {
 public:
     NodeRangeBase(const GraphType &G) : G(&G) {}
 
-    NodeRangeBase() : G(nullptr) {};
+    NodeRangeBase() : G(nullptr){};
 
     ~NodeRangeBase() = default;
 

--- a/include/networkit/graph/NodeIterators.hpp
+++ b/include/networkit/graph/NodeIterators.hpp
@@ -121,4 +121,4 @@ public:
 
 } // namespace NetworKit
 
-#endif //
+#endif // NETWORKIT_GRAPH_NODE_ITERATORS_HPP_

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -1009,4 +1009,22 @@ void ASB<PerEdge, Graph>::indexOK(index n) const {
     }
 }
 
+template <>
+bool EIB<Graph>::validEdge() const noexcept {
+    return G->isDirected() || (*nodeIter <= G->getIthNeighbor(Unsafe{}, *nodeIter, i));
+}
+
+template <>
+Edge EdgeTypeIterator<Graph, Edge>::operator*() const noexcept {
+    assert(nodeIter != G->nodeRange().end());
+    return Edge(*nodeIter, G->getIthNeighbor(Unsafe{}, *nodeIter, i));
+}
+
+template <>
+WeightedEdge EdgeTypeIterator<Graph, WeightedEdge>::operator*() const noexcept {
+    assert(nodeIter != G->nodeRange().end());
+    return WeightedEdge(*nodeIter, G->getIthNeighbor(Unsafe{}, *nodeIter, i),
+                        G->getIthNeighborWeight(Unsafe{}, *nodeIter, i));
+}
+
 } /* namespace NetworKit */

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -983,26 +983,26 @@ bool Graph::checkConsistency() const {
 /* ATTRIBUTE PREMISE AND INDEX CHECKS */
 
 template <>
-void Graph::ASB<Graph::PerNode>::checkPremise() const {
+void ASB<PerNode, Graph>::checkPremise() const {
     // nothing
 }
 
 template <>
-void Graph::ASB<Graph::PerEdge>::checkPremise() const {
+void ASB<PerEdge, Graph>::checkPremise() const {
     if (!theGraph->hasEdgeIds()) {
         throw std::runtime_error("Edges must be indexed");
     }
 }
 
 template <>
-void Graph::ASB<Graph::PerNode>::indexOK(index n) const {
+void ASB<PerNode, Graph>::indexOK(index n) const {
     if (!theGraph->hasNode(n)) {
         throw std::runtime_error("This node does not exist");
     }
 }
 
 template <>
-void Graph::ASB<Graph::PerEdge>::indexOK(index n) const {
+void ASB<PerEdge, Graph>::indexOK(index n) const {
     auto uv = theGraph->edgeById(n);
     if (!theGraph->hasEdge(uv.first, uv.second)) {
         throw std::runtime_error("This edgeId does not exist");


### PR DESCRIPTION
Currently, the PR is in draft mode. The plan is to extract and move functionality out of the graph data structure, which might be useful for other graph types (e.g. Hypergraphs). The graph type and basic data type (e.g. edge) should be deduced by template.

ToDo:

- [x] Move attributes to a separate header
- [x] Move node iterators to a separate header
- [x] Move edge iterators to a separate header
- [x] Add unsafe helper functions for fast external edge access
- [x] Move neighbor iterators to a separate header