### PR TITLE
replace const std::string& by std::string_view

### DIFF
--- a/include/networkit/GlobalState.hpp
+++ b/include/networkit/GlobalState.hpp
@@ -60,7 +60,7 @@ NETWORKIT_EXPORT bool getPrintLocation();
 NETWORKIT_EXPORT void setPrintLocation(bool b);
 
 NETWORKIT_EXPORT std::ofstream &getLogFile();
-NETWORKIT_EXPORT void setLogfile(const std::string &filename);
+NETWORKIT_EXPORT void setLogfile(std::string_view filename);
 
 NETWORKIT_EXPORT std::mutex &getLogFileMutex();
 

--- a/include/networkit/auxiliary/Enforce.hpp
+++ b/include/networkit/auxiliary/Enforce.hpp
@@ -34,8 +34,8 @@ inline void enforce(bool b, const char *msg = "") {
  * @param msg Message of the exception
  */
 template <typename Exception = std::runtime_error>
-inline void enforce(bool b, const std::string &msg) {
-    enforce<Exception>(b, msg.c_str());
+inline void enforce(bool b, std::string_view msg) {
+    enforce<Exception>(b, msg.data());
 }
 
 /**

--- a/include/networkit/auxiliary/Timer.hpp
+++ b/include/networkit/auxiliary/Timer.hpp
@@ -131,7 +131,7 @@ public:
      *              If logging at the given level is disable the Timer is very cheap to construct.
      *              If logging is disabled during construction or destruction, no message is shown.
      */
-    explicit LoggingTimer(const std::string &label = "",
+    explicit LoggingTimer(std::string_view label = "",
                           Aux::Log::LogLevel level = Aux::Log::LogLevel::DEBUG);
     ~LoggingTimer();
 

--- a/include/networkit/centrality/SpanningEdgeCentrality.hpp
+++ b/include/networkit/centrality/SpanningEdgeCentrality.hpp
@@ -66,7 +66,7 @@ public:
      * @param directory
      * @return Elapsed time in milliseconds.
      */
-    uint64_t TLX_DEPRECATED(runApproximationAndWriteVectors(const std::string &graphPath));
+    uint64_t TLX_DEPRECATED(runApproximationAndWriteVectors(std::string_view graphPath));
 
     /**
      * @return The elapsed time to setup the solver in milliseconds.

--- a/include/networkit/community/LouvainMapEquation.hpp
+++ b/include/networkit/community/LouvainMapEquation.hpp
@@ -53,7 +53,7 @@ public:
      */
     explicit LouvainMapEquation(const Graph &graph, bool hierarchical = false,
                                 count maxIterations = 32,
-                                const std::string &parallelizationStrategy = "relaxmap")
+                                std::string_view parallelizationStrategy = "relaxmap")
         : LouvainMapEquation(graph, hierarchical, maxIterations,
                              convertStringToParallelizationType(parallelizationStrategy)) {}
 
@@ -123,7 +123,7 @@ private:
     }
 
     ParallelizationType
-    convertStringToParallelizationType(const std::string &parallelizationStrategy) const {
+    convertStringToParallelizationType(std::string_view parallelizationStrategy) const {
         if (parallelizationStrategy == "none")
             return ParallelizationType::NONE;
         else if (parallelizationStrategy == "relaxmap")
@@ -132,7 +132,7 @@ private:
             return ParallelizationType::SYNCHRONOUS;
         else
             throw std::runtime_error("Invalid parallelization type for map equation Louvain: "
-                                     + parallelizationStrategy);
+                                     + std::string(parallelizationStrategy));
     }
 
 #ifndef NDEBUG

--- a/include/networkit/dynamics/DGSStreamParser.hpp
+++ b/include/networkit/dynamics/DGSStreamParser.hpp
@@ -23,7 +23,7 @@ namespace NetworKit {
 class DGSStreamParser final {
 
 public:
-    DGSStreamParser(const std::string &path, bool mapped = true, node baseIndex = 0);
+    DGSStreamParser(std::string_view path, bool mapped = true, node baseIndex = 0);
 
     std::vector<GraphEvent> getStream();
 

--- a/include/networkit/dynamics/DGSWriter.hpp
+++ b/include/networkit/dynamics/DGSWriter.hpp
@@ -22,7 +22,7 @@ class DGSWriter final {
 public:
     DGSWriter() = default;
 
-    void write(std::vector<GraphEvent> &stream, const std::string &path);
+    void write(std::vector<GraphEvent> &stream, std::string_view path);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/BinaryEdgeListPartitionReader.hpp
+++ b/include/networkit/io/BinaryEdgeListPartitionReader.hpp
@@ -33,7 +33,7 @@ public:
      * @param[in] path Path to file or to several files (which are read in order).
      * @return The partition contained in the file at @a path.
      */
-    Partition read(const std::string &path);
+    Partition read(std::string_view path);
 
     Partition read(const std::vector<std::string> &paths);
 

--- a/include/networkit/io/BinaryEdgeListPartitionWriter.hpp
+++ b/include/networkit/io/BinaryEdgeListPartitionWriter.hpp
@@ -36,7 +36,7 @@ public:
      * @param[in] zeta The partition to write.
      * @param[in] path The path to write to.
      */
-    void write(Partition &zeta, const std::string &path) const;
+    void write(Partition &zeta, std::string_view path) const;
 
 private:
     node firstNode;

--- a/include/networkit/io/BinaryPartitionReader.hpp
+++ b/include/networkit/io/BinaryPartitionReader.hpp
@@ -31,7 +31,7 @@ public:
      *
      * @param[in]  path  Path to file.
      */
-    Partition read(const std::string &path);
+    Partition read(std::string_view path);
 
 private:
     uint8_t width;

--- a/include/networkit/io/BinaryPartitionWriter.hpp
+++ b/include/networkit/io/BinaryPartitionWriter.hpp
@@ -34,7 +34,7 @@ public:
      * @param[in] zeta The partition to write.
      * @param[in] path The path to write to.
      */
-    void write(const Partition &zeta, const std::string &path) const;
+    void write(const Partition &zeta, std::string_view path) const;
 
 private:
     uint8_t width;

--- a/include/networkit/io/CoverReader.hpp
+++ b/include/networkit/io/CoverReader.hpp
@@ -19,7 +19,7 @@ public:
      * @param[in]  G     The graph for which the cover shall be read
      * @return The cover instance
      */
-    virtual Cover read(const std::string &path, Graph &G);
+    virtual Cover read(std::string_view path, Graph &G);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/CoverWriter.hpp
+++ b/include/networkit/io/CoverWriter.hpp
@@ -14,7 +14,7 @@ namespace NetworKit {
 
 class CoverWriter final {
 public:
-    void write(Cover &zeta, const std::string &path) const;
+    void write(Cover &zeta, std::string_view path) const;
 };
 } // namespace NetworKit
 

--- a/include/networkit/io/DibapGraphReader.hpp
+++ b/include/networkit/io/DibapGraphReader.hpp
@@ -26,7 +26,7 @@ class DibapGraphReader final : public GraphReader {
 public:
     DibapGraphReader() = default;
 
-    Graph read(const std::string &path) override;
+    Graph read(std::string_view path) override;
 
     const std::vector<Point<coordinate>> &getCoordinates() const noexcept { return coordinates; }
 

--- a/include/networkit/io/DotGraphWriter.hpp
+++ b/include/networkit/io/DotGraphWriter.hpp
@@ -32,7 +32,7 @@ public:
      * @param[in]	graph	The graph object
      * @param[in]	path	The file path to be written to
      */
-    void write(const Graph &G, const std::string &path) override;
+    void write(const Graph &G, std::string_view path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/DotPartitionWriter.hpp
+++ b/include/networkit/io/DotPartitionWriter.hpp
@@ -14,7 +14,7 @@ namespace NetworKit {
  */
 class DotPartitionWriter final {
 public:
-    void write(Graph &graph, Partition &zeta, const std::string &path) const;
+    void write(Graph &graph, Partition &zeta, std::string_view path) const;
 
     std::map<index, double> createHueMap(Graph &graph, Partition &zeta) const;
 };

--- a/include/networkit/io/EdgeListCoverReader.hpp
+++ b/include/networkit/io/EdgeListCoverReader.hpp
@@ -25,7 +25,7 @@ public:
      * @param[in]  G     The graph for which the cover shall be read
      * @return The cover instance
      */
-    Cover read(const std::string &path, Graph &G) override;
+    Cover read(std::string_view path, Graph &G) override;
 
 private:
     node firstNode;

--- a/include/networkit/io/EdgeListPartitionReader.hpp
+++ b/include/networkit/io/EdgeListPartitionReader.hpp
@@ -32,7 +32,7 @@ public:
      * @param[in]  path  Path to file.
      * @return The clustering contained in the file at @a path.
      */
-    Partition read(const std::string &path);
+    Partition read(std::string_view path);
 
 private:
     node firstNode;

--- a/include/networkit/io/EdgeListReader.hpp
+++ b/include/networkit/io/EdgeListReader.hpp
@@ -33,7 +33,7 @@ public:
      * @param[in]  continuous  boolean to specify if node ids are continuous
      * @param[in]  directed  read graph as directed
      */
-    EdgeListReader(char separator, node firstNode, const std::string &commentPrefix = "#",
+    EdgeListReader(char separator, node firstNode, std::string_view commentPrefix = "#",
                    bool continuous = true, bool directed = false);
 
     /**
@@ -41,7 +41,7 @@ public:
      *
      * @param[in]  path  input file path
      */
-    Graph read(const std::string &path) override;
+    Graph read(std::string_view path) override;
 
     /**
      * Return the node map, in case node ids are not continuous

--- a/include/networkit/io/EdgeListWriter.hpp
+++ b/include/networkit/io/EdgeListWriter.hpp
@@ -36,7 +36,7 @@ public:
      * @param[in]  G    the graph
      * @param[in]  path  the output file path
      */
-    void write(const Graph &G, const std::string &path) override;
+    void write(const Graph &G, std::string_view path) override;
 
 private:
     char separator; //!< character separating nodes in an edge line

--- a/include/networkit/io/GMLGraphReader.hpp
+++ b/include/networkit/io/GMLGraphReader.hpp
@@ -26,7 +26,7 @@ public:
      *
      * @param[out]  the graph read from file
      */
-    Graph read(const std::string &path) override;
+    Graph read(std::string_view path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/GMLGraphWriter.hpp
+++ b/include/networkit/io/GMLGraphWriter.hpp
@@ -26,7 +26,7 @@ public:
      * @param[in]  G     Graph of type NetworKit with 2D coordinates.
      * @param[in]  path  Path to file.
      */
-    void write(const Graph &G, const std::string &path) override;
+    void write(const Graph &G, std::string_view path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/GraphIO.hpp
+++ b/include/networkit/io/GraphIO.hpp
@@ -31,7 +31,7 @@ public:
      *     for each edge {u, v}:
      *       write line "u v"
      */
-    void writeEdgeList(const Graph &G, const std::string &path);
+    void writeEdgeList(const Graph &G, std::string_view path);
 
     /**
      * Writes graph to text file in adjacency list format.
@@ -45,7 +45,7 @@ public:
      *       write "x" for each edge {v, x}
      *       end line
      */
-    void writeAdjacencyList(const Graph &G, const std::string &path);
+    void writeAdjacencyList(const Graph &G, std::string_view path);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/GraphReader.hpp
+++ b/include/networkit/io/GraphReader.hpp
@@ -32,7 +32,7 @@ public:
      *
      * @param[in]  path  input file path
      */
-    virtual Graph read(const std::string &path) = 0;
+    virtual Graph read(std::string_view path) = 0;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/GraphToolBinaryReader.hpp
+++ b/include/networkit/io/GraphToolBinaryReader.hpp
@@ -29,7 +29,7 @@ public:
      *
      * @param[in]  path  input file path
      */
-    Graph read(const std::string &path) override;
+    Graph read(std::string_view path) override;
 
 private:
     bool littleEndianness;

--- a/include/networkit/io/GraphToolBinaryWriter.hpp
+++ b/include/networkit/io/GraphToolBinaryWriter.hpp
@@ -26,7 +26,7 @@ public:
      *
      * @param[in]  path  input file path
      */
-    void write(const Graph &G, const std::string &path) override;
+    void write(const Graph &G, std::string_view path) override;
 
 private:
     bool littleEndianness;

--- a/include/networkit/io/GraphWriter.hpp
+++ b/include/networkit/io/GraphWriter.hpp
@@ -20,7 +20,7 @@ class GraphWriter {
 public:
     virtual ~GraphWriter() = default;
 
-    virtual void write(const Graph &G, const std::string &path) = 0;
+    virtual void write(const Graph &G, std::string_view path) = 0;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/KONECTGraphReader.hpp
+++ b/include/networkit/io/KONECTGraphReader.hpp
@@ -34,7 +34,7 @@ public:
      *
      * @param[in]  path  input file path
      */
-    Graph read(const std::string &path) override;
+    Graph read(std::string_view path) override;
 
 private:
     bool remapNodes;

--- a/include/networkit/io/METISGraphReader.hpp
+++ b/include/networkit/io/METISGraphReader.hpp
@@ -29,7 +29,7 @@ public:
      *
      * @param[out]  the graph read from file
      */
-    Graph read(const std::string &path) override;
+    Graph read(std::string_view path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/METISGraphWriter.hpp
+++ b/include/networkit/io/METISGraphWriter.hpp
@@ -20,9 +20,9 @@ class METISGraphWriter final : public GraphWriter {
 public:
     METISGraphWriter() = default;
 
-    void write(const Graph &G, const std::string &path) override;
+    void write(const Graph &G, std::string_view path) override;
 
-    void write(const Graph &G, bool weighted, const std::string &path);
+    void write(const Graph &G, bool weighted, std::string_view path);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/METISParser.hpp
+++ b/include/networkit/io/METISParser.hpp
@@ -31,7 +31,7 @@ public:
      *
      * @param[in]  path  file path
      */
-    METISParser(const std::string &path);
+    METISParser(std::string_view path);
 
     /**
      * Get the METIS graph file header

--- a/include/networkit/io/MTXGraphReader.hpp
+++ b/include/networkit/io/MTXGraphReader.hpp
@@ -24,7 +24,7 @@ public:
      * @param path
      * @return Graph
      */
-    Graph read(const std::string &path) override;
+    Graph read(std::string_view path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/MatrixMarketReader.hpp
+++ b/include/networkit/io/MatrixMarketReader.hpp
@@ -23,7 +23,7 @@ class MatrixMarketReader final : public MatrixReader {
 public:
     MatrixMarketReader() = default;
 
-    CSRMatrix read(const std::string &path) override;
+    CSRMatrix read(std::string_view path) override;
 
     /** Reads the matrix in @a in. */
     CSRMatrix read(std::istream &in);

--- a/include/networkit/io/MatrixReader.hpp
+++ b/include/networkit/io/MatrixReader.hpp
@@ -23,10 +23,10 @@ public:
     /**
      * Reads the matrix in @a path.
      */
-    virtual CSRMatrix read(const std::string &path) = 0;
+    virtual CSRMatrix read(std::string_view path) = 0;
 
     /** only to be used by Cython - this eliminates an unnecessary copy */
-    CSRMatrix *_read(const std::string &path) { return new CSRMatrix{read(path)}; };
+    CSRMatrix *_read(std::string_view path) { return new CSRMatrix{read(path)}; };
 };
 
 } // namespace NetworKit

--- a/include/networkit/io/MemoryMappedFile.hpp
+++ b/include/networkit/io/MemoryMappedFile.hpp
@@ -33,7 +33,7 @@ public:
     MemoryMappedFile();
 
     //! Invokes open(path) automatically
-    explicit MemoryMappedFile(const std::string &path);
+    explicit MemoryMappedFile(std::string_view path);
 
     //! Invokes close
     ~MemoryMappedFile();
@@ -52,7 +52,7 @@ public:
 
     //! Opens the file and maps it to cbegin() ... cend()
     //! Opening an empty file is considered an error.
-    void open(const std::string &file);
+    void open(std::string_view file);
 
     //! If a file is mapped, it is closed. Otherwise, operation is carried out.
     //! @note This function is automatically called by the destructor.

--- a/include/networkit/io/NetworkitBinaryReader.hpp
+++ b/include/networkit/io/NetworkitBinaryReader.hpp
@@ -31,7 +31,7 @@ class NetworkitBinaryReader final : public GraphReader {
 public:
     NetworkitBinaryReader(){};
 
-    Graph read(const std::string &path) override;
+    Graph read(std::string_view path) override;
     Graph readFromBuffer(const std::vector<uint8_t> &data);
 
 private:

--- a/include/networkit/io/NetworkitBinaryWriter.hpp
+++ b/include/networkit/io/NetworkitBinaryWriter.hpp
@@ -53,7 +53,7 @@ public:
                           NetworkitBinaryWeights weightsType = NetworkitBinaryWeights::AUTO_DETECT,
                           NetworkitBinaryEdgeIDs edgeIndex = NetworkitBinaryEdgeIDs::AUTO_DETECT);
 
-    void write(const Graph &G, const std::string &path) override;
+    void write(const Graph &G, std::string_view path) override;
     std::vector<uint8_t> writeToBuffer(const Graph &G);
 
 private:

--- a/include/networkit/io/PartitionReader.hpp
+++ b/include/networkit/io/PartitionReader.hpp
@@ -27,7 +27,7 @@ public:
      *
      * @param[in]  path  Path to file.
      */
-    Partition read(const std::string &path);
+    Partition read(std::string_view path);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/PartitionWriter.hpp
+++ b/include/networkit/io/PartitionWriter.hpp
@@ -21,8 +21,8 @@ namespace NetworKit {
 class PartitionWriter final {
 
 public:
-    void write(const Partition &zeta, const std::string &path) const {
-        std::ofstream file{path};
+    void write(const Partition &zeta, std::string_view path) const {
+        std::ofstream file{path.data()};
         zeta.forEntries([&](node, const index c) { file << c << '\n'; });
     }
 };

--- a/include/networkit/io/RasterReader.hpp
+++ b/include/networkit/io/RasterReader.hpp
@@ -33,7 +33,7 @@ public:
      * @param[in] path Path and name of file to be read.
      * @return Vectors of x- and y-coordinates of the points.
      */
-    std::pair<std::vector<double>, std::vector<double>> read(const std::string &path);
+    std::pair<std::vector<double>, std::vector<double>> read(std::string_view path);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/SNAPEdgeListPartitionReader.hpp
+++ b/include/networkit/io/SNAPEdgeListPartitionReader.hpp
@@ -21,7 +21,7 @@ namespace NetworKit {
  */
 class SNAPEdgeListPartitionReader final {
 public:
-    Cover read(const std::string &path, std::unordered_map<node, node> &mapNodeIds, Graph &G);
+    Cover read(std::string_view path, std::unordered_map<node, node> &mapNodeIds, Graph &G);
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/SNAPGraphReader.hpp
+++ b/include/networkit/io/SNAPGraphReader.hpp
@@ -45,7 +45,7 @@ public:
      *
      * @param[in]  path  input file path
      */
-    Graph read(const std::string &path) override;
+    Graph read(std::string_view path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/SNAPGraphWriter.hpp
+++ b/include/networkit/io/SNAPGraphWriter.hpp
@@ -46,7 +46,7 @@ class SNAPGraphWriter final : public GraphWriter {
 public:
     SNAPGraphWriter() = default;
 
-    void write(const Graph &G, const std::string &path) override;
+    void write(const Graph &G, std::string_view path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/io/ThrillGraphBinaryReader.hpp
+++ b/include/networkit/io/ThrillGraphBinaryReader.hpp
@@ -32,7 +32,7 @@ public:
      *
      * @param[in]  path  input file path
      */
-    Graph read(const std::string &path) override;
+    Graph read(std::string_view path) override;
 
     Graph read(const std::vector<std::string> &path);
 

--- a/include/networkit/io/ThrillGraphBinaryWriter.hpp
+++ b/include/networkit/io/ThrillGraphBinaryWriter.hpp
@@ -19,7 +19,7 @@ public:
      * @param[in] G The graph to write.
      * @param[in] path The path where to write the graph.
      */
-    void write(const Graph &G, const std::string &path) override;
+    void write(const Graph &G, std::string_view path) override;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/viz/GraphLayoutAlgorithm.hpp
+++ b/include/networkit/viz/GraphLayoutAlgorithm.hpp
@@ -71,12 +71,12 @@ public:
         return 0;
     }
 
-    virtual bool writeGraphToGML(const std::string &filePath) {
+    virtual bool writeGraphToGML(std::string_view filePath) {
         if (vertexCoordinates.empty() || vertexCoordinates[0].getDimensions() < 2
             || vertexCoordinates[0].getDimensions() > 3)
             return false;
         count dim = vertexCoordinates[0].getDimensions();
-        std::ofstream file(filePath);
+        std::ofstream file(filePath.data());
         Aux::enforceOpened(file);
 
         file << "graph [\n";
@@ -110,11 +110,11 @@ public:
         return true;
     }
 
-    virtual bool writeKinemage(const std::string &filePath) {
+    virtual bool writeKinemage(std::string_view filePath) {
         if (vertexCoordinates.empty() || vertexCoordinates[0].getDimensions() != 3)
             return false;
-        std::string fileName = filePath.substr(filePath.find_last_of("/"));
-        std::ofstream file(filePath);
+        std::string_view fileName = filePath.substr(filePath.find_last_of("/"));
+        std::ofstream file(filePath.data());
         Aux::enforceOpened(file);
 
         file << "@whitebackground" << std::endl;

--- a/include/networkit/viz/PostscriptWriter.hpp
+++ b/include/networkit/viz/PostscriptWriter.hpp
@@ -42,7 +42,7 @@ public:
      * @note We assume g.upperNodeIdBound() == coordinates.size();
      */
     void write(const Graph &g, const std::vector<Point2D> &coordinates, const Partition &clustering,
-               const std::string &filename);
+               std::string_view filename);
 
     /**
      * Outputs an EPS file with name @a filename of the graph @a g with 2D coordinates.
@@ -52,8 +52,7 @@ public:
      *
      * @note We assume g.upperNodeIdBound() == coordinates.size();
      */
-    void write(const Graph &g, const std::vector<Point2D> &coordinates,
-               const std::string &filename);
+    void write(const Graph &g, const std::vector<Point2D> &coordinates, std::string_view filename);
 
 private:
     bool wrapAround;

--- a/networkit/cpp/GlobalState.cpp
+++ b/networkit/cpp/GlobalState.cpp
@@ -72,13 +72,13 @@ void setPrintLocation(bool b) {
 std::ofstream &getLogFile() {
     return logfile;
 }
-void setLogfile(const std::string &filename) {
+void setLogfile(std::string_view filename) {
     std::lock_guard<std::mutex> guard{logfileMutex};
     if (logfile.is_open()) {
         logfile.close();
     }
     if (filename.empty()) {
-        logfile.open(filename, std::ios_base::out | std::ios_base::app);
+        logfile.open(filename.data(), std::ios_base::out | std::ios_base::app);
         logfileIsOpen = logfile.is_open();
     } else {
         logfileIsOpen = false;

--- a/networkit/cpp/auxiliary/Timer.cpp
+++ b/networkit/cpp/auxiliary/Timer.cpp
@@ -63,7 +63,7 @@ Timer::my_steady_clock::time_point Timer::stopTimeOrNow() const noexcept {
     return running ? std::chrono::steady_clock::now() : stopped;
 }
 
-LoggingTimer::LoggingTimer(const std::string &label, Aux::Log::LogLevel level) : level(level) {
+LoggingTimer::LoggingTimer(std::string_view label, Aux::Log::LogLevel level) : level(level) {
     if (!Aux::Log::isLogLevelEnabled(level))
         return;
 

--- a/networkit/cpp/auxiliary/test/AuxGTest.cpp
+++ b/networkit/cpp/auxiliary/test/AuxGTest.cpp
@@ -497,7 +497,7 @@ TEST_F(AuxGTest, testNumberParsingBasicReal) {
 }
 
 TEST_F(AuxGTest, testNumberParsingAdvancedReal) {
-    auto helper = [](const std::string &str, double expected) {
+    auto helper = [](std::string_view str, double expected) {
         auto result = std::get<0>(Aux::Parsing::strTo<double>(str.begin(), str.end()));
         EXPECT_DOUBLE_EQ(result, expected);
     };

--- a/networkit/cpp/centrality/SpanningEdgeCentrality.cpp
+++ b/networkit/cpp/centrality/SpanningEdgeCentrality.cpp
@@ -142,7 +142,7 @@ void SpanningEdgeCentrality::runParallelApproximation() {
     hasRun = true;
 }
 
-uint64_t SpanningEdgeCentrality::runApproximationAndWriteVectors(const std::string &) {
+uint64_t SpanningEdgeCentrality::runApproximationAndWriteVectors(std::string_view) {
     WARN("SpanningEdgeCentrality::runApproximationAndWriteVectors should not be used and will be "
          "deprecated in the future.");
     Aux::Timer t;

--- a/networkit/cpp/dynamics/DGSStreamParser.cpp
+++ b/networkit/cpp/dynamics/DGSStreamParser.cpp
@@ -11,8 +11,8 @@
 
 namespace NetworKit {
 
-DGSStreamParser::DGSStreamParser(const std::string &path, bool mapped, node baseIndex)
-    : dgsFile(path), mapped(mapped), baseIndex(baseIndex), nextNode(0) {}
+DGSStreamParser::DGSStreamParser(std::string_view path, bool mapped, node baseIndex)
+    : dgsFile(path.data()), mapped(mapped), baseIndex(baseIndex), nextNode(0) {}
 
 std::vector<GraphEvent> DGSStreamParser::getStream() {
     if (!dgsFile.is_open()) {
@@ -42,12 +42,12 @@ std::vector<GraphEvent> DGSStreamParser::getStream() {
         /**
          * Maps key string to consecutive, 0-based node id.
          */
-        auto map = [&](const std::string &key) {
-            auto iter = this->key2id.find(key);
+        auto map = [&](std::string_view key) {
+            auto iter = this->key2id.find(key.data());
             if (iter == key2id.end()) {
-                key2id[key] = nextNode;
+                key2id[key.data()] = nextNode;
                 nextNode++;
-                return key2id[key];
+                return key2id[key.data()];
             } else {
                 return iter->second;
             }

--- a/networkit/cpp/dynamics/DGSWriter.cpp
+++ b/networkit/cpp/dynamics/DGSWriter.cpp
@@ -11,8 +11,8 @@
 
 namespace NetworKit {
 
-void DGSWriter::write(std::vector<GraphEvent> &stream, const std::string &path) {
-    std::ofstream out(path);
+void DGSWriter::write(std::vector<GraphEvent> &stream, std::string_view path) {
+    std::ofstream out(path.data());
 
     out << "DGS004\nnoname 0 0\n";
 

--- a/networkit/cpp/generators/test/GeneratorsGTest.cpp
+++ b/networkit/cpp/generators/test/GeneratorsGTest.cpp
@@ -59,8 +59,8 @@ class GeneratorsGTest : public testing::Test {
 
 protected:
     template <class Type>
-    std::vector<Type> readVector(const std::string &path) const {
-        std::ifstream inputFile(path);
+    std::vector<Type> readVector(std::string_view path) const {
+        std::ifstream inputFile(path.data());
         Type cur;
         std::vector<Type> data;
 

--- a/networkit/cpp/io/BinaryEdgeListPartitionReader.cpp
+++ b/networkit/cpp/io/BinaryEdgeListPartitionReader.cpp
@@ -11,8 +11,8 @@ BinaryEdgeListPartitionReader::BinaryEdgeListPartitionReader(node firstNode, uin
     }
 }
 
-Partition BinaryEdgeListPartitionReader::read(const std::string &path) {
-    return read(std::vector<std::string>(1, path));
+Partition BinaryEdgeListPartitionReader::read(std::string_view path) {
+    return read(std::vector<std::string>(1, path.data()));
 }
 
 Partition BinaryEdgeListPartitionReader::read(const std::vector<std::string> &paths) {

--- a/networkit/cpp/io/BinaryEdgeListPartitionWriter.cpp
+++ b/networkit/cpp/io/BinaryEdgeListPartitionWriter.cpp
@@ -11,7 +11,7 @@ BinaryEdgeListPartitionWriter::BinaryEdgeListPartitionWriter(node firstNode, uin
     }
 }
 
-void BinaryEdgeListPartitionWriter::write(Partition &zeta, const std::string &path) const {
+void BinaryEdgeListPartitionWriter::write(Partition &zeta, std::string_view path) const {
     auto write_little_endian = [](std::ofstream &os, index x, uint8_t width) {
         for (uint8_t w = 0; w < width; ++w) {
             os.put(uint8_t(x));
@@ -25,7 +25,7 @@ void BinaryEdgeListPartitionWriter::write(Partition &zeta, const std::string &pa
             "int of width 4. Please use a width of 8.");
     }
 
-    std::ofstream os(path, std::ios::trunc | std::ios::binary);
+    std::ofstream os(path.data(), std::ios::trunc | std::ios::binary);
 
     os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
 

--- a/networkit/cpp/io/BinaryPartitionReader.cpp
+++ b/networkit/cpp/io/BinaryPartitionReader.cpp
@@ -10,8 +10,8 @@ BinaryPartitionReader::BinaryPartitionReader(uint8_t width) : width(width) {
     }
 }
 
-Partition BinaryPartitionReader::read(const std::string &path) {
-    std::ifstream is(path, std::ios_base::in | std::ios_base::binary);
+Partition BinaryPartitionReader::read(std::string_view path) {
+    std::ifstream is(path.data(), std::ios_base::in | std::ios_base::binary);
 
     if (!is) {
         throw std::runtime_error("Error: partition file couldn't be opened");

--- a/networkit/cpp/io/BinaryPartitionWriter.cpp
+++ b/networkit/cpp/io/BinaryPartitionWriter.cpp
@@ -10,14 +10,14 @@ BinaryPartitionWriter::BinaryPartitionWriter(uint8_t width) : width(width) {
     }
 }
 
-void BinaryPartitionWriter::write(const Partition &zeta, const std::string &path) const {
+void BinaryPartitionWriter::write(const Partition &zeta, std::string_view path) const {
     if (width == 4 && zeta.upperBound() > std::numeric_limits<uint32_t>::max()) {
         throw std::runtime_error(
             "Error, the upper bound of the given partition cannot be represented by an unsigned "
             "int of width 4. Please use a width of 8.");
     }
 
-    std::ofstream os(path, std::ios::trunc | std::ios::binary);
+    std::ofstream os(path.data(), std::ios::trunc | std::ios::binary);
 
     os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
 

--- a/networkit/cpp/io/CoverReader.cpp
+++ b/networkit/cpp/io/CoverReader.cpp
@@ -6,9 +6,9 @@
 
 namespace NetworKit {
 
-Cover CoverReader::read(const std::string &path, Graph &G) {
+Cover CoverReader::read(std::string_view path, Graph &G) {
     std::ifstream file;
-    file.open(path);
+    file.open(path.data());
     if (!file.good()) {
         throw std::runtime_error("unable to read from file");
     }

--- a/networkit/cpp/io/CoverWriter.cpp
+++ b/networkit/cpp/io/CoverWriter.cpp
@@ -5,8 +5,8 @@
 
 namespace NetworKit {
 
-void CoverWriter::write(Cover &zeta, const std::string &path) const {
-    std::ofstream file{path};
+void CoverWriter::write(Cover &zeta, std::string_view path) const {
+    std::ofstream file{path.data()};
 
     std::vector<std::vector<index>> sets(zeta.upperBound());
     zeta.forEntries([&](index v, const std::set<index> &c) {

--- a/networkit/cpp/io/DibapGraphReader.cpp
+++ b/networkit/cpp/io/DibapGraphReader.cpp
@@ -29,7 +29,7 @@ enum class DibapIOType : short {
     TE = ('T' << 8) | 'E'
 };
 
-Graph DibapGraphReader::read(const std::string &path) {
+Graph DibapGraphReader::read(std::string_view path) {
     int n, i;
     short type;
     FILE *file = NULL; // TODO: Use std::ifstream; this function won't reliably close the handle
@@ -46,7 +46,7 @@ Graph DibapGraphReader::read(const std::string &path) {
 
     // init, try to open file
     DEBUG("reading graph in DibaP format... ");
-    file = fopen(path.c_str(), "r");
+    file = fopen(path.data(), "r");
     if (file == NULL) {
         throw std::runtime_error("cannot open file ");
         return 0;

--- a/networkit/cpp/io/DotGraphWriter.cpp
+++ b/networkit/cpp/io/DotGraphWriter.cpp
@@ -11,8 +11,8 @@
 
 namespace NetworKit {
 
-void DotGraphWriter::write(const Graph &G, const std::string &path) {
-    std::ofstream file{path};
+void DotGraphWriter::write(const Graph &G, std::string_view path) {
+    std::ofstream file{path.data()};
 
     file << "graph {\n";
     G.forEdges([&](node u, node v) { file << u << " -- " << v << ";\n"; });

--- a/networkit/cpp/io/DotPartitionWriter.cpp
+++ b/networkit/cpp/io/DotPartitionWriter.cpp
@@ -28,8 +28,8 @@ std::map<index, double> DotPartitionWriter::createHueMap(Graph &graph, Partition
     return clusterHueMap;
 }
 
-void DotPartitionWriter::write(Graph &graph, Partition &zeta, const std::string &path) const {
-    std::ofstream file{path};
+void DotPartitionWriter::write(Graph &graph, Partition &zeta, std::string_view path) const {
+    std::ofstream file{path.data()};
 
     auto hueMap = this->createHueMap(graph, zeta);
 

--- a/networkit/cpp/io/EdgeListCoverReader.cpp
+++ b/networkit/cpp/io/EdgeListCoverReader.cpp
@@ -9,9 +9,9 @@ namespace NetworKit {
 
 EdgeListCoverReader::EdgeListCoverReader(node firstNode) : firstNode(firstNode) {}
 
-Cover EdgeListCoverReader::read(const std::string &path, Graph &G) {
+Cover EdgeListCoverReader::read(std::string_view path, Graph &G) {
     std::ifstream file;
-    file.open(path);
+    file.open(path.data());
     if (!file.good()) {
         throw std::runtime_error("unable to read from file");
     }

--- a/networkit/cpp/io/EdgeListPartitionReader.cpp
+++ b/networkit/cpp/io/EdgeListPartitionReader.cpp
@@ -12,8 +12,8 @@ namespace NetworKit {
 EdgeListPartitionReader::EdgeListPartitionReader(node firstNode, char sepChar)
     : firstNode(firstNode), sepChar(sepChar) {}
 
-Partition EdgeListPartitionReader::read(const std::string &path) {
-    std::ifstream file(path);
+Partition EdgeListPartitionReader::read(std::string_view path) {
+    std::ifstream file(path.data());
 
     // check if file readable
     if (!file) {

--- a/networkit/cpp/io/EdgeListReader.cpp
+++ b/networkit/cpp/io/EdgeListReader.cpp
@@ -16,7 +16,7 @@
 
 namespace NetworKit {
 
-EdgeListReader::EdgeListReader(char separator, node firstNode, const std::string &commentPrefix,
+EdgeListReader::EdgeListReader(char separator, node firstNode, std::string_view commentPrefix,
                                bool continuous, bool directed)
     : separator(separator), commentPrefix(commentPrefix), firstNode(firstNode),
       continuous(continuous), mapNodeIds(), directed(directed) {
@@ -34,7 +34,7 @@ const std::map<std::string, node> &EdgeListReader::getNodeMap() const {
     return this->mapNodeIds;
 }
 
-Graph EdgeListReader::read(const std::string &path) {
+Graph EdgeListReader::read(std::string_view path) {
     this->mapNodeIds.clear();
     MemoryMappedFile mmfile(path);
     auto it = mmfile.cbegin();

--- a/networkit/cpp/io/EdgeListWriter.cpp
+++ b/networkit/cpp/io/EdgeListWriter.cpp
@@ -15,8 +15,8 @@ namespace NetworKit {
 EdgeListWriter::EdgeListWriter(char separator, node firstNode, bool bothDirections)
     : separator(separator), firstNode(firstNode), bothDirections(bothDirections) {}
 
-void EdgeListWriter::write(const Graph &G, const std::string &path) {
-    std::ofstream file(path);
+void EdgeListWriter::write(const Graph &G, std::string_view path) {
+    std::ofstream file(path.data());
     Aux::enforceOpened(file);
 
     auto writeWeightedEdge = [&](node u, node v, edgeweight weight) {

--- a/networkit/cpp/io/GMLGraphReader.cpp
+++ b/networkit/cpp/io/GMLGraphReader.cpp
@@ -18,8 +18,8 @@
 
 namespace NetworKit {
 
-Graph GMLGraphReader::read(const std::string &path) {
-    std::ifstream graphFile(path);
+Graph GMLGraphReader::read(std::string_view path) {
+    std::ifstream graphFile(path.data());
     Aux::enforceOpened(graphFile);
     std::string line;
 

--- a/networkit/cpp/io/GMLGraphWriter.cpp
+++ b/networkit/cpp/io/GMLGraphWriter.cpp
@@ -12,8 +12,8 @@
 
 namespace NetworKit {
 
-void GMLGraphWriter::write(const Graph &G, const std::string &path) {
-    std::ofstream file(path);
+void GMLGraphWriter::write(const Graph &G, std::string_view path) {
+    std::ofstream file(path.data());
     Aux::enforceOpened(file);
 
     file << "graph [\n";

--- a/networkit/cpp/io/GraphIO.cpp
+++ b/networkit/cpp/io/GraphIO.cpp
@@ -10,19 +10,19 @@
 
 namespace NetworKit {
 
-void GraphIO::writeEdgeList(const Graph &G, const std::string &path) {
+void GraphIO::writeEdgeList(const Graph &G, std::string_view path) {
 
     std::ofstream file;
-    file.open(path.c_str());
+    file.open(path.data());
 
     G.forEdges([&](const node v, const node w) { file << v << " " << w << '\n'; });
 
     file.close();
 }
 
-void GraphIO::writeAdjacencyList(const Graph &G, const std::string &path) {
+void GraphIO::writeAdjacencyList(const Graph &G, std::string_view path) {
     std::ofstream file;
-    file.open(path.c_str());
+    file.open(path.data());
 
     G.forNodes([&](const node v) {
         file << v;

--- a/networkit/cpp/io/GraphToolBinaryReader.cpp
+++ b/networkit/cpp/io/GraphToolBinaryReader.cpp
@@ -11,8 +11,8 @@
 
 namespace NetworKit {
 
-Graph GraphToolBinaryReader::read(const std::string &path) {
-    std::ifstream file(path, std::ios::binary | std::ios::in);
+Graph GraphToolBinaryReader::read(std::string_view path) {
+    std::ifstream file(path.data(), std::ios::binary | std::ios::in);
     Aux::enforceOpened(file);
     // if the header is ok, continue reading the file
     if (checkHeader(file)) {

--- a/networkit/cpp/io/GraphToolBinaryWriter.cpp
+++ b/networkit/cpp/io/GraphToolBinaryWriter.cpp
@@ -16,8 +16,8 @@ namespace NetworKit {
 GraphToolBinaryWriter::GraphToolBinaryWriter(bool littleEndianness)
     : littleEndianness(littleEndianness) {}
 
-void GraphToolBinaryWriter::write(const Graph &G, const std::string &path) {
-    std::ofstream file(path, std::ios::binary | std::ios::out);
+void GraphToolBinaryWriter::write(const Graph &G, std::string_view path) {
+    std::ofstream file(path.data(), std::ios::binary | std::ios::out);
     Aux::enforceOpened(file);
     writeHeader(file);
     writeComment(file);

--- a/networkit/cpp/io/KONECTGraphReader.cpp
+++ b/networkit/cpp/io/KONECTGraphReader.cpp
@@ -19,7 +19,7 @@ namespace NetworKit {
 KONECTGraphReader::KONECTGraphReader(bool remapNodes, MultipleEdgesHandling handlingmethod)
     : remapNodes(remapNodes), multipleEdgesHandlingMethod(handlingmethod) {}
 
-Graph KONECTGraphReader::read(const std::string &path) {
+Graph KONECTGraphReader::read(std::string_view path) {
     std::string graphFormat = "";
     std::string graphType = "";
     count numberOfNodes = -1;

--- a/networkit/cpp/io/METISGraphReader.cpp
+++ b/networkit/cpp/io/METISGraphReader.cpp
@@ -13,7 +13,7 @@
 
 namespace NetworKit {
 
-Graph METISGraphReader::read(const std::string &path) {
+Graph METISGraphReader::read(std::string_view path) {
 
     METISParser parser(path);
 

--- a/networkit/cpp/io/METISGraphWriter.cpp
+++ b/networkit/cpp/io/METISGraphWriter.cpp
@@ -13,15 +13,15 @@
 
 namespace NetworKit {
 
-void METISGraphWriter::write(const Graph &G, const std::string &path) {
+void METISGraphWriter::write(const Graph &G, std::string_view path) {
     this->write(G, G.isWeighted(), path);
 }
 
-void METISGraphWriter::write(const Graph &G, bool weighted, const std::string &path) {
+void METISGraphWriter::write(const Graph &G, bool weighted, std::string_view path) {
     if (G.isDirected()) {
         throw std::invalid_argument{"METIS does not support directed graphs"};
     }
-    std::ofstream file(path);
+    std::ofstream file(path.data());
     Aux::enforceOpened(file);
 
     count n = G.numberOfNodes();

--- a/networkit/cpp/io/METISParser.cpp
+++ b/networkit/cpp/io/METISParser.cpp
@@ -23,7 +23,7 @@ namespace NetworKit {
  *
  * @param[out]  adjacencies  node indices extracted from line
  */
-static std::vector<node> parseLine(const std::string &line, count ignoreFirst = 0) {
+static std::vector<node> parseLine(std::string_view line, count ignoreFirst = 0) {
     auto it = line.begin();
     auto end = line.end();
     std::vector<node> adjacencies;
@@ -86,7 +86,7 @@ static std::vector<std::pair<node, double>> parseWeightedLine(std::string line,
     return adjacencies;
 }
 
-METISParser::METISParser(const std::string &path) : graphFile(path) {
+METISParser::METISParser(std::string_view path) : graphFile(path.data()) {
     if (!(this->graphFile)) {
         ERROR("invalid graph file: ", path);
         throw std::runtime_error("invalid graph file");

--- a/networkit/cpp/io/MTXGraphReader.cpp
+++ b/networkit/cpp/io/MTXGraphReader.cpp
@@ -6,8 +6,8 @@
 
 namespace NetworKit {
 
-Graph MTXGraphReader::read(const std::string &path) {
-    MTXParser parser(path);
+Graph MTXGraphReader::read(std::string_view path) {
+    MTXParser parser(path.data());
 
     auto header = parser.getHeader();
     auto size = parser.getMatrixSize();

--- a/networkit/cpp/io/MatrixMarketReader.cpp
+++ b/networkit/cpp/io/MatrixMarketReader.cpp
@@ -19,17 +19,17 @@ static constexpr char COMMENT_CHAR = '%';
 static const std::string MAGIC1 = "%matrixmarket";
 static const std::string MAGIC2 = "%" + MAGIC1;
 
-std::string tolower(const std::string &str) {
+std::string tolower(std::string_view str) {
     std::string out;
     std::transform(str.begin(), str.end(), std::back_inserter(out), ::tolower);
     return out;
 }
 } // namespace
 
-CSRMatrix MatrixMarketReader::read(const std::string &path) {
-    std::ifstream in(path);
+CSRMatrix MatrixMarketReader::read(std::string_view path) {
+    std::ifstream in(path.data());
     if (!in.is_open()) {
-        throw std::runtime_error("could not open: " + path);
+        throw std::runtime_error("could not open: " + std::string(path));
     }
     return read(in);
 }

--- a/networkit/cpp/io/MemoryMappedFile.cpp
+++ b/networkit/cpp/io/MemoryMappedFile.cpp
@@ -5,7 +5,7 @@
 namespace NetworKit {
 MemoryMappedFile::MemoryMappedFile() {}
 
-MemoryMappedFile::MemoryMappedFile(const std::string &path) {
+MemoryMappedFile::MemoryMappedFile(std::string_view path) {
     open(path);
 }
 
@@ -48,7 +48,7 @@ struct MemoryMappedFileState {
     HANDLE hMap{nullptr};
 };
 
-void MemoryMappedFile::open(const std::string &path) {
+void MemoryMappedFile::open(std::string_view path) {
     if (!state) {
         state.reset(new MemoryMappedFileState{});
     } else {
@@ -56,10 +56,10 @@ void MemoryMappedFile::open(const std::string &path) {
     }
 
     state->hFile =
-        CreateFile(path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, 0);
+        CreateFile(path.data(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, 0);
     if (state->hFile == INVALID_HANDLE_VALUE) {
         DWORD dwErrorCode = ::GetLastError();
-        throw std::runtime_error("Unable to open file " + path + " "
+        throw std::runtime_error("Unable to open file " + std::string(path) + " "
                                  + std::system_category().message(dwErrorCode));
     }
 
@@ -118,11 +118,11 @@ namespace NetworKit {
 
 struct MemoryMappedFileState {};
 
-void MemoryMappedFile::open(const std::string &path) {
+void MemoryMappedFile::open(std::string_view path) {
     if (beginIt)
         close();
 
-    auto fd = ::open(path.c_str(), O_RDONLY);
+    auto fd = ::open(path.data(), O_RDONLY);
     if (fd < 0)
         throw std::runtime_error("Unable to open file");
 

--- a/networkit/cpp/io/NetworkitBinaryReader.cpp
+++ b/networkit/cpp/io/NetworkitBinaryReader.cpp
@@ -23,7 +23,7 @@ const char *accessData(const std::vector<uint8_t> &source) {
 
 namespace NetworKit {
 
-Graph NetworkitBinaryReader::read(const std::string &path) {
+Graph NetworkitBinaryReader::read(std::string_view path) {
     MemoryMappedFile mmfile(path);
     Graph G = readData(mmfile);
     return G;

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -22,8 +22,8 @@ NetworkitBinaryWriter::NetworkitBinaryWriter(uint64_t chunks, NetworkitBinaryWei
                                              NetworkitBinaryEdgeIDs edgeIndex)
     : chunks(chunks), weightsType(weightsType), edgeIndex(edgeIndex) {}
 
-void NetworkitBinaryWriter::write(const Graph &G, const std::string &path) {
-    std::ofstream outfile(path, std::ios::binary);
+void NetworkitBinaryWriter::write(const Graph &G, std::string_view path) {
+    std::ofstream outfile(path.data(), std::ios::binary);
     Aux::enforceOpened(outfile);
     writeData(outfile, G);
     INFO("Written graph to ", path);

--- a/networkit/cpp/io/PartitionReader.cpp
+++ b/networkit/cpp/io/PartitionReader.cpp
@@ -9,9 +9,9 @@
 
 namespace NetworKit {
 
-Partition PartitionReader::read(const std::string &path) {
+Partition PartitionReader::read(std::string_view path) {
 
-    std::ifstream file(path);
+    std::ifstream file(path.data());
 
     // check if file readable
     if (!file) {

--- a/networkit/cpp/io/RasterReader.cpp
+++ b/networkit/cpp/io/RasterReader.cpp
@@ -16,10 +16,10 @@ namespace NetworKit {
 
 RasterReader::RasterReader(double normalizationFactor) : normalizationFactor(normalizationFactor) {}
 
-std::pair<std::vector<double>, std::vector<double>> RasterReader::read(const std::string &path) {
+std::pair<std::vector<double>, std::vector<double>> RasterReader::read(std::string_view path) {
     DEBUG("start reading raster file...");
 
-    std::ifstream file(path);
+    std::ifstream file(path.data());
     Aux::enforceOpened(file);
     std::string line;
 

--- a/networkit/cpp/io/SNAPEdgeListPartitionReader.cpp
+++ b/networkit/cpp/io/SNAPEdgeListPartitionReader.cpp
@@ -19,7 +19,7 @@
 
 namespace NetworKit {
 
-Cover SNAPEdgeListPartitionReader::read(const std::string &path,
+Cover SNAPEdgeListPartitionReader::read(std::string_view path,
                                         std::unordered_map<node, node> &mapNodeIds, Graph &G) {
     std::ifstream file;
     std::string line; // the current line
@@ -28,7 +28,7 @@ Cover SNAPEdgeListPartitionReader::read(const std::string &path,
     // unfortunately there is an empty line at the ending of the file, so we need to get the line
     // before that
 
-    file.open(path);
+    file.open(path.data());
     if (!file.good()) {
         throw std::runtime_error("unable to read from file");
     }

--- a/networkit/cpp/io/SNAPGraphReader.cpp
+++ b/networkit/cpp/io/SNAPGraphReader.cpp
@@ -15,7 +15,7 @@ namespace NetworKit {
 SNAPGraphReader::SNAPGraphReader(bool directed, const bool &remapNodes, const count &nodeCount)
     : directed(directed), nodeCount(nodeCount), remapNodes(remapNodes) {}
 
-Graph SNAPGraphReader::read(const std::string &path) {
+Graph SNAPGraphReader::read(std::string_view path) {
     Graph graph(0, false, directed);
 
     // In the actual state this parameter has very little influence on the reader performance.

--- a/networkit/cpp/io/SNAPGraphWriter.cpp
+++ b/networkit/cpp/io/SNAPGraphWriter.cpp
@@ -12,8 +12,8 @@
 
 namespace NetworKit {
 
-void SNAPGraphWriter::write(const Graph &G, const std::string &path) {
-    std::ofstream file(path);
+void SNAPGraphWriter::write(const Graph &G, std::string_view path) {
+    std::ofstream file(path.data());
     Aux::enforceOpened(file);
 
     // write "problem line" - n, m, directed/undirected, weighted/weight type

--- a/networkit/cpp/io/ThrillGraphBinaryReader.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryReader.cpp
@@ -44,8 +44,8 @@ uint64_t get_variant(std::ifstream &is) {
 }
 } // namespace
 
-Graph ThrillGraphBinaryReader::read(const std::string &path) {
-    return read(std::vector<std::string>(1, path));
+Graph ThrillGraphBinaryReader::read(std::string_view path) {
+    return read(std::vector<std::string>(1, path.data()));
 }
 
 Graph ThrillGraphBinaryReader::read(const std::vector<std::string> &paths) {

--- a/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
@@ -10,13 +10,13 @@
 
 namespace NetworKit {
 
-void ThrillGraphBinaryWriter::write(const Graph &G, const std::string &path) {
+void ThrillGraphBinaryWriter::write(const Graph &G, std::string_view path) {
     if (G.upperNodeIdBound() > std::numeric_limits<uint32_t>::max()) {
         throw std::runtime_error(
             "Thrill binary graphs only support graphs with up to 2^32-1 nodes.");
     }
 
-    std::ofstream out_stream(path, std::ios::trunc | std::ios::binary);
+    std::ofstream out_stream(path.data(), std::ios::trunc | std::ios::binary);
 
     std::vector<uint32_t> neighbors;
 

--- a/networkit/cpp/io/test/IOBenchmark.cpp
+++ b/networkit/cpp/io/test/IOBenchmark.cpp
@@ -27,7 +27,7 @@ namespace NetworKit {
 class IOBenchmark : public testing::Test {
 public:
     static void convertToHeatMap(std::vector<bool> &infected, std::vector<double> &xcoords,
-                                 std::vector<double> &ycoords, const std::string &filename,
+                                 std::vector<double> &ycoords, std::string_view filename,
                                  double resolution = 1);
 };
 
@@ -35,7 +35,7 @@ public:
  * This should actually not be in the benchmark but somewhere else. Can't figure out where yet.
  */
 void IOBenchmark::convertToHeatMap(std::vector<bool> &infected, std::vector<double> &xcoords,
-                                   std::vector<double> &ycoords, const std::string &filename,
+                                   std::vector<double> &ycoords, std::string_view filename,
                                    double resolution) {
 
     auto minmaxx = std::minmax_element(xcoords.begin(), xcoords.end());
@@ -72,7 +72,7 @@ void IOBenchmark::convertToHeatMap(std::vector<bool> &infected, std::vector<doub
 
     // open output file
     std::ofstream file;
-    file.open(filename.c_str());
+    file.open(filename.data());
 
     // write column labels
     file << "x"

--- a/networkit/cpp/io/test/MemoryMappedFileGTest.cpp
+++ b/networkit/cpp/io/test/MemoryMappedFileGTest.cpp
@@ -84,7 +84,7 @@ public:
         }
     }
 
-    const std::string &filename() const { return path; }
+    std::string_view filename() const { return path; }
 
     const_iterator cbegin() const { return dataBegin.get(); }
 

--- a/networkit/cpp/viz/PostscriptWriter.cpp
+++ b/networkit/cpp/viz/PostscriptWriter.cpp
@@ -141,10 +141,10 @@ void PostscriptWriter::init(std::ofstream &file) const {
 }
 
 void PostscriptWriter::write(const Graph &g, const std::vector<Point2D> &coordinates,
-                             const Partition &clustering, const std::string &path) {
+                             const Partition &clustering, std::string_view path) {
     assert(g.upperNodeIdBound() == coordinates.size());
 
-    std::ofstream file(path);
+    std::ofstream file(path.data());
     init(file);
     computeBoundaryBox(coordinates);
 
@@ -158,7 +158,7 @@ void PostscriptWriter::write(const Graph &g, const std::vector<Point2D> &coordin
 }
 
 void PostscriptWriter::write(const Graph &g, const std::vector<Point2D> &coordinates,
-                             const std::string &path) {
+                             std::string_view path) {
     assert(g.upperNodeIdBound() == coordinates.size());
 
     ClusteringGenerator gen;

--- a/networkit/cpp/viz/test/MaxentStressGTest.cpp
+++ b/networkit/cpp/viz/test/MaxentStressGTest.cpp
@@ -49,7 +49,7 @@ TEST_F(MaxentStressGTest, benchMaxentStressCoordinatesLAMG) {
     std::vector<std::string> graphFiles = {"input/airfoil1.graph"};
     METISGraphReader reader;
 
-    for (const std::string &graphFile : graphFiles) {
+    for (std::string_view graphFile : graphFiles) {
         Graph graph = reader.read(graphFile);
 
         double runtime = 0;
@@ -83,7 +83,7 @@ TEST_F(MaxentStressGTest, benchMaxentStressConjGradIdPrecAlgebraicDistance) {
     std::vector<std::string> graphFiles = {"input/airfoil1.graph"};
     METISGraphReader reader;
 
-    for (const std::string &graphFile : graphFiles) {
+    for (std::string_view graphFile : graphFiles) {
         Graph graph = reader.read(graphFile);
 
         double runtime = 0;
@@ -117,7 +117,7 @@ TEST_F(MaxentStressGTest, benchMaxentStressConjGradDiagPrecond) {
     std::vector<std::string> graphFiles = {"input/airfoil1.graph"};
     METISGraphReader reader;
 
-    for (const std::string &graphFile : graphFiles) {
+    for (std::string_view graphFile : graphFiles) {
         Graph graph = reader.read(graphFile);
 
         double runtime = 0;
@@ -150,7 +150,7 @@ TEST_F(MaxentStressGTest, benchMaxentStressCoordConjGradIdPrecond) {
     std::vector<std::string> graphFiles = {"input/airfoil1.graph"};
     METISGraphReader reader;
 
-    for (const std::string &graphFile : graphFiles) {
+    for (std::string_view graphFile : graphFiles) {
         Graph graph = reader.read(graphFile);
 
         double runtime = 0;


### PR DESCRIPTION
This PR replaces each occasion of `const std::string&` by `std::string_view`. [This forum post](https://stackoverflow.com/questions/40127965/how-exactly-is-stdstring-view-faster-than-const-stdstring) leads to the assumption that using `std::string_view` provides runtime advantages, while having almost no downsides. 
