### PR TITLE
Apply consistent clang-format to all files

### DIFF
--- a/include/networkit/auxiliary/IncrementalUniformRandomSelector.hpp
+++ b/include/networkit/auxiliary/IncrementalUniformRandomSelector.hpp
@@ -24,7 +24,7 @@ public:
     /**
      * Initialize the random select for one element.
      */
-    IncrementalUniformRandomSelector() : counter(1){};
+    IncrementalUniformRandomSelector() : counter(1) {};
 
     /**
      * Add the next element.

--- a/include/networkit/generators/ErdosRenyiEnumerator.hpp
+++ b/include/networkit/generators/ErdosRenyiEnumerator.hpp
@@ -299,14 +299,14 @@ private:
 
     // SFINAE to allow using functors with and without thread id as parameter
     template <typename Handle>
-    auto callHandle(Handle h, unsigned tid, node u, node v) const
-        -> decltype(h(0u, node{0}, node{0})) {
+    auto callHandle(Handle h, unsigned tid, node u,
+                    node v) const -> decltype(h(0u, node{0}, node{0})) {
         return h(tid, u, v);
     }
 
     template <typename Handle>
-    auto callHandle(Handle h, unsigned /*tid*/, node u, node v) const
-        -> decltype(h(node{0}, node{0})) {
+    auto callHandle(Handle h, unsigned /*tid*/, node u,
+                    node v) const -> decltype(h(node{0}, node{0})) {
         return h(u, v);
     }
 };

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -135,7 +135,7 @@ public:
 
 private:
     std::vector<T> values; // the real attribute storage
-};                         // class AttributeStorage<NodeOrEdge, Base, T>
+}; // class AttributeStorage<NodeOrEdge, Base, T>
 
 template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
 class Attribute {

--- a/include/networkit/graph/EdgeIterators.hpp
+++ b/include/networkit/graph/EdgeIterators.hpp
@@ -151,7 +151,7 @@ class EdgeTypeRange {
 public:
     EdgeTypeRange(const GraphType &G) : G(&G) {}
 
-    EdgeTypeRange() : G(nullptr){};
+    EdgeTypeRange() : G(nullptr) {};
 
     ~EdgeTypeRange() = default;
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -433,8 +433,8 @@ private:
                                   typename Aux::FunctionTraits<F>::template arg<2>::type>::value
                   && std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<3>::type>::
                       value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid id) const
-        -> decltype(f(u, v, ew, id)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew,
+                    edgeid id) const -> decltype(f(u, v, ew, id)) {
         return f(u, v, ew, id);
     }
 
@@ -466,8 +466,8 @@ private:
                   (Aux::FunctionTraits<F>::arity >= 2)
                   && std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<
                                                   2>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight ew, edgeid /*id*/) const
-        -> decltype(f(u, v, ew)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight ew,
+                    edgeid /*id*/) const -> decltype(f(u, v, ew)) {
         return f(u, v, ew);
     }
 
@@ -480,8 +480,8 @@ private:
                            (Aux::FunctionTraits<F>::arity >= 1)
                            && std::is_same<node, typename Aux::FunctionTraits<F>::template arg<
                                                      1>::type>::value>::type * = (void *)0>
-    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/, edgeid /*id*/) const
-        -> decltype(f(u, v)) {
+    auto edgeLambda(F &f, node u, node v, edgeweight /*ew*/,
+                    edgeid /*id*/) const -> decltype(f(u, v)) {
         return f(u, v);
     }
 
@@ -558,7 +558,7 @@ public:
     public:
         NeighborRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborRange() : G(nullptr){};
+        NeighborRange() : G(nullptr) {};
 
         NeighborIterator begin() const {
             assert(G);
@@ -590,7 +590,7 @@ public:
     public:
         NeighborWeightRange(const Graph &G, node u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborWeightRange() : G(nullptr){};
+        NeighborWeightRange() : G(nullptr) {};
 
         NeighborWeightIterator begin() const {
             assert(G);
@@ -804,7 +804,7 @@ public:
           outEdgeIds(other.outEdgeIds),
           // call special constructors to copy attribute maps
           nodeAttributeMap(other.nodeAttributeMap, this),
-          edgeAttributeMap(other.edgeAttributeMap, this){};
+          edgeAttributeMap(other.edgeAttributeMap, this) {};
 
     /** move constructor */
     Graph(Graph &&other) noexcept

--- a/include/networkit/graph/GraphBuilder.hpp
+++ b/include/networkit/graph/GraphBuilder.hpp
@@ -58,8 +58,8 @@ class GraphBuilder {
         node source;
         node destination;
         // HalfEdge(node source, node destination);
-        HalfEdge(){};
-        HalfEdge(node source, node destination) : source(source), destination(destination){};
+        HalfEdge() {};
+        HalfEdge(node source, node destination) : source(source), destination(destination) {};
     };
 
     std::vector<std::vector<std::vector<HalfEdge>>>

--- a/include/networkit/graph/NodeIterators.hpp
+++ b/include/networkit/graph/NodeIterators.hpp
@@ -107,7 +107,7 @@ class NodeRangeBase {
 public:
     NodeRangeBase(const GraphType &G) : G(&G) {}
 
-    NodeRangeBase() : G(nullptr){};
+    NodeRangeBase() : G(nullptr) {};
 
     ~NodeRangeBase() = default;
 

--- a/include/networkit/graph/RandomMaximumSpanningForest.hpp
+++ b/include/networkit/graph/RandomMaximumSpanningForest.hpp
@@ -96,7 +96,7 @@ private:
                                && (u > other.u || (u == other.u && v > other.v)))));
         };
         weightedEdge(node u, node v, double attribute, edgeid eid = 0)
-            : attribute(attribute), u(u), v(v), eid(eid), rand(Aux::Random::integer()){};
+            : attribute(attribute), u(u), v(v), eid(eid), rand(Aux::Random::integer()) {};
     };
 
     const Graph &G;

