### PR TITLE
cython: change ordering of function signatures (nogil)

### DIFF
--- a/networkit/base.pxd
+++ b/networkit/base.pxd
@@ -3,7 +3,7 @@ from libcpp cimport bool as bool_t
 cdef extern from "<networkit/base/Algorithm.hpp>" namespace "NetworKit":
 	cdef cppclass _Algorithm "NetworKit::Algorithm":
 		_Algorithm()
-		void run() nogil except +
+		void run() except + nogil
 		bool_t hasFinished() except +
 
 cdef class _CythonParentClass:

--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -501,7 +501,7 @@ cdef extern from "<networkit/community/Modularity.hpp>":
 
 	cdef cppclass _Modularity "NetworKit::Modularity":
 		_Modularity() except +
-		double getQuality(_Partition _zeta, _Graph _G) nogil except +
+		double getQuality(_Partition _zeta, _Graph _G) except + nogil
 
 
 cdef class Modularity:
@@ -907,7 +907,7 @@ cdef extern from "<networkit/community/CutClustering.hpp>":
 
 cdef extern from "<networkit/community/CutClustering.hpp>" namespace "NetworKit::CutClustering":
 
-	map[double, _Partition] CutClustering_getClusterHierarchy "NetworKit::CutClustering::getClusterHierarchy"(const _Graph& G) nogil except +
+	map[double, _Partition] CutClustering_getClusterHierarchy "NetworKit::CutClustering::getClusterHierarchy"(const _Graph& G) except + nogil
 
 
 cdef class CutClustering(CommunityDetector):
@@ -971,7 +971,7 @@ cdef extern from "<networkit/community/NodeStructuralRandMeasure.hpp>":
 
 	cdef cppclass _NodeStructuralRandMeasure "NetworKit::NodeStructuralRandMeasure":
 		_NodeStructuralRandMeasure() except +
-		double getDissimilarity(_Graph G, _Partition first, _Partition second) nogil except +
+		double getDissimilarity(_Graph G, _Partition first, _Partition second) except + nogil
 
 cdef class NodeStructuralRandMeasure(DissimilarityMeasure):
 	""" 
@@ -1012,7 +1012,7 @@ cdef extern from "<networkit/community/GraphStructuralRandMeasure.hpp>":
 
 	cdef cppclass _GraphStructuralRandMeasure "NetworKit::GraphStructuralRandMeasure":
 		_GraphStructuralRandMeasure() except +
-		double getDissimilarity(_Graph G, _Partition first, _Partition second) nogil except +
+		double getDissimilarity(_Graph G, _Partition first, _Partition second) except + nogil
 
 cdef class GraphStructuralRandMeasure(DissimilarityMeasure):
 	""" 
@@ -1053,7 +1053,7 @@ cdef extern from "<networkit/community/JaccardMeasure.hpp>":
 
 	cdef cppclass _JaccardMeasure "NetworKit::JaccardMeasure":
 		_JaccardMeasure() except +
-		double getDissimilarity(_Graph G, _Partition first, _Partition second) nogil except +
+		double getDissimilarity(_Graph G, _Partition first, _Partition second) except + nogil
 
 cdef class JaccardMeasure(DissimilarityMeasure):
 	""" 
@@ -1090,7 +1090,7 @@ cdef extern from "<networkit/community/NMIDistance.hpp>":
 
 	cdef cppclass _NMIDistance "NetworKit::NMIDistance":
 		_NMIDistance() except +
-		double getDissimilarity(_Graph G, _Partition first, _Partition second) nogil except +
+		double getDissimilarity(_Graph G, _Partition first, _Partition second) except + nogil
 
 cdef class NMIDistance(DissimilarityMeasure):
 	""" 
@@ -1129,7 +1129,7 @@ cdef class NMIDistance(DissimilarityMeasure):
 cdef extern from "<networkit/community/AdjustedRandMeasure.hpp>":
 
 	cdef cppclass _AdjustedRandMeasure "NetworKit::AdjustedRandMeasure":
