### PR TITLE
python: fix addEdge when adding missing nodes

### DIFF
--- a/networkit/graph.pyx
+++ b/networkit/graph.pyx
@@ -408,8 +408,13 @@ cdef class Graph:
 				raise RuntimeError("Cannot create edge ({0}, {1}) as at least one end point does not exist".format(u,v))
 
 			k = max(u, v)
+			previous_num_nodes = self._this.numberOfNodes()
 			if k >= self._this.upperNodeIdBound():
 				self._this.addNodes(k - self._this.upperNodeIdBound() + 1)
+				# removing the nodes that have not been added by this edge 
+				for node in range(previous_num_nodes, self._this.numberOfNodes()):
+					if node != u and node != v:
+						self._this.removeNode(node)
 
 			if not self._this.hasNode(u):
 				self._this.restoreNode(u)

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -58,33 +58,22 @@ class TestGraph(unittest.TestCase):
 		G = nk.Graph(0)
 
 		with self.assertRaises(RuntimeError):
-			G.addEdge(0, 1)
+			G.addEdge(0, 1, addMissing = False)
 
 		self.assertEqual(G.numberOfNodes(), 0)
 		self.assertEqual(G.numberOfEdges(), 0)
 
 		G.addEdge(0, 2, addMissing = True)
 
-		self.assertEqual(G.numberOfNodes(), 3)
-		self.assertEqual(G.numberOfEdges(), 1)
-
-		G.removeNode(1)
-
-		self.assertEqual(G.numberOfNodes(), 2)
-		self.assertEqual(G.numberOfEdges(), 1)
+		self.assertTrue(G.hasNode(0))
+		self.assertTrue(G.hasNode(2))
+		self.assertTrue(G.hasEdge(0,2))
+		self.assertFalse(G.hasNode(1)) #this node should not be active
 
 		G.addEdge(0, 1, addMissing = True)
 
 		self.assertEqual(G.numberOfNodes(), 3)
 		self.assertEqual(G.numberOfEdges(), 2)
-
-		G.removeNode(2)
-
-		G.addEdge(1, 2, addMissing = True)
-
-		self.assertEqual(G.numberOfNodes(), 3)
-		self.assertEqual(G.numberOfEdges(), 2)
-	
 
 	def testEdgeIterator(self):
 		for weighted in [True, False]:


### PR DESCRIPTION
This PR addresses the issue that `addEdge(u,v)` in python behaves differently to c++ (and change the corresponding test). 

- Previously when the parameter `addMissing` has been set to True and either node u or v did not exist in the graph, all not existing nodes from the previous numberOfNodes() to max(u,v) have been added to the graph aswell as u or v. 
- This was not properly documented and furthermore created potentially many unused nodes.