--- a/include/networkit/graph/UnionMaximumSpanningForest.hpp
+++ b/include/networkit/graph/UnionMaximumSpanningForest.hpp
@@ -91,7 +91,7 @@ private:
                        && (u > other.u || (u == other.u && v > other.v)));
         };
         weightedEdge(node u, node v, edgeweight attribute, edgeid eid = 0)
-            : attribute(attribute), u(u), v(v), eid(eid){};
+            : attribute(attribute), u(u), v(v), eid(eid) {};
     };
 
     const Graph *G;

--- a/include/networkit/io/NetworkitBinaryReader.hpp
+++ b/include/networkit/io/NetworkitBinaryReader.hpp
@@ -29,7 +29,7 @@ namespace NetworKit {
 class NetworkitBinaryReader final : public GraphReader {
 
 public:
-    NetworkitBinaryReader(){};
+    NetworkitBinaryReader() {};
 
     Graph read(std::string_view path) override;
     Graph readFromBuffer(const std::vector<uint8_t> &data);

--- a/include/networkit/layout/LayoutAlgorithm.hpp
+++ b/include/networkit/layout/LayoutAlgorithm.hpp
@@ -22,9 +22,9 @@ class LayoutAlgorithm {
 
 public:
     LayoutAlgorithm(const Graph &G)
-        : G(G){
+        : G(G) {
 
-        };
+          };
 
     virtual void run() = 0;
 

--- a/include/networkit/structures/LocalCommunity.hpp
+++ b/include/networkit/structures/LocalCommunity.hpp
@@ -54,9 +54,9 @@ public:
             throw std::runtime_error("Decreasing value that is missing");
         }
 
-        OptionalValue(const ValueType &){};
+        OptionalValue(const ValueType &) {};
 
-        OptionalValue(){};
+        OptionalValue() {};
     };
 
     template <typename ValueType>
@@ -89,9 +89,9 @@ public:
             return *this;
         }
 
-        OptionalValue(const ValueType &v) : value(v){};
+        OptionalValue(const ValueType &v) : value(v) {};
 
-        OptionalValue() : value(){};
+        OptionalValue() : value() {};
 
         ValueType value;
     };

--- a/networkit/cpp/centrality/GroupClosenessGrowShrink.cpp
+++ b/networkit/cpp/centrality/GroupClosenessGrowShrink.cpp
@@ -15,15 +15,18 @@ GroupClosenessGrowShrink::GroupClosenessGrowShrink(const Graph &G, const std::ve
                                                    bool extended, count insertions,
                                                    count maxIterations)
     : G(&G),
-      weightedImpl{G.isWeighted() ? std::make_unique<
-                       GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<edgeweight>>(
-                       G, group, extended, insertions, maxIterations)
-                                  : nullptr},
-      unweightedImpl{G.isWeighted()
-                         ? nullptr
-                         : std::make_unique<
-                             GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<count>>(
-                             G, group, extended, insertions, maxIterations)} {}
+      weightedImpl{
+          G.isWeighted()
+              ? std::make_unique<
+                    GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<edgeweight>>(
+                    G, group, extended, insertions, maxIterations)
+              : nullptr},
+      unweightedImpl{
+          G.isWeighted()
+              ? nullptr
+              : std::make_unique<
+                    GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<count>>(
+                    G, group, extended, insertions, maxIterations)} {}
 
 GroupClosenessGrowShrink::~GroupClosenessGrowShrink() = default;
 

