### PR TITLE
Fix assignment for Attribute from other Attribute

### DIFF
--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -238,7 +238,7 @@ private:
 
         // move + copy assignment from other proxy objects
 
-        IndexProxy &operator=(IndexProxy &&other)
+        IndexProxy &operator=(IndexProxy &&other) noexcept
             requires(!isConst)
         {
             storage->set(idx, static_cast<T>(other));

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -219,6 +219,8 @@ private:
         //    - assigning to it (operator=) writes the value
     public:
         IndexProxy(AttributeStorage_type *storage, index idx) : storage{storage}, idx{idx} {}
+        IndexProxy(IndexProxy &&) = delete;
+        IndexProxy(const IndexProxy &) = delete;
 
         // reading at idx
         operator T() const {
@@ -227,10 +229,27 @@ private:
         }
 
         // writing at idx
-        template <bool ic = isConst>
-        std::enable_if_t<!ic, T> &operator=(T &&other) {
+        IndexProxy &operator=(T &&other)
+            requires(!isConst)
+        {
             storage->set(idx, std::move(other));
-            return storage->values[idx];
+            return *this;
+        }
+
+        // move + copy assignment from other proxy objects
+
+        IndexProxy &operator=(IndexProxy &&other)
+            requires(!isConst)
+        {
+            storage->set(idx, static_cast<T>(other));
+            return *this;
+        }
+
+        IndexProxy &operator=(const IndexProxy &other)
+            requires(!isConst)
+        {
+            storage->set(idx, static_cast<T>(other));
+            return *this;
         }
 
     private:

--- a/networkit/cpp/graph/test/AttributeGTest.cpp
+++ b/networkit/cpp/graph/test/AttributeGTest.cpp
@@ -475,4 +475,23 @@ TEST_F(AttributeGTest, testDeleteEdges) {
     EXPECT_EQ(attr(0, 1), 1.0);
 }
 
+TEST_F(AttributeGTest, assignAttributeToAttribute) {
+    Graph graph(3);
+    auto attr1 = graph.nodeAttributes().attach<int>("attr1");
+    auto attr2 = graph.nodeAttributes().attach<int>("attr2");
+
+    attr1[0] = 1;
+    attr2[0] = 3;
+    attr2[0] = attr1[0]; // operator=(IndexProxy&&)
+    EXPECT_EQ(attr2[0], 1);
+
+    attr1[1] = 4;
+    auto v1 = attr1[1];
+    EXPECT_EQ(v1, 4);
+    auto v2 = attr2[1];
+    v2 = v1; // operator=(const IndexProxy&)
+    EXPECT_EQ(v2, 4);
+    EXPECT_EQ(attr2[1], 4);
+}
+
 } // namespace NetworKit


### PR DESCRIPTION
Direct assignment of attributes to each other (`attr[i] = attr[j]`) previously used the implicitly defined assignment operators for `IndexProxy` which do not modify the attribute value. The new implementation with `requires` clauses also ensure that assignment operators are `deleted` for const attributes (the old implementation implicitly defined them).