### PR TITLE
Add Floyd-Warshall algorithm

### DIFF
--- a/include/networkit/distance/FloydWarshall.hpp
+++ b/include/networkit/distance/FloydWarshall.hpp
@@ -28,6 +28,7 @@ private:
     std::vector<std::vector<edgeweight>> distances;
     std::vector<uint8_t> nodesInNegativeCycle;
     std::vector<std::vector<node>> pathMatrix;
+    std::vector<std::vector<count>> hopCount;
     void tagNegativeCycles();
 };
 } // namespace NetworKit

--- a/include/networkit/distance/FloydWarshall.hpp
+++ b/include/networkit/distance/FloydWarshall.hpp
@@ -83,7 +83,7 @@ private:
     const Graph *graph;
     static constexpr edgeweight infiniteDistance = std::numeric_limits<edgeweight>::max();
     std::vector<std::vector<edgeweight>> distances;
-    std::vector<uint8_t> nodesInNegativeCycle;
+    std::vector<bool> nodesInNegativeCycle;
     std::vector<std::vector<node>> pathMatrix;
     std::vector<std::vector<count>> hops;
     void tagNegativeCycles();

--- a/include/networkit/distance/FloydWarshall.hpp
+++ b/include/networkit/distance/FloydWarshall.hpp
@@ -7,8 +7,10 @@
 
 #ifndef NETWORKIT_DISTANCE_FLOYD_WARSHALL_HPP_
 #define NETWORKIT_DISTANCE_FLOYD_WARSHALL_HPP_