--- a/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
@@ -21,8 +21,8 @@ namespace NetworKit {
 NeighborhoodFunctionHeuristic::NeighborhoodFunctionHeuristic(const Graph &G, count nSamples,
                                                              SelectionStrategy strategy)
     : Algorithm(), G(&G),
-      nSamples(!nSamples ? (count)std::ceil(
-                   std::max((double)0.15f * G.numberOfNodes(), std::sqrt(G.numberOfEdges())))
+      nSamples(!nSamples ? (count)std::ceil(std::max((double)0.15f * G.numberOfNodes(),
+                                                     std::sqrt(G.numberOfEdges())))
                          : nSamples),
       strategy(strategy) {
 

--- a/networkit/cpp/edgescores/PrefixJaccardScore.cpp
+++ b/networkit/cpp/edgescores/PrefixJaccardScore.cpp
@@ -30,7 +30,7 @@ void PrefixJaccardScore<AttributeT>::run() {
         AttributeT att;
         count rank;
 
-        RankedEdge(node u, AttributeT att, count rank) : u(u), att(att), rank(rank){};
+        RankedEdge(node u, AttributeT att, count rank) : u(u), att(att), rank(rank) {};
 
         bool operator<(const RankedEdge &other) const {
             return std::tie(rank, att, u) < std::tie(other.rank, other.att, other.u);

--- a/networkit/cpp/generators/test/GeneratorsGTest.cpp
+++ b/networkit/cpp/generators/test/GeneratorsGTest.cpp
@@ -1113,9 +1113,8 @@ TEST_F(GeneratorsGTest, testStaticDegreeSequenceGenerator) {
     for (int iter = 0; iter < 100; ++iter) {
         const auto n = distr_num_nodes(prng);
         std::vector<count> seq(n);
-        std::generate(seq.begin(), seq.end(), [&] {
-            return std::uniform_int_distribution<count>{0, n - 1}(prng);
-        });
+        std::generate(seq.begin(), seq.end(),
+                      [&] { return std::uniform_int_distribution<count>{0, n - 1}(prng); });
 
         HavelHakimiGenerator gen(seq, true);
         const auto isRealizable = gen.isRealizable();

--- a/networkit/cpp/scd/LocalDegreeDirectedGraph.hpp
+++ b/networkit/cpp/scd/LocalDegreeDirectedGraph.hpp
@@ -211,8 +211,7 @@ public:
      */
     template <typename F>
     void forTrianglesOf(node u, F callback) {
-        forTrianglesOf(
-            u, [](node, edgeweight) {}, callback);
+        forTrianglesOf(u, [](node, edgeweight) {}, callback);
     }
 
     /**

--- a/networkit/cpp/scd/LocalTightnessExpansion.cpp
+++ b/networkit/cpp/scd/LocalTightnessExpansion.cpp
@@ -66,7 +66,7 @@ private:
 public:
     LocalGraph(const Graph &g, NodeAddedCallbackType nodeAddedCallback)
         : LocalDegreeDirectedGraph<is_weighted, InnerNodeAddedCallback<NodeAddedCallbackType>>(
-            g, InnerNodeAddedCallback<NodeAddedCallbackType>{nodeAddedCallback, triangleSum}) {
+              g, InnerNodeAddedCallback<NodeAddedCallbackType>{nodeAddedCallback, triangleSum}) {
         if (g.isWeighted() != is_weighted) {
             throw std::runtime_error("Error, weighted/unweighted status of input graph does not "
                                      "match is_weighted template parameter");

--- a/networkit/cpp/viz/MaxentStress.cpp
+++ b/networkit/cpp/viz/MaxentStress.cpp
@@ -504,9 +504,8 @@ void MaxentStress::computeKnownDistances(const count k, const GraphDistance grap
     case EDGE_WEIGHT:
         // add edges to known distances
         G->parallelForNodes([&](node u) {
-            G->forNeighborsOf(u, [&](node v, edgeweight w) {
-                knownDistances[u].push_back({v, w});
-            });
+            G->forNeighborsOf(u,
+                              [&](node v, edgeweight w) { knownDistances[u].push_back({v, w}); });
             // add k-neighborhood
             if (k > 1) { // 1-neighborhood are adjacent vertices that are already added above
                 addKNeighborhoodOfVertex(u, k);

--- a/networkit/cpp/viz/test/VizGTest.cpp
+++ b/networkit/cpp/viz/test/VizGTest.cpp
@@ -33,9 +33,8 @@ TEST_F(VizGTest, testPostscriptWriterOnRandomGraph) {
     std::vector<Point2D> coordinates(G.upperNodeIdBound());
 
     // create coordinates
-    G.forNodes([&](node u) {
-        coordinates[u] = {Aux::Random::probability(), Aux::Random::probability()};
-    });
+    G.forNodes(
+        [&](node u) { coordinates[u] = {Aux::Random::probability(), Aux::Random::probability()}; });
 
     // write graph to file
     std::string path = "output/testGraph.eps";


### PR DESCRIPTION
**Summary**
This PR applies `clang-format` consistently across the codebase. Currently, running `clang-format` on the project results in changes to 20 files, indicating inconsistent formatting.

**Details**
- No functional changes were made; this is purely a formatting cleanup.
- The provided script './check_code.sh' with option '-w' was used.

Looking forward to your feedback!