-		double getDissimilarity(_Graph G, _Partition first, _Partition second) nogil except +
+		double getDissimilarity(_Graph G, _Partition first, _Partition second) except + nogil
 
 cdef class AdjustedRandMeasure(DissimilarityMeasure):
 	"""
@@ -1917,8 +1917,8 @@ cdef extern from "<networkit/community/OverlappingNMIDistance.hpp>":
 		_OverlappingNMIDistance() except +
 		_OverlappingNMIDistance(_Normalization normalization) except +
 		void setNormalization(_Normalization normalization) except +
-		double getDissimilarity(_Graph G, _Partition first, _Partition second) nogil except +
-		double getDissimilarity(_Graph G, _Cover first, _Cover second) nogil except +
+		double getDissimilarity(_Graph G, _Partition first, _Partition second) except + nogil
+		double getDissimilarity(_Graph G, _Cover first, _Cover second) except + nogil
 
 cdef class OverlappingNMIDistance(DissimilarityMeasure):
 	"""

--- a/networkit/components.pyx
+++ b/networkit/components.pyx
@@ -104,7 +104,7 @@ cdef extern from "<networkit/components/ConnectedComponents.hpp>":
 	cdef cppclass _ConnectedComponents "NetworKit::ConnectedComponents"(_ComponentDecomposition):
 		_ConnectedComponents(_Graph G) except +
 		@staticmethod
-		_Graph extractLargestConnectedComponent(_Graph G, bool_t) nogil except +
+		_Graph extractLargestConnectedComponent(_Graph G, bool_t) except + nogil
 
 cdef class ConnectedComponents(ComponentDecomposition):
 	"""

--- a/networkit/distance.pyx
+++ b/networkit/distance.pyx
@@ -482,7 +482,7 @@ cdef extern from "<networkit/distance/Diameter.hpp>" namespace "NetworKit::Diame
 
 	cdef cppclass _Diameter "NetworKit::Diameter"(_Algorithm):
 		_Diameter(_Graph G, _DiameterAlgo algo, double error, count nSamples) except +
-		pair[count, count] getDiameter() nogil except +
+		pair[count, count] getDiameter() except + nogil
 
 cdef class Diameter(Algorithm):
 	"""
@@ -777,8 +777,8 @@ cdef class NeighborhoodFunctionApproximation(Algorithm):
 
 cdef extern from "<networkit/distance/Volume.hpp>" namespace "NetworKit::Volume":
 
