### PR TITLE
Fixes to TopologicalSort

### DIFF
--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -422,7 +422,7 @@ void sortEdgesByWeight(Graph &G, bool decreasing = false);
  * @return                  A vector of node-ids sorted according to their topology.
  */
 std::vector<node> topologicalSort(const Graph &G,
-                                  std::unordered_map<node, node> &nodeIdMapping = defaultNodeIdMap,
+                                  const std::unordered_map<node, node> &nodeIdMapping = {},
                                   bool checkMapping = false);
 
 /**

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -412,13 +412,18 @@ void sortEdgesByWeight(Graph &G, bool decreasing = false);
  * Given a directed graph G, the topology sort algorithm creates one valid topology order of nodes.
  * Undirected graphs are not accepted as input, since a topology sort is a linear ordering of
  * vertices such that for every edge u -> v, node u comes before v in the ordering.
+ * Node ids must either be continuous or you must provide a continuous node id mapping.
  *
  * This is a helper function. Instead of calling it via GraphTools, it is also possible to create a
  * TopologicalSort-object from the base-class.
- * @param   G           Directed input graph
- * @return              A vector of node-ids sorted according to their topology.
+ * @param   G               Directed input graph
+ * @param   nodeIdMapping   Optional continuous node id mapping
+ * @return                  A vector of node-ids sorted according to their topology.
  */
 std::vector<node> topologicalSort(const Graph &G);
+
+std::vector<node> topologicalSort(const Graph &G,
+                                  const std::unordered_map<node, node> &nodeIdMapping);
 
 /**
  * Randomizes the weights of the given graph. The weights are uniformly distributed in

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include "networkit/graph/TopologicalSort.hpp"
 
 #include <tlx/unused.hpp>
 #include <networkit/GlobalState.hpp>
@@ -420,9 +421,8 @@ void sortEdgesByWeight(Graph &G, bool decreasing = false);
  * @param   nodeIdMapping   Optional continuous node id mapping
  * @return                  A vector of node-ids sorted according to their topology.
  */
