### PR TITLE
CI: Split coverage and leak build, fix leaks, remove aarch64 wheel build

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -54,45 +54,48 @@ jobs:
           path: ./wheelhouse/*cp313*.whl
           retention-days: ${{ env.ARTIFACT_RETENTION }}
 
-  cpython-linux-aarch64:
-    name: 'Linux CPython (${{ matrix.cibw_archs }}, ${{ matrix.manylinux_image }})'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-        cibw_archs: ["aarch64"]
-        manylinux_image: ["manylinux2014"]
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.12'
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.1
-        env:
-          CIBW_BEFORE_BUILD: pip install cython
-          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
-          CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs }}
-          CIBW_BUILD: ${{ github.ref == 'refs/heads/master' && 'cp312-* cp313-*' || 'cp312-*' }}
-          CIBW_SKIP: "pp* *-musllinux_*"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: 'linux-${{ matrix.cibw_archs }}-cp312-${{ github.run_id }}'
-          path: ./wheelhouse/*cp312*.whl
-          retention-days: ${{ env.ARTIFACT_RETENTION }}
-      - uses: actions/upload-artifact@v4
-        if: github.ref == 'refs/heads/master'
-        with:
-          name: 'linux-${{ matrix.cibw_archs }}-cp313-${{ github.run_id }}'
-          path: ./wheelhouse/*cp313*.whl
-          retention-days: ${{ env.ARTIFACT_RETENTION }}
+  # THIS ACTION IS DISABLED DUE TO SEGMENTATION FAULT IN GCC COMPILER
+  # Additional note: continue-on-error does not work currently for cibuildwheel: 
+  # https://github.com/pypa/cibuildwheel/issues/1062
+  # cpython-linux-aarch64:
+  #   name: 'Linux CPython (${{ matrix.cibw_archs }}, ${{ matrix.manylinux_image }})'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-20.04]
+  #       cibw_archs: ["aarch64"]
+  #       manylinux_image: ["manylinux2014"]
+  #   steps:
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
+  #       with:
+  #         platforms: all
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: true
+  #     - uses: actions/setup-python@v5
+  #       name: Install Python
+  #       with:
+  #         python-version: '3.12'
+  #     - name: Build wheels
+  #       uses: pypa/cibuildwheel@v2.21.1
+  #       env:
+  #         CIBW_BEFORE_BUILD: pip install cython
+  #         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
+  #         CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs }}
+  #         CIBW_BUILD: ${{ github.ref == 'refs/heads/master' && 'cp312-* cp313-*' || 'cp312-*' }}
+  #         CIBW_SKIP: "pp* *-musllinux_*"
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: 'linux-${{ matrix.cibw_archs }}-cp312-${{ github.run_id }}'
+  #         path: ./wheelhouse/*cp312*.whl
+  #         retention-days: ${{ env.ARTIFACT_RETENTION }}
+  #     - uses: actions/upload-artifact@v4
+  #       if: github.ref == 'refs/heads/master'
+  #       with:
+  #         name: 'linux-${{ matrix.cibw_archs }}-cp313-${{ github.run_id }}'
+  #         path: ./wheelhouse/*cp313*.whl
+  #         retention-days: ${{ env.ARTIFACT_RETENTION }}
 
   cpython-macos:
     name: 'macOS CPython  (${{ matrix.buildplat[1] }})'
@@ -235,7 +238,7 @@ jobs:
     if: needs.check-release-tag.outputs.is-release == 'true' && github.repository == 'networkit/networkit'
     name: 'PyPi release upload'
     runs-on: ubuntu-22.04
-    needs: [cpython-macos, cpython-linux-aarch64, cpython-linux-x86_64, cpython-windows, source-distribution, check-release-tag]
+    needs: [cpython-macos, cpython-linux-x86_64, cpython-windows, source-distribution, check-release-tag]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,8 +362,10 @@ jobs:
     steps:
       - name: Install prerequisites
         run:  |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          echo "deb http://apt.llvm.org/jammy llvm-toolchain-jammy-17 main" | sudo tee /etc/apt/sources.list.d/llvm17.list
           sudo apt-get update
-          sudo apt-get install ninja-build
+          sudo apt-get install libomp-17-dev clang-17 clang-tidy-17 ninja-build
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -371,7 +373,7 @@ jobs:
       - name: Prepare environment and run checks
         run:  |
           mkdir build && cd build
-          cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=${{ env.CXX_STANDARD }} -DNETWORKIT_WITH_SANITIZERS=leak  ..
+          cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=${{ env.CXX_STANDARD }} -DNETWORKIT_WITH_SANITIZERS=leak  -DCMAKE_CXX_COMPILER=/usr/bin/clang++-17 ..
           ninja
           ctest -V -C Debug
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
     name: "Linux (gcc-10, CPython 3.12): leak checks"
     runs-on: ubuntu-22.04
     env:
-      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1:report_error_type=1
     steps:
       - name: Install prerequisites
         run:  |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
     name: "Linux (gcc-10, CPython 3.12): leak checks"
     runs-on: ubuntu-22.04
     env:
-      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1:report_error_type=1
+      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1:report_error_type=1:suppressions=../UBSAN.filter
     steps:
       - name: Install prerequisites
         run:  |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
         run:  ${{ github.workspace }}/.github/workflows/scripts/clang_tidy.sh
         shell: bash
 
-  linux-build-core-sanitizers-coverage:
+  linux-build-coverage:
     name: "Linux (gcc-10, CPython 3.12): coverage"
     runs-on: ubuntu-22.04
     env:
@@ -330,7 +330,7 @@ jobs:
         with:
           submodules: true
       - name: Prepare environment and run checks
-        run:  ${{ github.workspace }}/.github/workflows/scripts/core_sanitizers_coverage.sh
+        run:  ${{ github.workspace }}/.github/workflows/scripts/coverage.sh
         shell: bash
         timeout-minutes: 180
       - name: Create C++ coverage
@@ -353,6 +353,29 @@ jobs:
           cd ${{ github.workspace }}
           . pyenv/bin/activate
           python3 ${{ github.workspace }}/.github/workflows/scripts/upload_coverage.py
+
+  linux-build-leak:
+    name: "Linux (gcc-10, CPython 3.12): leak checks"
+    runs-on: ubuntu-22.04
+    env:
+      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+    steps:
+      - name: Install prerequisites
+        run:  |
+          sudo apt-get update
+          sudo apt-get install ninja-build
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Prepare environment and run checks
+        run:  |
+          mkdir build && cd build
+          cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=${{ env.CXX_STANDARD }} -DNETWORKIT_WITH_SANITIZERS=leak  ..
+          ninja
+          ctest -V -C Debug
+        shell: bash
+        timeout-minutes: 180
 
   windows-build-msvc:
     name: "Windows (msvc 14.X): ${{ matrix.build-configuration }}"

--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -6,12 +6,12 @@ pip3 install coveralls cython gcovr matplotlib requests setuptools tabulate nump
 
 mkdir core_build && cd "$_"
 export CPU_COUNT=$(python3 $GITHUB_WORKSPACE/.github/workflows/scripts/get_core_count.py)
-cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_WITH_SANITIZERS=leak -DNETWORKIT_COVERAGE=ON ..
+cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_COVERAGE=ON ..
 make -j$CPU_COUNT
 
-ctest -V
-
 cd ..
+./core_build/networkit_tests -t
+
 export CMAKE_LIBRARY_PATH=${CMAKE_LIBRARY_PATH:+$CMAKE_LIBRARY_PATH:}$(pwd)/core_build
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$(pwd)/core_build
 

--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -2,7 +2,7 @@
 
 python3 -m venv pyenv && . pyenv/bin/activate
 pip3 install --upgrade pip
-pip3 install coveralls cython gcovr matplotlib requests setuptools tabulate numpy networkx ipycytoscape seaborn plotly
+pip3 install coveralls cython gcovr matplotlib requests setuptools tabulate numpy networkx ipycytoscape seaborn plotly anywidget
 
 mkdir core_build && cd "$_"
 export CPU_COUNT=$(python3 $GITHUB_WORKSPACE/.github/workflows/scripts/get_core_count.py)

--- a/UBSAN.filter
+++ b/UBSAN.filter
@@ -1,0 +1,1 @@
+bounds:random.tcc

--- a/include/networkit/community/LouvainMapEquation.hpp
+++ b/include/networkit/community/LouvainMapEquation.hpp
@@ -59,6 +59,19 @@ public:
 
     void run() override;
 
+    ParallelizationType
+    convertStringToParallelizationType(std::string parallelizationStrategy) const {
+        if (parallelizationStrategy == "none")
+            return ParallelizationType::NONE;
+        else if (parallelizationStrategy == "relaxmap")
+            return ParallelizationType::RELAX_MAP;
+        else if (parallelizationStrategy == "synchronous")
+            return ParallelizationType::SYNCHRONOUS;
+        else
+            throw std::runtime_error("Invalid parallelization type for map equation Louvain: "
+                                     + std::string(parallelizationStrategy));
+    }
+
 private:
     struct Move {
         node movedNode = none;
@@ -120,19 +133,6 @@ private:
 
     std::pair<count, count> chunkBounds(count i, count n, count chunkSize) const {
         return std::make_pair(i * chunkSize, std::min(n, (i + 1) * chunkSize));
-    }
-
-    ParallelizationType
-    convertStringToParallelizationType(std::string_view parallelizationStrategy) const {
-        if (parallelizationStrategy == "none")
-            return ParallelizationType::NONE;
-        else if (parallelizationStrategy == "relaxmap")
-            return ParallelizationType::RELAX_MAP;
-        else if (parallelizationStrategy == "synchronous")
-            return ParallelizationType::SYNCHRONOUS;
-        else
-            throw std::runtime_error("Invalid parallelization type for map equation Louvain: "
-                                     + std::string(parallelizationStrategy));
     }
 
 #ifndef NDEBUG

--- a/include/networkit/community/LouvainMapEquation.hpp
+++ b/include/networkit/community/LouvainMapEquation.hpp
@@ -16,9 +16,6 @@
 
 namespace NetworKit {
 
-// TODO: make enum public and use it for construction + string_view for compat
-// string_view again
-
 class LouvainMapEquation : public CommunityDetectionAlgorithm {
 public:
     enum class ParallelizationType : uint8_t {
@@ -136,7 +133,7 @@ private:
     }
 
     ParallelizationType
-    convertStringToParallelizationType(std::string parallelizationStrategy) const {
+    convertStringToParallelizationType(std::string &parallelizationStrategy) const {
         if (parallelizationStrategy == "none")
             return ParallelizationType::NONE;
         else if (parallelizationStrategy == "relaxmap")

--- a/include/networkit/community/LouvainMapEquation.hpp
+++ b/include/networkit/community/LouvainMapEquation.hpp
@@ -56,19 +56,6 @@ public:
 
     void run() override;
 
-    ParallelizationType
-    convertStringToParallelizationType(std::string_view parallelizationStrategy) const {
-        if (parallelizationStrategy == "none")
-            return ParallelizationType::NONE;
-        else if (parallelizationStrategy == "relaxmap")
-            return ParallelizationType::RELAX_MAP;
-        else if (parallelizationStrategy == "synchronous")
-            return ParallelizationType::SYNCHRONOUS;
-        else
-            throw std::runtime_error("Invalid parallelization type for map equation Louvain: "
-                                     + std::string(parallelizationStrategy));
-    }
-
 private:
     struct Move {
         node movedNode = none;
@@ -84,8 +71,8 @@ private:
     static_assert(std::is_trivially_destructible<Move>::value,
                   "LouvainMapEquation::Move struct is not trivially destructible");
 
-    bool parallel;
     ParallelizationType parallelizationType;
+    bool parallel;
 
     bool hierarchical;
     count maxIterations;
@@ -130,19 +117,6 @@ private:
 
     std::pair<count, count> chunkBounds(count i, count n, count chunkSize) const {
         return std::make_pair(i * chunkSize, std::min(n, (i + 1) * chunkSize));
-    }
-
-    ParallelizationType
-    convertStringToParallelizationType(std::string &parallelizationStrategy) const {
-        if (parallelizationStrategy == "none")
-            return ParallelizationType::NONE;
-        else if (parallelizationStrategy == "relaxmap")
-            return ParallelizationType::RELAX_MAP;
-        else if (parallelizationStrategy == "synchronous")
-            return ParallelizationType::SYNCHRONOUS;
-        else
-            throw std::runtime_error("Invalid parallelization type for map equation Louvain: "
-                                     + std::string(parallelizationStrategy));
     }
 
 #ifndef NDEBUG

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -418,11 +418,25 @@ void sortEdgesByWeight(Graph &G, bool decreasing = false);
  * This is a helper function. Instead of calling it via GraphTools, it is also possible to create a
  * TopologicalSort-object from the base-class.
  * @param   G               Directed input graph
+ * @return                  A vector of node-ids sorted according to their topology.
+ */
+std::vector<node> topologicalSort(const Graph &G);
+
+/**
+ * Given a directed graph G, the topology sort algorithm creates one valid topology order of nodes.
+ * Undirected graphs are not accepted as input, since a topology sort is a linear ordering of
+ * vertices such that for every edge u -> v, node u comes before v in the ordering.
+ * Node ids must either be continuous or you must provide a continuous node id mapping.
+ *
+ * This is a helper function. Instead of calling it via GraphTools, it is also possible to create a
+ * TopologicalSort-object from the base-class.
+ * @param   G               Directed input graph
  * @param   nodeIdMapping   Optional continuous node id mapping
+ * @param   checkMapping    Check whether the given node id map is continuous.
  * @return                  A vector of node-ids sorted according to their topology.
  */
 std::vector<node> topologicalSort(const Graph &G,
-                                  const std::unordered_map<node, node> &nodeIdMapping = {},
+                                  const std::unordered_map<node, node> &nodeIdMapping,
                                   bool checkMapping = false);
 
 /**

--- a/include/networkit/graph/TopologicalSort.hpp
+++ b/include/networkit/graph/TopologicalSort.hpp
@@ -22,12 +22,22 @@ namespace NetworKit {
 class TopologicalSort final : public Algorithm {
 public:
     /**
-     * Initialize the topological sort algorithm by passing an input graph. Note that topological
-     * sort is defined for directed graphs only. The node id mapping must be a continuous.
+     * Initialize the topological sort algorithm by passing an input graph.
      *
      * @param G The input graph.
      */
