### PR TITLE
Fix copy operations for attributes

### DIFF
--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -94,7 +94,7 @@ class Attribute;
 
 template <typename NodeOrEdge, typename GraphType, template <typename, typename> class Base,
           typename T>
-class AttributeStorage : public Base<NodeOrEdge, GraphType> {
+class AttributeStorage final : public Base<NodeOrEdge, GraphType> {
 public:
     AttributeStorage(std::string name) : Base<NodeOrEdge, GraphType>{std::move(name), typeid(T)} {}
 

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -138,7 +138,7 @@ public:
 private:
     using Base<NodeOrEdge, GraphType>::theGraph;
     std::vector<T> values; // the real attribute storage
-}; // class AttributeStorage<NodeOrEdge, Base, T>
+};                         // class AttributeStorage<NodeOrEdge, Base, T>
 
 template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
 class Attribute {
@@ -452,6 +452,35 @@ public:
     static constexpr bool edges = true;
 };
 
+/* ATTRIBUTE PREMISE AND INDEX CHECKS */
+
+template <>
+inline void ASB<PerNode, Graph>::checkPremise() const {
+    // nothing
+}
+
+template <>
+inline void ASB<PerEdge, Graph>::checkPremise() const {
+    if (!theGraph->hasEdgeIds()) {
+        throw std::runtime_error("Edges must be indexed");
+    }
+}
+
+template <>
+inline void ASB<PerNode, Graph>::indexOK(index n) const {
+    if (!theGraph->hasNode(n)) {
+        throw std::runtime_error("This node does not exist");
+    }
+}
+
+template <>
+inline void ASB<PerEdge, Graph>::indexOK(index n) const {
+    auto uv = theGraph->edgeById(n);
+    if (!theGraph->hasEdge(uv.first, uv.second)) {
+        throw std::runtime_error("This edgeId does not exist");
+    }
+}
+
 } // namespace NetworKit
 