-std::vector<node> topologicalSort(const Graph &G);
-
-std::vector<node> topologicalSort(const Graph &G, std::unordered_map<node, node> &nodeIdMapping,
+std::vector<node> topologicalSort(const Graph &G,
+                                  std::unordered_map<node, node> &nodeIdMapping = defaultNodeIdMap,
                                   bool checkMapping = false);
 
 /**

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -422,8 +422,8 @@ void sortEdgesByWeight(Graph &G, bool decreasing = false);
  */
 std::vector<node> topologicalSort(const Graph &G);
 
-std::vector<node> topologicalSort(const Graph &G,
-                                  const std::unordered_map<node, node> &nodeIdMapping);
+std::vector<node> topologicalSort(const Graph &G, std::unordered_map<node, node> &nodeIdMapping,
+                                  bool checkMapping = false);
 
 /**
  * Randomizes the weights of the given graph. The weights are uniformly distributed in

--- a/include/networkit/graph/TopologicalSort.hpp
+++ b/include/networkit/graph/TopologicalSort.hpp
@@ -7,6 +7,7 @@
 #ifndef NETWORKIT_GRAPH_TOPOLOGICAL_SORT_HPP_
 #define NETWORKIT_GRAPH_TOPOLOGICAL_SORT_HPP_
 
+#include <unordered_map>
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
 
@@ -21,11 +22,19 @@ class TopologicalSort final : public Algorithm {
 public:
     /**
      * Initialize the topological sort algorithm by passing an input graph. Note that topological
-     * sort is defined for directed graphs only.
+     * sort is defined for directed graphs only. Node ids must be continuous in the interval [0, n).
      *
      * @param G The input graph.
      */
     TopologicalSort(const Graph &G);
+
+    /**
+     * Initialize the topological sort algorithm by passing an input graph. Note that topological
+     * sort is defined for directed graphs only. The node id mapping must be a continuous.
+     *
+     * @param G The input graph.
+     */
+    TopologicalSort(const Graph &G, const std::unordered_map<node, node> &nodeIdMapping);
 
     /**
      * Execute the algorithm. The algorithm is not parallel.
@@ -47,6 +56,8 @@ private:
 
     const Graph *G;
 
+    const std::unordered_map<node, node> *nodeIdMap;
+
     // Used to mark the status of each node, one vector per thread
     std::vector<NodeMark> topSortMark;
 
@@ -55,6 +66,8 @@ private:
 
     // Helper structures
     count current;
+
+    void checkDirected();
 
     // Reset algorithm data structure
     void reset();

--- a/include/networkit/graph/TopologicalSort.hpp
+++ b/include/networkit/graph/TopologicalSort.hpp
@@ -59,7 +59,7 @@ private:
     const Graph *G;
 
     std::optional<std::unordered_map<node, node>> computedNodeIdMap;
-    
+
     std::unordered_map<node, node> * nodeIdMap;
 
     // Used to mark the status of each node, one vector per thread

--- a/include/networkit/graph/TopologicalSort.hpp
+++ b/include/networkit/graph/TopologicalSort.hpp
@@ -7,6 +7,7 @@
 #ifndef NETWORKIT_GRAPH_TOPOLOGICAL_SORT_HPP_
 #define NETWORKIT_GRAPH_TOPOLOGICAL_SORT_HPP_
 
+#include <optional>
 #include <unordered_map>
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
@@ -34,7 +35,8 @@ public:
      *
      * @param G The input graph.
      */
-    TopologicalSort(const Graph &G, const std::unordered_map<node, node> &nodeIdMapping);
+    TopologicalSort(const Graph &G, std::unordered_map<node, node> &nodeIdMapping,
+                    bool checkMapping = false);
 
     /**
      * Execute the algorithm. The algorithm is not parallel.
@@ -56,7 +58,9 @@ private:
 
     const Graph *G;
 
-    const std::unordered_map<node, node> *nodeIdMap;
+    std::optional<std::unordered_map<node, node>> computedNodeIdMap;
+    
+    std::unordered_map<node, node> *nodeIdMap;
 
     // Used to mark the status of each node, one vector per thread
     std::vector<NodeMark> topSortMark;

--- a/include/networkit/graph/TopologicalSort.hpp
+++ b/include/networkit/graph/TopologicalSort.hpp
@@ -14,6 +14,8 @@
 
 namespace NetworKit {
 
+static std::unordered_map<node, node> defaultNodeIdMap = {};
+
 /**
  * Given a directed graph G, the topology sort algorithm creates one valid topology order of nodes.
  * Undirected graphs are not accepted as input, since a topology sort is a linear ordering of
@@ -23,19 +25,12 @@ class TopologicalSort final : public Algorithm {
 public:
     /**
      * Initialize the topological sort algorithm by passing an input graph. Note that topological
-     * sort is defined for directed graphs only. Node ids must be continuous in the interval [0, n).
-     *
-     * @param G The input graph.
-     */
-    TopologicalSort(const Graph &G);
-
-    /**
-     * Initialize the topological sort algorithm by passing an input graph. Note that topological
      * sort is defined for directed graphs only. The node id mapping must be a continuous.
      *
      * @param G The input graph.
      */
-    TopologicalSort(const Graph &G, std::unordered_map<node, node> &nodeIdMapping,
+    TopologicalSort(const Graph &G,
+                    std::unordered_map<node, node> &nodeIdMapping = defaultNodeIdMap,
                     bool checkMapping = false);
 
     /**
@@ -56,11 +51,11 @@ public:
 private:
     enum class NodeMark : unsigned char { NONE, TEMP, PERM };
 
-    const Graph *G;
+    const Graph &G;
 
     std::optional<std::unordered_map<node, node>> computedNodeIdMap;
 
-    std::unordered_map<node, node> *nodeIdMap;
+    std::unordered_map<node, node> &nodeIdMap;
 
     // Used to mark the status of each node, one vector per thread
     std::vector<NodeMark> topSortMark;
@@ -74,6 +69,8 @@ private:
     void checkDirected();
 
     void checkNodeIdMap();
+
+    node mapNode(node u);
 
     // Reset algorithm data structure
     void reset();

--- a/include/networkit/graph/TopologicalSort.hpp
+++ b/include/networkit/graph/TopologicalSort.hpp
@@ -14,8 +14,6 @@
 
 namespace NetworKit {
 
-static std::unordered_map<node, node> defaultNodeIdMap = {};
-
 /**
  * Given a directed graph G, the topology sort algorithm creates one valid topology order of nodes.
  * Undirected graphs are not accepted as input, since a topology sort is a linear ordering of
@@ -29,8 +27,7 @@ public:
      *
      * @param G The input graph.
      */
-    TopologicalSort(const Graph &G,
-                    std::unordered_map<node, node> &nodeIdMapping = defaultNodeIdMap,
+    TopologicalSort(const Graph &G, const std::unordered_map<node, node> &nodeIdMapping = {},
                     bool checkMapping = false);
 
     /**
@@ -55,7 +52,7 @@ private:
 
     std::optional<std::unordered_map<node, node>> computedNodeIdMap;
 
-    std::unordered_map<node, node> &nodeIdMap;
+    const std::unordered_map<node, node> &nodeIdMap;
 
     // Used to mark the status of each node, one vector per thread
     std::vector<NodeMark> topSortMark;

--- a/include/networkit/graph/TopologicalSort.hpp
+++ b/include/networkit/graph/TopologicalSort.hpp
@@ -60,7 +60,7 @@ private:
 
     std::optional<std::unordered_map<node, node>> computedNodeIdMap;
 
-    std::unordered_map<node, node> * nodeIdMap;
+    std::unordered_map<node, node> *nodeIdMap;
 
     // Used to mark the status of each node, one vector per thread
     std::vector<NodeMark> topSortMark;

--- a/include/networkit/graph/TopologicalSort.hpp
+++ b/include/networkit/graph/TopologicalSort.hpp
@@ -60,7 +60,7 @@ private:
 
     std::optional<std::unordered_map<node, node>> computedNodeIdMap;
     
-    std::unordered_map<node, node> *nodeIdMap;
+    std::unordered_map<node, node> * nodeIdMap;
 
     // Used to mark the status of each node, one vector per thread
     std::vector<NodeMark> topSortMark;
@@ -72,6 +72,8 @@ private:
     count current;
 
     void checkDirected();
+
+    void checkNodeIdMap();
 
     // Reset algorithm data structure
     void reset();

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -514,7 +514,7 @@ void sortEdgesByWeight(Graph &G, bool decreasing) {
 }
 
 std::vector<node> topologicalSort(const Graph &G,
-                                  std::unordered_map<node, node> &nodeIdMapping,
+                                  const std::unordered_map<node, node> &nodeIdMapping,
                                   bool checkMapping) {
     TopologicalSort topSort(G, nodeIdMapping, checkMapping);
     topSort.run();

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -520,9 +520,9 @@ std::vector<node> topologicalSort(const Graph &G) {
     return topSort.getResult();
 }
 
-std::vector<node> topologicalSort(const Graph &G,
-                                  const std::unordered_map<node, node> &nodeIdMapping) {
-    TopologicalSort topSort(G, nodeIdMapping);
+std::vector<node> topologicalSort(const Graph &G, std::unordered_map<node, node> &nodeIdMapping,
+                                  bool checkMapping) {
+    TopologicalSort topSort(G, nodeIdMapping, checkMapping);
     topSort.run();
 
     return topSort.getResult();

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -513,14 +513,8 @@ void sortEdgesByWeight(Graph &G, bool decreasing) {
         });
 }
 
-std::vector<node> topologicalSort(const Graph &G) {
-    TopologicalSort topSort(G);
-    topSort.run();
-
-    return topSort.getResult();
-}
-
-std::vector<node> topologicalSort(const Graph &G, std::unordered_map<node, node> &nodeIdMapping,
+std::vector<node> topologicalSort(const Graph &G,
+                                  std::unordered_map<node, node> &nodeIdMapping,
                                   bool checkMapping) {
     TopologicalSort topSort(G, nodeIdMapping, checkMapping);
     topSort.run();

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -520,5 +520,13 @@ std::vector<node> topologicalSort(const Graph &G) {
     return topSort.getResult();
 }
 
+std::vector<node> topologicalSort(const Graph &G,
+                                  const std::unordered_map<node, node> &nodeIdMapping) {
+    TopologicalSort topSort(G, nodeIdMapping);
+    topSort.run();
+
+    return topSort.getResult();
+}
+
 } // namespace GraphTools
 } // namespace NetworKit

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -5,7 +5,7 @@
  *      Author: Fabian Brandt-Tumescheit
  */
 #include <stdexcept>
-#include "networkit/graph/GraphTools.hpp"
+#include <networkit/graph/GraphTools.hpp>
 #include <networkit/graph/TopologicalSort.hpp>
 
 namespace NetworKit {

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -11,7 +11,7 @@
 namespace NetworKit {
 
 TopologicalSort::TopologicalSort(const Graph &G)
-    : G(&G), nodeIdMap(nullptr), computedNodeIdMap({}) {
+    : G(&G), computedNodeIdMap(GraphTools::getContinuousNodeIds(G)) {
     checkDirected();
     if (G.upperNodeIdBound() != G.numberOfNodes() - 1) {
         computedNodeIdMap = GraphTools::getContinuousNodeIds(G);
@@ -23,11 +23,29 @@ TopologicalSort::TopologicalSort(const Graph &G, std::unordered_map<node, node> 
                                  bool checkMapping)
     : G(&G), nodeIdMap(&nodeIdMap), computedNodeIdMap({}) {
     checkDirected();
+    if (checkMapping) {
+        checkNodeIdMap();
+    }
 }
 
 void TopologicalSort::checkDirected() {
     if (!G->isDirected())
         throw std::runtime_error("Topological sort is defined for directed graphs only.");
+}
+
+void TopologicalSort::checkNodeIdMap() {
+    size_t numberOfNodes = G->numberOfNodes();
+    if (nodeIdMap->size() != numberOfNodes)
+        throw std::runtime_error("Node id mapping contains an incorrect number of entries");
+
+    std::vector<bool> checkTable(numberOfNodes);
+    for (auto it = nodeIdMap->begin(); it != nodeIdMap->end(); it++) {
+        node mappedNode = it->second;
+        if (mappedNode < numberOfNodes && !checkTable[mappedNode])
+            checkTable[mappedNode] = true;
+        else
+            throw std::runtime_error("Node id mapping is not continuous.");
+    }
 }
 
 void TopologicalSort::run() {

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -13,8 +13,7 @@ TopologicalSort::TopologicalSort(const Graph &G) : G(&G), nodeIdMap(nullptr) {
     checkDirected();
 }
 
-TopologicalSort::TopologicalSort(const Graph &G,
-                                 const std::unordered_map<node, node> &nodeIdMap)
+TopologicalSort::TopologicalSort(const Graph &G, const std::unordered_map<node, node> &nodeIdMap)
     : G(&G), nodeIdMap(&nodeIdMap) {
     checkDirected();
 }

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -21,7 +21,7 @@ TopologicalSort::TopologicalSort(const Graph &G)
 
 TopologicalSort::TopologicalSort(const Graph &G, std::unordered_map<node, node> &nodeIdMap,
                                  bool checkMapping)
-    : G(&G), nodeIdMap(&nodeIdMap), computedNodeIdMap({}) {
+    : G(&G), computedNodeIdMap({}), nodeIdMap(&nodeIdMap) {
     checkDirected();
     size_t numberOfNodes = G.numberOfNodes();
     if (nodeIdMap.size() != numberOfNodes)

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -10,9 +10,9 @@
 
 namespace NetworKit {
 
-TopologicalSort::TopologicalSort(const Graph &G, std::unordered_map<node, node> &nodeIdMap,
+TopologicalSort::TopologicalSort(const Graph &G, const std::unordered_map<node, node> &nodeIdMap,
                                  bool checkMapping)
-    : G(G), computedNodeIdMap({}), nodeIdMap(nodeIdMap) {
+    : G(G), nodeIdMap(nodeIdMap) {
     checkDirected();
     size_t numberOfNodes = G.numberOfNodes();
     if (!nodeIdMap.empty()) {
@@ -21,8 +21,7 @@ TopologicalSort::TopologicalSort(const Graph &G, std::unordered_map<node, node> 
                 "Node id mapping should contain exactly one entry for every node.");
         else if (checkMapping)
             checkNodeIdMap();
-    }
-    else {
+    } else {
         if (G.upperNodeIdBound() != numberOfNodes - 1) {
             computedNodeIdMap = GraphTools::getContinuousNodeIds(G);
         }
@@ -37,7 +36,7 @@ void TopologicalSort::checkDirected() {
 void TopologicalSort::checkNodeIdMap() {
     size_t numberOfNodes = G.numberOfNodes();
     std::vector<bool> checkTable(numberOfNodes);
-    for (auto& [origNode, mappedNode] : nodeIdMap) {
+    for (auto &[origNode, mappedNode] : nodeIdMap) {
         if (mappedNode < numberOfNodes && !checkTable[mappedNode])
             checkTable[mappedNode] = true;
         else
@@ -85,10 +84,16 @@ void TopologicalSort::run() {
 }
 
 node TopologicalSort::mapNode(node u) {
-    if (!nodeIdMap.empty())
-        return nodeIdMap[u];
-    else if (computedNodeIdMap.has_value())
-        return computedNodeIdMap.value()[u];
+    if (!nodeIdMap.empty()) {
+        auto it = nodeIdMap.find(u);
+        if (it == nodeIdMap.cend()) {
+            std::stringstream errorMsg;
+            errorMsg << "Node id mapping does not contain node " << u;
+            throw std::runtime_error(errorMsg.str());
+        }
+        return it->second;
+    } else if (computedNodeIdMap.has_value())
+        return computedNodeIdMap.value().at(u);
     else
         return u;
 }

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -23,9 +23,13 @@ TopologicalSort::TopologicalSort(const Graph &G, std::unordered_map<node, node> 
                                  bool checkMapping)
     : G(&G), nodeIdMap(&nodeIdMap), computedNodeIdMap({}) {
     checkDirected();
-    if (checkMapping) {
+    size_t numberOfNodes = G.numberOfNodes();
+    if (nodeIdMap.size() != numberOfNodes)
+        throw std::runtime_error(
+            "Node id mapping should contain exactly one entry for every node.");
+
+    if (checkMapping)
         checkNodeIdMap();
-    }
 }
 
 void TopologicalSort::checkDirected() {
@@ -35,9 +39,6 @@ void TopologicalSort::checkDirected() {
 
 void TopologicalSort::checkNodeIdMap() {
     size_t numberOfNodes = G->numberOfNodes();
-    if (nodeIdMap->size() != numberOfNodes)
-        throw std::runtime_error("Node id mapping contains an incorrect number of entries");
-
     std::vector<bool> checkTable(numberOfNodes);
     for (auto it = nodeIdMap->begin(); it != nodeIdMap->end(); it++) {
         node mappedNode = it->second;

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -10,38 +10,34 @@
 
 namespace NetworKit {
 
-TopologicalSort::TopologicalSort(const Graph &G)
-    : G(&G), computedNodeIdMap(GraphTools::getContinuousNodeIds(G)) {
+TopologicalSort::TopologicalSort(const Graph &G, std::unordered_map<node, node> &nodeIdMap,
+                                 bool checkMapping)
+    : G(G), computedNodeIdMap({}), nodeIdMap(nodeIdMap) {
     checkDirected();
-    if (G.upperNodeIdBound() != G.numberOfNodes() - 1) {
-        computedNodeIdMap = GraphTools::getContinuousNodeIds(G);
-        nodeIdMap = &computedNodeIdMap.value();
+    size_t numberOfNodes = G.numberOfNodes();
+    if (!nodeIdMap.empty()) {
+        if (nodeIdMap.size() != numberOfNodes)
+            throw std::runtime_error(
+                "Node id mapping should contain exactly one entry for every node.");
+        else if (checkMapping)
+            checkNodeIdMap();
+    }
+    else {
+        if (G.upperNodeIdBound() != numberOfNodes - 1) {
+            computedNodeIdMap = GraphTools::getContinuousNodeIds(G);
+        }
     }
 }
 
-TopologicalSort::TopologicalSort(const Graph &G, std::unordered_map<node, node> &nodeIdMap,
-                                 bool checkMapping)
-    : G(&G), computedNodeIdMap({}), nodeIdMap(&nodeIdMap) {
-    checkDirected();
-    size_t numberOfNodes = G.numberOfNodes();
-    if (nodeIdMap.size() != numberOfNodes)
-        throw std::runtime_error(
-            "Node id mapping should contain exactly one entry for every node.");
-
-    if (checkMapping)
-        checkNodeIdMap();
-}
-
 void TopologicalSort::checkDirected() {
-    if (!G->isDirected())
+    if (!G.isDirected())
         throw std::runtime_error("Topological sort is defined for directed graphs only.");
 }
 
 void TopologicalSort::checkNodeIdMap() {
-    size_t numberOfNodes = G->numberOfNodes();
+    size_t numberOfNodes = G.numberOfNodes();
     std::vector<bool> checkTable(numberOfNodes);
-    for (auto it = nodeIdMap->begin(); it != nodeIdMap->end(); it++) {
-        node mappedNode = it->second;
+    for (auto& [origNode, mappedNode] : nodeIdMap) {
         if (mappedNode < numberOfNodes && !checkTable[mappedNode])
             checkTable[mappedNode] = true;
         else
@@ -54,24 +50,15 @@ void TopologicalSort::run() {
 
     std::stack<node> nodeStack;
 
-    G->forNodes([&](node u) {
-        node mappedU;
-        if (nodeIdMap != nullptr)
-            mappedU = (*nodeIdMap)[u];
-        else
-            mappedU = u;
-
+    G.forNodes([&](node u) {
+        node mappedU = mapNode(u);
         if (topSortMark[mappedU] == NodeMark::PERM)
             return;
 
         nodeStack.push(u);
         do {
             node v = nodeStack.top();
-            node mappedV;
-            if (nodeIdMap != nullptr)
-                mappedV = (*nodeIdMap)[v];
-            else
-                mappedV = v;
+            node mappedV = mapNode(v);
 
             if (topSortMark[mappedV] != NodeMark::NONE) {
                 nodeStack.pop();
@@ -82,12 +69,8 @@ void TopologicalSort::run() {
                 }
             } else {
                 topSortMark[mappedV] = NodeMark::TEMP;
-                G->forNeighborsOf(v, [&](node w) {
-                    node mappedW;
-                    if (nodeIdMap != nullptr)
-                        mappedW = (*nodeIdMap)[w];
-                    else
-                        mappedW = w;
+                G.forNeighborsOf(v, [&](node w) {
+                    node mappedW = mapNode(w);
 
                     if (topSortMark[mappedW] == NodeMark::NONE)
                         nodeStack.push(w);
@@ -101,9 +84,18 @@ void TopologicalSort::run() {
     hasRun = true;
 }
 
+node TopologicalSort::mapNode(node u) {
+    if (!nodeIdMap.empty())
+        return nodeIdMap[u];
+    else if (computedNodeIdMap.has_value())
+        return computedNodeIdMap.value()[u];
+    else
+        return u;
+}
+
 void TopologicalSort::reset() {
     // Reset node marks
-    count n = G->numberOfNodes();
+    count n = G.numberOfNodes();
     if (n == 0)
         throw std::runtime_error("Graph should contain at least one node.");
 

--- a/networkit/cpp/graph/test/TopologicalSortGTest.cpp
+++ b/networkit/cpp/graph/test/TopologicalSortGTest.cpp
@@ -7,24 +7,18 @@
 
 #include <networkit/graph/TopologicalSort.hpp>
 
-#include <iostream>
+#include <stdexcept>
 #include <gtest/gtest.h>
 
 namespace NetworKit {
 
-class TopologicalSortGTest : public testing::TestWithParam<bool> {
+class TopologicalSortGTest : public testing::Test {
 protected:
-    bool directed() const noexcept;
+    Graph inputGraph(bool directed) const noexcept;
 };
 
-INSTANTIATE_TEST_SUITE_P(InstantiationName, TopologicalSortGTest, testing::Values(false, true));
-
-bool TopologicalSortGTest::directed() const noexcept {
-    return GetParam();
-}
-
-TEST_P(TopologicalSortGTest, testTopologicalSort) {
-    auto G = Graph(5, false, directed());
+Graph TopologicalSortGTest::inputGraph(bool directed) const noexcept {
+    auto G = Graph(5, false, directed);
 
     /**
      * /--> 1 --> 3
@@ -40,37 +34,85 @@ TEST_P(TopologicalSortGTest, testTopologicalSort) {
     G.addEdge(1, 3);
     G.addEdge(4, 2);
 
-    if (directed()) {
-        TopologicalSort topSort = TopologicalSort(G);
-        topSort.run();
-        std::vector<node> res = topSort.getResult();
+    return G;
+}
 
-        // Test for valid topology
-        auto indexNode0 = std::distance(res.begin(), std::find(res.begin(), res.end(), 0));
-        auto indexNode1 = std::distance(res.begin(), std::find(res.begin(), res.end(), 1));
-        auto indexNode2 = std::distance(res.begin(), std::find(res.begin(), res.end(), 2));
-        auto indexNode3 = std::distance(res.begin(), std::find(res.begin(), res.end(), 3));
-        auto indexNode4 = std::distance(res.begin(), std::find(res.begin(), res.end(), 4));
-        // node 2 is depending on node 0
-        EXPECT_TRUE(indexNode2 > indexNode0);
-        // node 2 is depending on node 4
-        EXPECT_TRUE(indexNode2 > indexNode4);
-        // node 1 is depending on node 2
-        EXPECT_TRUE(indexNode1 > indexNode2);
-        // node 3 is depending on node 1
-        EXPECT_TRUE(indexNode3 > indexNode1);
+TEST_F(TopologicalSortGTest, testTopologicalSort) {
+    auto G = inputGraph(true);
 
-        // Test for repeated runs
-        topSort.run();
-        std::vector<node> res2 = topSort.getResult();
-        EXPECT_TRUE(res == res2);
+    TopologicalSort topSort = TopologicalSort(G);
+    topSort.run();
+    std::vector<node> res = topSort.getResult();
 
-        // Test cycle detection
-        G.addEdge(3, 4);
-        topSort = TopologicalSort(G);
-        EXPECT_ANY_THROW(topSort.run());
-    } else {
-        EXPECT_ANY_THROW(new TopologicalSort(G));
-    }
+    // Test for valid topology
+    auto indexNode0 = std::distance(res.begin(), std::find(res.begin(), res.end(), 0));
+    auto indexNode1 = std::distance(res.begin(), std::find(res.begin(), res.end(), 1));
+    auto indexNode2 = std::distance(res.begin(), std::find(res.begin(), res.end(), 2));
+    auto indexNode3 = std::distance(res.begin(), std::find(res.begin(), res.end(), 3));
+    auto indexNode4 = std::distance(res.begin(), std::find(res.begin(), res.end(), 4));
+    EXPECT_EQ(res.size(), 5);
+    // node 2 is depending on node 0
+    EXPECT_TRUE(indexNode2 > indexNode0);
+    // node 2 is depending on node 4
+    EXPECT_TRUE(indexNode2 > indexNode4);
+    // node 1 is depending on node 2
+    EXPECT_TRUE(indexNode1 > indexNode2);
+    // node 3 is depending on node 1
+    EXPECT_TRUE(indexNode3 > indexNode1);
+}
+
+TEST_F(TopologicalSortGTest, testRepeatedRuns) {
+    auto G = inputGraph(true);
+    TopologicalSort topSort = TopologicalSort(G);
+    topSort.run();
+    std::vector<node> res = topSort.getResult();
+    topSort = TopologicalSort(G);
+    topSort.run();
+    std::vector<node> res2 = topSort.getResult();
+    EXPECT_TRUE(res == res2);
+}
+
+TEST_F(TopologicalSortGTest, testRejectGraphWithCycles) {
+    auto G = inputGraph(true);
+    G.addEdge(3, 4);
+    TopologicalSort topSort = TopologicalSort(G);
+    EXPECT_THROW(topSort.run(), std::runtime_error);
+}
+
+TEST_F(TopologicalSortGTest, testRejectUndirectedGraph) {
+    EXPECT_THROW(TopologicalSort(inputGraph(false)), std::runtime_error);
+}
+
+TEST_F(TopologicalSortGTest, testRejectNonContinuousNodeIds) {
+    auto G = inputGraph(true);
+    G.removeNode(3);
+    TopologicalSort topSort = TopologicalSort(G);
+    EXPECT_THROW(topSort.run(), std::runtime_error);
+}
+
+TEST_F(TopologicalSortGTest, testHandleNodeIdMapping) {
+    auto G = inputGraph(true);
+    G.removeNode(3);
+    std::unordered_map<node, node> mapping;
+    mapping[0] = 0;
+    mapping[1] = 1;
+    mapping[2] = 2;
+    mapping[4] = 3;
+    TopologicalSort topSort = TopologicalSort(G, mapping);
+    topSort.run();
+    std::vector<node> res = topSort.getResult();
+
+    // Test for valid topology
+    auto indexNode0 = std::distance(res.begin(), std::find(res.begin(), res.end(), 0));
+    auto indexNode1 = std::distance(res.begin(), std::find(res.begin(), res.end(), 1));
+    auto indexNode2 = std::distance(res.begin(), std::find(res.begin(), res.end(), 2));
+    auto indexNode4 = std::distance(res.begin(), std::find(res.begin(), res.end(), 4));
+    EXPECT_EQ(res.size(), 4);
+    // node 2 is depending on node 0
+    EXPECT_TRUE(indexNode2 > indexNode0);
+    // node 2 is depending on node 4
+    EXPECT_TRUE(indexNode2 > indexNode4);
+    // node 1 is depending on node 2
+    EXPECT_TRUE(indexNode1 > indexNode2);
 }
 } // namespace NetworKit

--- a/networkit/cpp/graph/test/TopologicalSortGTest.cpp
+++ b/networkit/cpp/graph/test/TopologicalSortGTest.cpp
@@ -51,7 +51,7 @@ std::unordered_map<node, node> TopologicalSortGTest::makeMapping() const noexcep
 }
 
 void TopologicalSortGTest::assertTopological(Graph &G, std::vector<node> &sort) {
-    std::vector<node> indices(G.numberOfNodes());
+    std::unordered_map<node, node> indices;
     EXPECT_EQ(sort.size(), G.numberOfNodes());
     G.forNodes([&](node u) {
         indices[u] = std::distance(sort.begin(), std::find(sort.begin(), sort.end(), u));

--- a/networkit/cpp/graph/test/TopologicalSortGTest.cpp
+++ b/networkit/cpp/graph/test/TopologicalSortGTest.cpp
@@ -128,6 +128,14 @@ TEST_F(TopologicalSortGTest, testNonContinuousNodeIdMapping) {
     std::unordered_map<node, node> mapping = makeMapping();
     mapping[1] = 4;
     EXPECT_THROW(TopologicalSort(G, mapping, true), std::runtime_error);
+
+    mapping = makeMapping();
+    mapping.erase(1);
+    // to get correct size
+    mapping[5] = 5;
+    EXPECT_THROW(TopologicalSort(G, mapping, true), std::runtime_error);
+    TopologicalSort topSort = TopologicalSort(G, mapping);
+    EXPECT_THROW(topSort.run(), std::runtime_error);
 }
 
 TEST_F(TopologicalSortGTest, testNonInjectiveNodeIdMapping) {

--- a/networkit/cpp/graph/test/TopologicalSortGTest.cpp
+++ b/networkit/cpp/graph/test/TopologicalSortGTest.cpp
@@ -130,6 +130,18 @@ TEST_F(TopologicalSortGTest, testCustomNodeIdMapping) {
     EXPECT_TRUE(indexNode1 > indexNode2);
 }
 
+TEST_F(TopologicalSortGTest, testWrongSizeOfNodeIdMapping) {
+    auto G = inputGraph(true);
+    G.removeNode(3);
+    std::unordered_map<node, node> mapping;
+    mapping[0] = 0;
+    mapping[1] = 1;
+    mapping[2] = 2;
+    mapping[4] = 3;
+    mapping[5] = 4;
+    EXPECT_THROW(TopologicalSort(G, mapping), std::runtime_error);
+}
+
 TEST_F(TopologicalSortGTest, testNonContinuousNodeIdMapping) {
     auto G = inputGraph(true);
     G.removeNode(3);

--- a/networkit/cpp/graph/test/TopologicalSortGTest.cpp
+++ b/networkit/cpp/graph/test/TopologicalSortGTest.cpp
@@ -129,4 +129,26 @@ TEST_F(TopologicalSortGTest, testCustomNodeIdMapping) {
     // node 1 is depending on node 2
     EXPECT_TRUE(indexNode1 > indexNode2);
 }
+
+TEST_F(TopologicalSortGTest, testNonContinuousNodeIdMapping) {
+    auto G = inputGraph(true);
+    G.removeNode(3);
+    std::unordered_map<node, node> mapping;
+    mapping[0] = 0;
+    mapping[1] = 4;
+    mapping[2] = 2;
+    mapping[4] = 3;
+    EXPECT_THROW(TopologicalSort(G, mapping, true), std::runtime_error);
+}
+
+TEST_F(TopologicalSortGTest, testNonInjectiveNodeIdMapping) {
+    auto G = inputGraph(true);
+    G.removeNode(3);
+    std::unordered_map<node, node> mapping;
+    mapping[0] = 0;
+    mapping[1] = 1;
+    mapping[2] = 1;
+    mapping[4] = 3;
+    EXPECT_THROW(TopologicalSort(G, mapping, true), std::runtime_error);
+}
 } // namespace NetworKit

--- a/networkit/cpp/graph/test/TopologicalSortGTest.cpp
+++ b/networkit/cpp/graph/test/TopologicalSortGTest.cpp
@@ -66,7 +66,6 @@ TEST_F(TopologicalSortGTest, testRepeatedRuns) {
     TopologicalSort topSort = TopologicalSort(G);
     topSort.run();
     std::vector<node> res = topSort.getResult();
-    topSort = TopologicalSort(G);
     topSort.run();
     std::vector<node> res2 = topSort.getResult();
     EXPECT_TRUE(res == res2);
@@ -83,14 +82,29 @@ TEST_F(TopologicalSortGTest, testRejectUndirectedGraph) {
     EXPECT_THROW(TopologicalSort(inputGraph(false)), std::runtime_error);
 }
 
-TEST_F(TopologicalSortGTest, testRejectNonContinuousNodeIds) {
+TEST_F(TopologicalSortGTest, testNonContinuousNodeIds) {
     auto G = inputGraph(true);
     G.removeNode(3);
+
     TopologicalSort topSort = TopologicalSort(G);
-    EXPECT_THROW(topSort.run(), std::runtime_error);
+    topSort.run();
+    std::vector<node> res = topSort.getResult();
+
+    // Test for valid topology
+    auto indexNode0 = std::distance(res.begin(), std::find(res.begin(), res.end(), 0));
+    auto indexNode1 = std::distance(res.begin(), std::find(res.begin(), res.end(), 1));
+    auto indexNode2 = std::distance(res.begin(), std::find(res.begin(), res.end(), 2));
+    auto indexNode4 = std::distance(res.begin(), std::find(res.begin(), res.end(), 4));
+    EXPECT_EQ(res.size(), 4);
+    // node 2 is depending on node 0
+    EXPECT_TRUE(indexNode2 > indexNode0);
+    // node 2 is depending on node 4
+    EXPECT_TRUE(indexNode2 > indexNode4);
+    // node 1 is depending on node 2
+    EXPECT_TRUE(indexNode1 > indexNode2);
 }
 
-TEST_F(TopologicalSortGTest, testHandleNodeIdMapping) {
+TEST_F(TopologicalSortGTest, testCustomNodeIdMapping) {
     auto G = inputGraph(true);
     G.removeNode(3);
     std::unordered_map<node, node> mapping;

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -40,6 +40,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) except + nogil
 	void sortEdgesByWeight(_Graph G, bool_t) except + nogil
 	vector[node] topologicalSort(_Graph G) except + nogil
+	vector[node] topologicalSort(_Graph G, unordered_map[node, node]) except + nogil
 	node augmentGraph(_Graph G) except + nogil
 	pair[_Graph, node] createAugmentedGraph(_Graph G) except + nogil
 	void randomizeWeights(_Graph G) except + nogil
@@ -629,19 +630,24 @@ cdef class GraphTools:
 		sortEdgesByWeight(G._this, decreasing)
 
 	@staticmethod
-	def topologicalSort(Graph G):
+	def topologicalSort(Graph G, dict[node, node] nodeIdMap = None):
 		"""
-		topologicalSort(G)
+		topologicalSort(G, nodeIdMap = None)
 
 		Given a directed graph G, the topology sort algorithm creates one valid topology order of nodes.
 		Undirected graphs are not accepted as input, since a topology sort is a linear ordering of vertices 
 		such that for every edge u -> v, node u comes before v in the ordering.
+		Node ids must either be continuous or you must provide a continuous node id mapping.
 
 		Parameters
 		----------
 		G : networkit.Graph
 			The directed input graph.
+		nodeIdMap : dict(int, int), optional
+					Optional continuous node id mapping
 		"""
+		if nodeIdMap is not None:
+			return topologicalSort(G._this, nodeIdMap)
 		return topologicalSort(G._this)
 
 	@staticmethod

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -40,7 +40,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) except + nogil
 	void sortEdgesByWeight(_Graph G, bool_t) except + nogil
 	vector[node] topologicalSort(_Graph G) except + nogil
-	vector[node] topologicalSort(_Graph G, unordered_map[node, node]) except + nogil
+	vector[node] topologicalSort(_Graph G, unordered_map[node, node], bool_t) except + nogil
 	node augmentGraph(_Graph G) except + nogil
 	pair[_Graph, node] createAugmentedGraph(_Graph G) except + nogil
 	void randomizeWeights(_Graph G) except + nogil
@@ -630,9 +630,9 @@ cdef class GraphTools:
 		sortEdgesByWeight(G._this, decreasing)
 
 	@staticmethod
-	def topologicalSort(Graph G, dict[node, node] nodeIdMap = None):
+	def topologicalSort(Graph G, dict[node, node] nodeIdMap = None, bool_t checkMapping = False):
 		"""
-		topologicalSort(G, nodeIdMap = None)
+		topologicalSort(G, nodeIdMap = None, checkMapping = False)
 
 		Given a directed graph G, the topology sort algorithm creates one valid topology order of nodes.
 		Undirected graphs are not accepted as input, since a topology sort is a linear ordering of vertices 
@@ -644,10 +644,16 @@ cdef class GraphTools:
 		G : networkit.Graph
 			The directed input graph.
 		nodeIdMap : dict(int, int), optional
-					Optional continuous node id mapping
+					Optional continuous node id mapping.
+		checkMapping : bool, optional
+					   Flag to determine if the node id mapping should be checked that it 
+					   is continuous. This check takes O(|V|) time and space.
 		"""
+		cdef unordered_map[node,node] cNodeIdMap
 		if nodeIdMap is not None:
-			return topologicalSort(G._this, nodeIdMap)
+			for node, mapped in nodeIdMap.items():
+				cNodeIdMap[node] = mapped
+			return topologicalSort(G._this, cNodeIdMap, checkMapping)
 		return topologicalSort(G._this)
 
 	@staticmethod

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -495,23 +495,68 @@ class TestGraphTools(unittest.TestCase):
 			G.addEdge(1, 3)
 			G.addEdge(4, 2)
 			return G
-		
-		for directed in [True, False]:
-			G = generateGraph(directed)
-			if(directed == False):
-				with self.assertRaises(Exception):
-					nk.graphtools.topologicalSort(G)
-			else:
-				res = nk.graphtools.topologicalSort(G)
-				indexNode0 = res.index(0)
-				indexNode1 = res.index(1)
-				indexNode2 = res.index(2)
-				indexNode3 = res.index(3)
-				indexNode4 = res.index(4)
-				self.assertLess(indexNode0, indexNode2)
-				self.assertLess(indexNode4, indexNode2)
-				self.assertLess(indexNode2, indexNode1)
-				self.assertLess(indexNode1, indexNode3)
+
+		G = generateGraph(False)
+		with self.assertRaises(Exception):
+			nk.graphtools.topologicalSort(G)
+
+		G = generateGraph(True)
+		res = nk.graphtools.topologicalSort(G)
+		indexNode0 = res.index(0)
+		indexNode1 = res.index(1)
+		indexNode2 = res.index(2)
+		indexNode3 = res.index(3)
+		indexNode4 = res.index(4)
+		self.assertEqual(res.size(), 5)
+		self.assertLess(indexNode0, indexNode2)
+		self.assertLess(indexNode4, indexNode2)
+		self.assertLess(indexNode2, indexNode1)
+		self.assertLess(indexNode1, indexNode3)
+
+		# create the cycle 3-4-2-1
+		G.addEdge(3, 4)
+		with self.assertRaises(Exception):
+			nk.graphtools.topologicalSort(G);
+
+		G.removeNode(3);
+		res = nk.graphtools.topologicalSort(G)
+		indexNode0 = res.index(0)
+		indexNode1 = res.index(1)
+		indexNode2 = res.index(2)
+		indexNode4 = res.index(4)
+		self.assertEqual(res.size(), 4)
+		self.assertLess(indexNode0, indexNode2)
+		self.assertLess(indexNode4, indexNode2)
+		self.assertLess(indexNode2, indexNode1)
+
+		mapping = dict()
+		mapping[0] = 0;
+		mapping[1] = 1;
+		mapping[2] = 2;
+		mapping[4] = 3;
+		res = nk.graphtools.topologicalSort(G, mapping);
+		indexNode0 = res.index(0)
+		indexNode1 = res.index(1)
+		indexNode2 = res.index(2)
+		indexNode4 = res.index(4)
+		self.assertEqual(res.size(), 4)
+		self.assertLess(indexNode0, indexNode2)
+		self.assertLess(indexNode4, indexNode2)
+		self.assertLess(indexNode2, indexNode1)
+
+		mapping[5] = 4;
+		with self.assertRaises(Exception):
+			nk.graphtools.topologicalSort(G, mapping)
+
+		del mapping[5]
+		mapping[1] = 4
+		with self.assertRaises(Exception):
+			nk.graphtools.topologicalSort(G, mapping, True)
+
+		mapping[1] = 1
+		mapping[2] = 1
+		with self.assertRaises(Exception):
+			nk.graphtools.topologicalSort(G, mapping, True)
 
 	def testVolume(self):
 		for directed in [True, False]:

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -505,8 +505,8 @@ class TestGraphTools(unittest.TestCase):
 			return mapping
 
 		def assertTopological(G, res):
-			indices = []
-			self.assertEqual(res.size(), G.numberOfNodes())
+			self.assertEqual(len(res), G.numberOfNodes())
+			indices = G.numberOfNodes() * [0]
 			for u in G.iterNodes():
 				indices[u] = res.index(u)
 			for u in G.iterNodes():

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -496,22 +496,32 @@ class TestGraphTools(unittest.TestCase):
 			G.addEdge(4, 2)
 			return G
 
+		def generateMapping():
+			mapping = dict()
+			mapping[0] = 0;
+			mapping[1] = 1;
+			mapping[2] = 2;
+			mapping[4] = 3;
+			return mapping
+
+		def assertTopological(G, res):
+			indices = []
+			self.assertEqual(res.size(), G.numberOfNodes())
+			for u in G.iterNodes():
+				indices[u] = res.index(u)
+			for u in G.iterNodes():
+				for v in G.iterNeighbors(u):
+					self.assertLess(indices[u], indices[v])
+		
 		G = generateGraph(False)
 		with self.assertRaises(Exception):
 			nk.graphtools.topologicalSort(G)
 
 		G = generateGraph(True)
 		res = nk.graphtools.topologicalSort(G)
-		indexNode0 = res.index(0)
-		indexNode1 = res.index(1)
-		indexNode2 = res.index(2)
-		indexNode3 = res.index(3)
-		indexNode4 = res.index(4)
-		self.assertEqual(res.size(), 5)
-		self.assertLess(indexNode0, indexNode2)
-		self.assertLess(indexNode4, indexNode2)
-		self.assertLess(indexNode2, indexNode1)
-		self.assertLess(indexNode1, indexNode3)
+		assertTopological(G, res)
+        res2 = nk.graphtools.topologicalSort(G);
+        self.assertEqual(res, res2);
 
 		# create the cycle 3-4-2-1
 		G.addEdge(3, 4)
@@ -520,40 +530,24 @@ class TestGraphTools(unittest.TestCase):
 
 		G.removeNode(3);
 		res = nk.graphtools.topologicalSort(G)
-		indexNode0 = res.index(0)
-		indexNode1 = res.index(1)
-		indexNode2 = res.index(2)
-		indexNode4 = res.index(4)
-		self.assertEqual(res.size(), 4)
-		self.assertLess(indexNode0, indexNode2)
-		self.assertLess(indexNode4, indexNode2)
-		self.assertLess(indexNode2, indexNode1)
+		assertTopological(G, res)
 
-		mapping = dict()
-		mapping[0] = 0;
-		mapping[1] = 1;
-		mapping[2] = 2;
-		mapping[4] = 3;
+		mapping = generateMapping()
 		res = nk.graphtools.topologicalSort(G, mapping);
-		indexNode0 = res.index(0)
-		indexNode1 = res.index(1)
-		indexNode2 = res.index(2)
-		indexNode4 = res.index(4)
-		self.assertEqual(res.size(), 4)
-		self.assertLess(indexNode0, indexNode2)
-		self.assertLess(indexNode4, indexNode2)
-		self.assertLess(indexNode2, indexNode1)
+		assertTopological(G, res)
 
 		mapping[5] = 4;
 		with self.assertRaises(Exception):
 			nk.graphtools.topologicalSort(G, mapping)
 
-		del mapping[5]
+		# make mapping non-continuous  
+		mapping = generateMapping()
 		mapping[1] = 4
 		with self.assertRaises(Exception):
 			nk.graphtools.topologicalSort(G, mapping, True)
 
-		mapping[1] = 1
+		# make mapping non-injective
+		mapping = generateMapping()
 		mapping[2] = 1
 		with self.assertRaises(Exception):
 			nk.graphtools.topologicalSort(G, mapping, True)

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -520,8 +520,8 @@ class TestGraphTools(unittest.TestCase):
 		G = generateGraph(True)
 		res = nk.graphtools.topologicalSort(G)
 		assertTopological(G, res)
-        res2 = nk.graphtools.topologicalSort(G);
-        self.assertEqual(res, res2);
+		res2 = nk.graphtools.topologicalSort(G);
+		self.assertEqual(res, res2);
 
 		# create the cycle 3-4-2-1
 		G.addEdge(3, 4)

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -546,6 +546,14 @@ class TestGraphTools(unittest.TestCase):
 		with self.assertRaises(Exception):
 			nk.graphtools.topologicalSort(G, mapping, True)
 
+		mapping = generateMapping()
+		del mapping[1];
+		mapping[5] = 5;
+		with self.assertRaises(Exception):
+			nk.graphtools.topologicalSort(G, mapping, True)
+		with self.assertRaises(Exception):
+			nk.graphtools.topologicalSort(G, mapping)
+
 		# make mapping non-injective
 		mapping = generateMapping()
 		mapping[2] = 1

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -497,7 +497,7 @@ class TestGraphTools(unittest.TestCase):
 			return G
 
 		def generateMapping():
-			mapping = dict()
+			mapping = {}
 			mapping[0] = 0;
 			mapping[1] = 1;
 			mapping[2] = 2;
@@ -506,7 +506,7 @@ class TestGraphTools(unittest.TestCase):
 
 		def assertTopological(G, res):
 			self.assertEqual(len(res), G.numberOfNodes())
-			indices = G.numberOfNodes() * [0]
+			indices = {}
 			for u in G.iterNodes():
 				indices[u] = res.index(u)
 			for u in G.iterNodes():


### PR DESCRIPTION
Fixed issue #1224 by adding an optional argument to for a continuous node id mapping, i.e. mapping of current node ids to [0,n). 
Replaced raw accesses into vectors by the index operator with calls to `.at()` which performs bounds checks. This fixes an unreported bug which causes undefined behaviour and specifically segmentation faults when node ids are not in the [0,n) interval. The new behaviour is to throw an exception with a descriptive message instead.
If a node id mapping is passed to the algorithm, it maps all node ids through the mapping (and performs bounds checks as in above paragraph). If node ids are not mapped to [0,n), the bounds checks will cause the algorithm to throw an exception with an appropriate message.
Also refactored tests for TopologicalSort and added new tests for bounds checks and node id mappings.