### PR TITLE
Issue #938: suppress warning for pandas in networkit/simulation.pyx

### DIFF
--- a/networkit/simulation.pyx
+++ b/networkit/simulation.pyx
@@ -58,7 +58,7 @@ cdef class EpidemicSimulationSEIR(Algorithm):
 		"""
 		try:
 			import pandas
-		return pandas.DataFrame((<_EpidemicSimulationSEIR*>(self._this)).getData(), columns=["zero", "time", "state", "count"])
+			return pandas.DataFrame((<_EpidemicSimulationSEIR*>(self._this)).getData(), columns=["zero", "time", "state", "count"])
 		except ImportError:
 			from .support import MissingDependencyError 
 			raise MissingDependencyError("pandas")

--- a/networkit/simulation.pyx
+++ b/networkit/simulation.pyx
@@ -7,12 +7,6 @@ from .graph cimport _Graph, Graph
 from .helpers import ReducedFunctionalityWarning
 from .structures cimport count, index, node
 
-import warnings
-try:
-	import pandas
-except:
-	warnings.warn("WARNING: module 'pandas' not found, some functionality will be restricted", ReducedFunctionalityWarning)
-
 cdef extern from "<networkit/Globals.hpp>" namespace "NetworKit":
 
 	index _none "NetworKit::none"
@@ -62,4 +56,10 @@ cdef class EpidemicSimulationSEIR(Algorithm):
 		pandas.DataFrame
 			The simulation data.
 		"""
+		try:
+			import pandas
 		return pandas.DataFrame((<_EpidemicSimulationSEIR*>(self._this)).getData(), columns=["zero", "time", "state", "count"])
+		except ImportError:
+			from .support import MissingDependencyError 
+			raise MissingDependencyError("pandas")
+


### PR DESCRIPTION
In networkit/simulation.pyx: We suppress now the warning after import of the pandas package and instead throw an error only when we actually want to use this package. This looks like this: 

Output without pandas when: 
'
>>> from networkit import *
>>> G = readGraph("./input/airfoil1.graph", Format.METIS)
>>> sim = simulation.EpidemicSimulationSEIR(G, 1, 0.1, 1, 0, 0)
>>> sim.getData()
' 


Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "networkit/simulation.pyx", line 70, in networkit.simulation.EpidemicSimulationSEIR.getData
    raise MissingDependencyError("pandas")
networkit.support.MissingDependencyError: Optional dependency pandas is not installed

##############################################

Output with pandas installed:

Empty DataFrame
Columns: [zero, time, state, count]
Index: []