-#endif //
+#endif // NETWORKIT_GRAPH_ATTRIBUTES_HPP_

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -439,7 +439,7 @@ public:
         // the shared_ptr and not the data
         for (auto &[key, value] : other.attrMap) {
             auto ptr = value->clone();
-            auto insertResult = attrMap.emplace(key, ptr);
+            attrMap.emplace(key, ptr);
         }
     }
 

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -1,0 +1,449 @@
+/*
+ * Attributes.hpp
+ *
+ *  Created on: 14.05.2024
+ *      Author: Klaus Ahrens
+ *              Eugenio Angriman
+ *              Lukas Berner
+ *              Fabian Brandt-Tumescheit
+ *              Alexander van der Grinten
+ */
+
+#ifndef NETWORKIT_GRAPH_ATTRIBUTES_HPP_
+#define NETWORKIT_GRAPH_ATTRIBUTES_HPP_
+
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+// base class for all node (and edge) attribute
+// storages with attribute type info
+// independent of the attribute type, holds bookkeeping info only:
+// - attribute name
+// - type info of derived (real storage holding) classes
+// - which indices are valid
+// - number of valid indices
+// - the associated graph (who knows, which nodes/edges exist)
+// - the validity of the whole storage (initially true, false after detach)
+// all indexed accesses by NetworKit::index: synonym both for node and edgeid
+
+template <typename NodeOrEdge, typename GraphType>
+class AttributeStorageBase { // alias ASB
+public:
+    AttributeStorageBase(const GraphType *graph, std::string name, std::type_index type)
+        : name{std::move(name)}, type{type}, theGraph{graph}, validStorage{true} {
+        checkPremise(); // node for PerNode, theGraph.hasEdgeIds() for PerEdges
+    }
+
+    void invalidateStorage() { validStorage = false; }
+
+    const std::string &getName() const noexcept { return name; }
+
+    std::type_index getType() const noexcept { return type; }
+
+    bool isValid(index n) const noexcept { return n < valid.size() && valid[n]; }
+
+    // Called by Graph when node/edgeid n is deleted.
+    void invalidate(index n) {
+        if (isValid(n)) {
+            valid[n] = false;
+            --validElements;
+        }
+    }
+
+protected:
+    void markValid(index n) {
+        indexOK(n); // specialized for node/edgeid
+        if (n >= valid.size())
+            valid.resize(n + 1);
+        if (!valid[n]) {
+            valid[n] = true;
+            ++validElements;
+        }
+    }
+
+    void checkIndex(index n) const {
+        indexOK(n);
+        if (!isValid(n)) {
+            throw std::runtime_error("Invalid attribute value");
+        }
+    }
+
+private:
+    std::string name;
+    std::type_index type;
+    std::vector<bool> valid; // For each node/edgeid: whether attribute is set or not.
+
+protected:
+    void indexOK(index n) const;
+    void checkPremise() const;
+    index validElements = 0;
+    const GraphType *theGraph;
+    bool validStorage; // Validity of the whole storage
+
+}; // class AttributeStorageBase
+
+template <typename NodeOrEdge, typename GraphType>
+using ASB = AttributeStorageBase<NodeOrEdge, GraphType>;
+
+template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
+class Attribute;
+
+template <typename NodeOrEdge, typename GraphType, template <typename, typename> class Base,
+          typename T>
+class AttributeStorage : public Base<NodeOrEdge, GraphType> {
+public:
+    AttributeStorage(const GraphType *theGraph, std::string name)
+        : Base<NodeOrEdge, GraphType>{theGraph, std::move(name), typeid(T)} {}
+
+    void resize(index i) {
+        if (i >= values.size())
+            values.resize(i + 1);
+    }
+
+    auto size() const noexcept { return this->validElements; }
+
+    void set(index i, T &&v) {
+        this->markValid(i);
+        resize(i);
+        values[i] = std::move(v);
+    }
+
+    // instead of returning an std::optional (C++17) we provide these
+    // C++14 options
+    // (1) throw an exception when invalid:
+    T get(index i) const { // may throw
+        this->checkIndex(i);
+        return values[i];
+    }
+
+    // (2) give default value when invalid:
+    T get(index i, T defaultT) const noexcept {
+        if (i >= values.size() || !this->isValid(i))
+            return defaultT;
+        return values[i];
+    }
+
+    friend Attribute<NodeOrEdge, GraphType, T, true>;
+    friend Attribute<NodeOrEdge, GraphType, T, false>;
+
+private:
+    using Base<NodeOrEdge, GraphType>::theGraph;
+    std::vector<T> values; // the real attribute storage
+}; // class AttributeStorage<NodeOrEdge, Base, T>
+
+template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
+class Attribute {
+public:
+    using AttributeStorage_type =
+        std::conditional_t<isConst, const AttributeStorage<NodeOrEdge, GraphType, ASB, T>,
+                           AttributeStorage<NodeOrEdge, GraphType, ASB, T>>;
+    class Iterator {
+    public:
+        // The value type of the attribute. Returned by
+        // operator*().
+        using value_type = T;
+
+        // Reference to the value_type, required by STL.
+        using reference = std::conditional_t<isConst, const value_type &, value_type &>;
+
+        // Pointer to the value_type, required by STL.
+        using pointer = std::conditional_t<isConst, const value_type *, value_type *>;
+
+        // STL iterator category.
+        using iterator_category = std::forward_iterator_tag;
+
+        // Signed integer type of the result of subtracting two pointers,
+        // required by STL.
+        using difference_type = ptrdiff_t;
+
+        Iterator() : storage{nullptr}, idx{0} {}
+        Iterator(AttributeStorage_type *storage) : storage{storage}, idx{0} {
+            if (storage) {
+                nextValid();
+            }
+        }
+
+        Iterator &nextValid() {
+            while (storage && !storage->isValid(idx)) {
+                if (idx >= storage->values.size()) {
+                    storage = nullptr;
+                    return *this;
+                }
+                ++idx;
+            }
+            return *this;
+        }
+
+        Iterator &operator++() {
+            if (!storage) {
+                throw std::runtime_error("Invalid attribute iterator");
+            }
+            ++idx;
+            return nextValid();
+        }
+
+        auto operator*() const {
+            if (!storage) {
+                throw std::runtime_error("Invalid attribute iterator");
+            }
+            return std::make_pair(idx, storage->values[idx]);
+        }
+
+        bool operator==(Iterator const &iter) const noexcept {
+            if (storage == nullptr && iter.storage == nullptr) {
+                return true;
+            }
+            return storage == iter.storage && idx == iter.idx;
+        }
+
+        bool operator!=(Iterator const &iter) const noexcept { return !(*this == iter); }
+
+    private:
+        AttributeStorage_type *storage;
+        index idx;
+    }; // class Iterator
+
+private:
+    class IndexProxy {
+        // a helper class for distinguished read and write on an indexed
+        // attribute
+        // operator[] on an attribute yields an IndexProxy holding
+        // location and index of access
+        //    - casting an IndexProxy to the attribute type reads the value
+        //    - assigning to it (operator=) writes the value
+    public:
+        IndexProxy(AttributeStorage_type *storage, index idx) : storage{storage}, idx{idx} {}
+
+        // reading at idx
+        operator T() const {
+            storage->checkIndex(idx);
+            return storage->values[idx];
+        }
+
+        // writing at idx
+        template <bool ic = isConst>
+        std::enable_if_t<!ic, T> &operator=(T &&other) {
+            storage->set(idx, std::move(other));
+            return storage->values[idx];
+        }
+
+    private:
+        AttributeStorage_type *storage;
+        index idx;
+    }; // class IndexProxy
+public:
+    explicit Attribute(std::shared_ptr<AttributeStorage_type> ownedStorage = nullptr)
+        : ownedStorage{ownedStorage}, valid{ownedStorage != nullptr} {}
+
+    Attribute(Attribute const &other) : ownedStorage{other.ownedStorage}, valid{other.valid} {}
+
+    template <bool ic = isConst, std::enable_if_t<ic, int> = 0>
+    Attribute(Attribute<NodeOrEdge, GraphType, T, false> const &other)
+        : ownedStorage{other.ownedStorage}, valid{other.valid} {}
+
+    Attribute &operator=(Attribute other) {
+        this->swap(other);
+        return *this;
+    }
+
+    void swap(Attribute &other) {
+        std::swap(ownedStorage, other.ownedStorage);
+        std::swap(valid, other.valid);
+    }
+
+    Attribute(Attribute &&other) noexcept
+        : ownedStorage{std::move(other.ownedStorage)}, valid{other.valid} {
+        other.valid = false;
+    }
+
+    template <bool ic = isConst, std::enable_if_t<ic, int> = 0>
+    Attribute(Attribute<NodeOrEdge, GraphType, T, false> &&other) noexcept
+        : ownedStorage{std::move(other.ownedStorage)}, valid{other.valid} {
+        other.valid = false;
+    }
+
+    auto begin() const {
+        checkAttribute();
+        return Iterator(ownedStorage.get()).nextValid();
+    }
+
+    auto end() const { return Iterator(nullptr); }
+
+    auto size() const noexcept { return ownedStorage->size(); }
+
+    template <bool ic = isConst>
+    std::enable_if_t<!ic> set(index i, T v) {
+        checkAttribute();
+        ownedStorage->set(i, std::move(v));
+    }
+
+    template <bool ic = isConst>
+    std::enable_if_t<!ic> set2(node u, node v, T t) {
+        static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
+        set(ownedStorage->theGraph->edgeId(u, v), t);
+    }
+
+    auto get(index i) const {
+        checkAttribute();
+        return ownedStorage->get(i);
+    }
+
+    auto get2(node u, node v) const {
+        static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
+        return get(ownedStorage->theGraph->edgeId(u, v));
+    }
+
+    auto get(index i, T defaultT) const {
+        checkAttribute();
+        return ownedStorage->get(i, defaultT);
+    }
+
+    auto get2(node u, node v, T defaultT) const {
+        static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
+        return get(ownedStorage->theGraph->edgeId(u, v), defaultT);
+    }
+
+    IndexProxy operator[](index i) const {
+        checkAttribute();
+        return IndexProxy(ownedStorage.get(), i);
+    }
+
+    IndexProxy operator()(node u, node v) const {
+        static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
+        checkAttribute();
+        return IndexProxy(ownedStorage.get(), ownedStorage->theGraph->edgeId(u, v));
+    }
+
+    void checkAttribute() const {
+        if (!ownedStorage->validStorage)
+            throw std::runtime_error("Invalid attribute");
+    }
+
+    auto getName() const {
+        checkAttribute();
+        return ownedStorage->getName();
+    }
+
+    void write(std::string const &filename) const {
+        std::ofstream out(filename);
+        if (!out)
+            ERROR("cannot open ", filename, " for writing");
+
+        for (auto it = begin(); it != end(); ++it) {
+            auto pair = *it;
+            auto n = pair.first;  // node/edgeid
+            auto v = pair.second; // value
+            out << n << "\t" << v << "\n";
+        }
+        out.close();
+    }
+
+    template <bool ic = isConst>
+    std::enable_if_t<!ic> read(const std::string &filename) {
+        std::ifstream in(filename);
+        if (!in) {
+            ERROR("cannot open ", filename, " for reading");
+        }
+        index n; // node/edgeid
+        T v;     // value
+        std::string line;
+        while (std::getline(in, line)) {
+            std::istringstream istring(line);
+            if constexpr (std::is_same_v<T, std::string>) {
+                istring >> n >> std::ws;
+                std::getline(istring, v);
+            } else {
+                istring >> n >> v;
+            }
+            set(n, v);
+        }
+    }
+
+private:
+    std::shared_ptr<AttributeStorage_type> ownedStorage;
+    bool valid;
+}; // class Attribute
+
+template <typename NodeOrEdge, typename GraphType>
+class AttributeMap {
+    friend GraphType;
+    const GraphType *theGraph;
+
+public:
+    std::unordered_map<std::string, std::shared_ptr<ASB<NodeOrEdge, GraphType>>> attrMap;
+
+    AttributeMap(const GraphType *g) : theGraph{g} {}
+
+    auto find(std::string const &name) {
+        auto it = attrMap.find(name);
+        if (it == attrMap.end()) {
+            throw std::runtime_error("No such attribute");
+        }
+        return it;
+    }
+
+    auto find(std::string const &name) const {
+        auto it = attrMap.find(name);
+        if (it == attrMap.end()) {
+            throw std::runtime_error("No such attribute");
+        }
+        return it;
+    }
+
+    template <typename T>
+    auto attach(const std::string &name) {
+        auto ownedPtr = std::make_shared<AttributeStorage<NodeOrEdge, GraphType, ASB, T>>(
+            theGraph, std::string{name});
+        auto insertResult = attrMap.emplace(ownedPtr->getName(), ownedPtr);
+        auto success = insertResult.second;
+        if (!success) {
+            throw std::runtime_error("Attribute with same name already exists");
+        }
+        return Attribute<NodeOrEdge, GraphType, T, false>{ownedPtr};
+    }
+
+    void detach(const std::string &name) {
+        auto it = find(name);
+        auto storage = it->second.get();
+        storage->invalidateStorage();
+        it->second.reset();
+        attrMap.erase(name);
+    }
+
+    template <typename T>
+    auto get(const std::string &name) {
+        auto it = find(name);
+        if (it->second.get()->getType() != typeid(T))
+            throw std::runtime_error("Type mismatch in Attributes().get()");
+        return Attribute<NodeOrEdge, GraphType, T, false>{
+            std::static_pointer_cast<AttributeStorage<NodeOrEdge, GraphType, ASB, T>>(it->second)};
+    }
+
+    template <typename T>
+    auto get(const std::string &name) const {
+        auto it = find(name);
+        if (it->second.get()->getType() != typeid(T))
+            throw std::runtime_error("Type mismatch in Attributes().get()");
+        return Attribute<NodeOrEdge, GraphType, T, true>{
+            std::static_pointer_cast<const AttributeStorage<NodeOrEdge, GraphType, ASB, T>>(
+                it->second)};
+    }
+
+}; // class AttributeMap
+
+/// @private
+class PerNode {
+public:
+    static constexpr bool edges = false;
+};
+
+/// @private
+class PerEdge {
+public:
+    static constexpr bool edges = true;
+};
+
+} // namespace NetworKit
+
+#endif //

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -12,7 +12,15 @@
 #ifndef NETWORKIT_GRAPH_ATTRIBUTES_HPP_
 #define NETWORKIT_GRAPH_ATTRIBUTES_HPP_
 
