### PR TITLE
CI: Update tlx version + set CI build to Release for external build

### DIFF
--- a/.github/workflows/scripts/full.sh
+++ b/.github/workflows/scripts/full.sh
@@ -14,7 +14,7 @@ pip3 install cython numpy ipython jupyter setuptools
 # Build tlx
 cd tlx
 mkdir build && cd "$_"
-cmake -GNinja -DCMAKE_INSTALL_PREFIX=$TLX_PATH ..
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$TLX_PATH ..
 ninja
 ninja install
 cd ../..


### PR DESCRIPTION
This fixes an issue, where tlx is built per default as debug build. New versions of CMake add `_debug` per default to lib names in this case. In addition tlx submodule is updated to the most recent version.