+
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
+
 namespace NetworKit {
 
 /**

--- a/include/networkit/distance/FloydWarshall.hpp
+++ b/include/networkit/distance/FloydWarshall.hpp
@@ -1,0 +1,38 @@
+/*  FloydWarshall.hpp
+ *
+ *	Created on: 15.02.2025
+ *  Authors: Andreas Scharf (andreas.b.scharf@gmail.com)
+ *
+ */
+
+#ifndef NETWORKIT_DISTANCE_FLOYD_WARSHALL_HPP_
+#define NETWORKIT_DISTANCE_FLOYD_WARSHALL_HPP_
+#include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
+namespace NetworKit {
+
+class FloydWarshall : public Algorithm {
+public:
+    FloydWarshall(const Graph &G, double densityThreshold = 0.5, node maximumNumberOfNodes = 500);
+
+    void run() override;
+
+    edgeweight getDistance(node source, node target) const;
+
+    std::vector<std::vector<edgeweight>> getAllDistances() const;
+
+    bool isNodeInNegativeCycle(node u) const;
+
+    std::vector<node> getNodesOnShortestPath(node source, node target) const;
+
+private:
+    const Graph *graph;
+    index numberOfNodes{};
+    std::vector<std::vector<edgeweight>> distances;
+    std::vector<uint8_t> nodesInNegativeCycle;
+    std::vector<std::vector<node>> pathMatrix;
+    void tagNegativeCycles();
+};
+} // namespace NetworKit
+
+#endif // NETWORKIT_DISTANCE_FLOYD_WARSHALL_HPP_

--- a/include/networkit/distance/FloydWarshall.hpp
+++ b/include/networkit/distance/FloydWarshall.hpp
@@ -11,12 +11,70 @@
 #include <networkit/graph/Graph.hpp>
 namespace NetworKit {
 
+/**
+ * @class FloydWarshall
+ * @brief Computes all-pairs shortest paths using the Floyd-Warshall algorithm.
+ *
+ * This algorithm finds the shortest paths between all node pairs in a weighted graph,
+ * supporting both directed and undirected graphs. It correctly handles negative edge
+ * weights and detects negative cycles. If multiple shortest paths exist, it returns
+ * one with the fewest nodes.
+ *
+ * The algorithm has a time complexity of O(n³), making it suitable for small to
+ * medium-sized graphs.
+ */
 class FloydWarshall : public Algorithm {
 public:
+    /**
+     * @brief Initializes the Floyd-Warshall algorithm for a given graph.
+     *
+     * The input graph must be weighted and may be either directed or undirected.
+     *
+     * @param G The graph on which shortest paths will be computed.
+     */
     FloydWarshall(const Graph &G);
+    /**
+     * @brief Runs the Floyd-Warshall algorithm.
+     *
+     * Computes shortest path distances and reconstructs paths between all node pairs.
+     * Also identifies nodes involved in negative cycles.
+     */
     void run() override;
+
+    /**
+     * @brief Returns the shortest distance between two nodes.
+     *
+     * If no path exists, returns `std::numeric_limits<edgeweight>::max()`.
+     *
+     * @param source The starting node.
+     * @param target The destination node.
+     * @return The shortest path distance from `source` to `target`.
+     */
     edgeweight getDistance(node source, node target) const;
+    /**
+     * @brief Checks whether a node is part of a negative cycle.
+     *
+     * A node is considered part of a negative cycle if its shortest path distance
+     * to itself is negative.
+     *
+     * @param u The node to check.
+     * @return `true` if the node is in a negative cycle, otherwise `false`.
+     */
     bool isNodeInNegativeCycle(node u) const;
+
+    /**
+     * @brief Retrieves the shortest path between two nodes.
+     *
+     * Returns a sequence of nodes representing the shortest path from `source` to
+     * `target`. If no path exists, returns an empty vector.
+     *
+     * If multiple shortest paths exist with the same total distance, the function
+     * returns the one with the fewest nodes.
+     *
+     * @param source The starting node.
+     * @param target The destination node.
+     * @return A vector of nodes forming the shortest path.
+     */
     std::vector<node> getNodesOnShortestPath(node source, node target) const;
 
 private:

--- a/include/networkit/distance/FloydWarshall.hpp
+++ b/include/networkit/distance/FloydWarshall.hpp
@@ -14,13 +14,9 @@ namespace NetworKit {
 class FloydWarshall : public Algorithm {
 public:
     FloydWarshall(const Graph &G);
-
     void run() override;
-
     edgeweight getDistance(node source, node target) const;
-
     bool isNodeInNegativeCycle(node u) const;
-
     std::vector<node> getNodesOnShortestPath(node source, node target) const;
 
 private:
@@ -28,7 +24,7 @@ private:
     std::vector<std::vector<edgeweight>> distances;
     std::vector<uint8_t> nodesInNegativeCycle;
     std::vector<std::vector<node>> pathMatrix;
-    std::vector<std::vector<count>> hopCount;
+    std::vector<std::vector<count>> hops;
     void tagNegativeCycles();
 };
 } // namespace NetworKit

--- a/include/networkit/distance/FloydWarshall.hpp
+++ b/include/networkit/distance/FloydWarshall.hpp
@@ -79,6 +79,7 @@ public:
 
 private:
     const Graph *graph;
+    static constexpr edgeweight infiniteDistance = std::numeric_limits<edgeweight>::max();
     std::vector<std::vector<edgeweight>> distances;
     std::vector<uint8_t> nodesInNegativeCycle;
     std::vector<std::vector<node>> pathMatrix;

--- a/include/networkit/distance/FloydWarshall.hpp
+++ b/include/networkit/distance/FloydWarshall.hpp
@@ -13,13 +13,13 @@ namespace NetworKit {
 
 class FloydWarshall : public Algorithm {
 public:
-    FloydWarshall(const Graph &G, double densityThreshold = 0.5, node maximumNumberOfNodes = 500);
+    FloydWarshall(const Graph &G);
 
     void run() override;
 
     edgeweight getDistance(node source, node target) const;
 
-    std::vector<std::vector<edgeweight>> getAllDistances() const;
+    const std::vector<std::vector<edgeweight>> & getAllDistances() const &;
 
     bool isNodeInNegativeCycle(node u) const;
 
@@ -27,7 +27,6 @@ public:
 
 private:
     const Graph *graph;
-    index numberOfNodes{};
     std::vector<std::vector<edgeweight>> distances;
     std::vector<uint8_t> nodesInNegativeCycle;
     std::vector<std::vector<node>> pathMatrix;

--- a/include/networkit/distance/FloydWarshall.hpp
+++ b/include/networkit/distance/FloydWarshall.hpp
@@ -19,8 +19,6 @@ public:
 
     edgeweight getDistance(node source, node target) const;
 
-    const std::vector<std::vector<edgeweight>> & getAllDistances() const &;
-
     bool isNodeInNegativeCycle(node u) const;
 
     std::vector<node> getNodesOnShortestPath(node source, node target) const;

--- a/networkit/cpp/distance/CMakeLists.txt
+++ b/networkit/cpp/distance/CMakeLists.txt
@@ -12,6 +12,7 @@ networkit_add_module(distance
     Eccentricity.cpp
     EffectiveDiameter.cpp
     EffectiveDiameterApproximation.cpp
+    FloydWarshall.cpp
     GraphDistance.cpp
     HopPlotApproximation.cpp
     IncompleteDijkstra.cpp

--- a/networkit/cpp/distance/FloydWarshall.cpp
+++ b/networkit/cpp/distance/FloydWarshall.cpp
@@ -56,19 +56,19 @@ void FloydWarshall::run() {
         }
     }
 
-    for (node w = 0; w < numberOfNodes; ++w) {
-        for (node u = 0; u < numberOfNodes; ++u) {
-            if (distances[u][w] == std::numeric_limits<edgeweight>::max())
-                continue;
-            for (node v = 0; v < numberOfNodes; ++v) {
-                if (distances[w][v] != std::numeric_limits<edgeweight>::max()
-                    && distances[u][w] + distances[w][v] < distances[u][v]) {
-                    distances[u][v] = distances[u][w] + distances[w][v];
-                    pathMatrix[u][v] = pathMatrix[u][w];
+        for (node w = 0; w < numberOfNodes; ++w) {
+            for (node u = 0; u < numberOfNodes; ++u) {
+                if (distances[u][w] == std::numeric_limits<edgeweight>::max())
+                    continue;
+                for (node v = 0; v < numberOfNodes; ++v) {
+                    if (distances[w][v] != std::numeric_limits<edgeweight>::max()
+                        && distances[u][w] + distances[w][v] < distances[u][v]) {
+                        distances[u][v] = distances[u][w] + distances[w][v];
+                        pathMatrix[u][v] = pathMatrix[u][w];
+                    }
                 }
             }
         }
-    }
 
     tagNegativeCycles();
     hasRun = true;
@@ -79,12 +79,6 @@ edgeweight FloydWarshall::getDistance(node source, node target) const {
     return distances[source][target];
 }
 
-const std::vector<std::vector<edgeweight>> & FloydWarshall::getAllDistances() const & {
-    assureFinished();
-    return distances;
-}
-
-    
 bool FloydWarshall::isNodeInNegativeCycle(node u) const {
     assureFinished();
     return nodesInNegativeCycle[u] == 1;

--- a/networkit/cpp/distance/FloydWarshall.cpp
+++ b/networkit/cpp/distance/FloydWarshall.cpp
@@ -84,7 +84,7 @@ const std::vector<std::vector<edgeweight>> & FloydWarshall::getAllDistances() co
     return distances;
 }
 
-
+    
 bool FloydWarshall::isNodeInNegativeCycle(node u) const {
     assureFinished();
     return nodesInNegativeCycle[u] == 1;

--- a/networkit/cpp/distance/FloydWarshall.cpp
+++ b/networkit/cpp/distance/FloydWarshall.cpp
@@ -21,9 +21,8 @@ FloydWarshall::FloydWarshall(const Graph &G, double densityThreshold, node maxim
         throw std::invalid_argument("Invalid maximum node count. Must be at least 1.");
     }
 
-    const index maximumNumberOfEdges = G.isDirected() ? maximumNumberOfNodes*(maximumNumberOfNodes-1) : maximumNumberOfNodes*(maximumNumberOfNodes-1)/2;
+    const index maximumNumberOfEdges = G.isDirected() ? numberOfNodes*(numberOfNodes-1) : numberOfNodes*(numberOfNodes-1)/2;
     const double density = static_cast<double>(G.numberOfEdges()) / maximumNumberOfEdges;
-
     if (density < densityThreshold) {
         throw std::domain_error("Graph density is below user-defined density-threshold of: " + std::to_string(densityThreshold));
     }

--- a/networkit/cpp/distance/FloydWarshall.cpp
+++ b/networkit/cpp/distance/FloydWarshall.cpp
@@ -1,0 +1,124 @@
+/*  FloydWarshall.cpp
+ *
+ *	Created on: 15.02.2025
+ *  Authors: Andreas Scharf (andreas.b.scharf@gmail.com)
+ *
+ */
+#include <networkit/distance/FloydWarshall.hpp>
+
+namespace NetworKit {
+
+FloydWarshall::FloydWarshall(const Graph &G, double densityThreshold, node maximumNumberOfNodes)
+    : graph(&G), numberOfNodes(G.numberOfNodes()) {
+
+    if (!G.isWeighted()) {
+        throw std::runtime_error("The input graph is unweighted!");
+    }
+    if (densityThreshold <= 0.0 || densityThreshold > 1.0) {
+        throw std::invalid_argument("Invalid density threshold. Must be in range (0, 1].");
+    }
+    if (maximumNumberOfNodes < 1) {
+        throw std::invalid_argument("Invalid maximum node count. Must be at least 1.");
+    }
+
+    const index maximumNumberOfEdges = G.isDirected() ? maximumNumberOfNodes*(maximumNumberOfNodes-1) : maximumNumberOfNodes*(maximumNumberOfNodes-1)/2;
+    const double density = static_cast<double>(G.numberOfEdges()) / maximumNumberOfEdges;
+
+    if (density < densityThreshold) {
+        throw std::domain_error("Graph density is below user-defined density-threshold of: " + std::to_string(densityThreshold));
+    }
+    if (numberOfNodes > maximumNumberOfNodes) {
+        throw std::domain_error("Graph size exceeds user-defined max-node-limit of: " + std::to_string(maximumNumberOfNodes));
+    }
+}
+
+void FloydWarshall::tagNegativeCycles() {
+    for (node w = 0; w < numberOfNodes; ++w) {
+        if (!(distances[w][w] < 0.0))
+            continue;
+        nodesInNegativeCycle[w] = 1;
+        for (node u = 0; u < numberOfNodes; ++u) {
+            if (distances[u][w] == std::numeric_limits<edgeweight>::max())
+                continue;
+            for (node v = 0; v < numberOfNodes; ++v) {
+                if (distances[w][v] != std::numeric_limits<edgeweight>::max()) {
+                    nodesInNegativeCycle[u] = 1;
+                    nodesInNegativeCycle[v] = 1;
+                    distances[u][v] = -std::numeric_limits<edgeweight>::infinity();
+                    pathMatrix[u][v] = none;
+                }
+            }
+        }
+    }
+}
+
+void FloydWarshall::run() {
+    distances = std::vector(numberOfNodes,
+                            std::vector(numberOfNodes, std::numeric_limits<edgeweight>::max()));
+    nodesInNegativeCycle = std::vector<uint8_t>(numberOfNodes);
+    pathMatrix = std::vector(numberOfNodes, std::vector(numberOfNodes, none));
+
+    for (node u = 0; u < numberOfNodes; ++u) {
+        distances[u][u] = 0.0;
+        pathMatrix[u][u] = u;
+    }
+
+    for (node u = 0; u < numberOfNodes; ++u) {
+        for (const node v : graph->neighborRange(u)) {
+            distances[u][v] = graph->weight(u, v);
+            pathMatrix[u][v] = v;
+        }
+    }
+
+    for (node w = 0; w < numberOfNodes; ++w) {
+        for (node u = 0; u < numberOfNodes; ++u) {
+            if (distances[u][w] == std::numeric_limits<edgeweight>::max())
+                continue;
+            for (node v = 0; v < numberOfNodes; ++v) {
+                if (distances[w][v] != std::numeric_limits<edgeweight>::max()
+                    && distances[u][w] + distances[w][v] < distances[u][v]) {
+                    distances[u][v] = distances[u][w] + distances[w][v];
+                    pathMatrix[u][v] = pathMatrix[u][w];
+                }
+            }
+        }
+    }
+
+    tagNegativeCycles();
+    hasRun = true;
+}
+
+edgeweight FloydWarshall::getDistance(node source, node target) const {
+    assureFinished();
+    return distances[source][target];
+}
+
+std::vector<std::vector<edgeweight>> FloydWarshall::getAllDistances() const {
+    assureFinished();
+    return distances;
+}
+
+bool FloydWarshall::isNodeInNegativeCycle(node u) const {
+    assureFinished();
+    return nodesInNegativeCycle[u] == 1;
+}
+
+std::vector<node> FloydWarshall::getNodesOnShortestPath(node source, node target) const {
+    assureFinished();
+    if (pathMatrix[source][target] == none) {
+        return {};
+    }
+    std::vector<node> path;
+    node currentNode = source;
+
+    while (currentNode != target) {
+        if (currentNode == none)
+            return {};
+        path.push_back(currentNode);
+        currentNode = pathMatrix[currentNode][target];
+    }
+    path.push_back(target);
+    return path;
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/distance/FloydWarshall.cpp
+++ b/networkit/cpp/distance/FloydWarshall.cpp
@@ -8,8 +8,7 @@
 
 namespace NetworKit {
 
-FloydWarshall::FloydWarshall(const Graph &G)
-    : graph(&G) {
+FloydWarshall::FloydWarshall(const Graph &G) : graph(&G) {
 
     if (!G.isWeighted()) {
         throw std::runtime_error("The input graph is unweighted!");
@@ -43,7 +42,8 @@ void FloydWarshall::run() {
                             std::vector(numberOfNodes, std::numeric_limits<edgeweight>::max()));
     nodesInNegativeCycle = std::vector<uint8_t>(numberOfNodes);
     pathMatrix = std::vector(numberOfNodes, std::vector(numberOfNodes, none));
-
+    hopCount =
+        std::vector<std::vector<count>>(numberOfNodes, std::vector<count>(numberOfNodes, none));
     for (node u = 0; u < numberOfNodes; ++u) {
         distances[u][u] = 0.0;
         pathMatrix[u][u] = u;
@@ -62,10 +62,20 @@ void FloydWarshall::run() {
             if (distances[source][intermediate] == std::numeric_limits<edgeweight>::max())
                 continue;
             for (node target = 0; target < numberOfNodes; ++target) {
-                if (distances[intermediate][target] != std::numeric_limits<edgeweight>::max()
-                    && distances[source][intermediate] + distances[intermediate][target] < distances[source][target]) {
-                    distances[source][target] = distances[source][intermediate] + distances[intermediate][target];
-                    pathMatrix[source][target] = pathMatrix[source][intermediate];
+                if (distances[intermediate][target] != std::numeric_limits<edgeweight>::max()) {
+                    if (distances[source][intermediate] + distances[intermediate][target]
+                        < distances[source][target]) {
+                        distances[source][target] =
+                            distances[source][intermediate] + distances[intermediate][target];
+                        pathMatrix[source][target] = pathMatrix[source][intermediate];
+                        hopCount[source][target] =
+                            hopCount[source][intermediate] + hopCount[intermediate][target] + 1;
+                    } else if (distances[source][intermediate] + distances[intermediate][target]
+                               == distances[source][target] & hopCount[source][intermediate] + hopCount[intermediate][target] + 1 < hopCount[source][target])
+                    {
+                        pathMatrix[source][target] = pathMatrix[source][intermediate];
+                        hopCount[source][target] = hopCount[source][intermediate] + hopCount[intermediate][target] + 1;
+                    }
                 }
             }
         }

--- a/networkit/cpp/distance/FloydWarshall.cpp
+++ b/networkit/cpp/distance/FloydWarshall.cpp
@@ -8,30 +8,16 @@
 
 namespace NetworKit {
 
-FloydWarshall::FloydWarshall(const Graph &G, double densityThreshold, node maximumNumberOfNodes)
-    : graph(&G), numberOfNodes(G.numberOfNodes()) {
+FloydWarshall::FloydWarshall(const Graph &G)
+    : graph(&G) {
 
     if (!G.isWeighted()) {
         throw std::runtime_error("The input graph is unweighted!");
     }
-    if (densityThreshold <= 0.0 || densityThreshold > 1.0) {
-        throw std::invalid_argument("Invalid density threshold. Must be in range (0, 1].");
-    }
-    if (maximumNumberOfNodes < 1) {
-        throw std::invalid_argument("Invalid maximum node count. Must be at least 1.");
-    }
-
-    const index maximumNumberOfEdges = G.isDirected() ? numberOfNodes*(numberOfNodes-1) : numberOfNodes*(numberOfNodes-1)/2;
-    const double density = static_cast<double>(G.numberOfEdges()) / maximumNumberOfEdges;
-    if (density < densityThreshold) {
-        throw std::domain_error("Graph density is below user-defined density-threshold of: " + std::to_string(densityThreshold));
-    }
-    if (numberOfNodes > maximumNumberOfNodes) {
-        throw std::domain_error("Graph size exceeds user-defined max-node-limit of: " + std::to_string(maximumNumberOfNodes));
-    }
 }
 
 void FloydWarshall::tagNegativeCycles() {
+    const index numberOfNodes = graph->numberOfNodes();
     for (node w = 0; w < numberOfNodes; ++w) {
         if (!(distances[w][w] < 0.0))
             continue;
@@ -52,6 +38,7 @@ void FloydWarshall::tagNegativeCycles() {
 }
 
 void FloydWarshall::run() {
+    const index numberOfNodes = graph->numberOfNodes();
     distances = std::vector(numberOfNodes,
                             std::vector(numberOfNodes, std::numeric_limits<edgeweight>::max()));
     nodesInNegativeCycle = std::vector<uint8_t>(numberOfNodes);
@@ -92,10 +79,11 @@ edgeweight FloydWarshall::getDistance(node source, node target) const {
     return distances[source][target];
 }
 
-std::vector<std::vector<edgeweight>> FloydWarshall::getAllDistances() const {
+const std::vector<std::vector<edgeweight>> & FloydWarshall::getAllDistances() const & {
     assureFinished();
     return distances;
 }
+
 
 bool FloydWarshall::isNodeInNegativeCycle(node u) const {
     assureFinished();

--- a/networkit/cpp/distance/FloydWarshall.cpp
+++ b/networkit/cpp/distance/FloydWarshall.cpp
@@ -60,7 +60,7 @@ void FloydWarshall::run() {
 
     for (node intermediate = 0; intermediate < numberOfNodes; ++intermediate) {
 #pragma omp parallel for
-        for (node source = 0; source < numberOfNodes; ++source) {
+        for (omp_index source = 0; source < numberOfNodes; ++source) {
             if (distances[source][intermediate] == std::numeric_limits<edgeweight>::max())
                 continue;
             for (node target = 0; target < numberOfNodes; ++target) {

--- a/networkit/cpp/distance/test/CMakeLists.txt
+++ b/networkit/cpp/distance/test/CMakeLists.txt
@@ -10,3 +10,5 @@ networkit_add_test(distance SSSPGTest
     auxiliary io)
 networkit_add_test(dyn_distance DynSSSPGTest
         auxiliary generators graph io)
+networkit_add_test(distance FloydWarshallGTest
+        graph)

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -91,24 +91,30 @@ public:
         return graph;
     }
 
-    void compareDistances(const std::vector<std::vector<edgeweight>> &expectedDistances, const FloydWarshall & testObject) {
+    void compareDistances(const std::vector<std::vector<edgeweight>> &expectedDistances,
+                          const FloydWarshall &testObject) {
         const node n = expectedDistances.size();
-        for (node source =0 ; source < n; ++source) {
-            for (node target =0 ; target < n; ++target) {
-                EXPECT_EQ(testObject.getDistance(source, target), expectedDistances[source][target]) << "source = " << source << ", target = " << target;;
+        for (node source = 0; source < n; ++source) {
+            for (node target = 0; target < n; ++target) {
+                EXPECT_EQ(testObject.getDistance(source, target), expectedDistances[source][target])
+                    << "source = " << source << ", target = " << target;
+                ;
             }
         }
     }
 
-    void compareNodesOnShortestPaths(const std::vector<std::vector<std::vector<node>>> &expectedPaths, const FloydWarshall & testObject) {
+    void
+    compareNodesOnShortestPaths(const std::vector<std::vector<std::vector<node>>> &expectedPaths,
+                                const FloydWarshall &testObject) {
         const node n = expectedPaths.size();
-        for (node source =0 ; source < n; ++source) {
-            for (node target =0 ; target < n; ++target) {
-                EXPECT_EQ(testObject.getNodesOnShortestPath(source, target), expectedPaths[source][target]) << "source = " << source << ", target = " << target;;
+        for (node source = 0; source < n; ++source) {
+            for (node target = 0; target < n; ++target) {
+                EXPECT_EQ(testObject.getNodesOnShortestPath(source, target),
+                          expectedPaths[source][target])
+                    << "source = " << source << ", target = " << target;
             }
         }
     }
-
 };
 
 TEST_F(FloydWarshallGTest, testConstructorThrowsUnweightedGraph) {

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -9,7 +9,27 @@
 
 namespace NetworKit {
 
-TEST(FloydWarshallTest, testConstructorThrowsUnweightedGraph) {
+class FloydWarshallGTest : public testing::Test {
+public:
+    Graph completeGraphK3() {
+        Graph graph(3, true);
+        graph.addEdge(0, 1, 1);
+        graph.addEdge(1, 2, 2);
+        graph.addEdge(0, 2, 4);
+        return graph;
+    }
+
+    Graph completeGraphK3NegativeCycle() {
+        Graph graph(3, true);
+        graph.addEdge(0, 1, 1);
+        graph.addEdge(1, 2, 2);
+        graph.addEdge(0, 2, -4);
+        return graph;
+    }
+
+};
+
+TEST_F(FloydWarshallGTest, testConstructorThrowsUnweightedGraph) {
     Graph graph(1, false);
     try {
         FloydWarshall test(graph);
@@ -21,76 +41,8 @@ TEST(FloydWarshallTest, testConstructorThrowsUnweightedGraph) {
     }
 }
 
-TEST(FloydWarshallTest, testConstructorThrowsInvalidDensityThreshold) {
+TEST_F(FloydWarshallGTest, testGetDistanceThrows) {
     Graph graph(1, true);
-    try {
-        FloydWarshall test(graph, 0.0);
-        FAIL() << "Expected std::invalid_argument";
-    } catch (const std::invalid_argument &e) {
-        EXPECT_STREQ(e.what(), "Invalid density threshold. Must be in range (0, 1].");
-    } catch (...) {
-        FAIL() << "Expected std::invalid_argument but got a different exception.";
-    }
-    try {
-        FloydWarshall test(graph, 1.1);
-        FAIL() << "Expected std::invalid_argument";
-    } catch (const std::invalid_argument &e) {
-        EXPECT_STREQ(e.what(), "Invalid density threshold. Must be in range (0, 1].");
-    } catch (...) {
-        FAIL() << "Expected std::invalid_argument but got a different exception.";
-    }
-}
-
-TEST(FloydWarshallTest, testConstructorThrowsInvalidMaximumNumberOfNodes) {
-    Graph graph(1, true);
-    try {
-        FloydWarshall test(graph, 0.5, 0);
-        FAIL() << "Expected std::invalid_argument";
-    } catch (const std::invalid_argument &e) {
-        EXPECT_STREQ(e.what(), "Invalid maximum node count. Must be at least 1.");
-    } catch (...) {
-        FAIL() << "Expected std::invalid_argument but got a different exception.";
-    }
-}
-
-TEST(FloydWarshallTest, testConstructorThrowsInvalidDensity) {
-    Graph graph(2, true);
-    constexpr double densityThreshold = 0.5;
-    const std::string exceptionString = "Graph density is below user-defined density-threshold of: "
-                                        + std::to_string(densityThreshold);
-    try {
-        FloydWarshall test(graph, densityThreshold);
-        FAIL() << "Expected std::domain_error";
-    } catch (const std::domain_error &e) {
-        EXPECT_STREQ(e.what(), exceptionString.c_str());
-    } catch (...) {
-        FAIL() << "Expected std::domain_error but got a different exception.";
-    }
-}
-
-TEST(FloydWarshallTest, testConstructorThrowsInvalidNumberOfNodes) {
-    Graph graph(2, true);
-    graph.addEdge(0, 0, 1);
-    constexpr node maximumNumberOfNodes = 1;
-    const std::string exceptionString = "Graph size exceeds user-defined max-node-limit of: "
-                                        + std::to_string(maximumNumberOfNodes);
-    try {
-        constexpr double densityThreshold = 0.5;
-        FloydWarshall test(graph, densityThreshold, maximumNumberOfNodes);
-        FAIL() << "Expected std::domain_error";
-    } catch (const std::domain_error &e) {
-        EXPECT_STREQ(e.what(), exceptionString.c_str());
-    } catch (...) {
-        FAIL() << "Expected std::domain_error but got a different exception.";
-    }
-}
-
-TEST(FloydWarshallTest, testGetDistanceThrows) {
-    constexpr index numberOfNodes{3};
-    Graph graph(numberOfNodes, true);
-    graph.addEdge(0, 1, 1);
-    graph.addEdge(1, 2, 2);
-    graph.addEdge(0, 2, 4);
     FloydWarshall test(graph);
     try {
         test.getDistance(0, 1);
@@ -102,28 +54,8 @@ TEST(FloydWarshallTest, testGetDistanceThrows) {
     }
 }
 
-TEST(FloydWarshallTest, testGetDistance) {
-    constexpr index numberOfNodes{3};
-    Graph graph(numberOfNodes, true);
-    graph.addEdge(0, 1, 1);
-    graph.addEdge(1, 2, 2);
-    graph.addEdge(0, 2, 4);
-    FloydWarshall test(graph);
-    test.run();
-    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, 3}, {1, 0, 2}, {3, 2, 0}};
-    for (node u = 0; u < numberOfNodes; ++u) {
-        for (node v = 0; v < numberOfNodes; ++v) {
-            EXPECT_EQ(test.getDistance(u, v), expectedDistances[u][v]) << "u = " << u << ", v = " << v;
-        }
-    }
-}
-
-TEST(FloydWarshallTest, testGetAllDistancesThrows) {
-    constexpr index numberOfNodes{3};
-    Graph graph(numberOfNodes, true);
-    graph.addEdge(0, 1, 1);
-    graph.addEdge(1, 2, 2);
-    graph.addEdge(0, 2, 4);
+TEST_F(FloydWarshallGTest, testGetAllDistancesThrows) {
+    Graph graph(1, true);
     FloydWarshall test(graph);
     try {
         test.getAllDistances();
@@ -135,19 +67,118 @@ TEST(FloydWarshallTest, testGetAllDistancesThrows) {
     }
 }
 
-TEST(FloydWarshallTest, testAllGetDistances) {
-    constexpr index numberOfNodes{3};
-    Graph graph(numberOfNodes, true);
-    graph.addEdge(0, 1, 1);
-    graph.addEdge(1, 2, 2);
-    graph.addEdge(0, 2, 4);
+TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleThrows) {
+    Graph graph(1, true);
+    FloydWarshall test(graph);
+    try {
+        test.isNodeInNegativeCycle(0);
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_STREQ(e.what(), "Error, run must be called first");
+    } catch (...) {
+        FAIL() << "Expected std::runtime_error but got a different exception.";
+    }
+}
+
+TEST_F(FloydWarshallGTest, testGetNodesOnShortestPathThrows) {
+    Graph graph(2, true);
+    FloydWarshall test(graph);
+    try {
+        test.getNodesOnShortestPath(0, 1);
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_STREQ(e.what(), "Error, run must be called first");
+    } catch (...) {
+        FAIL() << "Expected std::runtime_error but got a different exception.";
+    }
+}
+
+TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3) {
+    auto graph = completeGraphK3();
     FloydWarshall test(graph);
     test.run();
     const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, 3}, {1, 0, 2}, {3, 2, 0}};
-    const auto distances = test.getAllDistances();
-    for (node u = 0; u < numberOfNodes; ++u) {
-        for (node v = 0; v < numberOfNodes; ++v) {
-            EXPECT_EQ(distances[u][v], expectedDistances[u][v]) << "u = " << u << ", v = " << v;
+    for (node source = 0; source < graph.numberOfNodes(); ++source) {
+        for (node target = 0; target < graph.numberOfNodes(); ++target) {
+            EXPECT_EQ(test.getDistance(source, target), expectedDistances[source][target])
+                << "source = " << source << ", target = " << target;
+        }
+    }
+}
+
+TEST_F(FloydWarshallGTest, testAllGetDistancesCompleteGraphK3) {
+    auto graph = completeGraphK3();
+    FloydWarshall test(graph);
+    test.run();
+    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, 3}, {1, 0, 2}, {3, 2, 0}};
+    const auto & distances = test.getAllDistances();
+    EXPECT_EQ(distances, expectedDistances);
+}
+
+
+TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleCompleteGraphK3) {
+    auto graph = completeGraphK3();
+    FloydWarshall test(graph);
+    test.run();
+    for (node u = 0; u < graph.numberOfNodes(); ++u) {
+        EXPECT_FALSE(test.isNodeInNegativeCycle(u));
+    }
+}
+
+TEST_F(FloydWarshallGTest, getNodesOnShortestPathCompleteGraphK3) {
+    auto graph = completeGraphK3();
+    FloydWarshall test(graph);
+    test.run();
+    const std::vector<std::vector<std::vector<node>>> expectedNodesOnShortestPaths{
+        {{0}, {0, 1}, {0, 1, 2}}, {{1, 0}, {1}, {1, 2}}, {{2, 1, 0}, {2, 1}, {2}}};
+    for (node source = 0; source < graph.numberOfNodes(); ++source) {
+        for (node target = 0; target < graph.numberOfNodes(); ++target) {
+            EXPECT_EQ(test.getNodesOnShortestPath(source, target), expectedNodesOnShortestPaths[source][target]);
+        }
+    }
+}
+
+TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3NegativeCycle) {
+    auto graph = completeGraphK3NegativeCycle();
+    FloydWarshall test(graph);
+    test.run();
+    constexpr edgeweight expectedDistance{-std::numeric_limits<edgeweight>::infinity()};
+    for (node source = 0; source < graph.numberOfNodes(); ++source) {
+        for (node target = 0; target < graph.numberOfNodes(); ++target) {
+            EXPECT_EQ(test.getDistance(source, target), expectedDistance);
+        }
+    }
+}
+
+TEST_F(FloydWarshallGTest, testGetAllDistancesCompleteGraphK3NegativeCycle) {
+    auto graph = completeGraphK3NegativeCycle();
+    FloydWarshall test(graph);
+    test.run();
+    constexpr edgeweight expectedDistance{-std::numeric_limits<edgeweight>::infinity()};
+    const auto & distances = test.getAllDistances();
+    for (node source = 0; source < graph.numberOfNodes(); ++source) {
+        for (node target = 0; target < graph.numberOfNodes(); ++target) {
+            EXPECT_EQ(distances[source][target], expectedDistance);
+        }
+    }
+}
+
+TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleCompleteGraphK3NegativeCycle) {
+    auto graph = completeGraphK3NegativeCycle();
+    FloydWarshall test(graph);
+    test.run();
+    for (node source = 0; source < graph.numberOfNodes(); ++source) {
+        EXPECT_TRUE(test.isNodeInNegativeCycle(source));
+    }
+}
+
+TEST_F(FloydWarshallGTest, getNodesOnShortestPathCompleteGraphK3NegativeCycle) {
+    auto graph = completeGraphK3NegativeCycle();
+    FloydWarshall test(graph);
+    test.run();
+    for (node source = 0; source < graph.numberOfNodes(); ++source) {
+        for (node target = 0; target < graph.numberOfNodes(); ++target) {
+            EXPECT_EQ(test.getNodesOnShortestPath(source, target), std::vector<node>{});
         }
     }
 }

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -11,6 +11,7 @@ namespace NetworKit {
 
 class FloydWarshallGTest : public testing::Test {
 public:
+    static constexpr edgeweight maxDistance = std::numeric_limits<edgeweight>::max();
     Graph completeGraphK3() {
         Graph graph(3, true);
         graph.addEdge(0, 1, 1);
@@ -27,8 +28,8 @@ public:
         return graph;
     }
 
-    Graph completeGraphK3NegativeEdge() {
-        Graph graph(3, true);
+    Graph directedGraphNegativeEdge() {
+        Graph graph(3, true, true);
         graph.addEdge(0, 1, 1);
         graph.addEdge(1, 2, -2);
         graph.addEdge(0, 2, 4);
@@ -116,7 +117,8 @@ TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3) {
 
 TEST_F(FloydWarshallGTest, testAllGetDistancesCompleteGraphK3) {
     auto graph = completeGraphK3();
-    FloydWarshall test(graph);
+    FloydWarshall test(graph);    constexpr edgeweight maxDistance = std::numeric_limits<edgeweight>::max();
+
     test.run();
     const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, 3}, {1, 0, 2}, {3, 2, 0}};
     const auto & distances = test.getAllDistances();
@@ -192,10 +194,10 @@ TEST_F(FloydWarshallGTest, getNodesOnShortestPathCompleteGraphK3NegativeCycle) {
 }
 
 TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3NegativeEdge) {
-    auto graph = completeGraphK3NegativeEdge();
+    auto graph = directedGraphNegativeEdge();
     FloydWarshall test(graph);
     test.run();
-    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, -1}, {1, 0, -2}, {-1, -2, 0}};
+    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, -1}, {maxDistance, 0, -2}, {maxDistance,maxDistance, 0}};
     for (node source = 0; source < graph.numberOfNodes(); ++source) {
         for (node target = 0; target < graph.numberOfNodes(); ++target) {
             EXPECT_EQ(test.getDistance(source, target), expectedDistances[source][target]) << "source " << source << " target " << target;
@@ -204,16 +206,16 @@ TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3NegativeEdge) {
 }
 
 TEST_F(FloydWarshallGTest, testGetAllDistancesCompleteGraphK3NegativeEdge) {
-    auto graph = completeGraphK3NegativeEdge();
+    auto graph = directedGraphNegativeEdge();
     FloydWarshall test(graph);
     test.run();
-    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, -1}, {1, 0, -2}, {-1, -2, 0}};
+    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, -1}, {maxDistance, 0, -2}, {maxDistance,maxDistance, 0}};
     const auto & distances = test.getAllDistances();
     EXPECT_EQ(distances, expectedDistances);
 }
 
 TEST_F(FloydWarshallGTest, testIsNodeInNegativeEdgeCompleteGraphK3NegativeEdge) {
-    auto graph = completeGraphK3NegativeEdge();
+    auto graph = directedGraphNegativeEdge();
     FloydWarshall test(graph);
     test.run();
     for (node source = 0; source < graph.numberOfNodes(); ++source) {
@@ -222,14 +224,14 @@ TEST_F(FloydWarshallGTest, testIsNodeInNegativeEdgeCompleteGraphK3NegativeEdge) 
 }
 
 TEST_F(FloydWarshallGTest, getNodesOnShortestPathCompleteGraphK3NegativeEdge) {
-    auto graph = completeGraphK3NegativeEdge();
+    auto graph = directedGraphNegativeEdge();
     FloydWarshall test(graph);
     test.run();
     const std::vector<std::vector<std::vector<node>>> expectedNodesOnShortestPaths{
-            {{0}, {0, 1}, {0, 1, 2}}, {{1, 0}, {1}, {1, 2}}, {{2, 1, 0}, {2, 1}, {2}}};
+            {{0}, {0, 1}, {0, 1, 2}}, {{}, {1}, {1, 2}}, {{}, {}, {2}}};
     for (node source = 0; source < graph.numberOfNodes(); ++source) {
         for (node target = 0; target < graph.numberOfNodes(); ++target) {
-            EXPECT_EQ(test.getNodesOnShortestPath(source, target), expectedNodesOnShortestPaths[source][target]);
+            EXPECT_EQ(test.getNodesOnShortestPath(source, target), expectedNodesOnShortestPaths[source][target]) << source << ", " << target;
         }
     }
 }

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -351,12 +351,13 @@ TEST_F(FloydWarshallGTest, testGetDistanceWithMediumSizedGraph) {
             if ((source & 1) && (target & 1)) {
                 EXPECT_EQ(test.getDistance(source, target), 0.0) << source << ", " << target;
             }
-            if (!(source & 1) && !(target & 1))
+            if (!(source & 1) && !(target & 1)) {
                 if (target == source + 2) {
                     EXPECT_EQ(test.getDistance(source, target), 1.0) << source << ", " << target;
                 } else {
                     EXPECT_EQ(test.getDistance(source, target), 2.0) << source << ", " << target;
                 }
+            }
             if ((!(source & 1) && (target & 1)) || ((source & 1) && !(target & 1))) {
                 EXPECT_EQ(test.getDistance(source, target), 1.0) << source << ", " << target;
             }
@@ -377,7 +378,7 @@ TEST_F(FloydWarshallGTest, testGetNodesOnShortestPathWithMediumSizedGraph) {
                 }
                 EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
             }
-            if (!(source & 1) && !(target & 1))
+            if (!(source & 1) && !(target & 1)) {
                 if (target == source + 2) {
                     std::vector<node> expected_path{source, target};
                     EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
@@ -392,6 +393,7 @@ TEST_F(FloydWarshallGTest, testGetNodesOnShortestPathWithMediumSizedGraph) {
                     expected_path.push_back(target);
                     EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
                 }
+            }
             if (!(source & 1) && (target & 1)) {
                 std::vector<node> expected_path{source};
                 for (node u = source + 1; u <= target; u += 2) {

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -95,6 +95,7 @@ public:
                 graph.addEdge(u, u + 2, 1);
             }
         }
+        graph.addEdge(98, 99, 1);
         return graph;
     }
 };
@@ -324,6 +325,31 @@ TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleDirectedGraphWithNegativeSel
     }
 }
 
+TEST_F(FloydWarshallGTest, testMultipleShortestDistancePaths) {
+    Graph graph(11, true);
+    // Shortest path, first case [0,10] with 5 nodes (inclusive)
+    graph.addEdge(0, 1, 1);
+    graph.addEdge(1, 2, 1);
+    graph.addEdge(2, 3, 1);
+    graph.addEdge(3, 10, 2);
+    // Shortest path, second case [0,10] with 4 nodes (inclusive)
+    graph.addEdge(0, 4, 1);
+    graph.addEdge(4, 5, 1);
+    graph.addEdge(5, 10, 3);
+    // Shortest path, third case [0,10] with 6 nodes (inclusive)
+    graph.addEdge(0, 6, 1);
+    graph.addEdge(6, 7, 1);
+    graph.addEdge(7, 8, 1);
+    graph.addEdge(8, 9, 1);
+    graph.addEdge(9, 10, 1);
+    FloydWarshall test(graph);
+    test.run();
+    constexpr edgeweight expectedShortestDistance = 5.0;
+    const std::vector<node> expectedPath{0, 4, 5, 10};
+    EXPECT_EQ(test.getDistance(0, 10), expectedShortestDistance);
+    EXPECT_EQ(test.getNodesOnShortestPath(0, 10), expectedPath);
+}
+
 TEST_F(FloydWarshallGTest, testGetDistanceWithMediumSizedGraph) {
     auto graph = oddNodeEdgesHaveZeroWeightGraph();
     FloydWarshall test(graph);
@@ -363,13 +389,10 @@ TEST_F(FloydWarshallGTest, testGetNodesOnShortestPathWithMediumSizedGraph) {
                 if (target == source + 2) {
                     std::vector<node> expected_path{source, target};
                     EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
-                }
-                else if (target == source + 4) {
-                    std::vector<node> expected_path{source, source+2, target};
+                } else if (target == source + 4) {
+                    std::vector<node> expected_path{source, source + 2, target};
                     EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
-                }
-                else
-                {
+                } else {
                     std::vector<node> expected_path{source};
                     for (node u = source + 1; u <= target - 1; u += 2) {
                         expected_path.push_back(u);
@@ -385,16 +408,14 @@ TEST_F(FloydWarshallGTest, testGetNodesOnShortestPathWithMediumSizedGraph) {
                 EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
             }
             if ((source & 1) && !(target & 1)) {
-                std::vector<node> expected_path{};
-                for (node u = source; u <= target-1; u += 2) {
+                std::vector<node> expected_path;
+                for (node u = source; u <= target - 1; u += 2) {
                     expected_path.push_back(u);
                 }
                 expected_path.push_back(target);
                 EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
             }
-
         }
     }
 }
-
 } // namespace NetworKit

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -62,16 +62,7 @@ public:
 
         return graph;
     }
-    //        ___
-    //       |   | self-loop on node 1
-    // 0---->1<---
-    // A     |
-    // |     |
-    // |     V
-    // |     2
-    // |     |
-    // |     V
-    // 4<----3
+
     Graph directedGraphWithNegativeSelfLoop() {
         Graph graph(5, true, true);
         graph.addEdge(0, 1, 3);
@@ -86,7 +77,8 @@ public:
     Graph oddNodeEdgesHaveZeroWeightGraph() {
         Graph graph(100, true);
         for (node u = 0; u < 98; ++u) {
-            // All edges between odd edge id's are zero
+            // All weights between odd edge IDs are zero
+            // All other weights are one
             if (u & 1) {
                 graph.addEdge(u, u + 1, 1);
                 graph.addEdge(u, u + 2, 0);

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -27,6 +27,14 @@ public:
         return graph;
     }
 
+    Graph completeGraphK3NegativeEdge() {
+        Graph graph(3, true);
+        graph.addEdge(0, 1, 1);
+        graph.addEdge(1, 2, -2);
+        graph.addEdge(0, 2, 4);
+        return graph;
+    }
+
 };
 
 TEST_F(FloydWarshallGTest, testConstructorThrowsUnweightedGraph) {
@@ -183,5 +191,81 @@ TEST_F(FloydWarshallGTest, getNodesOnShortestPathCompleteGraphK3NegativeCycle) {
     }
 }
 
+TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3NegativeEdge) {
+    auto graph = completeGraphK3NegativeEdge();
+    FloydWarshall test(graph);
+    test.run();
+    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, -1}, {1, 0, -2}, {-1, -2, 0}};
+    for (node source = 0; source < graph.numberOfNodes(); ++source) {
+        for (node target = 0; target < graph.numberOfNodes(); ++target) {
+            EXPECT_EQ(test.getDistance(source, target), expectedDistances[source][target]) << "source " << source << " target " << target;
+        }
+    }
+}
+
+TEST_F(FloydWarshallGTest, testGetAllDistancesCompleteGraphK3NegativeEdge) {
+    auto graph = completeGraphK3NegativeEdge();
+    FloydWarshall test(graph);
+    test.run();
+    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, -1}, {1, 0, -2}, {-1, -2, 0}};
+    const auto & distances = test.getAllDistances();
+    EXPECT_EQ(distances, expectedDistances);
+}
+
+TEST_F(FloydWarshallGTest, testIsNodeInNegativeEdgeCompleteGraphK3NegativeEdge) {
+    auto graph = completeGraphK3NegativeEdge();
+    FloydWarshall test(graph);
+    test.run();
+    for (node source = 0; source < graph.numberOfNodes(); ++source) {
+        EXPECT_FALSE(test.isNodeInNegativeCycle(source));
+    }
+}
+
+TEST_F(FloydWarshallGTest, getNodesOnShortestPathCompleteGraphK3NegativeEdge) {
+    auto graph = completeGraphK3NegativeEdge();
+    FloydWarshall test(graph);
+    test.run();
+    const std::vector<std::vector<std::vector<node>>> expectedNodesOnShortestPaths{
+            {{0}, {0, 1}, {0, 1, 2}}, {{1, 0}, {1}, {1, 2}}, {{2, 1, 0}, {2, 1}, {2}}};
+    for (node source = 0; source < graph.numberOfNodes(); ++source) {
+        for (node target = 0; target < graph.numberOfNodes(); ++target) {
+            EXPECT_EQ(test.getNodesOnShortestPath(source, target), expectedNodesOnShortestPaths[source][target]);
+        }
+    }
+}
+
+TEST_F(FloydWarshallGTest, testDisconnectedGraph) {
+    Graph graph(4, true);
+    graph.addEdge(0, 1, 3);
+    graph.addEdge(1, 2, 2);
+    // No edges to/from node 3
+    FloydWarshall test(graph);
+    test.run();
+    EXPECT_EQ(test.getDistance(0, 3), std::numeric_limits<edgeweight>::max());
+    EXPECT_EQ(test.getDistance(1, 3), std::numeric_limits<edgeweight>::max());
+    EXPECT_EQ(test.getDistance(2, 3), std::numeric_limits<edgeweight>::max());
+}
+
+TEST_F(FloydWarshallGTest, testZeroWeightEdges) {
+    Graph graph(3, true);
+    graph.addEdge(0, 1, 0.0);
+    graph.addEdge(1, 2, 0.0);
+    graph.addEdge(0, 2, 3.0);
+    FloydWarshall test(graph);
+    test.run();
+    EXPECT_EQ(test.getDistance(0, 1), 0.0);
+    EXPECT_EQ(test.getDistance(1, 2), 0.0);
+    EXPECT_EQ(test.getDistance(0, 2), 0.0);
+}
+
+TEST_F(FloydWarshallGTest, testSelfLoops) {
+    Graph graph(3, true);
+    graph.addEdge(0, 0, -2);
+    graph.addEdge(1, 1, 3);
+    FloydWarshall test(graph);
+    test.run();
+    EXPECT_EQ(test.getDistance(0, 0), -std::numeric_limits<edgeweight>::infinity());
+    EXPECT_EQ(test.getDistance(1, 1), 3);
+}
 
 } // namespace NetworKit

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -1,0 +1,156 @@
+/*  FloydWarshallGTest.cpp
+ *
+ *	Created on: 19.02.2025
+ *  Authors: Andreas Scharf (andreas.b.scharf@gmail.com)
+ *
+ */
+#include <gtest/gtest.h>
+#include <networkit/distance/FloydWarshall.hpp>
+
+namespace NetworKit {
+
+TEST(FloydWarshallTest, testConstructorThrowsUnweightedGraph) {
+    Graph graph(1, false);
+    try {
+        FloydWarshall test(graph);
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_STREQ(e.what(), "The input graph is unweighted!");
+    } catch (...) {
+        FAIL() << "Expected std::runtime_error but got a different exception.";
+    }
+}
+
+TEST(FloydWarshallTest, testConstructorThrowsInvalidDensityThreshold) {
+    Graph graph(1, true);
+    try {
+        FloydWarshall test(graph, 0.0);
+        FAIL() << "Expected std::invalid_argument";
+    } catch (const std::invalid_argument &e) {
+        EXPECT_STREQ(e.what(), "Invalid density threshold. Must be in range (0, 1].");
+    } catch (...) {
+        FAIL() << "Expected std::invalid_argument but got a different exception.";
+    }
+    try {
+        FloydWarshall test(graph, 1.1);
+        FAIL() << "Expected std::invalid_argument";
+    } catch (const std::invalid_argument &e) {
+        EXPECT_STREQ(e.what(), "Invalid density threshold. Must be in range (0, 1].");
+    } catch (...) {
+        FAIL() << "Expected std::invalid_argument but got a different exception.";
+    }
+}
+
+TEST(FloydWarshallTest, testConstructorThrowsInvalidMaximumNumberOfNodes) {
+    Graph graph(1, true);
+    try {
+        FloydWarshall test(graph, 0.5, 0);
+        FAIL() << "Expected std::invalid_argument";
+    } catch (const std::invalid_argument &e) {
+        EXPECT_STREQ(e.what(), "Invalid maximum node count. Must be at least 1.");
+    } catch (...) {
+        FAIL() << "Expected std::invalid_argument but got a different exception.";
+    }
+}
+
+TEST(FloydWarshallTest, testConstructorThrowsInvalidDensity) {
+    Graph graph(2, true);
+    constexpr double densityThreshold = 0.5;
+    const std::string exceptionString = "Graph density is below user-defined density-threshold of: "
+                                        + std::to_string(densityThreshold);
+    try {
+        FloydWarshall test(graph, densityThreshold);
+        FAIL() << "Expected std::domain_error";
+    } catch (const std::domain_error &e) {
+        EXPECT_STREQ(e.what(), exceptionString.c_str());
+    } catch (...) {
+        FAIL() << "Expected std::domain_error but got a different exception.";
+    }
+}
+
+TEST(FloydWarshallTest, testConstructorThrowsInvalidNumberOfNodes) {
+    Graph graph(2, true);
+    graph.addEdge(0, 0, 1);
+    constexpr node maximumNumberOfNodes = 1;
+    const std::string exceptionString = "Graph size exceeds user-defined max-node-limit of: "
+                                        + std::to_string(maximumNumberOfNodes);
+    try {
+        constexpr double densityThreshold = 0.5;
+        FloydWarshall test(graph, densityThreshold, maximumNumberOfNodes);
+        FAIL() << "Expected std::domain_error";
+    } catch (const std::domain_error &e) {
+        EXPECT_STREQ(e.what(), exceptionString.c_str());
+    } catch (...) {
+        FAIL() << "Expected std::domain_error but got a different exception.";
+    }
+}
+
+TEST(FloydWarshallTest, testGetDistanceThrows) {
+    constexpr index numberOfNodes{3};
+    Graph graph(numberOfNodes, true);
+    graph.addEdge(0, 1, 1);
+    graph.addEdge(1, 2, 2);
+    graph.addEdge(0, 2, 4);
+    FloydWarshall test(graph);
+    try {
+        test.getDistance(0, 1);
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_STREQ(e.what(), "Error, run must be called first");
+    } catch (...) {
+        FAIL() << "Expected std::runtime_error but got a different exception.";
+    }
+}
+
+TEST(FloydWarshallTest, testGetDistance) {
+    constexpr index numberOfNodes{3};
+    Graph graph(numberOfNodes, true);
+    graph.addEdge(0, 1, 1);
+    graph.addEdge(1, 2, 2);
+    graph.addEdge(0, 2, 4);
+    FloydWarshall test(graph);
+    test.run();
+    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, 3}, {1, 0, 2}, {3, 2, 0}};
+    for (node u = 0; u < numberOfNodes; ++u) {
+        for (node v = 0; v < numberOfNodes; ++v) {
+            EXPECT_EQ(test.getDistance(u, v), expectedDistances[u][v]) << "u = " << u << ", v = " << v;
+        }
+    }
+}
+
+TEST(FloydWarshallTest, testGetAllDistancesThrows) {
+    constexpr index numberOfNodes{3};
+    Graph graph(numberOfNodes, true);
+    graph.addEdge(0, 1, 1);
+    graph.addEdge(1, 2, 2);
+    graph.addEdge(0, 2, 4);
+    FloydWarshall test(graph);
+    try {
+        test.getAllDistances();
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_STREQ(e.what(), "Error, run must be called first");
+    } catch (...) {
+        FAIL() << "Expected std::runtime_error but got a different exception.";
+    }
+}
+
+TEST(FloydWarshallTest, testAllGetDistances) {
+    constexpr index numberOfNodes{3};
+    Graph graph(numberOfNodes, true);
+    graph.addEdge(0, 1, 1);
+    graph.addEdge(1, 2, 2);
+    graph.addEdge(0, 2, 4);
+    FloydWarshall test(graph);
+    test.run();
+    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, 3}, {1, 0, 2}, {3, 2, 0}};
+    const auto distances = test.getAllDistances();
+    for (node u = 0; u < numberOfNodes; ++u) {
+        for (node v = 0; v < numberOfNodes; ++v) {
+            EXPECT_EQ(distances[u][v], expectedDistances[u][v]) << "u = " << u << ", v = " << v;
+        }
+    }
+}
+
+
+} // namespace NetworKit

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -75,8 +75,8 @@ public:
     }
 
     Graph oddNodeEdgesHaveZeroWeightGraph() {
-        Graph graph(100, true);
-        for (node u = 0; u < 98; ++u) {
+        Graph graph(1000, true);
+        for (node u = 0; u < 998; ++u) {
             // All weights between odd edge IDs are zero
             // All other weights are one
             if (u & 1) {
@@ -87,7 +87,7 @@ public:
                 graph.addEdge(u, u + 2, 1);
             }
         }
-        graph.addEdge(98, 99, 1);
+        graph.addEdge(998, 999, 1);
         return graph;
     }
 };

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -74,23 +74,6 @@ public:
         return graph;
     }
 
-    Graph oddNodeEdgesHaveZeroWeightGraph() {
-        Graph graph(1000, true);
-        for (node u = 0; u < 998; ++u) {
-            // All weights between odd edge IDs are zero
-            // All other weights are one
-            if (u & 1) {
-                graph.addEdge(u, u + 1, 1);
-                graph.addEdge(u, u + 2, 0);
-            } else {
-                graph.addEdge(u, u + 1, 1);
-                graph.addEdge(u, u + 2, 1);
-            }
-        }
-        graph.addEdge(998, 999, 1);
-        return graph;
-    }
-
     void compareDistances(const std::vector<std::vector<edgeweight>> &expectedDistances,
                           const FloydWarshall &testObject) {
         const node n = expectedDistances.size();

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -90,6 +90,25 @@ public:
         graph.addEdge(998, 999, 1);
         return graph;
     }
+
+    void compareDistances(const std::vector<std::vector<edgeweight>> &expectedDistances, const FloydWarshall & testObject) {
+        const node n = expectedDistances.size();
+        for (node source =0 ; source < n; ++source) {
+            for (node target =0 ; target < n; ++target) {
+                EXPECT_EQ(testObject.getDistance(source, target), expectedDistances[source][target]) << "source = " << source << ", target = " << target;;
+            }
+        }
+    }
+
+    void compareNodesOnShortestPaths(const std::vector<std::vector<std::vector<node>>> &expectedPaths, const FloydWarshall & testObject) {
+        const node n = expectedPaths.size();
+        for (node source =0 ; source < n; ++source) {
+            for (node target =0 ; target < n; ++target) {
+                EXPECT_EQ(testObject.getNodesOnShortestPath(source, target), expectedPaths[source][target]) << "source = " << source << ", target = " << target;;
+            }
+        }
+    }
+
 };
 
 TEST_F(FloydWarshallGTest, testConstructorThrowsUnweightedGraph) {
@@ -148,12 +167,7 @@ TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3) {
     FloydWarshall test(graph);
     test.run();
     const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, 3}, {1, 0, 2}, {3, 2, 0}};
-    for (node source = 0; source < graph.numberOfNodes(); ++source) {
-        for (node target = 0; target < graph.numberOfNodes(); ++target) {
-            EXPECT_EQ(test.getDistance(source, target), expectedDistances[source][target])
-                << "source = " << source << ", target = " << target;
-        }
-    }
+    compareDistances(expectedDistances, test);
 }
 
 TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleCompleteGraphK3) {
@@ -171,12 +185,7 @@ TEST_F(FloydWarshallGTest, getNodesOnShortestPathCompleteGraphK3) {
     test.run();
     const std::vector<std::vector<std::vector<node>>> expectedNodesOnShortestPaths{
         {{0}, {0, 1}, {0, 1, 2}}, {{1, 0}, {1}, {1, 2}}, {{2, 1, 0}, {2, 1}, {2}}};
-    for (node source = 0; source < graph.numberOfNodes(); ++source) {
-        for (node target = 0; target < graph.numberOfNodes(); ++target) {
-            EXPECT_EQ(test.getNodesOnShortestPath(source, target),
-                      expectedNodesOnShortestPaths[source][target]);
-        }
-    }
+    compareNodesOnShortestPaths(expectedNodesOnShortestPaths, test);
 }
 
 TEST_F(FloydWarshallGTest, testGetDistanceUndirectedGraphWithNegativeEdge) {
@@ -220,12 +229,7 @@ TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3NegativeEdge) {
     test.run();
     const std::vector<std::vector<edgeweight>> expectedDistances{
         {0, 1, -1}, {maxDistance, 0, -2}, {maxDistance, maxDistance, 0}};
-    for (node source = 0; source < graph.numberOfNodes(); ++source) {
-        for (node target = 0; target < graph.numberOfNodes(); ++target) {
-            EXPECT_EQ(test.getDistance(source, target), expectedDistances[source][target])
-                << "source " << source << " target " << target;
-        }
-    }
+    compareDistances(expectedDistances, test);
 }
 
 TEST_F(FloydWarshallGTest, testIsNodeInNegativeEdgeCompleteGraphK3NegativeEdge) {
@@ -243,13 +247,7 @@ TEST_F(FloydWarshallGTest, testGetNodesOnShortestPathCompleteGraphK3NegativeEdge
     test.run();
     const std::vector<std::vector<std::vector<node>>> expectedNodesOnShortestPaths{
         {{0}, {0, 1}, {0, 1, 2}}, {{}, {1}, {1, 2}}, {{}, {}, {2}}};
-    for (node source = 0; source < graph.numberOfNodes(); ++source) {
-        for (node target = 0; target < graph.numberOfNodes(); ++target) {
-            EXPECT_EQ(test.getNodesOnShortestPath(source, target),
-                      expectedNodesOnShortestPaths[source][target])
-                << source << ", " << target;
-        }
-    }
+    compareNodesOnShortestPaths(expectedNodesOnShortestPaths, test);
 }
 
 TEST_F(FloydWarshallGTest, testGetDistanceDisconnectedGraph) {
@@ -261,12 +259,7 @@ TEST_F(FloydWarshallGTest, testGetDistanceDisconnectedGraph) {
         {3, 0, 2, maxDistance},
         {5, 2, 0, maxDistance},
         {maxDistance, maxDistance, maxDistance, 0}};
-    for (node source = 0; source < graph.numberOfNodes(); ++source) {
-        for (node target = 0; target < graph.numberOfNodes(); ++target) {
-            EXPECT_EQ(test.getDistance(source, target), expectedDistances[source][target])
-                << "source " << source << " target " << target;
-        }
-    }
+    compareDistances(expectedDistances, test);
 }
 
 TEST_F(FloydWarshallGTest, testGetNodesOnShortestPathDisconnectedGraph) {
@@ -278,13 +271,7 @@ TEST_F(FloydWarshallGTest, testGetNodesOnShortestPathDisconnectedGraph) {
         {{1, 0}, {1}, {1, 2}, {}},
         {{2, 1, 0}, {2, 1}, {2}, {}},
         {{}, {}, {}, {3}}};
-    for (node source = 0; source < graph.numberOfNodes(); ++source) {
-        for (node target = 0; target < graph.numberOfNodes(); ++target) {
-            EXPECT_EQ(test.getNodesOnShortestPath(source, target),
-                      expectedNodesOnShortestPaths[source][target])
-                << source << ", " << target;
-        }
-    }
+    compareNodesOnShortestPaths(expectedNodesOnShortestPaths, test);
 }
 
 TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleDisconnectedGraph) {
@@ -340,76 +327,5 @@ TEST_F(FloydWarshallGTest, testMultipleShortestDistancePaths) {
     const std::vector<node> expectedPath{0, 4, 5, 10};
     EXPECT_EQ(test.getDistance(0, 10), expectedShortestDistance);
     EXPECT_EQ(test.getNodesOnShortestPath(0, 10), expectedPath);
-}
-
-TEST_F(FloydWarshallGTest, testGetDistanceWithMediumSizedGraph) {
-    auto graph = oddNodeEdgesHaveZeroWeightGraph();
-    FloydWarshall test(graph);
-    test.run();
-    for (node source = 0; source < graph.numberOfNodes(); ++source) {
-        for (node target = {source + 1}; target < graph.numberOfNodes(); ++target) {
-            if ((source & 1) && (target & 1)) {
-                EXPECT_EQ(test.getDistance(source, target), 0.0) << source << ", " << target;
-            }
-            if (!(source & 1) && !(target & 1)) {
-                if (target == source + 2) {
-                    EXPECT_EQ(test.getDistance(source, target), 1.0) << source << ", " << target;
-                } else {
-                    EXPECT_EQ(test.getDistance(source, target), 2.0) << source << ", " << target;
-                }
-            }
-            if ((!(source & 1) && (target & 1)) || ((source & 1) && !(target & 1))) {
-                EXPECT_EQ(test.getDistance(source, target), 1.0) << source << ", " << target;
-            }
-        }
-    }
-}
-
-TEST_F(FloydWarshallGTest, testGetNodesOnShortestPathWithMediumSizedGraph) {
-    auto graph = oddNodeEdgesHaveZeroWeightGraph();
-    FloydWarshall test(graph);
-    test.run();
-    for (node source = 0; source < graph.numberOfNodes(); ++source) {
-        for (node target = {source + 1}; target < graph.numberOfNodes(); ++target) {
-            if ((source & 1) && (target & 1)) {
-                std::vector<node> expected_path;
-                for (node u = source; u <= target; u += 2) {
-                    expected_path.push_back(u);
-                }
-                EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
-            }
-            if (!(source & 1) && !(target & 1)) {
-                if (target == source + 2) {
-                    std::vector<node> expected_path{source, target};
-                    EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
-                } else if (target == source + 4) {
-                    std::vector<node> expected_path{source, source + 2, target};
-                    EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
-                } else {
-                    std::vector<node> expected_path{source};
-                    for (node u = source + 1; u <= target - 1; u += 2) {
-                        expected_path.push_back(u);
-                    }
-                    expected_path.push_back(target);
-                    EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
-                }
-            }
-            if (!(source & 1) && (target & 1)) {
-                std::vector<node> expected_path{source};
-                for (node u = source + 1; u <= target; u += 2) {
-                    expected_path.push_back(u);
-                }
-                EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
-            }
-            if ((source & 1) && !(target & 1)) {
-                std::vector<node> expected_path;
-                for (node u = source; u <= target - 1; u += 2) {
-                    expected_path.push_back(u);
-                }
-                expected_path.push_back(target);
-                EXPECT_EQ(expected_path, test.getNodesOnShortestPath(source, target));
-            }
-        }
-    }
 }
 } // namespace NetworKit

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -12,9 +12,6 @@ namespace NetworKit {
 class FloydWarshallGTest : public testing::Test {
 public:
     static constexpr edgeweight maxDistance = std::numeric_limits<edgeweight>::max();
-    static constexpr edgeweight largeWeight{10.0};
-    static constexpr edgeweight smallWeight{1.0};
-    static constexpr edgeweight mediumWeight{1.0};
     Graph completeGraphK3() {
         Graph graph(3, true);
         graph.addEdge(0, 1, 1);

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -20,11 +20,11 @@ public:
         return graph;
     }
 
-    Graph completeGraphK3NegativeCycle() {
+    Graph undirectedGraphWithNegativeEdge() {
         Graph graph(3, true);
         graph.addEdge(0, 1, 1);
         graph.addEdge(1, 2, 2);
-        graph.addEdge(0, 2, -4);
+        graph.addEdge(0, 2, -0.5);
         return graph;
     }
 
@@ -36,6 +36,21 @@ public:
         return graph;
     }
 
+    Graph completGraphK5NegativeEdges() {
+        Graph graph(5, true);
+        graph.addEdge(0, 1, -3);
+        graph.addEdge(2, 3, -2);
+        graph.addEdge(0, 2, 5);
+        graph.addEdge(0, 3, 4);
+        graph.addEdge(0, 4, 6);
+        graph.addEdge(1, 2, 2);
+        graph.addEdge(1, 3, 3);
+        graph.addEdge(1, 4, 7);
+        graph.addEdge(2, 4, 4);
+        graph.addEdge(3, 4, 5);
+
+        return graph;
+    }
 };
 
 TEST_F(FloydWarshallGTest, testConstructorThrowsUnweightedGraph) {
@@ -63,18 +78,6 @@ TEST_F(FloydWarshallGTest, testGetDistanceThrows) {
     }
 }
 
-TEST_F(FloydWarshallGTest, testGetAllDistancesThrows) {
-    Graph graph(1, true);
-    FloydWarshall test(graph);
-    try {
-        test.getAllDistances();
-        FAIL() << "Expected std::runtime_error";
-    } catch (const std::runtime_error &e) {
-        EXPECT_STREQ(e.what(), "Error, run must be called first");
-    } catch (...) {
-        FAIL() << "Expected std::runtime_error but got a different exception.";
-    }
-}
 
 TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleThrows) {
     Graph graph(1, true);
@@ -115,16 +118,6 @@ TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3) {
     }
 }
 
-TEST_F(FloydWarshallGTest, testAllGetDistancesCompleteGraphK3) {
-    auto graph = completeGraphK3();
-    FloydWarshall test(graph);    constexpr edgeweight maxDistance = std::numeric_limits<edgeweight>::max();
-
-    test.run();
-    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, 3}, {1, 0, 2}, {3, 2, 0}};
-    const auto & distances = test.getAllDistances();
-    EXPECT_EQ(distances, expectedDistances);
-}
-
 
 TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleCompleteGraphK3) {
     auto graph = completeGraphK3();
@@ -148,8 +141,9 @@ TEST_F(FloydWarshallGTest, getNodesOnShortestPathCompleteGraphK3) {
     }
 }
 
-TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3NegativeCycle) {
-    auto graph = completeGraphK3NegativeCycle();
+TEST_F(FloydWarshallGTest, testGetDistanceUndirectedGraphWithNegativeEdge) {
+    // Undirected graph with one negative edge results in negative cycles for all edges
+    auto graph = undirectedGraphWithNegativeEdge();
     FloydWarshall test(graph);
     test.run();
     constexpr edgeweight expectedDistance{-std::numeric_limits<edgeweight>::infinity()};
@@ -160,21 +154,10 @@ TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3NegativeCycle) {
     }
 }
 
-TEST_F(FloydWarshallGTest, testGetAllDistancesCompleteGraphK3NegativeCycle) {
-    auto graph = completeGraphK3NegativeCycle();
-    FloydWarshall test(graph);
-    test.run();
-    constexpr edgeweight expectedDistance{-std::numeric_limits<edgeweight>::infinity()};
-    const auto & distances = test.getAllDistances();
-    for (node source = 0; source < graph.numberOfNodes(); ++source) {
-        for (node target = 0; target < graph.numberOfNodes(); ++target) {
-            EXPECT_EQ(distances[source][target], expectedDistance);
-        }
-    }
-}
 
-TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleCompleteGraphK3NegativeCycle) {
-    auto graph = completeGraphK3NegativeCycle();
+TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleUndirectedGraphWithNegativeEdge) {
+    // Undirected graph with one negative edge results in negative cycles for all edges
+    auto graph = undirectedGraphWithNegativeEdge();
     FloydWarshall test(graph);
     test.run();
     for (node source = 0; source < graph.numberOfNodes(); ++source) {
@@ -182,8 +165,9 @@ TEST_F(FloydWarshallGTest, testIsNodeInNegativeCycleCompleteGraphK3NegativeCycle
     }
 }
 
-TEST_F(FloydWarshallGTest, getNodesOnShortestPathCompleteGraphK3NegativeCycle) {
-    auto graph = completeGraphK3NegativeCycle();
+TEST_F(FloydWarshallGTest, getNodesOnShortestPathUndirectedGraphWithNegativeEdge) {
+    // Undirected graph with one negative edge results in negative cycles for all edges
+    auto graph = undirectedGraphWithNegativeEdge();
     FloydWarshall test(graph);
     test.run();
     for (node source = 0; source < graph.numberOfNodes(); ++source) {
@@ -203,15 +187,6 @@ TEST_F(FloydWarshallGTest, testGetDistanceCompleteGraphK3NegativeEdge) {
             EXPECT_EQ(test.getDistance(source, target), expectedDistances[source][target]) << "source " << source << " target " << target;
         }
     }
-}
-
-TEST_F(FloydWarshallGTest, testGetAllDistancesCompleteGraphK3NegativeEdge) {
-    auto graph = directedGraphNegativeEdge();
-    FloydWarshall test(graph);
-    test.run();
-    const std::vector<std::vector<edgeweight>> expectedDistances{{0, 1, -1}, {maxDistance, 0, -2}, {maxDistance,maxDistance, 0}};
-    const auto & distances = test.getAllDistances();
-    EXPECT_EQ(distances, expectedDistances);
 }
 
 TEST_F(FloydWarshallGTest, testIsNodeInNegativeEdgeCompleteGraphK3NegativeEdge) {
@@ -240,7 +215,6 @@ TEST_F(FloydWarshallGTest, testDisconnectedGraph) {
     Graph graph(4, true);
     graph.addEdge(0, 1, 3);
     graph.addEdge(1, 2, 2);
-    // No edges to/from node 3
     FloydWarshall test(graph);
     test.run();
     EXPECT_EQ(test.getDistance(0, 3), std::numeric_limits<edgeweight>::max());
@@ -258,6 +232,8 @@ TEST_F(FloydWarshallGTest, testZeroWeightEdges) {
     EXPECT_EQ(test.getDistance(0, 1), 0.0);
     EXPECT_EQ(test.getDistance(1, 2), 0.0);
     EXPECT_EQ(test.getDistance(0, 2), 0.0);
+
+
 }
 
 TEST_F(FloydWarshallGTest, testSelfLoops) {


### PR DESCRIPTION
# Implement Floyd-Warshall Algorithm for All-Pairs Shortest Paths

This PR introduces the Floyd-Warshall algorithm for computing all-pairs shortest paths in a weighted graph. It supports both directed and undirected graphs, correctly handles negative edge weights, and detects negative cycles. If multiple shortest paths exist with the same distance, the algorithm selects the one with the fewest nodes.

## Features  
- Computes shortest path distances between all node pairs.  
- Detects negative cycles in the graph.  
- Provides path reconstruction via `getNodesOnShortestPath(source, target)`.  
- Prefers the shortest path with the fewest nodes when multiple exist.  

The algorithm runs in O(n³) time complexity, with n representing the number of nodes, making it suitable for small to medium-sized graphs.