-#include <networkit/graph/Graph.hpp>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <typeindex>
+#include <unordered_map>
+#include <vector>
+
+#include <networkit/Globals.hpp>
+#include <networkit/auxiliary/Log.hpp>
 
 namespace NetworKit {
 

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -98,7 +98,7 @@ class AttributeStorage : public Base<NodeOrEdge, GraphType> {
 public:
     AttributeStorage(std::string name) : Base<NodeOrEdge, GraphType>{std::move(name), typeid(T)} {}
 
-    virtual std::shared_ptr<Base<NodeOrEdge, GraphType>> clone() const override {
+    std::shared_ptr<Base<NodeOrEdge, GraphType>> clone() const override {
         return std::make_shared<AttributeStorage>(*this);
     };
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1276,16 +1276,55 @@ public:
           nodeAttributeMap(other.nodeAttributeMap, this),
           edgeAttributeMap(other.edgeAttributeMap, this){};
 
-    /** Default move constructor */
-    Graph(Graph &&other) noexcept = default;
+    /** move constructor */
+    Graph(Graph &&other) noexcept
+        : n(std::move(other.n)), m(std::move(other.m)),
+          storedNumberOfSelfLoops(std::move(other.storedNumberOfSelfLoops)), z(std::move(other.z)),
+          omega(std::move(other.omega)), t(std::move(other.t)), weighted(std::move(other.weighted)),
+          directed(std::move(other.directed)), edgesIndexed(std::move(other.edgesIndexed)),
+          exists(std::move(other.exists)), inEdges(std::move(other.inEdges)),
+          outEdges(std::move(other.outEdges)), inEdgeWeights(std::move(other.inEdgeWeights)),
+          outEdgeWeights(std::move(other.outEdgeWeights)), inEdgeIds(std::move(other.inEdgeIds)),
+          outEdgeIds(std::move(other.outEdgeIds)),
+          nodeAttributeMap(std::move(other.nodeAttributeMap)),
+          edgeAttributeMap(std::move(other.edgeAttributeMap)) {
+        // attributes: set graph pointer to this new graph
+        nodeAttributeMap.theGraph = this;
+        edgeAttributeMap.theGraph = this;
+    };
 
     /** Default destructor */
     ~Graph() = default;
 
-    /** Default move assignment operator */
-    Graph &operator=(Graph &&other) noexcept = default;
+    /** move assignment operator */
+    Graph &operator=(Graph &&other) noexcept {
+        std::swap(n, other.n);
+        std::swap(m, other.m);
+        std::swap(storedNumberOfSelfLoops, other.storedNumberOfSelfLoops);
+        std::swap(z, other.z);
+        std::swap(omega, other.omega);
+        std::swap(t, other.t);
+        std::swap(weighted, other.weighted);
+        std::swap(directed, other.directed);
+        std::swap(edgesIndexed, other.edgesIndexed);
+        std::swap(exists, other.exists);
+        std::swap(inEdges, other.inEdges);
+        std::swap(outEdges, other.outEdges);
+        std::swap(inEdgeWeights, other.inEdgeWeights);
+        std::swap(outEdgeWeights, other.outEdgeWeights);
+        std::swap(inEdgeIds, other.inEdgeIds);
+        std::swap(outEdgeIds, other.outEdgeIds);
 
-    /** Default copy assignment operator */
+        // attributes: set graph pointer to this new graph
+        std::swap(nodeAttributeMap, other.nodeAttributeMap);
+        std::swap(edgeAttributeMap, other.edgeAttributeMap);
+        nodeAttributeMap.theGraph = this;
+        edgeAttributeMap.theGraph = this;
+
+        return *this;
+    };
+
+    /** copy assignment operator */
     Graph &operator=(const Graph &other) {
         n = other.n;
         m = other.m;

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -429,8 +429,8 @@ private:
                                   typename Aux::FunctionTraits<F>::template arg<2>::type>::value
                   && std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<3>::type>::
                       value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew,
-                    edgeid id) const -> decltype(f(u, v, ew, id)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid id) const
+        -> decltype(f(u, v, ew, id)) {
         return f(u, v, ew, id);
     }
 
@@ -462,8 +462,8 @@ private:
                   (Aux::FunctionTraits<F>::arity >= 2)
                   && std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<
                                                   2>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew,
-                    edgeid /*id*/) const -> decltype(f(u, v, ew)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid /*id*/) const
+        -> decltype(f(u, v, ew)) {
         return f(u, v, ew);
     }
 
@@ -476,8 +476,8 @@ private:
                            (Aux::FunctionTraits<F>::arity >= 1)
                            && std::is_same<node, typename Aux::FunctionTraits<F>::template arg<
                                                      1>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/,
-                    edgeid /*id*/) const -> decltype(f(u, v)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/, edgeid /*id*/) const
+        -> decltype(f(u, v)) {
         return f(u, v);
     }
 
@@ -613,7 +613,7 @@ public:
     public:
         NodeRange(const Graph &G) : G(&G) {}
 
-        NodeRange() : G(nullptr) {};
+        NodeRange() : G(nullptr){};
 
         ~NodeRange() = default;
 
@@ -838,7 +838,7 @@ public:
     public:
         EdgeRange(const Graph &G) : G(&G) {}
 
-        EdgeRange() : G(nullptr) {};
+        EdgeRange() : G(nullptr){};
 
         ~EdgeRange() = default;
 
@@ -863,7 +863,7 @@ public:
     public:
         EdgeWeightRange(const Graph &G) : G(&G) {}
 
-        EdgeWeightRange() : G(nullptr) {};
+        EdgeWeightRange() : G(nullptr){};
 
         ~EdgeWeightRange() = default;
 
@@ -1028,7 +1028,7 @@ public:
     public:
         NeighborRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborRange() : G(nullptr) {};
+        NeighborRange() : G(nullptr){};
 
         NeighborIterator begin() const {
             assert(G);
@@ -1060,7 +1060,7 @@ public:
     public:
         NeighborWeightRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborWeightRange() : G(nullptr) {};
+        NeighborWeightRange() : G(nullptr){};
 
         NeighborWeightIterator begin() const {
             assert(G);

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1278,10 +1278,9 @@ public:
 
     /** move constructor */
     Graph(Graph &&other) noexcept
-        : n(std::move(other.n)), m(std::move(other.m)),
-          storedNumberOfSelfLoops(std::move(other.storedNumberOfSelfLoops)), z(std::move(other.z)),
-          omega(std::move(other.omega)), t(std::move(other.t)), weighted(std::move(other.weighted)),
-          directed(std::move(other.directed)), edgesIndexed(std::move(other.edgesIndexed)),
+        : n(other.n), m(other.m), storedNumberOfSelfLoops(other.storedNumberOfSelfLoops),
+          z(other.z), omega(other.omega), t(other.t), weighted(other.weighted),
+          directed(other.directed), edgesIndexed(other.edgesIndexed),
           exists(std::move(other.exists)), inEdges(std::move(other.inEdges)),
           outEdges(std::move(other.outEdges)), inEdgeWeights(std::move(other.inEdgeWeights)),
           outEdgeWeights(std::move(other.outEdgeWeights)), inEdgeIds(std::move(other.inEdgeIds)),

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -32,6 +32,7 @@
 #include <networkit/auxiliary/FunctionTraits.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>
+#include <networkit/graph/Attributes.hpp>
 
 #include <tlx/define/deprecated.hpp>
 
@@ -156,431 +157,8 @@ class Graph final {
     std::vector<std::vector<edgeid>> outEdgeIds;
 
 private:
-    // base class for all node (and edge) attribute
-    // storages with attribute type info
-    // independent of the attribute type, holds bookkeeping info only:
-    // - attribute name
-    // - type info of derived (real storage holding) classes
-    // - which indices are valid
-    // - number of valid indices
-    // - the associated graph (who knows, which nodes/edges exist)
-    // - the validity of the whole storage (initially true, false after detach)
-    // all indexed accesses by NetworKit::index: synonym both for node and edgeid
-
-    class PerNode {
-    public:
-        static constexpr bool edges = false;
-    };
-    class PerEdge {
-    public:
-        static constexpr bool edges = true;
-    };
-
-    template <typename NodeOrEdge>
-    class AttributeStorageBase { // alias ASB
-    public:
-        AttributeStorageBase(const Graph *graph, std::string name, std::type_index type)
-            : name{std::move(name)}, type{type}, theGraph{graph}, validStorage{true} {
-            checkPremise(); // node for PerNode, theGraph.hasEdgeIds() for PerEdges
-        }
-
-        void invalidateStorage() { validStorage = false; }
-
-        const std::string &getName() const noexcept { return name; }
-
-        std::type_index getType() const noexcept { return type; }
-
-        bool isValid(index n) const noexcept { return n < valid.size() && valid[n]; }
-
-        // Called by Graph when node/edgeid n is deleted.
-        void invalidate(index n) {
-            if (isValid(n)) {
-                valid[n] = false;
-                --validElements;
-            }
-        }
-
-    protected:
-        void markValid(index n) {
-            indexOK(n); // specialized for node/edgeid
-            if (n >= valid.size())
-                valid.resize(n + 1);
-            if (!valid[n]) {
-                valid[n] = true;
-                ++validElements;
-            }
-        }
-
-        void checkIndex(index n) const {
-            indexOK(n);
-            if (!isValid(n)) {
-                throw std::runtime_error("Invalid attribute value");
-            }
-        }
-
-    private:
-        std::string name;
-        std::type_index type;
-        std::vector<bool> valid; // For each node/edgeid: whether attribute is set or not.
-
-    protected:
-        void indexOK(index n) const;
-        void checkPremise() const;
-        index validElements = 0;
-        const Graph *theGraph;
-        bool validStorage; // Validity of the whole storage
-
-    }; // class AttributeStorageBase
-
-    template <typename NodeOrEdge>
-    using ASB = AttributeStorageBase<NodeOrEdge>;
-
-    template <typename NodeOrEdge, typename T, bool isConst>
-    class Attribute;
-
-    template <typename NodeOrEdge, template <typename> class Base, typename T>
-    class AttributeStorage : public Base<NodeOrEdge> {
-    public:
-        AttributeStorage(const Graph *theGraph, std::string name)
-            : Base<NodeOrEdge>{theGraph, std::move(name), typeid(T)} {}
-
-        void resize(index i) {
-            if (i >= values.size())
-                values.resize(i + 1);
-        }
-
-        auto size() const noexcept { return this->validElements; }
-
-        void set(index i, T &&v) {
-            this->markValid(i);
-            resize(i);
-            values[i] = std::move(v);
-        }
-
-        // instead of returning an std::optional (C++17) we provide these
-        // C++14 options
-        // (1) throw an exception when invalid:
-        T get(index i) const { // may throw
-            this->checkIndex(i);
-            return values[i];
-        }
-
-        // (2) give default value when invalid:
-        T get(index i, T defaultT) const noexcept {
-            if (i >= values.size() || !this->isValid(i))
-                return defaultT;
-            return values[i];
-        }
-
-        friend Attribute<NodeOrEdge, T, true>;
-        friend Attribute<NodeOrEdge, T, false>;
-
-    private:
-        using Base<NodeOrEdge>::theGraph;
-        std::vector<T> values; // the real attribute storage
-    };                         // class AttributeStorage<NodeOrEdge, Base, T>
-
-    template <typename NodeOrEdge, typename T, bool isConst>
-    class Attribute {
-    public:
-        using AttributeStorage_type =
-            std::conditional_t<isConst, const AttributeStorage<NodeOrEdge, ASB, T>,
-                               AttributeStorage<NodeOrEdge, ASB, T>>;
-        class Iterator {
-        public:
-            // The value type of the attribute. Returned by
-            // operator*().
-            using value_type = T;
-
-            // Reference to the value_type, required by STL.
-            using reference = std::conditional_t<isConst, const value_type &, value_type &>;
-
-            // Pointer to the value_type, required by STL.
-            using pointer = std::conditional_t<isConst, const value_type *, value_type *>;
-
-            // STL iterator category.
-            using iterator_category = std::forward_iterator_tag;
-
-            // Signed integer type of the result of subtracting two pointers,
-            // required by STL.
-            using difference_type = ptrdiff_t;
-
-            Iterator() : storage{nullptr}, idx{0} {}
-            Iterator(AttributeStorage_type *storage) : storage{storage}, idx{0} {
-                if (storage) {
-                    nextValid();
-                }
-            }
-
-            Iterator &nextValid() {
-                while (storage && !storage->isValid(idx)) {
-                    if (idx >= storage->values.size()) {
-                        storage = nullptr;
-                        return *this;
-                    }
-                    ++idx;
-                }
-                return *this;
-            }
-
-            Iterator &operator++() {
-                if (!storage) {
-                    throw std::runtime_error("Invalid attribute iterator");
-                }
-                ++idx;
-                return nextValid();
-            }
-
-            auto operator*() const {
-                if (!storage) {
-                    throw std::runtime_error("Invalid attribute iterator");
-                }
-                return std::make_pair(idx, storage->values[idx]);
-            }
-
-            bool operator==(Iterator const &iter) const noexcept {
-                if (storage == nullptr && iter.storage == nullptr) {
-                    return true;
-                }
-                return storage == iter.storage && idx == iter.idx;
-            }
-
-            bool operator!=(Iterator const &iter) const noexcept { return !(*this == iter); }
-
-        private:
-            AttributeStorage_type *storage;
-            index idx;
-        }; // class Iterator
-
-    private:
-        class IndexProxy {
-            // a helper class for distinguished read and write on an indexed
-            // attribute
-            // operator[] on an attribute yields an IndexProxy holding
-            // location and index of access
-            //    - casting an IndexProxy to the attribute type reads the value
-            //    - assigning to it (operator=) writes the value
-        public:
-            IndexProxy(AttributeStorage_type *storage, index idx) : storage{storage}, idx{idx} {}
-
-            // reading at idx
-            operator T() const {
-                storage->checkIndex(idx);
-                return storage->values[idx];
-            }
-
-            // writing at idx
-            template <bool ic = isConst>
-            std::enable_if_t<!ic, T> &operator=(T &&other) {
-                storage->set(idx, std::move(other));
-                return storage->values[idx];
-            }
-
-        private:
-            AttributeStorage_type *storage;
-            index idx;
-        }; // class IndexProxy
-    public:
-        explicit Attribute(std::shared_ptr<AttributeStorage_type> ownedStorage = nullptr)
-            : ownedStorage{ownedStorage}, valid{ownedStorage != nullptr} {}
-
-        Attribute(Attribute const &other) : ownedStorage{other.ownedStorage}, valid{other.valid} {}
-
-        template <bool ic = isConst, std::enable_if_t<ic, int> = 0>
-        Attribute(Attribute<NodeOrEdge, T, false> const &other)
-            : ownedStorage{other.ownedStorage}, valid{other.valid} {}
-
-        Attribute &operator=(Attribute other) {
-            this->swap(other);
-            return *this;
-        }
-
-        void swap(Attribute &other) {
-            std::swap(ownedStorage, other.ownedStorage);
-            std::swap(valid, other.valid);
-        }
-
-        Attribute(Attribute &&other) noexcept
-            : ownedStorage{std::move(other.ownedStorage)}, valid{other.valid} {
-            other.valid = false;
-        }
-
-        template <bool ic = isConst, std::enable_if_t<ic, int> = 0>
-        Attribute(Attribute<NodeOrEdge, T, false> &&other) noexcept
-            : ownedStorage{std::move(other.ownedStorage)}, valid{other.valid} {
-            other.valid = false;
-        }
-
-        auto begin() const {
-            checkAttribute();
-            return Iterator(ownedStorage.get()).nextValid();
-        }
-
-        auto end() const { return Iterator(nullptr); }
-
-        auto size() const noexcept { return ownedStorage->size(); }
-
-        template <bool ic = isConst>
-        std::enable_if_t<!ic> set(index i, T v) {
-            checkAttribute();
-            ownedStorage->set(i, std::move(v));
-        }
-
-        template <bool ic = isConst>
-        std::enable_if_t<!ic> set2(node u, node v, T t) {
-            static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
-            set(ownedStorage->theGraph->edgeId(u, v), t);
-        }
-
-        auto get(index i) const {
-            checkAttribute();
-            return ownedStorage->get(i);
-        }
-
-        auto get2(node u, node v) const {
-            static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
-            return get(ownedStorage->theGraph->edgeId(u, v));
-        }
-
-        auto get(index i, T defaultT) const {
-            checkAttribute();
-            return ownedStorage->get(i, defaultT);
-        }
-
-        auto get2(node u, node v, T defaultT) const {
-            static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
-            return get(ownedStorage->theGraph->edgeId(u, v), defaultT);
-        }
-
-        IndexProxy operator[](index i) const {
-            checkAttribute();
-            return IndexProxy(ownedStorage.get(), i);
-        }
-
-        IndexProxy operator()(node u, node v) const {
-            static_assert(NodeOrEdge::edges, "attribute(u,v) for edges only");
-            checkAttribute();
-            return IndexProxy(ownedStorage.get(), ownedStorage->theGraph->edgeId(u, v));
-        }
-
-        void checkAttribute() const {
-            if (!ownedStorage->validStorage)
-                throw std::runtime_error("Invalid attribute");
-        }
-
-        auto getName() const {
-            checkAttribute();
-            return ownedStorage->getName();
-        }
-
-        void write(std::string const &filename) const {
-            std::ofstream out(filename);
-            if (!out)
-                ERROR("cannot open ", filename, " for writing");
-
-            for (auto it = begin(); it != end(); ++it) {
-                auto pair = *it;
-                auto n = pair.first;  // node/edgeid
-                auto v = pair.second; // value
-                out << n << "\t" << v << "\n";
-            }
-            out.close();
-        }
-
-        template <bool ic = isConst>
-        std::enable_if_t<!ic> read(const std::string &filename) {
-            std::ifstream in(filename);
-            if (!in) {
-                ERROR("cannot open ", filename, " for reading");
-            }
-            index n; // node/edgeid
-            T v;     // value
-            std::string line;
-            while (std::getline(in, line)) {
-                std::istringstream istring(line);
-                if constexpr (std::is_same_v<T, std::string>) {
-                    istring >> n >> std::ws;
-                    std::getline(istring, v);
-                } else {
-                    istring >> n >> v;
-                }
-                set(n, v);
-            }
-        }
-
-    private:
-        std::shared_ptr<AttributeStorage_type> ownedStorage;
-        bool valid;
-    }; // class Attribute
-
-    template <typename NodeOrEdge>
-    class AttributeMap {
-        friend Graph;
-        const Graph *theGraph;
-
-    public:
-        std::unordered_map<std::string, std::shared_ptr<ASB<NodeOrEdge>>> attrMap;
-
-        AttributeMap(const Graph *g) : theGraph{g} {}
-
-        auto find(std::string const &name) {
-            auto it = attrMap.find(name);
-            if (it == attrMap.end()) {
-                throw std::runtime_error("No such attribute");
-            }
-            return it;
-        }
-
-        auto find(std::string const &name) const {
-            auto it = attrMap.find(name);
-            if (it == attrMap.end()) {
-                throw std::runtime_error("No such attribute");
-            }
-            return it;
-        }
-
-        template <typename T>
-        auto attach(const std::string &name) {
-            auto ownedPtr =
-                std::make_shared<AttributeStorage<NodeOrEdge, ASB, T>>(theGraph, std::string{name});
-            auto insertResult = attrMap.emplace(ownedPtr->getName(), ownedPtr);
-            auto success = insertResult.second;
-            if (!success) {
-                throw std::runtime_error("Attribute with same name already exists");
-            }
-            return Attribute<NodeOrEdge, T, false>{ownedPtr};
-        }
-
-        void detach(const std::string &name) {
-            auto it = find(name);
-            auto storage = it->second.get();
-            storage->invalidateStorage();
-            it->second.reset();
-            attrMap.erase(name);
-        }
-
-        template <typename T>
-        auto get(const std::string &name) {
-            auto it = find(name);
-            if (it->second.get()->getType() != typeid(T))
-                throw std::runtime_error("Type mismatch in Attributes().get()");
-            return Attribute<NodeOrEdge, T, false>{
-                std::static_pointer_cast<AttributeStorage<NodeOrEdge, ASB, T>>(it->second)};
-        }
-
-        template <typename T>
-        auto get(const std::string &name) const {
-            auto it = find(name);
-            if (it->second.get()->getType() != typeid(T))
-                throw std::runtime_error("Type mismatch in Attributes().get()");
-            return Attribute<NodeOrEdge, T, true>{
-                std::static_pointer_cast<const AttributeStorage<NodeOrEdge, ASB, T>>(it->second)};
-        }
-
-    }; // class AttributeMap
-
-    AttributeMap<PerNode> nodeAttributeMap;
-    AttributeMap<PerEdge> edgeAttributeMap;
+    AttributeMap<PerNode, Graph> nodeAttributeMap;
+    AttributeMap<PerEdge, Graph> edgeAttributeMap;
 
 public:
     auto &nodeAttributes() noexcept { return nodeAttributeMap; }
@@ -661,13 +239,13 @@ public:
         edgeAttributes().detach(name);
     }
 
-    using NodeIntAttribute = Attribute<PerNode, int, false>;
-    using NodeDoubleAttribute = Attribute<PerNode, double, false>;
-    using NodeStringAttribute = Attribute<PerNode, std::string, false>;
+    using NodeIntAttribute = Attribute<PerNode, Graph, int, false>;
+    using NodeDoubleAttribute = Attribute<PerNode, Graph, double, false>;
+    using NodeStringAttribute = Attribute<PerNode, Graph, std::string, false>;
 
-    using EdgeIntAttribute = Attribute<PerEdge, int, false>;
-    using EdgeDoubleAttribute = Attribute<PerEdge, double, false>;
-    using EdgeStringAttribute = Attribute<PerEdge, std::string, false>;
+    using EdgeIntAttribute = Attribute<PerEdge, Graph, int, false>;
+    using EdgeDoubleAttribute = Attribute<PerEdge, Graph, double, false>;
+    using EdgeStringAttribute = Attribute<PerEdge, Graph, std::string, false>;
 
 private:
     /**
@@ -851,8 +429,8 @@ private:
                                   typename Aux::FunctionTraits<F>::template arg<2>::type>::value
                   && std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<3>::type>::
                       value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid id) const
-        -> decltype(f(u, v, ew, id)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew,
+                    edgeid id) const -> decltype(f(u, v, ew, id)) {
         return f(u, v, ew, id);
     }
 
@@ -884,8 +462,8 @@ private:
                   (Aux::FunctionTraits<F>::arity >= 2)
                   && std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<
                                                   2>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid /*id*/) const
-        -> decltype(f(u, v, ew)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew,
+                    edgeid /*id*/) const -> decltype(f(u, v, ew)) {
         return f(u, v, ew);
     }
 
@@ -898,8 +476,8 @@ private:
                            (Aux::FunctionTraits<F>::arity >= 1)
                            && std::is_same<node, typename Aux::FunctionTraits<F>::template arg<
                                                      1>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/, edgeid /*id*/) const
-        -> decltype(f(u, v)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/,
+                    edgeid /*id*/) const -> decltype(f(u, v)) {
         return f(u, v);
     }
 
@@ -1035,7 +613,7 @@ public:
     public:
         NodeRange(const Graph &G) : G(&G) {}
 
-        NodeRange() : G(nullptr){};
+        NodeRange() : G(nullptr) {};
 
         ~NodeRange() = default;
 
@@ -1260,7 +838,7 @@ public:
     public:
         EdgeRange(const Graph &G) : G(&G) {}
 
-        EdgeRange() : G(nullptr){};
+        EdgeRange() : G(nullptr) {};
 
         ~EdgeRange() = default;
 
@@ -1285,7 +863,7 @@ public:
     public:
         EdgeWeightRange(const Graph &G) : G(&G) {}
 
-        EdgeWeightRange() : G(nullptr){};
+        EdgeWeightRange() : G(nullptr) {};
 
         ~EdgeWeightRange() = default;
 
@@ -1450,7 +1028,7 @@ public:
     public:
         NeighborRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborRange() : G(nullptr){};
+        NeighborRange() : G(nullptr) {};
 
         NeighborIterator begin() const {
             assert(G);
@@ -1482,7 +1060,7 @@ public:
     public:
         NeighborWeightRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborWeightRange() : G(nullptr){};
+        NeighborWeightRange() : G(nullptr) {};
 
         NeighborWeightIterator begin() const {
             assert(G);

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -980,33 +980,4 @@ bool Graph::checkConsistency() const {
     return noMultiEdges && correctNodeUpperbound && correctNumberOfEdges;
 }
 
-/* ATTRIBUTE PREMISE AND INDEX CHECKS */
-
-template <>
-void ASB<PerNode, Graph>::checkPremise() const {
-    // nothing
-}
-
-template <>
-void ASB<PerEdge, Graph>::checkPremise() const {
-    if (!theGraph->hasEdgeIds()) {
-        throw std::runtime_error("Edges must be indexed");
-    }
-}
-
-template <>
-void ASB<PerNode, Graph>::indexOK(index n) const {
-    if (!theGraph->hasNode(n)) {
-        throw std::runtime_error("This node does not exist");
-    }
-}
-
-template <>
-void ASB<PerEdge, Graph>::indexOK(index n) const {
-    auto uv = theGraph->edgeById(n);
-    if (!theGraph->hasEdge(uv.first, uv.second)) {
-        throw std::runtime_error("This edgeId does not exist");
-    }
-}
-
 } /* namespace NetworKit */

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -983,26 +983,26 @@ bool Graph::checkConsistency() const {
 /* ATTRIBUTE PREMISE AND INDEX CHECKS */
 
 template <>
-void Graph::ASB<Graph::PerNode>::checkPremise() const {
+void ASB<PerNode, Graph>::checkPremise() const {
     // nothing
 }
 
 template <>
-void Graph::ASB<Graph::PerEdge>::checkPremise() const {
+void ASB<PerEdge, Graph>::checkPremise() const {
     if (!theGraph->hasEdgeIds()) {
         throw std::runtime_error("Edges must be indexed");
     }
 }
 
 template <>
-void Graph::ASB<Graph::PerNode>::indexOK(index n) const {
+void ASB<PerNode, Graph>::indexOK(index n) const {
     if (!theGraph->hasNode(n)) {
         throw std::runtime_error("This node does not exist");
     }
 }
 
 template <>
-void Graph::ASB<Graph::PerEdge>::indexOK(index n) const {
+void ASB<PerEdge, Graph>::indexOK(index n) const {
     auto uv = theGraph->edgeById(n);
     if (!theGraph->hasEdge(uv.first, uv.second)) {
         throw std::runtime_error("This edgeId does not exist");

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -328,7 +328,7 @@ Graph toUnweighted(const Graph &G) {
         WARN("The graph is already unweighted");
     }
 
-    return Graph(G, false, G.isDirected());
+    return Graph(G, false, G.isDirected(), G.hasEdgeIds());
 }
 
 Graph toWeighted(const Graph &G) {
@@ -336,7 +336,7 @@ Graph toWeighted(const Graph &G) {
         WARN("The graph is already weighted");
     }
 
-    return Graph(G, true, G.isDirected());
+    return Graph(G, true, G.isDirected(), G.hasEdgeIds());
 }
 
 Graph transpose(const Graph &G) {

--- a/networkit/cpp/graph/test/AttributeGTest.cpp
+++ b/networkit/cpp/graph/test/AttributeGTest.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphTools.hpp>
 
 namespace NetworKit {
 
@@ -374,6 +375,53 @@ TEST_F(AttributeGTest, testAttributeDoubleAttach) {
 
     tester(graph.nodeAttributes());
     tester(graph.edgeAttributes());
+}
+
+TEST_F(AttributeGTest, testAttributeCopy) {
+
+    Graph graph1(5);
+    graph1.addEdge(0, 1);
+    graph1.indexEdges();
+
+    auto edgeAttr1 = graph1.edgeAttributes().attach<int>("int edge attr");
+    edgeAttr1(0, 1) = 3;
+
+    // make copy of graph (and its attributes)
+    Graph graph2{graph1};
+
+    // modify attribute of graph1
+    edgeAttr1(0, 1) = 4;
+
+    auto edgeAttr2 = graph2.edgeAttributes().get<int>("int edge attr");
+
+    EXPECT_EQ(edgeAttr2(0, 1), 3);
+
+    // modify graph1
+    graph1.removeEdge(0, 1);
+
+    EXPECT_EQ(edgeAttr2(0, 1), 3);
+}
+
+TEST_F(AttributeGTest, testGraphModeChange) {
+    Graph dgraph(5, false, true);
+    dgraph.indexEdges();
+    dgraph.addEdge(0, 1);
+    auto edgeAttr = dgraph.edgeAttributes().attach<int>("int edge attr");
+    edgeAttr(0, 1) = 3;
+    auto nodeAttr = dgraph.nodeAttributes().attach<int>("int node attr");
+    nodeAttr[2] = 4;
+
+    auto wdgraph = GraphTools::toWeighted(dgraph);
+    auto wNodeAttr = wdgraph.nodeAttributes().get<int>("int node attr");
+    EXPECT_EQ(wNodeAttr[2], 4);
+    auto wEdgeAttr = wdgraph.edgeAttributes().get<int>("int edge attr");
+    EXPECT_EQ(wEdgeAttr(0, 1), 3);
+
+    auto graph3 = GraphTools::toUnweighted(wdgraph);
+    auto wNodeAttr3 = graph3.nodeAttributes().get<int>("int node attr");
+    EXPECT_EQ(wNodeAttr3[2], 4);
+    auto wEdgeAttr3 = graph3.edgeAttributes().get<int>("int edge attr");
+    EXPECT_EQ(wEdgeAttr3(0, 1), 3);
 }
 
 TEST_F(AttributeGTest, testInvalidate) {

--- a/networkit/cpp/graph/test/AttributeGTest.cpp
+++ b/networkit/cpp/graph/test/AttributeGTest.cpp
@@ -424,6 +424,18 @@ TEST_F(AttributeGTest, testGraphModeChange) {
     EXPECT_EQ(wEdgeAttr3(0, 1), 3);
 }
 
+TEST_F(AttributeGTest, testMoveGraph) {
+    Graph graph1(3);
+    graph1.indexEdges();
+    graph1.addEdge(0, 1);
+    auto attr1 = graph1.edgeAttributes().attach<int>("attr");
+    attr1(0, 1) = 1;
+    Graph graph2(std::move(graph1));
+    // make sure that attr2 does not point to graph1 which was moved and may not be accessed anymore
+    auto attr2 = graph2.edgeAttributes().get<int>("attr");
+    EXPECT_EQ(attr2(0, 1), 1);
+}
+
 TEST_F(AttributeGTest, testInvalidate) {
 
     Graph graph(10);

--- a/networkit/cpp/graph/test/AttributeGTest.cpp
+++ b/networkit/cpp/graph/test/AttributeGTest.cpp
@@ -298,35 +298,6 @@ TEST_F(AttributeGTest, testConstGetEdgeAttribute) {
 
 /// COMBINED ATTRIBUTE TESTS ///
 
-TEST_F(AttributeGTest, testAttributeSetGetOnNonExistingNodes) {
-
-    auto tester = [&](auto &attributeMap) {
-        auto intAttr = attributeMap.template attach<int>("some int attribute");
-
-        auto readAtIndex = [&intAttr](node n) -> int { return intAttr[n]; };
-
-        EXPECT_THROW(intAttr.set(5, 5), std::runtime_error);
-        EXPECT_THROW(intAttr.get(5), std::runtime_error);
-        EXPECT_THROW(intAttr[5] = 5, std::runtime_error);
-        // trigger read access by int conversion
-        EXPECT_THROW(readAtIndex(5), std::runtime_error);
-
-        EXPECT_THROW(intAttr.set(3, 3), std::runtime_error);
-        EXPECT_THROW(intAttr.get(3), std::runtime_error);
-        EXPECT_THROW(intAttr[3] = 3, std::runtime_error);
-        // trigger read access by int conversion
-        EXPECT_THROW(readAtIndex(3), std::runtime_error);
-
-        attributeMap.detach("some int attribute");
-    };
-
-    Graph graph(5, false, false, true);
-    graph.removeNode(3);
-
-    tester(graph.nodeAttributes());
-    tester(graph.edgeAttributes());
-}
-
 TEST_F(AttributeGTest, testAttributeAttachDetachAttach) {
 
     auto tester = [&](auto &attributeMap) {

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -314,14 +314,6 @@ class TestGraph(unittest.TestCase):
 		with self.assertRaises(Exception):
 			G.attachEdgeAttribute("my Attr", int)
 
-	def testEdgeAttributesNonExisting(self):
-		G = nk.Graph(5)
-		G.indexEdges()
-		myAttr = G.attachEdgeAttribute("my Attr", int)
-
-		with self.assertRaises(Exception):
-			myAttr[0] = 1
-
 	def testEdgeAttributesByIndex(self):
 		G = nk.Graph(5)
 		G.indexEdges()


### PR DESCRIPTION
This PR fixes some copy and move bugs for attributes. Previously, the graph pointer stored in some attribute classes did not change when the graph was copied, and data stored in attributes was not copied.

Changes:
- Attribute classes are now a seperate header (taken from #1222)
- Sanity checks are now debug-mode only (solves #1248)
- There is now a clear 1:1 relation between `Graph` and `AttributeMap`
- `AttributeMap` cannot be copied implicitly; a new graph pointer is required
- removed the graph pointer from AttributeStorage; validity checks are now done in Attribute instead
- added explicit copy assignment and constructor to Graph to use the new AttributeMap copy constructor
- fix some details in the graphTools conversion code
- Graph move operators will update the pointer in AttributeMap; Attribute objects are invalid after a move.
