### PR TITLE
Add post-release tag for fixing pypi linux build.

### DIFF
--- a/networkit/__init__.py
+++ b/networkit/__init__.py
@@ -30,7 +30,7 @@ __credits__ = ["Eugenio Angriman", "Lukas Barth", "Miriam Beddig", "Elisabetta B
     "Moritz v. Looz", "Yassine Marrakchi", "Henning Meyerhenke", "Manuel Penschuck", "Lucas Archimedes Gregorio Henr Petersen", "Marcel Radermacher", "Klara Reichard", \
 	"Marvin Ritter", "Aleksejs Sazonovs", "Hung Tran", "Alexander van der Grinten", "Florian Weber", "Michael Wegner", "Jörg Weisbarth"]
 __license__ = "MIT"
-__version__ = "11.1"
+__version__ = "11.1.post1"
 
 # standard library modules
 import csv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "networkit"
-version = "11.1"
+version = "11.1.post1"
 description = "NetworKit is a toolbox for high-performance network analysis"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 name='networkit'
 
-version='11.1'
+version='11.1.post1'
 
 url='https://networkit.github.io/'
 


### PR DESCRIPTION
This PR raises the version from `11.1` -> `11.1.post1`. 

See issue #1314 for details why the Linux package is broken in the newest release. Since the code itself is ok and this is merely a building environment problem, we do a `post`-release instead of a patch release.