### PR TITLE
cpp: adds MTXGraphReader and corresponding tests

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -124,7 +124,7 @@ jobs:
             brew install libomp ninja
           CIBW_ARCHS_MACOS: ${{ matrix.buildplat[1] }}
           CIBW_BUILD: ${{ github.ref == 'refs/heads/master' && 'cp38-* cp39-* cp310-* cp311-* cp312-*' || 'cp312-*' }}
-          CIBW_ENVIRONMENT: CXX='c++' NETWORKIT_OSX_CROSSBUILD=ON
+          CIBW_ENVIRONMENT: CXX='c++' NETWORKIT_OSX_CROSSBUILD=ON MACOSX_DEPLOYMENT_TARGET='11.0'
           CIBW_SKIP: "pp* *-musllinux_*"
       - uses: actions/upload-artifact@v4
         if: github.ref == 'refs/heads/master'

--- a/include/networkit/io/MTXGraphReader.hpp
+++ b/include/networkit/io/MTXGraphReader.hpp
@@ -1,0 +1,31 @@
+#ifndef NETWORKIT_IO_MTX_GRAPH_READER_HPP_
+#define NETWORKIT_IO_MTX_GRAPH_READER_HPP_
+
+#include <networkit/io/GraphReader.hpp>
+
+namespace NetworKit {
+
+/**
+ * @ingroup io
+ *
+ * Reader for the matrix market file format documented in
+ * https://networkrepository.com/mtx-matrix-market-format.html
+ *
+ * Does not allow complex fields.
+ *
+ */
+class MTXGraphReader final : public GraphReader {
+public:
+    MTXGraphReader() = default;
+
+    /**
+     * Takes a file path as parameter and returns a graph.
+     *
+     * @param path
+     * @return Graph
+     */
+    Graph read(const std::string &path) override;
+};
+
+} /* namespace NetworKit */
+#endif // NETWORKIT_IO_MTX_GRAPH_READER_HPP_

--- a/include/networkit/io/MTXParser.hpp
+++ b/include/networkit/io/MTXParser.hpp
@@ -1,0 +1,87 @@
+#ifndef NETWORKIT_IO_MTX_PARSER_HPP_
+#define NETWORKIT_IO_MTX_PARSER_HPP_
+
+#include <fstream>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include <networkit/Globals.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+/**
+ * @ingroup io
+ * Parser for the MTX file format.
+ */
+class MTXParser final {
+
+    std::ifstream graphFile;
+    std::string currentLine;
+
+public:
+    enum class Object { Matrix, Vector };
+    enum class Format { Coordinate, Array };
+    enum class Field { Real, Double, Complex, Integer, Pattern };
+    enum class Symmetry { General, Symmetric, SkewSymmetric, Hermitian };
+
+    std::unordered_map<std::string, Object> objectMap = {{"matrix", Object::Matrix},
+                                                         {"vector", Object::Vector}};
+    std::unordered_map<std::string, Format> formatMap = {{"coordinate", Format::Coordinate},
+                                                         {"array", Format::Array}};
+    std::unordered_map<std::string, Field> fieldMap = {{"real", Field::Real},
+                                                       {"double", Field::Double},
+                                                       {"integer", Field::Integer},
+                                                       {"pattern", Field::Pattern}};
+    std::unordered_map<std::string, Symmetry> symmetryMap = {
+        {"general", Symmetry::General},
+        {"symmetric", Symmetry::Symmetric},
+        {"skew-symmetric", Symmetry::SkewSymmetric}};
+
+    struct MTXHeader {
+        Object object;
+        Format format;
+        Field field;
+        Symmetry symmetry;
+    };
+
+    struct MatrixSize {
+        count rows;
+        count columns;
+        count nonzeros;
+
+        MatrixSize(count r, count c, count nz) : rows(r), columns(c), nonzeros(nz) {}
+    };
+
+    struct Edge {
+        node from;
+        node to;
+        std::optional<double> weight;
+
+        Edge(node f, node t, std::optional<double> w) : from(f), to(t), weight(w) {}
+    };
+
+    MTXParser(const std::string &path);
+
+    /**
+     * Get the MTX graph file header.
+     */
+    MTXHeader getHeader();
+
+    /**
+     * Get the MTX graph file matrix size header.
+     */
+    MatrixSize getMatrixSize();
+
+    /**
+     * Get the (weighted) edge from the next line in the MTX graph file if present.
+     *
+     * @param weighted
+     * @return std::optional<std::pair<NetworKit::Edge, NetworKit::edgeweight>>
+     */
+    std::optional<NetworKit::WeightedEdge> getNext(bool weighted);
+};
+} /* namespace NetworKit */
+#endif // NETWORKIT_IO_MTX_PARSER_HPP_