-    TopologicalSort(const Graph &G, const std::unordered_map<node, node> &nodeIdMapping = {},
+    TopologicalSort(const Graph &G);
+
+    /**
+     * Initialize the topological sort algorithm by passing an input graph and an node id map.
+     * The node id mapping must be a continuous. This can be checked by setting checkMapping to
+     * true.
+     *
+     * @param G The input graph.
+     * @param nodeIdMapping Node id mapping from non-continuous to continuous ids.
+     * @param checkMapping Check whether the given node id map is continuous.
+     */
+    TopologicalSort(const Graph &G, const std::unordered_map<node, node> &nodeIdMapping,
                     bool checkMapping = false);
 
     /**
@@ -52,7 +62,7 @@ private:
 
     std::optional<std::unordered_map<node, node>> computedNodeIdMap;
 
-    const std::unordered_map<node, node> &nodeIdMap;
+    const std::unordered_map<node, node> *nodeIdMap = nullptr;
 
     // Used to mark the status of each node, one vector per thread
     std::vector<NodeMark> topSortMark;

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1977,13 +1977,12 @@ TEST_F(CentralityGTest, testGroupClosenessEmptyGroups) {
 }
 
 TEST_P(CentralityGTest, testGroupClosenessGrowShrink) {
-    omp_set_num_threads(2);
-    const count k = 3;
+    const count k = 5;
     auto G = EdgeListReader{'\t', 0, "#", false, false}.read("input/MIT8.edgelist");
     G = ConnectedComponents::extractLargestConnectedComponent(G);
 
     if (isWeighted()) {
-        Aux::Random::setSeed(42, true);
+        Aux::Random::setSeed(42, false);
         GraphTools::randomizeWeights(G);
     }
 

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -2003,7 +2003,7 @@ TEST_P(CentralityGTest, testGroupClosenessGrowShrink) {
     };
 
     for (int seed : {1, 2, 3}) {
-        Aux::Random::setSeed(seed, false);
+        Aux::Random::setSeed(seed, true);
 
         std::unordered_set<node> group;
 

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1961,27 +1961,29 @@ TEST_F(CentralityGTest, testApproxElectricalCloseness) {
     }
 }
 
+TEST_F(CentralityGTest, testGroupClosenessDirected) {
+    // directed graphs are not supported
+    Graph G(10, false, true);
+    std::array<node, 1> group = {{0}};
+    EXPECT_THROW(GroupClosenessGrowShrink(G, group.begin(), group.end()), std::runtime_error);
+}
+
+TEST_F(CentralityGTest, testGroupClosenessEmptyGroups) {
+    // Empty input groups are not supported
+    Graph G(10);
+    std::vector<node> emptyGroup;
+    EXPECT_THROW(GroupClosenessGrowShrink(G, emptyGroup.begin(), emptyGroup.end()),
+                 std::runtime_error);
+}
+
 TEST_P(CentralityGTest, testGroupClosenessGrowShrink) {
-    if (isDirected()) { // directed graphs are not supported
-        Graph G(10, isWeighted(), true);
-        std::array<node, 1> group = {{0}};
-        EXPECT_THROW(GroupClosenessGrowShrink(G, group.begin(), group.end()), std::runtime_error);
-        return;
-    }
-
-    { // Empty input groups are not supported
-        Graph G(10, isWeighted(), false);
-        std::vector<node> emptyGroup;
-        EXPECT_THROW(GroupClosenessGrowShrink(G, emptyGroup.begin(), emptyGroup.end()),
-                     std::runtime_error);
-    }
-
-    const count k = 5;
+    omp_set_num_threads(2);
+    const count k = 3;
     auto G = EdgeListReader{'\t', 0, "#", false, false}.read("input/MIT8.edgelist");
     G = ConnectedComponents::extractLargestConnectedComponent(G);
 
     if (isWeighted()) {
-        Aux::Random::setSeed(42, false);
+        Aux::Random::setSeed(42, true);
         GraphTools::randomizeWeights(G);
     }
 
@@ -2001,7 +2003,7 @@ TEST_P(CentralityGTest, testGroupClosenessGrowShrink) {
     };
 
     for (int seed : {1, 2, 3}) {
-        Aux::Random::setSeed(seed, true);
+        Aux::Random::setSeed(seed, false);
 
         std::unordered_set<node> group;
 

--- a/networkit/cpp/community/LouvainMapEquation.cpp
+++ b/networkit/cpp/community/LouvainMapEquation.cpp
@@ -36,8 +36,8 @@ convertStringToParallelizationType(std::string_view parallelizationStrategy) {
 
 LouvainMapEquation::LouvainMapEquation(const Graph &graph, bool hierarchical, count maxIterations,
                                        ParallelizationType parallelizationType)
-    : CommunityDetectionAlgorithm(graph), parallel(parallelizationType > ParallelizationType::NONE),
-      parallelizationType(parallelizationType), hierarchical(hierarchical),
+    : CommunityDetectionAlgorithm(graph), parallelizationType(parallelizationType),
+      parallel(parallelizationType > ParallelizationType::NONE), hierarchical(hierarchical),
       maxIterations(maxIterations), clusterCut(graph.upperNodeIdBound()),
       clusterVolume(graph.upperNodeIdBound()),
       locks(parallelizationType == ParallelizationType::RELAX_MAP ? graph.upperNodeIdBound() : 0),
@@ -49,14 +49,15 @@ LouvainMapEquation::LouvainMapEquation(const Graph &graph, bool hierarchical, co
 
 LouvainMapEquation::LouvainMapEquation(const Graph &graph, bool hierarchical, count maxIterations,
                                        std::string_view parallelizationStrategy)
-    : CommunityDetectionAlgorithm(graph), hierarchical(hierarchical), maxIterations(maxIterations),
-      clusterCut(graph.upperNodeIdBound()), clusterVolume(graph.upperNodeIdBound()),
+    : CommunityDetectionAlgorithm(graph),
       parallelizationType(convertStringToParallelizationType(parallelizationStrategy)),
-      parallel(parallelizationType != ParallelizationType::NONE),
+      parallel(parallelizationType != ParallelizationType::NONE), hierarchical(hierarchical),
+      maxIterations(maxIterations), clusterCut(graph.upperNodeIdBound()),
+      clusterVolume(graph.upperNodeIdBound()),
+      locks(parallelizationType == ParallelizationType::RELAX_MAP ? graph.upperNodeIdBound() : 0),
       nextPartition(
           parallelizationType == ParallelizationType::SYNCHRONOUS ? graph.upperNodeIdBound() : 0),
-      ets_neighborClusterWeights(parallel ? Aux::getMaxNumberOfThreads() : 1),
-      locks(parallelizationType == ParallelizationType::RELAX_MAP ? graph.upperNodeIdBound() : 0) {
+      ets_neighborClusterWeights(parallel ? Aux::getMaxNumberOfThreads() : 1) {
     result = Partition(graph.upperNodeIdBound());
 }
 

--- a/networkit/cpp/community/LouvainMapEquation.cpp
+++ b/networkit/cpp/community/LouvainMapEquation.cpp
@@ -21,6 +21,19 @@
 
 namespace NetworKit {
 
+LouvainMapEquation::ParallelizationType
+convertStringToParallelizationType(std::string_view parallelizationStrategy) {
+    if (parallelizationStrategy == "none")
+        return LouvainMapEquation::ParallelizationType::NONE;
+    else if (parallelizationStrategy == "relaxmap")
+        return LouvainMapEquation::ParallelizationType::RELAX_MAP;
+    else if (parallelizationStrategy == "synchronous")
+        return LouvainMapEquation::ParallelizationType::SYNCHRONOUS;
+    else
+        throw std::runtime_error("Invalid parallelization type for map equation Louvain: "
+                                 + std::string(parallelizationStrategy));
+}
+
 LouvainMapEquation::LouvainMapEquation(const Graph &graph, bool hierarchical, count maxIterations,
                                        ParallelizationType parallelizationType)
     : CommunityDetectionAlgorithm(graph), parallel(parallelizationType > ParallelizationType::NONE),
@@ -37,15 +50,13 @@ LouvainMapEquation::LouvainMapEquation(const Graph &graph, bool hierarchical, co
 LouvainMapEquation::LouvainMapEquation(const Graph &graph, bool hierarchical, count maxIterations,
                                        std::string_view parallelizationStrategy)
     : CommunityDetectionAlgorithm(graph), hierarchical(hierarchical), maxIterations(maxIterations),
-      clusterCut(graph.upperNodeIdBound()), clusterVolume(graph.upperNodeIdBound()) {
-    parallelizationType = convertStringToParallelizationType(parallelizationStrategy);
-    parallel = (parallelizationType > ParallelizationType::NONE);
-    nextPartition = Partition(
-        parallelizationType == ParallelizationType::SYNCHRONOUS ? graph.upperNodeIdBound() : 0);
-    ets_neighborClusterWeights =
-        std::vector<SparseVector<double>>(parallel ? Aux::getMaxNumberOfThreads() : 1);
-    locks = std::vector<Aux::Spinlock>(
-        parallelizationType == ParallelizationType::RELAX_MAP ? graph.upperNodeIdBound() : 0);
+      clusterCut(graph.upperNodeIdBound()), clusterVolume(graph.upperNodeIdBound()),
+      parallelizationType(convertStringToParallelizationType(parallelizationStrategy)),
+      parallel(parallelizationType != ParallelizationType::NONE),
+      nextPartition(
+          parallelizationType == ParallelizationType::SYNCHRONOUS ? graph.upperNodeIdBound() : 0),
+      ets_neighborClusterWeights(parallel ? Aux::getMaxNumberOfThreads() : 1),
+      locks(parallelizationType == ParallelizationType::RELAX_MAP ? graph.upperNodeIdBound() : 0) {
     result = Partition(graph.upperNodeIdBound());
 }
 

--- a/networkit/cpp/generators/ChungLuGeneratorAlamEtAl.cpp
+++ b/networkit/cpp/generators/ChungLuGeneratorAlamEtAl.cpp
@@ -81,6 +81,8 @@ void ChungLuGeneratorAlamEtAl::edgeSkipping(std::mt19937_64 &rng, F &&addEdge, i
     do {
         double randVal = real(rng);
         double l = std::floor(std::log(randVal) * logP);
+        if (l == std::numeric_limits<double>::infinity())
+            continue;
         x += static_cast<index>(l + 1);
         if (x >= end) {
             end_arrived = true;
@@ -121,10 +123,13 @@ Graph ChungLuGeneratorAlamEtAl::generateSequential() {
             const double p_j = static_cast<double>(groups[i].degrees)
                                * static_cast<double>(groups[j].degrees)
                                / static_cast<double>(sum_deg);
-            edgeSkipping(rng, addEdge, i, j, p_j, groups[i].vertexCount * groups[j].vertexCount);
+            if (p_j > 0.0)
+                edgeSkipping(rng, addEdge, i, j, p_j,
+                             groups[i].vertexCount * groups[j].vertexCount);
         }
-        edgeSkipping(rng, addEdge, i, i, p_i,
-                     groups[i].vertexCount * (groups[i].vertexCount - 1) / 2);
+        if (p_i > 0.0)
+            edgeSkipping(rng, addEdge, i, i, p_i,
+                         groups[i].vertexCount * (groups[i].vertexCount - 1) / 2);
     }
 
     return G;

--- a/networkit/cpp/generators/ChungLuGeneratorAlamEtAl.cpp
+++ b/networkit/cpp/generators/ChungLuGeneratorAlamEtAl.cpp
@@ -75,6 +75,9 @@ double real(std::mt19937_64 &rng) {
 template <typename F>
 void ChungLuGeneratorAlamEtAl::edgeSkipping(std::mt19937_64 &rng, F &&addEdge, index i, index j,
                                             double p, index end) {
+    if (p == 0.0)
+        return;
+
     index x = 0 - 1;
     double logP = 1.0 / std::log(1.0 - p);
     bool end_arrived = false;
@@ -123,13 +126,10 @@ Graph ChungLuGeneratorAlamEtAl::generateSequential() {
             const double p_j = static_cast<double>(groups[i].degrees)
                                * static_cast<double>(groups[j].degrees)
                                / static_cast<double>(sum_deg);
-            if (p_j > 0.0)
-                edgeSkipping(rng, addEdge, i, j, p_j,
-                             groups[i].vertexCount * groups[j].vertexCount);
+            edgeSkipping(rng, addEdge, i, j, p_j, groups[i].vertexCount * groups[j].vertexCount);
         }
-        if (p_i > 0.0)
-            edgeSkipping(rng, addEdge, i, i, p_i,
-                         groups[i].vertexCount * (groups[i].vertexCount - 1) / 2);
+        edgeSkipping(rng, addEdge, i, i, p_i,
+                     groups[i].vertexCount * (groups[i].vertexCount - 1) / 2);
     }
 
     return G;

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -513,6 +513,13 @@ void sortEdgesByWeight(Graph &G, bool decreasing) {
         });
 }
 
+std::vector<node> topologicalSort(const Graph &G) {
+    TopologicalSort topSort(G);
+    topSort.run();
+
+    return topSort.getResult();
+}
+
 std::vector<node> topologicalSort(const Graph &G,
                                   const std::unordered_map<node, node> &nodeIdMapping,
                                   bool checkMapping) {

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -10,7 +10,8 @@
 
 namespace NetworKit {
 
-TopologicalSort::TopologicalSort(const Graph &G) : G(G), computedNodeIdMap(GraphTools::getContinuousNodeIds(G)) {
+TopologicalSort::TopologicalSort(const Graph &G)
+    : G(G), computedNodeIdMap(GraphTools::getContinuousNodeIds(G)) {
     checkDirected();
 }
 

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -32,6 +32,8 @@ void TopologicalSort::checkDirected() {
 }
 
 void TopologicalSort::checkNodeIdMap() {
+    if (!nodeIdMap) return;
+
     size_t numberOfNodes = G.numberOfNodes();
     std::vector<bool> checkTable(numberOfNodes);
     for (auto &[origNode, mappedNode] : *nodeIdMap) {

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -10,22 +10,19 @@
 
 namespace NetworKit {
 
+TopologicalSort::TopologicalSort(const Graph &G) : G(G), computedNodeIdMap(GraphTools::getContinuousNodeIds(G)) {
+    checkDirected();
+}
+
 TopologicalSort::TopologicalSort(const Graph &G, const std::unordered_map<node, node> &nodeIdMap,
                                  bool checkMapping)
-    : G(G), nodeIdMap(nodeIdMap) {
+    : G(G), nodeIdMap(&nodeIdMap) {
     checkDirected();
-    size_t numberOfNodes = G.numberOfNodes();
-    if (!nodeIdMap.empty()) {
-        if (nodeIdMap.size() != numberOfNodes)
-            throw std::runtime_error(
-                "Node id mapping should contain exactly one entry for every node.");
-        else if (checkMapping)
-            checkNodeIdMap();
-    } else {
-        if (G.upperNodeIdBound() != numberOfNodes - 1) {
-            computedNodeIdMap = GraphTools::getContinuousNodeIds(G);
-        }
-    }
+    if (nodeIdMap.size() != G.numberOfNodes())
+        throw std::runtime_error(
+            "Node id mapping should contain exactly one entry for every node.");
+    else if (checkMapping)
+        checkNodeIdMap();
 }
 
 void TopologicalSort::checkDirected() {
@@ -36,7 +33,7 @@ void TopologicalSort::checkDirected() {
 void TopologicalSort::checkNodeIdMap() {
     size_t numberOfNodes = G.numberOfNodes();
     std::vector<bool> checkTable(numberOfNodes);
-    for (auto &[origNode, mappedNode] : nodeIdMap) {
+    for (auto &[origNode, mappedNode] : *nodeIdMap) {
         if (mappedNode < numberOfNodes && !checkTable[mappedNode])
             checkTable[mappedNode] = true;
         else
@@ -84,9 +81,9 @@ void TopologicalSort::run() {
 }
 
 node TopologicalSort::mapNode(node u) {
-    if (!nodeIdMap.empty()) {
-        auto it = nodeIdMap.find(u);
-        if (it == nodeIdMap.cend()) {
+    if (nodeIdMap) {
+        auto it = nodeIdMap->find(u);
+        if (it == nodeIdMap->cend()) {
             std::stringstream errorMsg;
             errorMsg << "Node id mapping does not contain node " << u;
             throw std::runtime_error(errorMsg.str());

--- a/networkit/cpp/graph/TopologicalSort.cpp
+++ b/networkit/cpp/graph/TopologicalSort.cpp
@@ -32,7 +32,8 @@ void TopologicalSort::checkDirected() {
 }
 
 void TopologicalSort::checkNodeIdMap() {
-    if (!nodeIdMap) return;
+    if (!nodeIdMap)
+        return;
 
     size_t numberOfNodes = G.numberOfNodes();
     std::vector<bool> checkTable(numberOfNodes);


### PR DESCRIPTION
This PR effectively fixes the broken coverage upload. Due to also testing for leaks and continuing on errors, the coverage for the C++ code way empty if a potential address leak is found. Both tests are now split into different runs. This should also speedup the coverage run due to having both leak checks and coverage at the same time.

In addition several potential leaks are fixed. One fix in `random.cc` from libstd is not fixed, since it is intentional. The fix instead is to remove the out-of-bound sanitizer checks for this file by adding a filter.