-	double volume(const _Graph G, const double r, const count samples) nogil except +
-	vector[double] volume(const _Graph G, const vector[double] r, const count samples) nogil except +
+	double volume(const _Graph G, const double r, const count samples) except + nogil
+	vector[double] volume(const _Graph G, const vector[double] r, const count samples) except + nogil
 
 cdef class Volume:
 	"""
@@ -1604,7 +1604,7 @@ cdef extern from "<networkit/reachability/AllSimplePaths.hpp>":
 
 	cdef cppclass _AllSimplePaths "NetworKit::AllSimplePaths":
 		_AllSimplePaths(_Graph G, node source, node target, count cutoff) except +
-		void run() nogil except +
+		void run() except + nogil
 		count numberOfSimplePaths() except +
 		vector[vector[node]] getAllSimplePaths() except +
 		void forAllSimplePaths[Callback](Callback c) except +

--- a/networkit/dynamics.pyx
+++ b/networkit/dynamics.pyx
@@ -387,7 +387,7 @@ cdef extern from "<networkit/dynamics/GraphUpdater.hpp>":
 
 	cdef cppclass _GraphUpdater "NetworKit::GraphUpdater":
 		_GraphUpdater(_Graph G) except +
-		void update(vector[_GraphEvent] stream) nogil except +
+		void update(vector[_GraphEvent] stream) except + nogil
 		vector[pair[count, count]] &getSizeTimeline() except +
 
 cdef class GraphUpdater:

--- a/networkit/dynbase.pxd
+++ b/networkit/dynbase.pxd
@@ -4,5 +4,5 @@ from .dynamics cimport _GraphEvent, GraphEvent
 
 cdef extern from "<networkit/base/DynAlgorithm.hpp>":
 	cdef cppclass _DynAlgorithm "NetworKit::DynAlgorithm":
-		void update(_GraphEvent) nogil except +
-		void updateBatch(vector[_GraphEvent]) nogil except +
+		void update(_GraphEvent) except + nogil
+		void updateBatch(vector[_GraphEvent]) except + nogil

--- a/networkit/generators.pyx
+++ b/networkit/generators.pyx
@@ -619,14 +619,14 @@ cdef extern from "<networkit/generators/PowerlawDegreeSequence.hpp>":
 		_PowerlawDegreeSequence(count minDeg, count maxDeg, double gamma) except +
 		_PowerlawDegreeSequence(_Graph) except +
 		_PowerlawDegreeSequence(vector[double]) except +
-		void setMinimumFromAverageDegree(double avgDeg) nogil except +
-		void setGammaFromAverageDegree(double avgDeg, double minGamma, double maxGamma) nogil except +
+		void setMinimumFromAverageDegree(double avgDeg) except + nogil
+		void setGammaFromAverageDegree(double avgDeg, double minGamma, double maxGamma) except + nogil
 		double getExpectedAverageDegree() except +
 		count getMinimumDegree() const
 		count getMaximumDegree() const
 		double getGamma() const
 		double setGamma(double) const
-		void run() nogil except +
+		void run() except + nogil
 		vector[count] getDegreeSequence(count numNodes) except +
 		count getDegree() except +
 
@@ -816,14 +816,14 @@ cdef extern from "<networkit/generators/LFRGenerator.hpp>":
 
 	cdef cppclass _LFRGenerator "NetworKit::LFRGenerator"(_Algorithm):
 		_LFRGenerator(count n) except +
-		void setDegreeSequence(vector[count] degreeSequence) nogil except +
-		void generatePowerlawDegreeSequence(count avgDegree, count maxDegree, double nodeDegreeExp) nogil except +
-		void setCommunitySizeSequence(vector[count] communitySizeSequence) nogil except +
-		void setPartition(_Partition zeta) nogil except +
-		void generatePowerlawCommunitySizeSequence(count minCommunitySize, count maxCommunitySize, double communitySizeExp) nogil except +
-		void setMu(double mu) nogil except +
-		void setMu(const vector[double] & mu) nogil except +
-		void setMuWithBinomialDistribution(double mu) nogil except +
+		void setDegreeSequence(vector[count] degreeSequence) except + nogil
+		void generatePowerlawDegreeSequence(count avgDegree, count maxDegree, double nodeDegreeExp) except + nogil
+		void setCommunitySizeSequence(vector[count] communitySizeSequence) except + nogil
+		void setPartition(_Partition zeta) except + nogil
+		void generatePowerlawCommunitySizeSequence(count minCommunitySize, count maxCommunitySize, double communitySizeExp) except + nogil
+		void setMu(double mu) except + nogil
+		void setMu(const vector[double] & mu) except + nogil
+		void setMuWithBinomialDistribution(double mu) except + nogil
 		_Graph getGraph() except +
 		_Partition getPartition() except +
 		_Graph generate() except +

--- a/networkit/globals.pyx
+++ b/networkit/globals.pyx
@@ -8,11 +8,11 @@ from .structures cimport count
 
 cdef extern from "<networkit/global/ClusteringCoefficient.hpp>" namespace "NetworKit::ClusteringCoefficient":
 
-		double avgLocal(_Graph G, bool_t turbo) nogil except +
-		double sequentialAvgLocal(_Graph G) nogil except +
-		double approxAvgLocal(_Graph G, count trials) nogil except +
-		double exactGlobal(_Graph G) nogil except +
-		double approxGlobal(_Graph G, count trials) nogil except +
+		double avgLocal(_Graph G, bool_t turbo) except + nogil
+		double sequentialAvgLocal(_Graph G) except + nogil
+		double approxAvgLocal(_Graph G, count trials) except + nogil
+		double exactGlobal(_Graph G) except + nogil
+		double approxGlobal(_Graph G, count trials) except + nogil
 
 cdef class ClusteringCoefficient:
 	"""

--- a/networkit/graph.pxd
+++ b/networkit/graph.pxd
@@ -336,7 +336,7 @@ cdef extern from "<networkit/graph/SpanningForest.hpp>":
 
 	cdef cppclass _SpanningForest "NetworKit::SpanningForest":
 		_SpanningForest(_Graph) except +
-		void run() nogil except +
+		void run() except + nogil
 		_Graph getForest() except +
 
 

--- a/networkit/graphio.pyx
+++ b/networkit/graphio.pyx
@@ -37,8 +37,8 @@ cdef extern from "<algorithm>" namespace "std":
 cdef extern from "<networkit/io/GraphReader.hpp>":
 
 	cdef cppclass _GraphReader "NetworKit::GraphReader":
-		_GraphReader() nogil except +
-		_Graph read(string path) nogil except +
+		_GraphReader() except + nogil
+		_Graph read(string path) except + nogil
 
 cdef class GraphReader:
 	""" Abstract base class for graph readers"""
