### PR TITLE
Pin Cython to <3.1.0 due to regression

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -218,7 +218,7 @@ jobs:
           python-version: '3.12'
       - name: Create sdist source
         run: |
-          pip install cython numpy setuptools
+          pip install cython==3.0.9 numpy setuptools
           python3 setup.py build_ext
           python3 setup.py sdist
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,7 +438,7 @@ jobs:
           cd ../..
           python -m venv pyenv
           . ./pyenv/Scripts/activate
-          pip install cython ipython ipywidgets==7.7.1 jupyter jupyterlab-widgets==1.1.1 numpy setuptools
+          pip install cython==3.0.9 ipython ipywidgets==7.7.1 jupyter jupyterlab-widgets==1.1.1 numpy setuptools
           mkdir build && cd build
           cmake -GNinja -DNETWORKIT_BUILD_TESTS=ON -DNETWORKIT_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DNETWORKIT_CXX_STANDARD=${{ env.CXX_STANDARD }} -DNETWORKIT_WARNINGS=ON -DNETWORKIT_WARNINGS_AS_ERRORS=ON -DNETWORKIT_EXT_TLX=${{ env.TLX_PATH_WIN }} -DNETWORKIT_NATIVE=${{ env.NATIVE }} ..
           ninja

--- a/.github/workflows/scripts/full.sh
+++ b/.github/workflows/scripts/full.sh
@@ -9,7 +9,7 @@ cmake --version
 # Note: setuptools<69.0.0 is needed for editable installs. Normal installs work with more recent releases of setuptools
 python3 -m venv pyenv && . pyenv/bin/activate
 pip3 install --upgrade pip
-pip3 install cython numpy ipython jupyter setuptools
+pip3 install cython==3.0.9 numpy ipython jupyter setuptools
 
 # Build tlx
 cd tlx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ changelog = "https://github.com/networkit/networkit/blob/master/CHANGES.md"
 
 [build-system]
 requires = [
-  "cython",
+  "cython<3.1.0",
   "numpy",
   "setuptools",
   "wheel"


### PR DESCRIPTION
This is needed for both CI and local dev builds. At the moment, cythonization of pyx files fails for `volume` in `graphtools.pyx`due to using the non-parametrized version of the function.

See here for more details: https://github.com/cython/cython/pull/6827

Likely we can unpin Cython with 3.12 (or later).