### PR TITLE
Fix RMatGenerator for large instances 

### DIFF
--- a/networkit/cpp/generators/RmatGenerator.cpp
+++ b/networkit/cpp/generators/RmatGenerator.cpp
@@ -169,7 +169,7 @@ std::pair<node, node> RmatGenerator::sampleEdge(uint8_t input_bits) {
 }
 
 Graph RmatGenerator::generate() {
-    double n = (1 << scale);
+    double n = std::pow(2.0, static_cast<double>(scale));
     if (n <= reduceNodes) {
         throw std::runtime_error("Error, shall delete more nodes than the graph originally has");
     }


### PR DESCRIPTION
This fixes an issue, where a variable is implicitly cast to uint32, leading to wrong results for the expected number of nodes.