--- a/networkit/cpp/io/CMakeLists.txt
+++ b/networkit/cpp/io/CMakeLists.txt
@@ -23,6 +23,8 @@ networkit_add_module(io
     METISGraphReader.cpp
     METISGraphWriter.cpp
     METISParser.cpp
+    MTXGraphReader.cpp
+    MTXParser.cpp
     NetworkitBinaryReader.cpp
     NetworkitBinaryWriter.cpp
     MatrixMarketReader.cpp

--- a/networkit/cpp/io/MTXGraphReader.cpp
+++ b/networkit/cpp/io/MTXGraphReader.cpp
@@ -1,0 +1,36 @@
+#include <networkit/auxiliary/Enforce.hpp>
+#include <networkit/auxiliary/Log.hpp>
+#include <networkit/auxiliary/StringTools.hpp>
+#include <networkit/io/MTXGraphReader.hpp>
+#include <networkit/io/MTXParser.hpp>
+
+namespace NetworKit {
+
+Graph MTXGraphReader::read(const std::string &path) {
+    MTXParser parser(path);
+
+    auto header = parser.getHeader();
+    auto size = parser.getMatrixSize();
+    auto weighted = true;
+    auto symmetric = true;
+
+    if (header.field == MTXParser::Field::Pattern)
+        weighted = false;
+    if (header.symmetry == MTXParser::Symmetry::General)
+        symmetric = false;
+
+    Graph G(std::max(size.rows, size.columns), weighted, !symmetric);
+    std::string graphName =
+        Aux::StringTools::split(Aux::StringTools::split(path, '/').back(), '.').front();
+
+    auto current_edge = parser.getNext(weighted);
+
+    while (current_edge.has_value()) {
+        WeightedEdge e = current_edge.value();
+        G.addEdge(e.u, e.v, e.weight);
+        current_edge = parser.getNext(weighted);
+    }
+    return G;
+} // namespace NetworKit
+
+} /* namespace NetworKit */

--- a/networkit/cpp/io/MTXParser.cpp
+++ b/networkit/cpp/io/MTXParser.cpp
@@ -1,0 +1,113 @@
+#include <networkit/auxiliary/Enforce.hpp>
+#include <networkit/auxiliary/Log.hpp>
+#include <networkit/auxiliary/NumberParsing.hpp>
+#include <networkit/io/MTXParser.hpp>
+
+#include <stdexcept>
+
+namespace NetworKit {
+
+/**
+ * Extract a (weighted) edge from a line in the file.
+ */
+MTXParser::Edge parseLine(const std::string &line, const bool weighted) {
+    node i, j;
+    std::optional<double> value;
+    std::istringstream istring(line);
+    istring >> i >> j;
+    i--;
+    j--;
+
+    if (weighted) {
+        double tmp;
+        if (istring >> tmp)
+            value = tmp;
+    }
+    return MTXParser::Edge(i, j, value);
+}
+
+MTXParser::MTXParser(const std::string &path) : graphFile(path) {
+    if (!(graphFile)) {
+        ERROR("invalid graph file: ", path);
+        throw std::runtime_error("invalid graph file");
+    }
+}
+
+MTXParser::MTXHeader MTXParser::getHeader() {
+
+    auto tolower = [](const std::string &str) {
+        std::string out;
+        std::transform(str.begin(), str.end(), std::back_inserter(out), ::tolower);
+        return out;
+    };
+
+    MTXParser::MTXHeader header;
+    std::string identifier, object, format, field, symmetry;
+    std::string line;
+
+    Aux::enforceOpened(graphFile);
+    if (std::getline(graphFile, line)) {
+        std::istringstream istring(line);
+        if (!(istring >> identifier >> object >> format >> field >> symmetry)) {
+            throw std::runtime_error("Invalid header format.");
+        }
+        // the header line must start with %%MatrixMarket or %MatrixMarket
+        if (identifier != "%%MatrixMarket" && identifier != "%MatrixMarket") {
+            throw std::runtime_error("Invalid identifier.");
+        }
+        try {
+            header.object = objectMap.at(tolower(object));
+            header.format = formatMap.at(tolower(format));
+            header.field = fieldMap.at(tolower(field));
+            header.symmetry = symmetryMap.at(tolower(symmetry));
+        } catch (const std::out_of_range &) {
+            throw std::runtime_error("Invalid header field.");
+        }
+        return header;
+    } else {
+        throw std::runtime_error("Getting MTX header failed.");
+    }
+}
+
+MTXParser::MatrixSize MTXParser::getMatrixSize() {
+    count rows, columns, nonzeros;
+    std::string line;
+
+    Aux::enforceOpened(graphFile);
+    if (std::getline(graphFile, line)) {
+        while (line[0] == '%') {
+            std::getline(graphFile, line);
+        }
+        std::istringstream istring(line);
+        if (!(istring >> rows >> columns >> nonzeros)) {
+            throw std::runtime_error("Invalid matrix size line format.");
+        }
+        return MTXParser::MatrixSize(rows, columns, nonzeros);
+    } else {
+        throw std::runtime_error("Getting MTX matrix size line failed.");
+    }
+}
+
+std::optional<NetworKit::WeightedEdge> MTXParser::getNext(bool weighted) {
+    std::string line;
+
+    do {
+        auto hasLine = static_cast<bool>(std::getline(graphFile, line));
+        if (!hasLine)
+            return std::nullopt;
+        // check for comment line starting with '%'
+        if (line[0] == '%') {
+            throw std::runtime_error(
+                "Invalid MTX file structure. No comments allowed after size line.");
+        } else {
+            auto e = parseLine(line, weighted);
+            edgeweight w = 1.0;
+            if (weighted) {
+                w = e.weight.value();
+            }
+            return std::optional<NetworKit::WeightedEdge>({e.from, e.to, w});
+        }
+    } while (true);
+}
+
+} /* namespace NetworKit */

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/algebraic/MatrixTools.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/io/BinaryEdgeListPartitionReader.hpp>
 #include <networkit/io/BinaryEdgeListPartitionWriter.hpp>
@@ -39,6 +40,7 @@
 #include <networkit/io/KONECTGraphReader.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/io/METISGraphWriter.hpp>
+#include <networkit/io/MTXGraphReader.hpp>
 #include <networkit/io/MatrixMarketReader.hpp>
 #include <networkit/io/NetworkitBinaryGraph.hpp>
 #include <networkit/io/NetworkitBinaryReader.hpp>
@@ -1257,6 +1259,16 @@ TEST_F(IOGTest, testMatrixMarketReaderUnweightedUndirected) {
     EXPECT_EQ(csr(26, 13), 1.0);
     csr.forNonZeroElementsInRowOrder(
         [&](index i, index j, double) { EXPECT_EQ(csr(i, j), csr(j, i)); });
+
+    // check that the MTXGraphReader is equivalent
+    Graph G = MTXGraphReader{}.read("input/chesapeake.mtx");
+    Graph G_from_csr = MatrixTools::matrixToGraph(csr);
+    EXPECT_EQ(G.numberOfNodes(), G_from_csr.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), G_from_csr.numberOfEdges());
+    G.forEdges([&](node u, node v, edgeweight w) {
+        EXPECT_TRUE(G_from_csr.hasEdge(u, v));
+        EXPECT_EQ(G_from_csr.weight(u, v), w);
+    });
 }
 
 TEST_F(IOGTest, testMatrixMarketReaderUnweightedDirected) {
@@ -1269,6 +1281,16 @@ TEST_F(IOGTest, testMatrixMarketReaderUnweightedDirected) {
     EXPECT_EQ(csr(3, 9), 1.0);
     EXPECT_EQ(csr(11, 12), 1.0);
     EXPECT_EQ(csr(17, 13), 1.0);
+
+    // check that the MTXGraphReader is equivalent
+    Graph G = MTXGraphReader{}.read("input/GD01_b.mtx");
+    Graph G_from_csr = MatrixTools::matrixToGraph(csr);
+    EXPECT_EQ(G.numberOfNodes(), G_from_csr.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), G_from_csr.numberOfEdges());
+    G.forEdges([&](node u, node v, edgeweight w) {
+        EXPECT_TRUE(G_from_csr.hasEdge(u, v));
+        EXPECT_EQ(G_from_csr.weight(u, v), w);
+    });
 }
 
 TEST_F(IOGTest, testMatrixMarketReaderWeightedUndirected) {
@@ -1284,6 +1306,16 @@ TEST_F(IOGTest, testMatrixMarketReaderWeightedUndirected) {
     EXPECT_EQ(csr(13, 11), 94.2528);
     csr.forNonZeroElementsInRowOrder(
         [&](index i, index j, double) { EXPECT_EQ(csr(i, j), csr(j, i)); });
+
+    // check that the MTXGraphReader is equivalent
+    Graph G = MTXGraphReader{}.read("input/LFAT5.mtx");
+    Graph G_from_csr = MatrixTools::matrixToGraph(csr);
+    EXPECT_EQ(G.numberOfNodes(), G_from_csr.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), G_from_csr.numberOfEdges());
+    G.forEdges([&](node u, node v, edgeweight w) {
+        EXPECT_TRUE(G_from_csr.hasEdge(u, v));
+        EXPECT_EQ(G_from_csr.weight(u, v), w);
+    });
 }
 
 TEST_F(IOGTest, testMatrixMarketReaderWeightedDirected) {
@@ -1296,6 +1328,16 @@ TEST_F(IOGTest, testMatrixMarketReaderWeightedDirected) {
     EXPECT_EQ(csr(5, 9), -0.2039265503510711);
     EXPECT_EQ(csr(9, 16), 0.2213493690543944);
     EXPECT_EQ(csr(11, 23), 0.04492168652740657);
+
+    // check that the MTXGraphReader is equivalent
+    Graph G = MTXGraphReader{}.read("input/Hamrle1.mtx");
+    Graph G_from_csr = MatrixTools::matrixToGraph(csr);
+    EXPECT_EQ(G.numberOfNodes(), G_from_csr.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), G_from_csr.numberOfEdges());
+    G.forEdges([&](node u, node v, edgeweight w) {
+        EXPECT_TRUE(G_from_csr.hasEdge(u, v));
+        EXPECT_EQ(G_from_csr.weight(u, v), w);
+    });
 }
 
 TEST_F(IOGTest, testMatrixMarketReaderIntegerWeights) {
@@ -1308,6 +1350,16 @@ TEST_F(IOGTest, testMatrixMarketReaderIntegerWeights) {
     EXPECT_EQ(csr(23, 9), 2.0);
     EXPECT_EQ(csr(4, 10), 4.0);
     EXPECT_EQ(csr(21, 21), 6.0);
+
+    // check that the MTXGraphReader is equivalent
+    Graph G = MTXGraphReader{}.read("input/Ragusa16.mtx");
+    Graph G_from_csr = MatrixTools::matrixToGraph(csr);
+    EXPECT_EQ(G.numberOfNodes(), G_from_csr.numberOfNodes());
+    EXPECT_EQ(G.numberOfEdges(), G_from_csr.numberOfEdges());
+    G.forEdges([&](node u, node v, edgeweight w) {
+        EXPECT_TRUE(G_from_csr.hasEdge(u, v));
+        EXPECT_EQ(G_from_csr.weight(u, v), w);
+    });
 }
 
 } /* namespace NetworKit */


### PR DESCRIPTION
This PR finalizes #1132 with the additional tests. Note that the original code has been slightly adjusted, namely the `MTXGraphReader.cpp` now uses `addEdge()` instead of `addPartialEdge()` which resulted in a incomplete Graph data structure in some cases. 