### PR TITLE
fix edge attribute indexing bugs when changing edge ids

### DIFF
--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -151,7 +151,7 @@ public:
 
 private:
     std::vector<T> values; // the real attribute storage
-}; // class AttributeStorage<NodeOrEdge, Base, T>
+};                         // class AttributeStorage<NodeOrEdge, Base, T>
 
 template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
 class Attribute {

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -48,6 +48,8 @@ public:
     std::type_index getType() const noexcept { return type; }
 
     virtual std::shared_ptr<AttributeStorageBase> clone() const = 0;
+    virtual void erase(index i) = 0;
+    virtual void swapData(index i, index j) = 0;
 
     bool isValid(index n) const noexcept { return n < valid.size() && valid[n]; }
 
@@ -78,11 +80,11 @@ protected:
 private:
     std::string name;
     std::type_index type;
-    std::vector<bool> valid; // For each node/edgeid: whether attribute is set or not.
 
 protected:
     index validElements = 0;
-    bool validStorage; // Validity of the whole storage
+    bool validStorage;       // Validity of the whole storage
+    std::vector<bool> valid; // For each node/edgeid: whether attribute is set or not.
 
 }; // class AttributeStorageBase
 
@@ -101,6 +103,19 @@ public:
     std::shared_ptr<Base<NodeOrEdge, GraphType>> clone() const override {
         return std::make_shared<AttributeStorage>(*this);
     };
+
+    void swapData(index i, index j) override {
+        assert(i < values.size());
+        assert(j < values.size());
+        std::swap(values[i], values[j]);
+        std::swap(this->valid[i], this->valid[j]);
+    }
+
+    void erase(index i) override {
+        assert(i < values.size());
+        values.erase(values.begin() + i);
+        this->valid.erase(this->valid.begin() + i);
+    }
 
     void resize(index i) {
         if (i >= values.size())

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -107,8 +107,9 @@ public:
     void swapData(index i, index j) override {
         assert(i < values.size());
         assert(j < values.size());
-        std::swap(values[i], values[j]);
-        std::swap(this->valid[i], this->valid[j]);
+        using std::swap;
+        swap(values[i], values[j]);
+        swap(this->valid[i], this->valid[j]);
     }
 
     void erase(index i) override {
@@ -150,7 +151,7 @@ public:
 
 private:
     std::vector<T> values; // the real attribute storage
-};                         // class AttributeStorage<NodeOrEdge, Base, T>
+}; // class AttributeStorage<NodeOrEdge, Base, T>
 
 template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
 class Attribute {

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -609,8 +609,8 @@ void Graph::removeEdge(node u, node v) {
         throw std::runtime_error("Edges have to be indexed if maintainCompactEdges is set to true");
     }
 
-    index vi = indexInOutEdgeArray(u, v);
-    index ui = indexInInEdgeArray(v, u);
+    index vi = indexInOutEdgeArray(u, v); // index in outEdges array
+    index ui = indexInInEdgeArray(v, u);  // index in inEdges array
 
     if (edgesIndexed) {
         deletedID = edgeId(u, v);
@@ -660,6 +660,12 @@ void Graph::removeEdge(node u, node v) {
             std::swap(outEdges[u][cur], outEdges[u][cur + 1]);
             if (edgesIndexed) {
                 std::swap(outEdgeIds[u][cur], outEdgeIds[u][cur + 1]);
+                // swap attributes as well
+                auto &theMap = edgeAttributeMap.attrMap;
+                for (auto it = theMap.begin(); it != theMap.end(); ++it) {
+                    auto attributeStorageBase = it->second.get();
+                    attributeStorageBase->swapData(outEdgeIds[u][cur], outEdgeIds[u][cur + 1]);
+                }
             }
             ++cur;
         }
@@ -687,6 +693,12 @@ void Graph::removeEdge(node u, node v) {
                 }
             }
         });
+        // use erase to remove data entry at index `deletedID` and compact the data vector again
+        auto &theMap = edgeAttributeMap.attrMap;
+        for (auto it = theMap.begin(); it != theMap.end(); ++it) {
+            auto attributeStorageBase = it->second.get();
+            attributeStorageBase->erase(deletedID);
+        }
     }
     if (directed) {
         assert(ui != none);

--- a/networkit/cpp/graph/test/AttributeGTest.cpp
+++ b/networkit/cpp/graph/test/AttributeGTest.cpp
@@ -494,4 +494,56 @@ TEST_F(AttributeGTest, assignAttributeToAttribute) {
     EXPECT_EQ(attr2[1], 4);
 }
 
+TEST_F(AttributeGTest, testMaintainCompactEdges) {
+    Graph graph(3);
+    graph.indexEdges();
+    graph.addEdge(0, 1);
+    graph.addEdge(0, 2);
+
+    graph.setMaintainCompactEdges();
+
+    auto attr = graph.edgeAttributes().attach<int>("attr");
+    attr(0, 1) = 0;
+    attr(0, 2) = 1;
+
+    graph.removeEdge(0, 1);
+
+    EXPECT_EQ(attr(0, 2), 1);
+}
+
+TEST_F(AttributeGTest, testMaintainSortedEdges) {
+    Graph graph(3);
+    graph.indexEdges();
+    graph.addEdge(0, 1);
+    graph.addEdge(0, 2);
+
+    graph.setKeepEdgesSorted();
+
+    auto attr = graph.edgeAttributes().attach<int>("attr");
+    attr(0, 1) = 0;
+    attr(0, 2) = 1;
+
+    graph.removeEdge(0, 1);
+
+    EXPECT_EQ(attr(0, 2), 1);
+}
+
+TEST_F(AttributeGTest, testMaintainSortedAndCompactEdges) {
+    Graph graph(3);
+    graph.indexEdges();
+    graph.addEdge(0, 1);
+    graph.addEdge(0, 2);
+
+    graph.setMaintainCompactEdges();
+    graph.setKeepEdgesSorted();
+
+    auto attr = graph.edgeAttributes().attach<int>("attr");
+    attr(0, 1) = 0;
+    attr(0, 2) = 1;
+
+    graph.removeEdge(0, 1);
+
+    EXPECT_EQ(attr(0, 2), 1);
+}
+
 } // namespace NetworKit


### PR DESCRIPTION
fixes #1277 and additionally fixes the same issue for `maintainSortedEdges` as well.