@@ -98,8 +98,8 @@ class MultipleEdgesHandling:
 cdef extern from "<networkit/io/GraphWriter.hpp>":
 
 	cdef cppclass _GraphWriter "NetworKit::GraphWriter":
-		_GraphWriter() nogil except +
-		void write(_Graph G, string path) nogil except +
+		_GraphWriter() except + nogil
+		void write(_Graph G, string path) except + nogil
 
 
 cdef class GraphWriter:
@@ -141,7 +141,7 @@ cdef class GraphWriter:
 cdef extern from "<networkit/io/METISGraphReader.hpp>":
 
 	cdef cppclass _METISGraphReader "NetworKit::METISGraphReader" (_GraphReader):
-		_METISGraphReader() nogil except +
+		_METISGraphReader() except + nogil
 
 cdef class METISGraphReader(GraphReader):
 	"""
@@ -237,7 +237,7 @@ cdef extern from "<networkit/io/ThrillGraphBinaryReader.hpp>":
 
 	cdef cppclass _ThrillGraphBinaryReader "NetworKit::ThrillGraphBinaryReader" (_GraphReader):
 		_ThrillGraphBinaryReader(count n) except +
-		_Graph read(vector[string] paths) nogil except +
+		_Graph read(vector[string] paths) except + nogil
 
 cdef class ThrillGraphBinaryReader(GraphReader):
 	"""
@@ -617,7 +617,7 @@ cdef extern from "<networkit/io/PartitionWriter.hpp>":
 
 	cdef cppclass _PartitionWriter "NetworKit::PartitionWriter":
 		_PartitionWriter() except +
-		void write(_Partition, string path) nogil except +
+		void write(_Partition, string path) except + nogil
 
 
 cdef class PartitionWriter:
@@ -695,7 +695,7 @@ cdef extern from "<networkit/io/BinaryPartitionWriter.hpp>":
 	cdef cppclass _BinaryPartitionWriter "NetworKit::BinaryPartitionWriter":
 		_BinaryPartitionWriter() except +
 		_BinaryPartitionWriter(uint8_t width) except +
-		_Partition write(_Partition zeta, string path) nogil except +
+		_Partition write(_Partition zeta, string path) except + nogil
 
 cdef class BinaryPartitionWriter:
 	"""
@@ -780,8 +780,8 @@ cdef extern from "<networkit/io/BinaryEdgeListPartitionReader.hpp>":
 	cdef cppclass _BinaryEdgeListPartitionReader "NetworKit::BinaryEdgeListPartitionReader":
 		_BinaryEdgeListPartitionReader() except +
 		_BinaryEdgeListPartitionReader(node firstNode, uint8_t width) except +
-		_Partition read(string path) nogil except +
-		_Partition read(vector[string] paths) nogil except +
+		_Partition read(string path) except + nogil
+		_Partition read(vector[string] paths) except + nogil
 
 cdef class BinaryEdgeListPartitionReader:
 	"""
@@ -840,7 +840,7 @@ cdef extern from "<networkit/io/BinaryEdgeListPartitionWriter.hpp>":
 	cdef cppclass _BinaryEdgeListPartitionWriter "NetworKit::BinaryEdgeListPartitionWriter":
 		_BinaryEdgeListPartitionWriter() except +
 		_BinaryEdgeListPartitionWriter(node firstNode, uint8_t width) except +
