### PR TITLE
Refactor sortNeighbors with OpenMP Parallelization & Evaluate Reuse in sortEdges

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -2289,17 +2289,10 @@ void Graph::sortNeighbors(Lambda lambda) {
         // Sort the outEdge-Attributes
         auto &outIndices = threadData[omp_get_thread_num()];
         outIndices.clear();
-        if (outEdges[w].empty())
-            return;
         outIndices.resize(outEdges[w].size());
 
         std::iota(outIndices.begin(), outIndices.end(), 0);
         std::ranges::sort(outIndices, [&](index a, index b) {
-            if (a >= outEdges[w].size() || b >= outEdges[w].size()) {
-                std::cerr << "Invalid index in outEdges: " << a << ", " << b
-                          << " (max: " << outEdges[w].size() << ")\n";
-                std::terminate();
-            }
             return extLambda(w, outEdges[w][a], outEdges[w][b]);
         });
 
@@ -2317,10 +2310,12 @@ void Graph::sortNeighbors(Lambda lambda) {
         }
         // For directed graphs we need to sort the inEdge-Attributes separately
         if (directed) {
+            if (inEdges[w].empty())
+                return;
             auto &inIndices = threadData[omp_get_thread_num()];
             inIndices.clear();
-            if (inEdges[w].size() > inIndices.size())
-                inIndices.resize(inEdges[w].size());
+
+            inIndices.resize(inEdges[w].size());
             std::iota(inIndices.begin(), inIndices.end(), 0);
 
             std::ranges::sort(inIndices, [&](index a, index b) {

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1002,7 +1002,7 @@ public:
      *               precede the second in the sorted order.
      */
     template <typename Lambda>
-    void sortNeighbors(node u, Lambda lambda);
+    void sortNeighbors(Lambda lambda);
 
     /**
      * Sorts the adjacency arrays by node id. While the running time is linear
@@ -2279,48 +2279,70 @@ std::pair<count, count> Graph::removeAdjacentEdges(node u, Condition condition, 
 }
 
 template <typename Lambda>
-void Graph::sortNeighbors(node u, Lambda lambda) {
-    if ((degreeIn(u) < 2) && (degree(u) < 2)) {
-        return;
-    }
-    // Sort the outEdge-Attributes
-    std::vector<index> outIndices(outEdges[u].size());
-    std::iota(outIndices.begin(), outIndices.end(), 0);
-    std::ranges::sort(outIndices,
-                      [&](index a, index b) { return lambda(outEdges[u][a], outEdges[u][b]); });
+void Graph::sortNeighbors(Lambda lambda) {
+    std::vector<std::vector<index>> threadData(omp_get_max_threads());
 
-    Aux::ArrayTools::applyPermutation(outEdges[u].begin(), outEdges[u].end(), outIndices.begin());
+    const auto sortNeighborLists = [&](node w, Lambda extLambda) {
+        if ((degreeIn(w) < 2) && (degree(w) < 2)) {
+            return;
+        }
+        // Sort the outEdge-Attributes
+        auto &outIndices = threadData[omp_get_thread_num()];
+        outIndices.clear();
+        if (outEdges[w].empty())
+            return;
+        outIndices.resize(outEdges[w].size());
 
-    if (weighted) {
-        Aux::ArrayTools::applyPermutation(outEdgeWeights[u].begin(), outEdgeWeights[u].end(),
+        std::iota(outIndices.begin(), outIndices.end(), 0);
+        std::ranges::sort(outIndices, [&](index a, index b) {
+            if (a >= outEdges[w].size() || b >= outEdges[w].size()) {
+                std::cerr << "Invalid index in outEdges: " << a << ", " << b
+                          << " (max: " << outEdges[w].size() << ")\n";
+                std::terminate();
+            }
+            return extLambda(w, outEdges[w][a], outEdges[w][b]);
+        });
+
+        Aux::ArrayTools::applyPermutation(outEdges[w].begin(), outEdges[w].end(),
                                           outIndices.begin());
-    }
-
-    if (edgesIndexed) {
-        Aux::ArrayTools::applyPermutation(outEdgeIds[u].begin(), outEdgeIds[u].end(),
-                                          outIndices.begin());
-    }
-
-    // For directed graphs we need to sort the inEdge-Attributes separately
-    if (directed) {
-        std::vector<index> inIndices(inEdges[u].size());
-        std::iota(inIndices.begin(), inIndices.end(), 0);
-
-        std::ranges::sort(inIndices,
-                          [&](index a, index b) { return lambda(inEdges[u][a], inEdges[u][b]); });
-
-        Aux::ArrayTools::applyPermutation(inEdges[u].begin(), inEdges[u].end(), inIndices.begin());
 
         if (weighted) {
-            Aux::ArrayTools::applyPermutation(inEdgeWeights[u].begin(), inEdgeWeights[u].end(),
-                                              inIndices.begin());
+            Aux::ArrayTools::applyPermutation(outEdgeWeights[w].begin(), outEdgeWeights[w].end(),
+                                              outIndices.begin());
         }
 
         if (edgesIndexed) {
-            Aux::ArrayTools::applyPermutation(inEdgeIds[u].begin(), inEdgeIds[u].end(),
-                                              inIndices.begin());
+            Aux::ArrayTools::applyPermutation(outEdgeIds[w].begin(), outEdgeIds[w].end(),
+                                              outIndices.begin());
         }
-    }
+        // For directed graphs we need to sort the inEdge-Attributes separately
+        if (directed) {
+            auto &inIndices = threadData[omp_get_thread_num()];
+            inIndices.clear();
+            if (inEdges[w].size() > inIndices.size())
+                inIndices.resize(inEdges[w].size());
+            std::iota(inIndices.begin(), inIndices.end(), 0);
+
+            std::ranges::sort(inIndices, [&](index a, index b) {
+                return extLambda(w, inEdges[w][a], inEdges[w][b]);
+            });
+
+            Aux::ArrayTools::applyPermutation(inEdges[w].begin(), inEdges[w].end(),
+                                              inIndices.begin());
+
+            if (weighted) {
+                Aux::ArrayTools::applyPermutation(inEdgeWeights[w].begin(), inEdgeWeights[w].end(),
+                                                  inIndices.begin());
+            }
+
+            if (edgesIndexed) {
+                Aux::ArrayTools::applyPermutation(inEdgeIds[w].begin(), inEdgeIds[w].end(),
+                                                  inIndices.begin());
+            }
+        }
+    };
+
+    balancedParallelForNodes([&](const node v) { sortNeighborLists(v, lambda); });
 }
 
 template <class Lambda>

--- a/include/networkit/planarity/LeftRightPlanarityCheck.hpp
+++ b/include/networkit/planarity/LeftRightPlanarityCheck.hpp
@@ -93,7 +93,6 @@ private:
     bool dfsTesting(node startNode);
     bool applyConstraints(const Edge &edge, const Edge &parentEdge);
     void removeBackEdges(const Edge &edge);
-    void sortAdjacencyListByNestingDepth();
     bool conflicting(const Interval &interval, const Edge &edge);
     count getLowestLowPoint(const ConflictPair &conflictPair);
     std::vector<count> heights;

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -2396,11 +2396,8 @@ TEST(GraphGTest, testSortNeighborsUndirectedGraph) {
     });
 
     // Sort neighbors
-    G.forNodes([&](const node currentNode) {
-        G.sortNeighbors(currentNode, [&](const node neighbor1, const node neighbor2) {
-            return neighbor1 < neighbor2;
-        });
-    });
+    G.sortNeighbors(
+        [&](node currentNode, node neighbor1, node neighbor2) { return neighbor1 < neighbor2; });
 
     // Validate sorting for outgoing neighbors
     G.forNodes([&](const node currentNode) {
@@ -2438,11 +2435,8 @@ TEST(GraphGTest, testSortNeighborsUndirectedIndexedGraph) {
     });
 
     // Sort neighbors
-    G.forNodes([&](const node currentNode) {
-        G.sortNeighbors(currentNode, [&](const node neighbor1, const node neighbor2) {
-            return neighbor1 < neighbor2;
-        });
-    });
+    G.sortNeighbors(
+        [&](node currentNode, node neighbor1, node neighbor2) { return neighbor1 < neighbor2; });
 
     G.forNodes([&](const node currentNode) {
         const auto &sortedNeighbors = G.neighborRange(currentNode);
@@ -2477,10 +2471,8 @@ TEST(GraphGTest, testSortNeighborsWeightedUndirectedGraphByWeights) {
     G.addEdge(2, 3, 6.0);
     G.addEdge(3, 4, 7.0);
 
-    G.forNodes([&](const node currentNode) {
-        G.sortNeighbors(currentNode, [&](const node neighbor1, const node neighbor2) {
-            return G.weight(currentNode, neighbor1) < G.weight(currentNode, neighbor2);
-        });
+    G.sortNeighbors([&](node currentNode, node neighbor1, node neighbor2) {
+        return G.weight(currentNode, neighbor1) < G.weight(currentNode, neighbor2);
     });
 
     // Validate that neighbors are sorted according to weights
@@ -2517,11 +2509,9 @@ TEST(GraphGTest, testSortNeighborsDirectedGraph) {
     });
 
     // Sort neighbors
-    G.forNodes([&](const node currentNode) {
-        G.sortNeighbors(currentNode, [&](const node neighbor1, const node neighbor2) {
-            return neighbor1 < neighbor2;
-        });
-    });
+
+    G.sortNeighbors(
+        [&](node currentNode, node neighbor1, node neighbor2) { return neighbor1 < neighbor2; });
 
     G.forNodes([&](const node currentNode) {
         // Validate sorting of outgoing neighbors
@@ -2537,7 +2527,6 @@ TEST(GraphGTest, testSortNeighborsDirectedGraph) {
         std::vector<node> sortedInNeighborVector(sortedInNeighbors.begin(),
                                                  sortedInNeighbors.end());
         EXPECT_TRUE(std::ranges::is_sorted(sortedInNeighborVector));
-
         if (!std::ranges::is_sorted(originalInNeighbors[currentNode])) {
             EXPECT_NE(originalInNeighbors[currentNode], sortedInNeighborVector);
         }
@@ -2559,10 +2548,8 @@ TEST(GraphGTest, testSortNeighborsWeightedDirectedGraphByWeights) {
     G.addEdge(2, 4, 10.0);
 
     // Sort neighbors according to weights
-    G.forNodes([&](const node currentNode) {
-        G.sortNeighbors(currentNode, [&](const node neighbor1, const node neighbor2) {
-            return G.weight(currentNode, neighbor1) < G.weight(currentNode, neighbor2);
-        });
+    G.sortNeighbors([&](node currentNode, node neighbor1, node neighbor2) {
+        return G.weight(currentNode, neighbor1) < G.weight(currentNode, neighbor2);
     });
 
     // Validate that neighbors are sorted according to weights
@@ -2630,11 +2617,8 @@ TEST(GraphGTest, testSortNeighborsWeightedDirectedIndexedGraph) {
     });
 
     // Sort neighbors
-    G.forNodes([&](const node currentNode) {
-        G.sortNeighbors(currentNode, [&](const node neighbor1, const node neighbor2) {
-            return neighbor1 < neighbor2;
-        });
-    });
+    G.sortNeighbors(
+        [&](node currentNode, node neighbor1, node neighbor2) { return neighbor1 < neighbor2; });
 
     // Validate sorting for outgoing neighbors
     G.forNodes([&](const node currentNode) {

--- a/networkit/cpp/planarity/LeftRightPlanarityCheck.cpp
+++ b/networkit/cpp/planarity/LeftRightPlanarityCheck.cpp
@@ -28,23 +28,17 @@ void LeftRightPlanarityCheck::run() {
         }
     });
 
-    sortAdjacencyListByNestingDepth();
+    dfsGraph.sortNeighbors([&](node currentNode, node neighbor1, node neighbor2) {
+        if (auto it1 = nestingDepth.find(Edge(currentNode, neighbor1)),
+            it2 = nestingDepth.find(Edge(currentNode, neighbor2));
+            it1 != nestingDepth.end() && it2 != nestingDepth.end()) {
+            return it1->second < it2->second;
+        }
+        return false;
+    });
     isGraphPlanar =
         std::ranges::all_of(roots, [this](node rootNode) { return dfsTesting(rootNode); });
     hasRun = true;
-}
-
-void LeftRightPlanarityCheck::sortAdjacencyListByNestingDepth() {
-    dfsGraph.forNodes([&](node currentNode) {
-        dfsGraph.sortNeighbors(currentNode, [&](node neighbor1, node neighbor2) {
-            if (auto it1 = nestingDepth.find(Edge(currentNode, neighbor1)),
-                it2 = nestingDepth.find(Edge(currentNode, neighbor2));
-                it1 != nestingDepth.end() && it2 != nestingDepth.end()) {
-                return it1->second < it2->second;
-            }
-            return false;
-        });
-    });
 }
 
 bool LeftRightPlanarityCheck::conflicting(const Interval &interval, const Edge &edge) {


### PR DESCRIPTION
# Refactor `sortNeighbors` with OpenMP Parallelization & Evaluate Reuse in `sortEdges`

## Summary  
This PR refactors `sortNeighbors` to leverage OpenMP for parallel sorting. The goal was to explore whether `sortNeighbors` could replace the `sortAdjacencyArrays` lambda inside `sortEdges`, as suggested in a [previous discussion](https://github.com/networkit/networkit/pull/1276#discussion_r1921507461). 

## Key Changes  
- Parallelized `sortNeighbors` similar to `sortEdges`
- Resolved race conditions that arose due to parallel execution.  

## Challenges & Findings  
- While the parallelization improves `sortNeighbors`, I did not see an obvious way how to reuse it in `sortEdges`.  
- Both `sortNeighbors` and `sortEdges` now utilize OpenMP, but their structures differ, raising the question of whether they should remain separate or be unified.  

## Next Steps & Request for Feedback  
I would appreciate input on:  
- Whether the refactored `sortNeighbors` should be merged as is, even if it doesn't fully replace the existing logic in `sortEdges`.  
- Any suggestions for unifying the sorting logic while maintaining performance and correctness are welcome since I have only limited experience in multi-threaded environments.

Tagging @angriman and other reviewers for their thoughts. Any guidance, best practices regarding multi-threaded applications would be very welcome! 🚀  
