### PR TITLE
cpp: fix bug in DynDijkstra and adjust test

### DIFF
--- a/networkit/cpp/distance/DynDijkstra.cpp
+++ b/networkit/cpp/distance/DynDijkstra.cpp
@@ -149,6 +149,11 @@ void DynDijkstra::updateBatch(const std::vector<GraphEvent> &batch) {
     while (!updateHeap.empty()) {
         mod = true;
         node current = updateHeap.extract_top();
+        // the previous vector for the current node is potentially outdated and will be refilled
+        // during the update
+        if (storePreds) {
+            previous[current].clear();
+        }
         if (color[current] == BLACK
             && Aux::NumericTools::logically_equal(updateDistances[current], distances[current])) {
             auto tmp = npaths[current];

--- a/networkit/cpp/distance/test/DynSSSPGTest.cpp
+++ b/networkit/cpp/distance/test/DynSSSPGTest.cpp
@@ -471,6 +471,7 @@ TEST_F(DynSSSPGTest, testDynamicDijkstraBatchesEdgeDeletions) {
         G.forNodes([&](node i) {
             EXPECT_EQ(dyn_dij.distance(i), dij.distance(i));
             EXPECT_EQ(dyn_dij.numberOfPaths(i), dij.numberOfPaths(i));
+            EXPECT_EQ(dyn_dij.getPaths(i), dij.getPaths(i));
             if (i != source) {
                 EXPECT_NE(dyn_dij.distance(i), 0);
             }


### PR DESCRIPTION
This PR addresses the [issue](https://github.com/orgs/networkit/projects/1/views/1?pane=issue&itemId=59028430) whereby the DynDijkstra algorithm did not properly adjust the previous vector that is being used to construct the shortest paths. Furthermore it adds the corresponding test in the already existing DynDijkstra test-suite. 