-		_Partition write(_Partition P, string path) nogil except +
+		_Partition write(_Partition P, string path) except + nogil
 
 cdef class BinaryEdgeListPartitionWriter:
 	"""
@@ -935,7 +935,7 @@ cdef extern from "<networkit/io/CoverWriter.hpp>":
 
 	cdef cppclass _CoverWriter "NetworKit::CoverWriter":
 		_CoverWriter() except +
-		void write(_Cover, string path) nogil except +
+		void write(_Cover, string path) except + nogil
 
 
 cdef class CoverWriter:

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -11,38 +11,38 @@ from .structures cimport count, index, node, edgeweight
 
 cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphTools":
 
-	count maxDegree(_Graph G) nogil except +
-	count maxInDegree(_Graph G) nogil except +
-	edgeweight maxWeightedDegree(_Graph G) nogil except +
-	edgeweight maxWeightedInDegree(_Graph G) nogil except +
-	node randomNode(_Graph G) nogil except +
-	vector[node] randomNodes(_Graph G, count n) nogil except +
-	node randomNeighbor(_Graph G, node u) nogil except +
-	pair[node, node] randomEdge(_Graph G, bool_t uniformDistribution) nogil except +
-	vector[pair[node, node]] randomEdges(_Graph G, count numEdges) nogil except +
-	pair[count, count] size(_Graph G) nogil except +
-	double density(_Graph G) nogil except +
-	double volume(_Graph G) nogil except +
-	double volume[InputIt](_Graph G, InputIt first, InputIt last) nogil except +
-	double inVolume[InputIt](_Graph G, InputIt first, InputIt last) nogil except +
-	_Graph copyNodes(_Graph G) nogil except +
-	_Graph toUndirected(_Graph G) nogil except +
-	_Graph toUnweighted(_Graph G) nogil except +
-	_Graph toWeighted(_Graph G) nogil except +
-	_Graph subgraphFromNodes[InputIt](_Graph G, InputIt first, InputIt last, bool_t compact) nogil except +
-	_Graph subgraphAndNeighborsFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
-	void append(_Graph G, _Graph G1) nogil except +
-	void merge(_Graph G, _Graph G1) nogil except +
+	count maxDegree(_Graph G) except + nogil
+	count maxInDegree(_Graph G) except + nogil
+	edgeweight maxWeightedDegree(_Graph G) except + nogil
+	edgeweight maxWeightedInDegree(_Graph G) except + nogil
+	node randomNode(_Graph G) except + nogil
+	vector[node] randomNodes(_Graph G, count n) except + nogil
+	node randomNeighbor(_Graph G, node u) except + nogil
+	pair[node, node] randomEdge(_Graph G, bool_t uniformDistribution) except + nogil
+	vector[pair[node, node]] randomEdges(_Graph G, count numEdges) except + nogil
+	pair[count, count] size(_Graph G) except + nogil
+	double density(_Graph G) except + nogil
+	double volume(_Graph G) except + nogil
+	double volume[InputIt](_Graph G, InputIt first, InputIt last) except + nogil
+	double inVolume[InputIt](_Graph G, InputIt first, InputIt last) except + nogil
+	_Graph copyNodes(_Graph G) except + nogil
+	_Graph toUndirected(_Graph G) except + nogil
+	_Graph toUnweighted(_Graph G) except + nogil
+	_Graph toWeighted(_Graph G) except + nogil
+	_Graph subgraphFromNodes[InputIt](_Graph G, InputIt first, InputIt last, bool_t compact) except + nogil
+	_Graph subgraphAndNeighborsFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) except + nogil
+	void append(_Graph G, _Graph G1) except + nogil
+	void merge(_Graph G, _Graph G1) except + nogil
 	void removeEdgesFromIsolatedSet[InputIt](_Graph G, InputIt first, InputIt last) except +
-	_Graph getCompactedGraph(_Graph G, unordered_map[node,node]) nogil except +
-	_Graph transpose(_Graph G) nogil except +
-	unordered_map[node,node] getContinuousNodeIds(_Graph G) nogil except +
-	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
-	void sortEdgesByWeight(_Graph G, bool_t) nogil except +
-	vector[node] topologicalSort(_Graph G) nogil except +
-	node augmentGraph(_Graph G) nogil except +
-	pair[_Graph, node] createAugmentedGraph(_Graph G) nogil except +
-	void randomizeWeights(_Graph G) nogil except +
+	_Graph getCompactedGraph(_Graph G, unordered_map[node,node]) except + nogil
+	_Graph transpose(_Graph G) except + nogil
+	unordered_map[node,node] getContinuousNodeIds(_Graph G) except + nogil
+	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) except + nogil
+	void sortEdgesByWeight(_Graph G, bool_t) except + nogil
+	vector[node] topologicalSort(_Graph G) except + nogil
+	node augmentGraph(_Graph G) except + nogil
+	pair[_Graph, node] createAugmentedGraph(_Graph G) except + nogil
+	void randomizeWeights(_Graph G) except + nogil
 
 cdef class GraphTools:
 

--- a/networkit/randomization.pyx
+++ b/networkit/randomization.pyx
@@ -11,7 +11,7 @@ from .structures cimport count, index, node
 cdef extern from "<networkit/randomization/EdgeSwitching.hpp>":
 	cdef cppclass _EdgeSwitching "NetworKit::EdgeSwitching"(_Algorithm):
 		_EdgeSwitching(_Graph, double, bool_t) except +
-		void run(count) nogil except +
+		void run(count) except + nogil
 		_Graph getGraph() except +
 		count getNumberOfAffectedEdges()
 		double getNumberOfSwitchesPerEdge()
@@ -19,7 +19,7 @@ cdef extern from "<networkit/randomization/EdgeSwitching.hpp>":
 
 	cdef cppclass _EdgeSwitchingInPlace "NetworKit::EdgeSwitchingInPlace"(_Algorithm):
 		_EdgeSwitchingInPlace(_Graph, double) except +
-		void run(count) nogil except +
+		void run(count) except + nogil
 		count getNumberOfAffectedEdges()
 		double getNumberOfSwitchesPerEdge()
 		void setNumberOfSwitchesPerEdge(double)
@@ -244,7 +244,7 @@ cdef extern from "<networkit/randomization/CurveballUniformTradeGenerator.hpp>":
 
 	cdef cppclass _CurveballUniformTradeGenerator "NetworKit::CurveballUniformTradeGenerator":
 		_CurveballUniformTradeGenerator(count runLength, count numNodes) except +
-		vector[pair[node, node]] generate() nogil except +
+		vector[pair[node, node]] generate() except + nogil
 
 cdef class CurveballUniformTradeGenerator:
 	"""
