### PR TITLE
fix DynamicMatrix * DynamicMatrix

### DIFF
--- a/networkit/cpp/algebraic/DynamicMatrix.cpp
+++ b/networkit/cpp/algebraic/DynamicMatrix.cpp
@@ -148,7 +148,7 @@ DynamicMatrix DynamicMatrix::operator*(const DynamicMatrix &other) const {
     assert(nCols == other.nRows);
 
     DynamicMatrix result(numberOfRows(), other.numberOfColumns());
-    SparseAccumulator spa(other.numberOfRows());
+    SparseAccumulator spa(other.numberOfColumns());
     for (index r = 0; r < numberOfRows(); ++r) {
         graph.forNeighborsOf(r, [&](node v, double w1) {
             other.graph.forNeighborsOf(v, [&](node u, double w2) {

--- a/networkit/cpp/algebraic/test/MatricesGTest.cpp
+++ b/networkit/cpp/algebraic/test/MatricesGTest.cpp
@@ -1472,6 +1472,26 @@ TYPED_TEST(MatricesGTest, testPrint) {
     ss << L;
     EXPECT_EQ(ss.str(), "0, 0, 0\n0, 1, -1\n0, -1, 1");
 }
+
+TYPED_TEST(MatricesGTest, test1by4) {
+    using Matrix = typename TestFixture::Matrix;
+
+    Matrix m1(4, 1, 0);
+    Matrix m2(1, 4, 0);
+
+    m1(0, 0) = 1;
+    m1(1, 0) = 1;
+    m1(2, 0) = 1;
+    m1(3, 0) = 1;
+
+    m2(0, 0) = 1;
+    m2(0, 1) = 1;
+    m2(0, 2) = 1;
+    m2(0, 3) = 1;
+
+    Matrix m3 = m1 * m2;
+}
+
 } // namespace
 
 namespace {


### PR DESCRIPTION
For two matrices A (n\*m) and B(m\*p), the size of the resulting matrix C=AB is n\*p. The sparse accumulator should have size p - which is `B.numberOfColumns()`