@@ -276,7 +276,7 @@ cdef extern from "<networkit/randomization/CurveballGlobalTradeGenerator.hpp>":
 
 	cdef cppclass _CurveballGlobalTradeGenerator "NetworKit::CurveballGlobalTradeGenerator":
 		_CurveballGlobalTradeGenerator(count runLength, count numNodes) except +
-		vector[pair[node, node]] generate() nogil except +
+		vector[pair[node, node]] generate() except + nogil
 
 cdef class CurveballGlobalTradeGenerator:
 	"""
@@ -321,7 +321,7 @@ cdef extern from "<networkit/randomization/Curveball.hpp>":
 
 	cdef cppclass _Curveball "NetworKit::Curveball"(_Algorithm):
 		_Curveball(_Graph) except +
-		void run(vector[pair[node, node]] trades) nogil except +
+		void run(vector[pair[node, node]] trades) except + nogil
 		_Graph getGraph() except +
 		vector[pair[node, node]] getEdges() except +
 		count getNumberOfAffectedEdges() except +

--- a/networkit/traversal.pyx
+++ b/networkit/traversal.pyx
@@ -75,16 +75,16 @@ cdef cppclass TraversalNodePairCallbackWrapper:
 
 cdef extern from "<networkit/graph/BFS.hpp>" namespace "NetworKit::Traversal":
 
-	void BFSfrom[InputIt, Callback](_Graph G, InputIt first, InputIt last, Callback c) nogil except +
-	void BFSEdgesFrom[Callback](_Graph G, node source, Callback c) nogil except +
+	void BFSfrom[InputIt, Callback](_Graph G, InputIt first, InputIt last, Callback c) except + nogil
+	void BFSEdgesFrom[Callback](_Graph G, node source, Callback c) except + nogil
 
 cdef extern from "<networkit/graph/DFS.hpp>" namespace "NetworKit::Traversal":
-	void DFSfrom[Callback](_Graph G, node source, Callback c) nogil except +
-	void DFSEdgesFrom[Callback](_Graph G, node source, Callback c) nogil except +
+	void DFSfrom[Callback](_Graph G, node source, Callback c) except + nogil
+	void DFSEdgesFrom[Callback](_Graph G, node source, Callback c) except + nogil
 
 cdef extern from "<networkit/graph/Dijkstra.hpp>" namespace "NetworKit::Traversal":
 
-	void DijkstraFrom[InputIt, Callback](_Graph G, InputIt first, InputIt last, Callback c) nogil except +
+	void DijkstraFrom[InputIt, Callback](_Graph G, InputIt first, InputIt last, Callback c) except + nogil
 
 cdef class Traversal:
 	"""

--- a/networkit/viz.pyx
+++ b/networkit/viz.pyx
@@ -36,7 +36,7 @@ cdef extern from "<networkit/viz/GraphLayoutAlgorithm.hpp>":
 		vector[Point[double]] getCoordinates() except +
 		bool_t writeGraphToGML(string path) except +
 		bool_t writeKinemage(string path) except +
-		void run() nogil except +
+		void run() except + nogil
 
 cdef class GraphLayoutAlgorithm:
 	"""


### PR DESCRIPTION
this PR changes the cython function signatures, because in version >3.0 of cython the previous signatures result in warnings and will eventually be disallowed