### PR TITLE
Add parallel hash map 

### DIFF
--- a/include/networkit/auxiliary/AtomicUtils.hpp
+++ b/include/networkit/auxiliary/AtomicUtils.hpp
@@ -1,0 +1,51 @@
+#ifndef NETWORKIT_AUXILIARY_ATOMIC_UTILS_HPP_
+#define NETWORKIT_AUXILIARY_ATOMIC_UTILS_HPP_
+
+#include <atomic>
+
+namespace Aux {
+inline uint32_t unset_bit_atomically(std::atomic_uint32_t &bitmask, size_t position) {
+    uint32_t current_bitmask = bitmask.load();
+    uint32_t desired_bitmask = current_bitmask & ~(1u << position);
+
+    while (!bitmask.compare_exchange_weak(current_bitmask, desired_bitmask)) {
+        current_bitmask = bitmask.load();
+        desired_bitmask = current_bitmask & ~(1u << position);
+    }
+
+    return desired_bitmask;
+};
+
+inline uint32_t set_bit_atomically(std::atomic_uint32_t &bitmask, size_t position) {
+    uint32_t current_bitmask = bitmask.load();
+    uint32_t desired_bitmask = current_bitmask | (1u << position);
+
+    while (!bitmask.compare_exchange_weak(current_bitmask, desired_bitmask)) {
+        current_bitmask = bitmask.load();
+        desired_bitmask = current_bitmask | (1u << position);
+    }
+
+    return desired_bitmask;
+}
+
+template <typename T>
+void swap_atomics_non_atomically(std::atomic<T> &a, std::atomic<T> &b) {
+    T const a_temp = a.load();
+    a.store(b);
+    b.store(a_temp);
+};
+
+template <typename T>
+T increment_atomically(std::atomic<T> &value, T increment = T(1)) {
+    T current_value = value.load();
+    T incremented_value = current_value + increment;
+
+    while (!value.compare_exchange_weak(current_value, incremented_value)) {
+        incremented_value = current_value + increment;
+    }
+
+    return incremented_value;
+}
+} // namespace Aux
+
+#endif // NETWORKIT_AUXILIARY_ATOMIC_UTILS_HPP_

--- a/include/networkit/auxiliary/AtomicUtils.hpp
+++ b/include/networkit/auxiliary/AtomicUtils.hpp
@@ -4,7 +4,7 @@
 #include <atomic>
 
 namespace Aux {
-inline uint32_t unset_bit_atomically(std::atomic_uint32_t &bitmask, size_t position) {
+inline uint32_t unsetBitAtomically(std::atomic_uint32_t &bitmask, size_t position) {
     uint32_t current_bitmask = bitmask.load();
     uint32_t desired_bitmask = current_bitmask & ~(1u << position);
 
@@ -16,7 +16,7 @@ inline uint32_t unset_bit_atomically(std::atomic_uint32_t &bitmask, size_t posit
     return desired_bitmask;
 };
 
-inline uint32_t set_bit_atomically(std::atomic_uint32_t &bitmask, size_t position) {
+inline uint32_t setBitAtomically(std::atomic_uint32_t &bitmask, size_t position) {
     uint32_t current_bitmask = bitmask.load();
     uint32_t desired_bitmask = current_bitmask | (1u << position);
 
@@ -29,14 +29,14 @@ inline uint32_t set_bit_atomically(std::atomic_uint32_t &bitmask, size_t positio
 }
 
 template <typename T>
-void swap_atomics_non_atomically(std::atomic<T> &a, std::atomic<T> &b) {
+void swapAtomicsNonAtomically(std::atomic<T> &a, std::atomic<T> &b) {
     T const a_temp = a.load();
     a.store(b);
     b.store(a_temp);
 };
 
 template <typename T>
-T increment_atomically(std::atomic<T> &value, T increment = T(1)) {
+T incrementAtomically(std::atomic<T> &value, T increment = T(1)) {
     T current_value = value.load();
     T incremented_value = current_value + increment;
 

--- a/include/networkit/auxiliary/HashUtils.hpp
+++ b/include/networkit/auxiliary/HashUtils.hpp
@@ -16,7 +16,7 @@ void hashCombine(std::size_t &seed, T const &v) {
 // capacity: must be power of 2
 // T shall be unsigned.
 template <typename T>
-T fast_mod(T const idx, size_t const capacity) {
+T fastMod(T const idx, size_t const capacity) {
     return idx & (capacity - 1);
 }
 

--- a/include/networkit/auxiliary/HashUtils.hpp
+++ b/include/networkit/auxiliary/HashUtils.hpp
@@ -13,6 +13,39 @@ void hashCombine(std::size_t &seed, T const &v) {
     seed ^= std::hash<T>()(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
+// capacity: must be power of 2
+// T shall be unsigned.
+template <typename T>
+T fast_mod(T const idx, size_t const capacity) {
+    return idx & (capacity - 1);
+}
+
+// Thanks to David Stafford for his further research on Austin Appleby's
+// MurmurHash3 specifically for input values with low entropy such as it is the
+// case for our dynamic hashtable that shall store vertex ids - and are more
+// close to counting numbers than random ones.
+//
+// The one we are using here is Mix13.
+//
+// Please go to
+// http://zimbry.blogspot.com/2011/09/better-bit-mixing-improving-on.html for
+// further reading.
+//
+// Also thanks to Thomas Mueller for his answer on good integer hashing:
+// https://stackoverflow.com/questions/664014/what-integer-hash-function-are-good-that-accepts-an-integer-hash-key
+//
+// The final function definition comes from Sebastiano Vigna:
+// https://xorshift.di.unimi.it/splitmix64.c
+inline uint64_t hash64(uint64_t x) {
+    constexpr uint64_t op_a = 0xbf58476d1ce4e5b9;
+    constexpr uint64_t op_b = 0x94d049bb133111eb;
+
+    x = (x ^ (x >> 30)) * op_a;
+    x = (x ^ (x >> 27)) * op_b;
+    x = x ^ (x >> 31);
+    return x;
+}
+
 struct PairHash {
     template <typename A, typename B>
     std::size_t operator()(const std::pair<A, B> &pair) const {

--- a/include/networkit/auxiliary/ParallelHashMap.hpp
+++ b/include/networkit/auxiliary/ParallelHashMap.hpp
@@ -22,8 +22,8 @@ public:
 
         swap(p.m_source, q.m_source);
         swap(p.m_target, q.m_target);
-        swap_atomics_non_atomically<uint32_t>(p.m_busy_bitset, q.m_busy_bitset);
-        swap_atomics_non_atomically<bool>(p.m_request_growth, q.m_request_growth);
+        swapAtomicsNonAtomically<uint32_t>(p.m_busy_bitset, q.m_busy_bitset);
+        swapAtomicsNonAtomically<bool>(p.m_request_growth, q.m_request_growth);
     }
 
     class HTHandle;
@@ -55,11 +55,11 @@ public:
         return *this;
     }
 
-    std::unique_ptr<HTHandle> make_handle();
+    std::unique_ptr<HTHandle> makeHandle();
 
-    HTAtomic128 const *const current_table() const;
+    HTAtomic128 const *const currentTable() const;
 
-    uint32_t random_thread_range();
+    uint32_t randomThreadRange();
 
 private:
     std::unique_ptr<HTAtomic128> m_source;
@@ -109,7 +109,7 @@ public:
         swap(a.m_cells, b.m_cells);
         swap(a.m_capacity, b.m_capacity);
         swap(a.m_log_capacity, b.m_log_capacity);
-        swap_atomics_non_atomically(a.m_global_occupancy, b.m_global_occupancy);
+        swapAtomicsNonAtomically(a.m_global_occupancy, b.m_global_occupancy);
     }
 
     // Returns false if key already exists, and true if (key, value) was
@@ -169,9 +169,9 @@ public:
 
     Iterator end() const;
 
-    size_t increment_global_occupancy(size_t increment);
+    size_t incrementGlobalOccupancy(size_t increment);
 
-    size_t global_occupancy() const;
+    size_t globalOccupancy() const;
 
     size_t capacity() const;
 
@@ -194,18 +194,18 @@ public:
 
     std::pair<ParallelHashMap::HTAtomic128::Cells::const_iterator,
               ParallelHashMap::HTAtomic128::Cells::const_iterator>
-    cluster_range(uint32_t const p_count = 1, uint32_t const p_id = 0);
+    clusterRange(uint32_t const p_count = 1, uint32_t const p_id = 0);
 
 private:
-    static Cell make_cell(uint64_t key, uint64_t value) {
+    static Cell makeCell(uint64_t key, uint64_t value) {
         Cell c;
         c.key = key;
         c.value = value;
         return c;
     }
 
-    static Cell invalid_cell() {
-        return make_cell(ParallelHashMap::ht_invalid_key, ParallelHashMap::ht_invalid_value);
+    static Cell invalidCell() {
+        return makeCell(ParallelHashMap::ht_invalid_key, ParallelHashMap::ht_invalid_value);
     }
 
     // Double Width Compare And Swap:
@@ -246,9 +246,9 @@ private:
         return res;
     }
 
-    void move_cells(ParallelHashMap::HTAtomic128::Cells::const_iterator begin,
-                    ParallelHashMap::HTAtomic128::Cells::const_iterator end,
-                    ParallelHashMap::HTAtomic128 &target);
+    void moveCells(ParallelHashMap::HTAtomic128::Cells::const_iterator begin,
+                   ParallelHashMap::HTAtomic128::Cells::const_iterator end,
+                   ParallelHashMap::HTAtomic128 &target);
 
 private:
     size_t m_capacity{ParallelHashMap::ht_begin_capacity};

--- a/include/networkit/auxiliary/ParallelHashMap.hpp
+++ b/include/networkit/auxiliary/ParallelHashMap.hpp
@@ -1,0 +1,303 @@
+#ifndef NETWORKIT_AUXILIARY_PARALLEL_HASH_MAP_HPP_
+#define NETWORKIT_AUXILIARY_PARALLEL_HASH_MAP_HPP_
+
+#include <omp.h>
+
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include <networkit/auxiliary/AtomicUtils.hpp>
+#include <networkit/auxiliary/HashUtils.hpp>
+
+namespace Aux {
+
+// An object of this class will handle a dynamic hashtable and offers factory
+// methods to acquire hashtable resources.
+class ParallelHashMap {
+public:
+    friend void swap(ParallelHashMap &p, ParallelHashMap &q) noexcept {
+        using std::swap;
+
+        swap(p.m_source, q.m_source);
+        swap(p.m_target, q.m_target);
+        swap_atomics_non_atomically<uint32_t>(p.m_busy_bitset, q.m_busy_bitset);
+        swap_atomics_non_atomically<bool>(p.m_request_growth, q.m_request_growth);
+    }
+
+    class HTHandle;
+    class HTAtomic128;
+    class HTSyncData;
+
+    static constexpr uint64_t ht_invalid_key = std::numeric_limits<uint64_t>::max();
+    static constexpr uint64_t ht_invalid_value = std::numeric_limits<uint64_t>::max() - 1;
+
+    // This value shall represent some storage capacity that can be handled within a
+    // CPU cache (e.g. private MLC).
+    static constexpr size_t const ht_begin_capacity = 4096u;
+
+    static constexpr uint64_t ht_key_space = sizeof(uint64_t) * 8;
+
+    ParallelHashMap();
+
+    // begin_capacity: Must be multiple of 2.
+    ParallelHashMap(size_t const begin_capacity);
+
+    ~ParallelHashMap() = default;
+
+    ParallelHashMap(ParallelHashMap const &other);
+
+    ParallelHashMap(ParallelHashMap &&other);
+
+    ParallelHashMap &operator=(ParallelHashMap other) {
+        swap(*this, other);
+        return *this;
+    }
+
+    std::unique_ptr<HTHandle> make_handle();
+
+    HTAtomic128 const *const current_table() const;
+
+    uint32_t random_thread_range();
+
+private:
+    std::unique_ptr<HTAtomic128> m_source;
+    std::unique_ptr<HTAtomic128> m_target;
+    std::atomic_uint32_t m_busy_bitset{0u};
+    std::atomic_bool m_request_growth{false};
+
+    // Used to determine how often to check for the hashtables fill factor for
+    // every 1 to p inserts. We're keeping this an internal random number
+    // generator engine. However, this could also be injected when constructing.
+    std::mt19937 m_generator;
+};
+
+// This is the Hashtable Atomic 128 (HTAtomic128) class which stores (key,
+// value) pairs, both of 64 bit and operates on them atomically using DWCAS
+// operations.
+//
+// The basis of this implementation is the "Concurrent Hash Tables: Fast and
+// general(?)!" from Maier et al. (2016).
+//
+// Some interfaces are not needed for our case such as insertOrUpdate() or
+// update(). We expect the key's never to be updated during runtime: the handle
+// for vertex u will never change during the execution of the program.
+class ParallelHashMap::HTAtomic128 {
+public:
+    // In order to use DWCAS we must align our Cell within a 16 bytes window.
+    struct alignas(16) Cell {
+        uint64_t key{ParallelHashMap::ht_invalid_key};
+        uint64_t value{ParallelHashMap::ht_invalid_value};
+    };
+
+    using Cells = std::vector<Cell>;
+
+    HTAtomic128();
+    HTAtomic128(size_t const capacity);
+    ~HTAtomic128() = default;
+    HTAtomic128(HTAtomic128 const &other);
+    HTAtomic128(HTAtomic128 &&other);
+
+    HTAtomic128 &operator=(HTAtomic128 other);
+
+    // Thanks to GManNickG on Stackoverflow explaining the copy-swap idiom:
+    // https://stackoverflow.com/a/3279550
+    friend void swap(HTAtomic128 &a, HTAtomic128 &b) {
+        using std::swap;
+
+        swap(a.m_cells, b.m_cells);
+        swap(a.m_capacity, b.m_capacity);
+        swap(a.m_log_capacity, b.m_log_capacity);
+        swap_atomics_non_atomically(a.m_global_occupancy, b.m_global_occupancy);
+    }
+
+    // Returns false if key already exists, and true if (key, value) was
+    // successfully inserted.
+    bool insert(uint64_t const key, uint64_t const value);
+
+    // Returns the actual value of the cell if key is present, ht_invalid_key
+    // otherwise.
+    uint64_t find(uint64_t const key) const;
+
+    // Returns false if key does not exist, true if (key, value) was
+    // successfully updated.
+    bool update(uint64_t const key, uint64_t const value);
+
+    struct Iterator {
+        using iterator_category = std::input_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = Cell const;
+        using pointer = Cell const *;
+        using reference = Cell const &;
+
+        Iterator(Cells const &cells);
+
+        friend void swap(Iterator &a, Iterator &b) {
+            using std::swap;
+
+            swap(a.m_cells_it, b.m_cells_it);
+            swap(a.m_cells_end, b.m_cells_end);
+        }
+
+        reference operator*() { return *m_cells_it; }
+        pointer operator->();
+
+        // Prefix increment operator
+        Iterator &operator++();
+
+        // Postfix increment operator
+        Iterator operator++(int);
+
+        bool operator==(const HTAtomic128::Iterator &b) const {
+            return this->m_cells_it == b.m_cells_it;
+        }
+
+        bool operator!=(const HTAtomic128::Iterator &b) const { return !(*this == b); }
+
+        void invalidate();
+
+    private:
+        void next();
+
+    private:
+        Cells::const_iterator m_cells_it;
+        Cells::const_iterator m_cells_end;
+    };
+
+    Iterator begin() const { return HTAtomic128::Iterator{m_cells}; }
+
+    Iterator end() const;
+
+    size_t increment_global_occupancy(size_t increment);
+
+    size_t global_occupancy() const;
+
+    size_t capacity() const;
+
+    Cells const &cells() const { return m_cells; }
+
+    // Filled whenever occupancy reaches greater equal than half of the
+    // capacity (alpha = 0.5 * capacity).
+    bool filled() const;
+
+    // Roams source to target with respect to the calling thread which will be given
+    // a defined space of the source table to insert in target. This will guarantee
+    // correctness and roams elements without any synchronisation between threads.
+    // See chapter 5.3.2 for more details and proof.
+    //
+    // scale_factor: is power of 2
+    //
+    // p_count: must be >= 1
+    void roam(ParallelHashMap::HTAtomic128 &target, uint32_t const p_count = 1,
+              uint32_t const p_id = 0);
+
+    std::pair<ParallelHashMap::HTAtomic128::Cells::const_iterator,
+              ParallelHashMap::HTAtomic128::Cells::const_iterator>
+    cluster_range(uint32_t const p_count = 1, uint32_t const p_id = 0);
+
+private:
+    static Cell make_cell(uint64_t key, uint64_t value) {
+        Cell c;
+        c.key = key;
+        c.value = value;
+        return c;
+    }
+
+    static Cell invalid_cell() {
+        return make_cell(ParallelHashMap::ht_invalid_key, ParallelHashMap::ht_invalid_value);
+    }
+
+    // Double Width Compare And Swap:
+    //
+    // If r matches expected, write desired to r and return true. Otherwise,
+    // read r into expected and return false.
+    //
+    // We using this user defined dwcas since we can't be sure we're operating
+    // atomically on two 64-bit values: https://timur.audio/dwcas-in-c
+    static bool dwcas(HTAtomic128::Cell &r, HTAtomic128::Cell &expected,
+                      HTAtomic128::Cell const &desired) {
+        bool res;
+#if __x86_64__
+        asm volatile("lock cmpxchg16b %1"
+                     : "=@ccz"(res), "+m"(r), "+a"(expected.key), "+d"(expected.value)
+                     : "b"(desired.key), "c"(desired.value)
+                     : "memory");
+#else
+        // For ARM64 we use the ld/stxp instruction pair to perform the DWCAS operation.
+        // See:
+        // https://github.com/boostorg/atomic/blob/master/include/boost/atomic/detail/core_arch_ops_gcc_aarch64.hpp
+        HTAtomic128::Cell original;
+        asm volatile("mov %w[success], #0\n\t"
+                     "ldxp %x[original_0], %x[original_1], %[storage]\n\t"
+                     "cmp %x[original_0], %x[expected_0]\n\t"
+                     "ccmp %x[original_1], %x[expected_1], #0, eq\n\t"
+                     "b.ne 1f\n\t"
+                     "stxp %w[success], %x[desired_0], %x[desired_1], %[storage]\n\t"
+                     "eor %w[success], %w[success], #1\n\t"
+                     "1:\n\t"
+                     : [success] "=&r"(res), [storage] "+Q"(r), [original_0] "=&r"(original.key),
+                       [original_1] "=&r"(original.value)
+                     : [desired_0] "r"(desired.key), [desired_1] "r"(desired.value),
+                       [expected_0] "r"(expected.key), [expected_1] "r"(expected.value)
+                     : "cc"
+                       "memory");
+#endif
+        return res;
+    }
+
+    void move_cells(ParallelHashMap::HTAtomic128::Cells::const_iterator begin,
+                    ParallelHashMap::HTAtomic128::Cells::const_iterator end,
+                    ParallelHashMap::HTAtomic128 &target);
+
+private:
+    size_t m_capacity{ParallelHashMap::ht_begin_capacity};
+    uint64_t m_log_capacity{static_cast<uint64_t>(std::log2(m_capacity))};
+    Cells m_cells;
+    std::atomic_size_t m_global_occupancy{0};
+};
+
+class ParallelHashMap::HTSyncData {
+public:
+    HTSyncData(std::unique_ptr<HTAtomic128> &_source, std::unique_ptr<HTAtomic128> &_target,
+               std::atomic_uint32_t &_busy, std::atomic_bool &_request_growth, int _p_count,
+               int _p_id, uint32_t _insert_threshold);
+
+    std::unique_ptr<HTAtomic128> &source;
+    std::unique_ptr<HTAtomic128> &target;
+
+    // Represents a bitset where the bit is set to 1 at position p_id if the
+    // thread is still busy operating on hash table operations.
+    std::atomic_uint32_t &busy;
+    uint32_t insert_counter{0};
+    uint32_t const insert_threshold;
+
+    // Whenever this is set, the hashtable has to be grown by all threads of the
+    // omp team.
+    std::atomic_bool &request_growth;
+    int const p_count;
+    int const p_id;
+};
+
+class ParallelHashMap::HTHandle {
+public:
+    HTHandle(HTSyncData sync_data);
+
+    ~HTHandle();
+
+    bool insert(uint64_t const key, uint64_t const value);
+
+    uint64_t find(uint64_t const key) const;
+
+    bool update(uint64_t const key, uint64_t const value) const;
+
+    HTAtomic128 const &hashtable();
+
+private:
+    HTAtomic128 *m_ht;
+    HTSyncData m_sync_data;
+};
+
+} // namespace Aux
+
+#endif // NETWORKIT_AUXILIARY_PARALLEL_HASH_MAP_HPP_

--- a/networkit/cpp/auxiliary/CMakeLists.txt
+++ b/networkit/cpp/auxiliary/CMakeLists.txt
@@ -3,6 +3,7 @@ networkit_add_module(auxiliary
     BucketPQ.cpp
     Log.cpp
     NumericTools.cpp
+    ParallelHashMap.cpp
     Parallelism.cpp
     Random.cpp
     SignalHandling.cpp

--- a/networkit/cpp/auxiliary/ParallelHashMap.cpp
+++ b/networkit/cpp/auxiliary/ParallelHashMap.cpp
@@ -1,0 +1,405 @@
+#include <omp.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cuchar>
+#include <iterator>
+#include <thread>
+
+#include <networkit/auxiliary/ParallelHashMap.hpp>
+
+namespace Aux {
+
+namespace {
+// From 5.3.1 of "Concurrent Hash Tables: Fast and general(?)!" from Maier et
+// al. (2016): h_c(x) := floor(h(x) * (c/U)) where c = capacity and U = key
+// space = 64 (bit) in our case. Since capacity and U are both power of 2 we can
+// change the formula to use bit-shifting.
+uint64_t scaling(uint64_t const h, size_t const capacity) {
+    return h >> uint64_t(ParallelHashMap::ht_key_space - std::log2(capacity));
+}
+
+// Use this if you already precomputed log2(capacity).
+uint64_t scaling_log(uint64_t const h, uint64_t const log_2_capacity) {
+    return h >> (ParallelHashMap::ht_key_space - log_2_capacity);
+}
+
+size_t index(uint64_t const key, uint64_t const offset, size_t const capacity) {
+    uint64_t const h_c = scaling(key, capacity);
+    return fast_mod(h_c + offset, capacity);
+}
+
+bool ht_filled(size_t const occupancy, size_t const capacity) {
+    uint64_t const alpha_elements_count = capacity >> 1;
+    return occupancy > alpha_elements_count;
+}
+
+ParallelHashMap::HTAtomic128 *grow_hashtable(std::unique_ptr<ParallelHashMap::HTAtomic128> &source,
+                                             std::unique_ptr<ParallelHashMap::HTAtomic128> &target,
+                                             std::atomic_bool &request_growth, int const p_count,
+                                             int const p_id) {
+    request_growth.store(true);
+
+#pragma omp single
+    { target = std::make_unique<ParallelHashMap::HTAtomic128>(source->capacity() << 1); }
+    // omp implicit barrier
+
+    source->roam(*target, p_count, p_id);
+#pragma omp barrier
+
+#pragma omp single
+    {
+        request_growth.store(false);
+        source = std::move(target);
+    }
+    // omp implicit barrier
+
+    return source.get();
+}
+
+} // namespace
+
+using HTAtomic128 = ParallelHashMap::HTAtomic128;
+using HTSyncData = ParallelHashMap::HTSyncData;
+using HTHandle = ParallelHashMap::HTHandle;
+
+HTAtomic128::HTAtomic128() : m_cells(m_capacity, Cell{}) {}
+
+HTAtomic128::HTAtomic128(size_t const capacity)
+    : m_cells(capacity, Cell{}), m_capacity(capacity), m_log_capacity(std::log2(capacity)) {}
+
+HTAtomic128::HTAtomic128(HTAtomic128 const &other)
+    : m_cells(other.m_cells), m_capacity(other.m_capacity), m_log_capacity(other.m_log_capacity),
+      m_global_occupancy(other.m_global_occupancy.load()) {}
+
+HTAtomic128::HTAtomic128(HTAtomic128 &&other) : HTAtomic128() {
+    swap(*this, other);
+}
+
+HTAtomic128 &HTAtomic128::operator=(HTAtomic128 other) {
+    swap(*this, other);
+    return *this;
+}
+
+bool HTAtomic128::insert(uint64_t const key, uint64_t const value) {
+    Cell const desired = make_cell(key, value);
+    Cell expected = invalid_cell();
+    uint64_t const hashed_key = hash64(key);
+    size_t idx = scaling_log(hashed_key, m_log_capacity);
+
+    while (true) {
+        idx = fast_mod(idx, m_capacity);
+        assert(idx < m_capacity);
+
+        Cell &cell = m_cells[idx];
+
+#pragma omp atomic read
+        expected.key = cell.key;
+
+        if (desired.key == expected.key) {
+            return false;
+        }
+
+#pragma omp atomic read
+        expected.value = cell.value;
+
+        // Data Race check on invalid and desired
+        if (expected.key == ParallelHashMap::ht_invalid_key) {
+            if (dwcas(cell, expected, desired)) {
+                return true;
+            }
+            // DWCAS did not work.. thus reaching this line due to a race on
+            // the cells index with another thread when trying to write. We
+            // simply don't increment the idx variable which will try again
+            // with the same idx and proceed with linear probing.
+        } else {
+            idx++;
+        }
+    }
+}
+
+uint64_t HTAtomic128::find(uint64_t const key) const {
+    Cell actual = invalid_cell();
+    uint64_t const hashed_key = hash64(key);
+    size_t idx = scaling_log(hashed_key, m_log_capacity);
+
+    while (true) {
+        idx = fast_mod(idx, m_capacity);
+        assert(idx < m_capacity);
+
+        Cell const &cell = m_cells[idx];
+
+#pragma omp atomic read
+        actual.key = cell.key;
+
+#pragma omp atomic read
+        actual.value = cell.value;
+
+        if (actual.key == key) {
+            return actual.value;
+        }
+
+        if (actual.key == ParallelHashMap::ht_invalid_key) {
+            return ParallelHashMap::ht_invalid_value;
+        }
+
+        idx++;
+    }
+}
+
+bool HTAtomic128::update(uint64_t const key, uint64_t const value) {
+    Cell const desired = make_cell(key, value);
+    Cell expected = invalid_cell();
+    uint64_t const hashed_key = hash64(key);
+    size_t idx = scaling_log(hashed_key, m_log_capacity);
+
+    while (true) {
+        idx = fast_mod(idx, m_capacity);
+        assert(idx < m_capacity);
+
+        Cell &cell = m_cells[idx];
+
+#pragma omp atomic read
+        expected.key = cell.key;
+
+#pragma omp atomic read
+        expected.value = cell.value;
+
+        if (expected.key == desired.key) {
+            // If DWCAS fails we simply try again for the same cell.
+            if (dwcas(cell, expected, desired)) {
+                return true;
+            }
+        } else if (expected.key == ParallelHashMap::ht_invalid_key) {
+            return false;
+        } else {
+            idx++;
+        }
+    }
+}
+
+HTAtomic128::Iterator::Iterator(Cells const &cells)
+    : m_cells_it(std::begin(cells)), m_cells_end(std::end(cells)) {
+    while (m_cells_it != m_cells_end && m_cells_it->key == ParallelHashMap::ht_invalid_key) {
+        m_cells_it++;
+    }
+}
+
+HTAtomic128::Iterator::pointer HTAtomic128::Iterator::operator->() {
+    return &*m_cells_it;
+}
+
+HTAtomic128::Iterator &HTAtomic128::Iterator::operator++() {
+    next();
+    return *this;
+}
+
+HTAtomic128::Iterator HTAtomic128::Iterator::operator++(int) {
+    Iterator tmp = *this;
+    next();
+    return tmp;
+}
+
+void HTAtomic128::Iterator::invalidate() {
+    m_cells_it = m_cells_end;
+}
+
+void HTAtomic128::Iterator::next() {
+    if (m_cells_it == m_cells_end) {
+        return;
+    }
+
+    do {
+        m_cells_it++;
+    } while (m_cells_it != m_cells_end && m_cells_it->key == ParallelHashMap::ht_invalid_key);
+}
+
+HTAtomic128::Iterator HTAtomic128::end() const {
+    HTAtomic128::Iterator end_it{m_cells};
+    end_it.invalidate();
+    return end_it;
+}
+
+size_t HTAtomic128::increment_global_occupancy(size_t increment) {
+    return Aux::increment_atomically(m_global_occupancy, increment);
+}
+
+size_t HTAtomic128::global_occupancy() const {
+    return m_global_occupancy.load();
+}
+
+size_t HTAtomic128::capacity() const {
+    return m_capacity;
+}
+
+bool HTAtomic128::filled() const {
+    return ht_filled(m_global_occupancy.load(), m_capacity);
+}
+
+void HTAtomic128::roam(HTAtomic128 &target, uint32_t const p_count, uint32_t const p_id) {
+    auto range_to_move = cluster_range(p_count, p_id);
+    move_cells(range_to_move.first, range_to_move.second, target);
+}
+
+void HTAtomic128::move_cells(HTAtomic128::Cells::const_iterator begin,
+                             HTAtomic128::Cells::const_iterator end, HTAtomic128 &target) {
+    size_t local_occupancy = 0;
+    for (HTAtomic128::Cells::const_iterator c = begin; c != end; ++c) {
+        if (c->key != ParallelHashMap::ht_invalid_key) {
+            bool inserted = target.insert(c->key, c->value);
+            assert(inserted);
+            local_occupancy += size_t(inserted);
+        }
+    }
+    target.increment_global_occupancy(local_occupancy);
+}
+
+std::pair<ParallelHashMap::HTAtomic128::Cells::const_iterator,
+          ParallelHashMap::HTAtomic128::Cells::const_iterator>
+HTAtomic128::cluster_range(uint32_t const p_count, uint32_t const p_id) {
+    auto cells_begin = m_cells.begin();
+    auto cells_end = m_cells.end();
+
+    if (cells_begin == cells_end) {
+        return std::make_pair(cells_end, cells_end);
+    }
+
+    HTAtomic128::Cells::difference_type const cell_count = std::distance(cells_begin, cells_end);
+    if (cell_count < (p_count * p_count)) {
+        if (p_id == 0) {
+            return std::make_pair(cells_begin, cells_end);
+        }
+
+        return std::make_pair(cells_end, cells_end);
+    }
+
+    size_t const cells_per_thread = cell_count / p_count;
+
+    auto p_cells_end = cells_begin;
+    if (p_id == (p_count - 1)) {
+        p_cells_end = cells_end;
+    } else {
+        size_t const max_advance = std::min<size_t>((p_id + 1) * cells_per_thread, cell_count);
+        std::advance(p_cells_end, max_advance);
+
+        while (p_cells_end != cells_end && p_cells_end->key != ParallelHashMap::ht_invalid_key) {
+            ++p_cells_end;
+        }
+    }
+
+    auto p_cells_begin = cells_begin;
+    if (p_id > 0) {
+        size_t const max_advance =
+            std::min<size_t>(p_id * cells_per_thread, std::distance(p_cells_begin, p_cells_end));
+        std::advance(p_cells_begin, max_advance);
+
+        while (p_cells_begin != p_cells_end
+               && p_cells_begin->key != ParallelHashMap::ht_invalid_key) {
+            ++p_cells_begin;
+        }
+    }
+
+    return std::make_pair(p_cells_begin, p_cells_end);
+}
+
+HTSyncData::HTSyncData(std::unique_ptr<HTAtomic128> &_source, std::unique_ptr<HTAtomic128> &_target,
+                       std::atomic_uint32_t &_busy, std::atomic_bool &_request_growth, int _p_count,
+                       int _p_id, uint32_t _insert_threshold)
+    : source(_source), target(_target), busy(_busy), request_growth(_request_growth),
+      p_count(_p_count), p_id(_p_id), insert_threshold(_insert_threshold) {}
+
+HTHandle::HTHandle(HTSyncData sync_data) : m_ht(sync_data.source.get()), m_sync_data(sync_data) {
+    set_bit_atomically(m_sync_data.busy, m_sync_data.p_id);
+}
+
+HTHandle::~HTHandle() {
+    size_t const occupancy = m_ht->increment_global_occupancy(m_sync_data.insert_counter);
+
+    if (ht_filled(occupancy, m_ht->capacity())) {
+        m_ht = grow_hashtable(m_sync_data.source, m_sync_data.target, m_sync_data.request_growth,
+                              m_sync_data.p_count, m_sync_data.p_id);
+    }
+
+    Aux::unset_bit_atomically(m_sync_data.busy, m_sync_data.p_id);
+
+    while (m_sync_data.busy.load() != 0u) {
+        if (m_sync_data.request_growth.load()) {
+            auto disposable_ht =
+                grow_hashtable(m_sync_data.source, m_sync_data.target, m_sync_data.request_growth,
+                               m_sync_data.p_count, m_sync_data.p_id);
+        }
+    }
+}
+
+bool HTHandle::insert(uint64_t const key, uint64_t const value) {
+    bool const success = m_ht->insert(key, value);
+    m_sync_data.insert_counter += uint32_t(success);
+
+    if (m_sync_data.insert_threshold == m_sync_data.insert_counter) {
+        size_t const occupancy = m_ht->increment_global_occupancy(m_sync_data.insert_counter);
+
+        if (ht_filled(occupancy, m_ht->capacity())) {
+            m_ht =
+                grow_hashtable(m_sync_data.source, m_sync_data.target, m_sync_data.request_growth,
+                               m_sync_data.p_count, m_sync_data.p_id);
+        }
+
+        m_sync_data.insert_counter = 0;
+    }
+
+    return success;
+}
+
+uint64_t HTHandle::find(uint64_t const key) const {
+    return m_ht->find(key);
+}
+
+bool HTHandle::update(uint64_t const key, uint64_t const value) const {
+    return m_ht->update(key, value);
+}
+
+HTAtomic128 const &HTHandle::hashtable() {
+    return *m_ht;
+}
+
+ParallelHashMap::ParallelHashMap() : ParallelHashMap(ParallelHashMap::ht_begin_capacity) {}
+
+ParallelHashMap::ParallelHashMap(size_t const begin_capacity) {
+    m_source = std::make_unique<HTAtomic128>(begin_capacity);
+}
+
+ParallelHashMap::ParallelHashMap(ParallelHashMap const &other) {
+    m_source = std::make_unique<HTAtomic128>(*other.m_source.get());
+}
+
+ParallelHashMap::ParallelHashMap(ParallelHashMap &&other) : ParallelHashMap() {
+    swap(*this, other);
+}
+
+std::unique_ptr<HTHandle> ParallelHashMap::make_handle() {
+    Aux::HTSyncData sync_data{m_source,
+                              m_target,
+                              m_busy_bitset,
+                              m_request_growth,
+                              omp_get_num_threads(),
+                              omp_get_thread_num(),
+                              random_thread_range()};
+
+    auto handle = std::make_unique<HTHandle>(sync_data);
+
+    return handle;
+}
+
+HTAtomic128 const *const ParallelHashMap::current_table() const {
+    return m_source.get();
+}
+
+uint32_t ParallelHashMap::random_thread_range() {
+    std::uniform_int_distribution<uint32_t> m_dist(1, omp_get_num_threads());
+    return m_dist(m_generator);
+}
+
+} // namespace Aux

--- a/networkit/cpp/auxiliary/test/AuxParallelHashMapGTest.cpp
+++ b/networkit/cpp/auxiliary/test/AuxParallelHashMapGTest.cpp
@@ -24,7 +24,7 @@ using HTSyncData = Aux::ParallelHashMap::HTSyncData;
 class AuxParallelGrowingHTGTest : public testing::Test {
 
 public:
-    bool get_and_check_all(std::vector<node> const &mockup_data, HTAtomic128 &ht) {
+    bool getAndCheckAll(std::vector<node> const &mockup_data, HTAtomic128 &ht) {
         size_t idx = 0;
         bool all_good = true;
         for (size_t i = 0; i < mockup_data.size() && all_good; ++i) {
@@ -65,7 +65,7 @@ public:
         return all_good;
     }
 
-    bool insert_data(HTAtomic128 &ht, MockupData const &data) {
+    bool insertData(HTAtomic128 &ht, MockupData const &data) {
         bool all_inserted_successful = true;
         for (size_t i = 0; i < data.size(); ++i) {
             all_inserted_successful = ht.insert(data[i].first, data[i].second);
@@ -76,7 +76,7 @@ public:
         return all_inserted_successful;
     }
 
-    bool insert_data(HTHandle &handle, MockupData const &data) {
+    bool insertData(HTHandle &handle, MockupData const &data) {
         bool all_inserted_successful = true;
         for (size_t i = 0; i < data.size() && all_inserted_successful; ++i) {
             all_inserted_successful = handle.insert(data[i].first, data[i].second);
@@ -89,17 +89,17 @@ TEST_F(AuxParallelGrowingHTGTest, testHashUtilsfastMod) {
     uint32_t idx = 8;
     size_t capacity = 16;
 
-    uint32_t idx_wrapped = Aux::fast_mod(idx, capacity);
+    uint32_t idx_wrapped = Aux::fastMod(idx, capacity);
 
     ASSERT_EQ(idx_wrapped, idx);
 
     idx = 13;
-    idx_wrapped = Aux::fast_mod(idx, capacity);
+    idx_wrapped = Aux::fastMod(idx, capacity);
 
     ASSERT_EQ(idx_wrapped, idx);
 
     idx = 17;
-    idx_wrapped = Aux::fast_mod(idx, capacity);
+    idx_wrapped = Aux::fastMod(idx, capacity);
 
     ASSERT_EQ(idx_wrapped, 1);
 }
@@ -138,7 +138,7 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128Constructor) {
         ht.insert(mockupData[i], i);
     }
 
-    ASSERT_TRUE(get_and_check_all(mockupData, ht));
+    ASSERT_TRUE(getAndCheckAll(mockupData, ht));
 }
 
 TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128CopyConstructor) {
@@ -158,8 +158,8 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128CopyConstructor) {
 
     HTAtomic128 dvh_copy(ht);
 
-    ASSERT_TRUE(get_and_check_all(mockupData, dvh_copy));
-    ASSERT_TRUE(get_and_check_all(mockupData, ht));
+    ASSERT_TRUE(getAndCheckAll(mockupData, dvh_copy));
+    ASSERT_TRUE(getAndCheckAll(mockupData, ht));
 }
 
 TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128MoveConstructor) {
@@ -179,7 +179,7 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128MoveConstructor) {
 
     HTAtomic128 dvh_moved(std::move(ht));
 
-    ASSERT_TRUE(get_and_check_all(mockupData, dvh_moved));
+    ASSERT_TRUE(getAndCheckAll(mockupData, dvh_moved));
 }
 
 TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128Swap) {
@@ -211,12 +211,12 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128Swap) {
         ht_b.insert(mockupDataB[i], i);
     }
 
-    ht_b.increment_global_occupancy(mockupDataB.size());
+    ht_b.incrementGlobalOccupancy(mockupDataB.size());
 
     swap(ht, ht_b);
 
-    ASSERT_TRUE(get_and_check_all(mockupDataB, ht));
-    ASSERT_TRUE(get_and_check_all(mockupData, ht_b));
+    ASSERT_TRUE(getAndCheckAll(mockupDataB, ht));
+    ASSERT_TRUE(getAndCheckAll(mockupData, ht_b));
 }
 
 TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128CopyAssignment) {
@@ -236,8 +236,8 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128CopyAssignment) {
     HTAtomic128 ht_b{Aux::ParallelHashMap::ht_begin_capacity};
     ht_b = ht;
 
-    ASSERT_TRUE(get_and_check_all(mockupData, ht_b));
-    ASSERT_TRUE(get_and_check_all(mockupData, ht));
+    ASSERT_TRUE(getAndCheckAll(mockupData, ht_b));
+    ASSERT_TRUE(getAndCheckAll(mockupData, ht));
 }
 
 TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128InputIterator) {
@@ -456,7 +456,7 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128ClusterRangeSingleThread) {
     auto const cells_begin = std::cbegin(source.cells());
     auto const cells_end = std::cend(source.cells());
 
-    auto c_range = source.cluster_range();
+    auto c_range = source.clusterRange();
     ASSERT_EQ(c_range.first, cells_begin);
     ASSERT_EQ(c_range.second, cells_end);
 }
@@ -478,11 +478,11 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128ClusterRangeDualThread) {
     auto const cells_begin = std::cbegin(source.cells());
     auto const cells_end = std::cend(source.cells());
 
-    auto c_range_t0 = source.cluster_range(2, 0);
+    auto c_range_t0 = source.clusterRange(2, 0);
     ASSERT_EQ(c_range_t0.first, cells_begin);
     ASSERT_TRUE(c_range_t0.second != cells_end);
 
-    auto c_range_t1 = source.cluster_range(2, 1);
+    auto c_range_t1 = source.clusterRange(2, 1);
     ASSERT_TRUE(c_range_t1.first != cells_begin);
     ASSERT_EQ(c_range_t1.second, cells_end);
 
@@ -508,21 +508,21 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128ClusterRangeQuadrupleThread) {
 
     uint32_t const thread_count = 4;
 
-    auto c_range_t0 = source.cluster_range(thread_count, 0);
+    auto c_range_t0 = source.clusterRange(thread_count, 0);
     ASSERT_EQ(c_range_t0.first, cells_begin);
     ASSERT_TRUE(c_range_t0.second != cells_end);
 
-    auto c_range_t1 = source.cluster_range(thread_count, 1);
+    auto c_range_t1 = source.clusterRange(thread_count, 1);
     ASSERT_TRUE(c_range_t1.first != cells_begin);
     ASSERT_TRUE(c_range_t1.second != cells_end);
     ASSERT_EQ(c_range_t0.second, c_range_t1.first);
 
-    auto c_range_t2 = source.cluster_range(thread_count, 2);
+    auto c_range_t2 = source.clusterRange(thread_count, 2);
     ASSERT_TRUE(c_range_t2.first != cells_begin);
     ASSERT_TRUE(c_range_t2.second != cells_end);
     ASSERT_EQ(c_range_t1.second, c_range_t2.first);
 
-    auto c_range_t3 = source.cluster_range(thread_count, 3);
+    auto c_range_t3 = source.clusterRange(thread_count, 3);
     ASSERT_TRUE(c_range_t3.first != cells_begin);
     ASSERT_EQ(c_range_t3.second, cells_end);
     ASSERT_EQ(c_range_t2.second, c_range_t3.first);
@@ -561,7 +561,7 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128RoamingDualThread) {
     constexpr size_t begin_capacity = 32;
     HTAtomic128 ht_first{begin_capacity};
 
-    bool all_inserted_successful = insert_data(ht_first, mockup_data);
+    bool all_inserted_successful = insertData(ht_first, mockup_data);
 
     ASSERT_TRUE(all_inserted_successful);
     ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht_first));
@@ -584,7 +584,7 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128BigRoaming) {
     constexpr size_t begin_capacity = 16384u; //
     HTAtomic128 ht_first{begin_capacity};
 
-    bool all_inserted_successful = insert_data(ht_first, mockup_data);
+    bool all_inserted_successful = insertData(ht_first, mockup_data);
 
     ASSERT_TRUE(all_inserted_successful);
     ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht_first));
@@ -615,13 +615,13 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128HTHandleHTRoamingSingleThread) 
         source, target, busy_bitset, request_growth, 1, Aux::getCurrentNumberOfThreads(), 2};
     HTHandle handle{sync_data};
 
-    bool const all_inserted_successful = insert_data(handle, mockup_data);
+    bool const all_inserted_successful = insertData(handle, mockup_data);
 
     ASSERT_TRUE(all_inserted_successful);
 
     ASSERT_TRUE(checkEntriesForMockupData(mockup_data, handle.hashtable()));
 
-    ASSERT_EQ(handle.hashtable().global_occupancy(), mockup_data.size());
+    ASSERT_EQ(handle.hashtable().globalOccupancy(), mockup_data.size());
 }
 
 TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128HTHandleHTRoamingDualThread) {
@@ -663,7 +663,7 @@ TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128HTHandleHTRoamingDualThread) {
 
     ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht));
 
-    ASSERT_EQ(ht.global_occupancy(), mockup_data.size());
+    ASSERT_EQ(ht.globalOccupancy(), mockup_data.size());
 }
 
 TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128HTHandleHTRoamingDualThreadRoaming) {
@@ -722,16 +722,16 @@ TEST_F(AuxParallelGrowingHTGTest, testHTCustodianConstructor) {
 
     MockupData mockup_data = generateMockupData();
 
-    auto handle_a = phm_a.make_handle();
-    auto handle_b = phm_b.make_handle();
+    auto handle_a = phm_a.makeHandle();
+    auto handle_b = phm_b.makeHandle();
 
     ASSERT_TRUE(handle_a->insert(mockup_data[0].first, mockup_data[0].second));
     ASSERT_TRUE(handle_b->insert(mockup_data[1].first, mockup_data[1].second));
 
     swap(phm_a, phm_b);
 
-    auto handle_a_new = phm_a.make_handle();
-    auto handle_b_new = phm_b.make_handle();
+    auto handle_a_new = phm_a.makeHandle();
+    auto handle_b_new = phm_b.makeHandle();
 
     ASSERT_TRUE(handle_a_new->find(mockup_data[1].first) == mockup_data[1].second);
     ASSERT_TRUE(handle_b_new->find(mockup_data[0].first) == mockup_data[0].second);
@@ -741,15 +741,15 @@ TEST_F(AuxParallelGrowingHTGTest, testHTCustodianCopyConstructor) {
     Aux::ParallelHashMap phm_a;
     auto mockup_data = generateMockupData();
 
-    auto handle_a = phm_a.make_handle();
+    auto handle_a = phm_a.makeHandle();
 
-    bool all_inserted_successful = insert_data(*handle_a.get(), mockup_data);
+    bool all_inserted_successful = insertData(*handle_a.get(), mockup_data);
 
     ASSERT_TRUE(checkEntriesForMockupData(mockup_data, handle_a->hashtable()));
 
     Aux::ParallelHashMap phm_b(phm_a);
 
-    auto handle_b = phm_b.make_handle();
+    auto handle_b = phm_b.makeHandle();
 
     ASSERT_TRUE(checkEntriesForMockupData(mockup_data, handle_b->hashtable()));
 }
@@ -759,13 +759,13 @@ TEST_F(AuxParallelGrowingHTGTest, testHTCustodianMoveConstructor) {
     Aux::ParallelHashMap phm_a;
     auto mockup_data = generateMockupData();
 
-    auto handle_a = phm_a.make_handle();
+    auto handle_a = phm_a.makeHandle();
 
-    bool all_inserted_successful = insert_data(*handle_a.get(), mockup_data);
+    bool all_inserted_successful = insertData(*handle_a.get(), mockup_data);
 
     Aux::ParallelHashMap phm_b(std::move(phm_a));
 
-    auto handle_b = phm_b.make_handle();
+    auto handle_b = phm_b.makeHandle();
 
     ASSERT_TRUE(checkEntriesForMockupData(mockup_data, handle_b->hashtable()));
 }
@@ -774,14 +774,14 @@ TEST_F(AuxParallelGrowingHTGTest, testHTCustodianCopyAssignment) {
     Aux::ParallelHashMap phm_a;
     auto mockup_data = generateMockupData();
 
-    auto handle_a = phm_a.make_handle();
+    auto handle_a = phm_a.makeHandle();
 
-    bool all_inserted_successful = insert_data(*handle_a.get(), mockup_data);
+    bool all_inserted_successful = insertData(*handle_a.get(), mockup_data);
 
     Aux::ParallelHashMap phm_b;
     phm_b = phm_a;
 
-    auto handle_b = phm_b.make_handle();
+    auto handle_b = phm_b.makeHandle();
 
     ASSERT_TRUE(checkEntriesForMockupData(mockup_data, handle_b->hashtable()));
 }
@@ -796,13 +796,13 @@ TEST_F(AuxParallelGrowingHTGTest, testHTCustodianSingleThread) {
 
 #pragma omp parallel num_threads(1) shared(phm)
     {
-        auto handle = phm.make_handle();
+        auto handle = phm.makeHandle();
         for (auto it = std::cbegin(mockup_data); it != std::cend(mockup_data); ++it) {
             handle->insert(it->first, it->second);
         }
     }
 
-    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, *phm.current_table()));
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, *phm.currentTable()));
 }
 
 TEST_F(AuxParallelGrowingHTGTest, testHTCustodianDualThread) {
@@ -817,7 +817,7 @@ TEST_F(AuxParallelGrowingHTGTest, testHTCustodianDualThread) {
 #pragma omp parallel num_threads(2) shared(phm, mockup_data)
     {
         uint32_t const thread_id = omp_get_thread_num();
-        auto handle = phm.make_handle();
+        auto handle = phm.makeHandle();
 
         auto local_begin = std::cbegin(mockup_data);
         size_t const elements_per_thread = mockup_data.size() / 2;
@@ -841,7 +841,7 @@ TEST_F(AuxParallelGrowingHTGTest, testHTCustodianDualThread) {
 
     ASSERT_TRUE(successful_inserts[0]);
     ASSERT_TRUE(successful_inserts[1]);
-    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, *phm.current_table()));
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, *phm.currentTable()));
 }
 
 TEST_F(AuxParallelGrowingHTGTest, testHTCustodianQuadrupleThread) {
@@ -856,7 +856,7 @@ TEST_F(AuxParallelGrowingHTGTest, testHTCustodianQuadrupleThread) {
 #pragma omp parallel num_threads(4) shared(phm, mockup_data)
     {
         uint32_t const thread_id = omp_get_thread_num();
-        auto handle = phm.make_handle();
+        auto handle = phm.makeHandle();
 
         auto local_begin = std::cbegin(mockup_data);
         size_t const elements_per_thread = mockup_data.size() / 4;
@@ -882,7 +882,7 @@ TEST_F(AuxParallelGrowingHTGTest, testHTCustodianQuadrupleThread) {
     ASSERT_TRUE(successful_inserts[1]);
     ASSERT_TRUE(successful_inserts[2]);
     ASSERT_TRUE(successful_inserts[3]);
-    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, *phm.current_table()));
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, *phm.currentTable()));
 }
 
 } // namespace NetworKit

--- a/networkit/cpp/auxiliary/test/AuxParallelHashMapGTest.cpp
+++ b/networkit/cpp/auxiliary/test/AuxParallelHashMapGTest.cpp
@@ -1,0 +1,888 @@
+/*
+ * AuxGTest.cpp
+ *
+ *  Created on: 20.05.2025
+ *      Author: Fabian Brandt-Tumescheit
+ *              Florian Willich
+ */
+
+#include <gtest/gtest.h>
+
+#include <networkit/Globals.hpp>
+#include <networkit/auxiliary/AtomicUtils.hpp>
+#include <networkit/auxiliary/ParallelHashMap.hpp>
+#include <networkit/auxiliary/Parallelism.hpp>
+#include <networkit/auxiliary/Random.hpp>
+
+namespace NetworKit {
+
+using MockupData = std::vector<std::pair<node, size_t>>;
+using HTAtomic128 = Aux::ParallelHashMap::HTAtomic128;
+using HTHandle = Aux::ParallelHashMap::HTHandle;
+using HTSyncData = Aux::ParallelHashMap::HTSyncData;
+
+class AuxParallelGrowingHTGTest : public testing::Test {
+
+public:
+    bool get_and_check_all(std::vector<node> const &mockup_data, HTAtomic128 &ht) {
+        size_t idx = 0;
+        bool all_good = true;
+        for (size_t i = 0; i < mockup_data.size() && all_good; ++i) {
+            idx = ht.find(mockup_data[i]);
+
+            all_good = idx < mockup_data.size();
+            all_good = all_good && mockup_data[idx] == mockup_data[i];
+        }
+
+        return all_good;
+    }
+
+    MockupData generateMockupData(size_t const fill_64bit_values = 148) {
+        MockupData mockup_data;
+
+        constexpr node minimum_of_range = 1;
+        constexpr node maximum_of_range = 356;
+        auto &prng = Aux::Random::getURNG();
+        std::uniform_int_distribution<uint64_t> distr{minimum_of_range, maximum_of_range};
+
+        node u = 0;
+        for (size_t i = 0; i < fill_64bit_values; ++i) {
+            u += distr(prng);
+            mockup_data.push_back(std::make_pair(u, i));
+        }
+
+        return mockup_data;
+    }
+
+    bool checkEntriesForMockupData(MockupData const &mockup_data, HTAtomic128 const &ht) {
+        bool all_good = true;
+        for (size_t i = 0; i < mockup_data.size() && all_good; ++i) {
+            size_t const retrieved_idx = ht.find(mockup_data[i].first);
+
+            all_good = retrieved_idx < mockup_data.size();
+            all_good = all_good && retrieved_idx == mockup_data[i].second;
+        }
+        return all_good;
+    }
+
+    bool insert_data(HTAtomic128 &ht, MockupData const &data) {
+        bool all_inserted_successful = true;
+        for (size_t i = 0; i < data.size(); ++i) {
+            all_inserted_successful = ht.insert(data[i].first, data[i].second);
+            if (!all_inserted_successful) {
+                break;
+            }
+        }
+        return all_inserted_successful;
+    }
+
+    bool insert_data(HTHandle &handle, MockupData const &data) {
+        bool all_inserted_successful = true;
+        for (size_t i = 0; i < data.size() && all_inserted_successful; ++i) {
+            all_inserted_successful = handle.insert(data[i].first, data[i].second);
+        }
+        return all_inserted_successful;
+    }
+};
+
+TEST_F(AuxParallelGrowingHTGTest, testHashUtilsfastMod) {
+    uint32_t idx = 8;
+    size_t capacity = 16;
+
+    uint32_t idx_wrapped = Aux::fast_mod(idx, capacity);
+
+    ASSERT_EQ(idx_wrapped, idx);
+
+    idx = 13;
+    idx_wrapped = Aux::fast_mod(idx, capacity);
+
+    ASSERT_EQ(idx_wrapped, idx);
+
+    idx = 17;
+    idx_wrapped = Aux::fast_mod(idx, capacity);
+
+    ASSERT_EQ(idx_wrapped, 1);
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128Capacity) {
+    MockupData const mockup_data = generateMockupData(125000);
+
+    HTAtomic128 ht{131072};
+
+    for (size_t i = 0; i < mockup_data.size(); ++i) {
+        ht.insert(mockup_data[i].first, mockup_data[i].second);
+    }
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128Empty) {
+    HTAtomic128 ht{Aux::ParallelHashMap::ht_begin_capacity};
+
+    ASSERT_EQ(ht.find(0), Aux::ParallelHashMap::ht_invalid_value);
+    ASSERT_EQ(ht.find(155), Aux::ParallelHashMap::ht_invalid_value);
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128Constructor) {
+    std::vector<node> mockupData;
+    constexpr size_t fill_value_with_64bit_values = 148;
+    constexpr node vertex_offset_from_index = 25;
+
+    for (size_t i = 0; i < fill_value_with_64bit_values; ++i) {
+        mockupData.push_back(i + vertex_offset_from_index);
+    }
+
+    HTAtomic128 ht{Aux::ParallelHashMap::ht_begin_capacity};
+
+    for (size_t i = 0; i < mockupData.size(); ++i) {
+        ht.insert(mockupData[i], i);
+    }
+
+    ASSERT_TRUE(get_and_check_all(mockupData, ht));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128CopyConstructor) {
+    std::vector<node> mockupData;
+    constexpr size_t fill_value_with_64bit_values = 148;
+    constexpr node vertex_offset_from_index = 25;
+
+    for (size_t i = 0; i < fill_value_with_64bit_values; ++i) {
+        mockupData.push_back(i + vertex_offset_from_index);
+    }
+
+    HTAtomic128 ht{Aux::ParallelHashMap::ht_begin_capacity};
+
+    for (size_t i = 0; i < mockupData.size(); ++i) {
+        ht.insert(mockupData[i], i);
+    }
+
+    HTAtomic128 dvh_copy(ht);
+
+    ASSERT_TRUE(get_and_check_all(mockupData, dvh_copy));
+    ASSERT_TRUE(get_and_check_all(mockupData, ht));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128MoveConstructor) {
+    std::vector<node> mockupData;
+    constexpr size_t fill_value_with_64bit_values = 148;
+    constexpr node vertex_offset_from_index = 25;
+
+    for (size_t i = 0; i < fill_value_with_64bit_values; ++i) {
+        mockupData.push_back(i + vertex_offset_from_index);
+    }
+
+    HTAtomic128 ht{Aux::ParallelHashMap::ht_begin_capacity};
+
+    for (size_t i = 0; i < mockupData.size(); ++i) {
+        ht.insert(mockupData[i], i);
+    }
+
+    HTAtomic128 dvh_moved(std::move(ht));
+
+    ASSERT_TRUE(get_and_check_all(mockupData, dvh_moved));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128Swap) {
+    std::vector<node> mockupData;
+    constexpr size_t fill_value_with_64bit_values = 148;
+    constexpr node vertex_offset_from_index = 25;
+
+    for (size_t i = 0; i < fill_value_with_64bit_values; ++i) {
+        mockupData.push_back(i + vertex_offset_from_index);
+    }
+
+    HTAtomic128 ht{Aux::ParallelHashMap::ht_begin_capacity};
+
+    for (size_t i = 0; i < mockupData.size(); ++i) {
+        ht.insert(mockupData[i], i);
+    }
+
+    std::vector<node> mockupDataB;
+    constexpr size_t fill_value_with_64bit_values_b = 54;
+    constexpr node vertex_offset_from_index_b = 26;
+
+    for (size_t i = 0; i < fill_value_with_64bit_values_b; ++i) {
+        mockupDataB.push_back(i + vertex_offset_from_index_b);
+    }
+
+    HTAtomic128 ht_b{Aux::ParallelHashMap::ht_begin_capacity};
+
+    for (size_t i = 0; i < mockupDataB.size(); ++i) {
+        ht_b.insert(mockupDataB[i], i);
+    }
+
+    ht_b.increment_global_occupancy(mockupDataB.size());
+
+    swap(ht, ht_b);
+
+    ASSERT_TRUE(get_and_check_all(mockupDataB, ht));
+    ASSERT_TRUE(get_and_check_all(mockupData, ht_b));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128CopyAssignment) {
+    std::vector<node> mockupData;
+    constexpr size_t fill_value_with_64bit_values = 148;
+    constexpr node vertex_offset_from_index = 25;
+
+    for (size_t i = 0; i < fill_value_with_64bit_values; ++i) {
+        mockupData.push_back(i + vertex_offset_from_index);
+    }
+
+    HTAtomic128 ht{Aux::ParallelHashMap::ht_begin_capacity};
+
+    for (size_t i = 0; i < mockupData.size(); ++i) {
+        ht.insert(mockupData[i], i);
+    }
+    HTAtomic128 ht_b{Aux::ParallelHashMap::ht_begin_capacity};
+    ht_b = ht;
+
+    ASSERT_TRUE(get_and_check_all(mockupData, ht_b));
+    ASSERT_TRUE(get_and_check_all(mockupData, ht));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128InputIterator) {
+    MockupData const mockup_data = generateMockupData();
+
+    HTAtomic128 ht{Aux::ParallelHashMap::ht_begin_capacity};
+    bool all_inserted_successful = true;
+    for (size_t i = 0; i < mockup_data.size() && all_inserted_successful; ++i) {
+        all_inserted_successful = ht.insert(mockup_data[i].first, mockup_data[i].second);
+    }
+
+    ASSERT_TRUE(all_inserted_successful);
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht));
+
+    // Begin and End Iterator
+    HTAtomic128::Iterator it = ht.begin();
+    HTAtomic128::Iterator it_end = ht.end();
+
+    ASSERT_TRUE(it != it_end);
+
+    auto it_2 = ht.begin();
+
+    ASSERT_TRUE(it == it_2);
+
+    auto it_end_2 = ht.end();
+
+    ASSERT_TRUE(it_end == it_end_2);
+
+    it.invalidate();
+
+    ASSERT_TRUE(it == it_end);
+
+    // Manual check
+    it = ht.begin();
+    size_t iterated_elements = 0;
+
+    bool all_valid = true;
+    bool not_end = true;
+    while (iterated_elements < mockup_data.size() && all_valid && not_end) {
+        all_valid = it->key != Aux::ParallelHashMap::ht_invalid_key;
+        not_end = it != ht.end();
+        it++;
+        iterated_elements++;
+    }
+
+    ASSERT_TRUE(all_valid);
+    ASSERT_TRUE(not_end);
+    ASSERT_EQ(iterated_elements, mockup_data.size());
+
+    it++;
+    ASSERT_TRUE(it == ht.end());
+
+    // Iterate
+    bool keys_are_correct = true;
+    bool values_are_correct = true;
+    size_t elements_iterated = 0;
+
+    bool it_not_end = true;
+    for (auto it = ht.begin(); it != ht.end() && keys_are_correct && values_are_correct; ++it) {
+        keys_are_correct = it->key == mockup_data[it->value].first;
+        values_are_correct = it->value == mockup_data[it->value].second;
+        it_not_end = it != ht.end();
+        elements_iterated++;
+    }
+
+    ASSERT_TRUE(it_not_end);
+    ASSERT_TRUE(keys_are_correct);
+    ASSERT_TRUE(values_are_correct);
+    ASSERT_EQ(elements_iterated, mockup_data.size());
+
+    // For
+    elements_iterated = 0;
+
+    keys_are_correct = true;
+    values_are_correct = true;
+    for (auto c : ht) {
+        keys_are_correct = keys_are_correct && (c.key == mockup_data[c.value].first);
+        values_are_correct = values_are_correct && (c.value == mockup_data[c.value].second);
+        elements_iterated++;
+    }
+
+    ASSERT_TRUE(keys_are_correct);
+    ASSERT_TRUE(values_are_correct);
+    ASSERT_TRUE(elements_iterated == mockup_data.size());
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128ConcurrentAccess) {
+    Aux::setNumberOfThreads(2);
+
+    constexpr size_t one_megabyte_filled_with_64bit_values = 125000;
+
+    auto mockup_data = generateMockupData(one_megabyte_filled_with_64bit_values);
+
+    constexpr size_t begin_capacity = 131072;
+    HTAtomic128 ht{begin_capacity};
+
+#pragma omp parallel for
+    for (auto e : mockup_data) {
+        ht.insert(e.first, e.second);
+    }
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128ConcurrentAccessWithRandomWrites) {
+    Aux::setNumberOfThreads(2);
+
+    HTAtomic128 ht_r;
+
+#pragma omp parallel
+    {
+        int thread_id = omp_get_thread_num();
+
+        if (thread_id == 0) {
+            ht_r.insert(0, 0);
+            ht_r.insert(1, 0);
+        }
+
+        if (thread_id == 1) {
+            ht_r.insert(0, 1);
+            ht_r.insert(1, 1);
+        }
+    }
+
+    node zero = ht_r.find(0);
+    ASSERT_TRUE((zero == 0 || zero == 1));
+    node one = ht_r.find(1);
+    ASSERT_TRUE((one == 0 || one == 1));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128ConcurrentAccessWithBarrier) {
+    Aux::setNumberOfThreads(2);
+
+    HTAtomic128 ht_l;
+    uint64_t foundZero = 0;
+    uint64_t foundOne = 0;
+
+#pragma omp parallel
+    {
+        int thread_id = omp_get_thread_num();
+
+        if (thread_id == 0) {
+            ht_l.insert(0, 0);
+            ht_l.insert(1, 0);
+        }
+
+#pragma omp barrier
+        if (thread_id == 1) {
+            foundZero = ht_l.find(0);
+            foundOne = ht_l.find(1);
+        }
+    }
+
+    ASSERT_EQ(foundZero, 0);
+    ASSERT_EQ(foundOne, 0);
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128ConcurrentAccessWithUpdate) {
+    Aux::setNumberOfThreads(2);
+
+    HTAtomic128 ht_u;
+
+    ht_u.insert(0, 0);
+    ht_u.insert(1, 0);
+
+#pragma omp parallel
+    {
+        int thread_id = omp_get_thread_num();
+
+        if (thread_id == 0) {
+            ht_u.update(0, 2);
+        } else {
+            ht_u.update(0, 3);
+        }
+    }
+
+    uint64_t const updated_value = ht_u.find(0);
+
+    ASSERT_TRUE((updated_value == 2 || updated_value == 3));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128InsertDualThread) {
+    Aux::setNumberOfThreads(2);
+
+    constexpr size_t fill_64bit_values = 10254;
+    MockupData mockup_data = generateMockupData(fill_64bit_values);
+
+    constexpr size_t begin_capacity = 16384u;
+    HTAtomic128 ht_first{begin_capacity};
+
+    bool all_inserted_successful = true;
+#pragma omp parallel
+    for (size_t i = 0; i < mockup_data.size() && all_inserted_successful; ++i) {
+        all_inserted_successful = ht_first.insert(mockup_data[i].first, mockup_data[i].second);
+    }
+
+    ASSERT_TRUE(all_inserted_successful);
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht_first));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128ClusterRangeSingleThread) {
+    constexpr size_t fill_64bit_values = 345;
+    MockupData mockup_data = generateMockupData(fill_64bit_values);
+
+    constexpr size_t begin_capacity = 512;
+    HTAtomic128 source{begin_capacity};
+
+    bool all_inserted_successful = true;
+    for (size_t i = 0; i < mockup_data.size() && all_inserted_successful; ++i) {
+        all_inserted_successful = source.insert(mockup_data[i].first, mockup_data[i].second);
+    }
+    ASSERT_TRUE(all_inserted_successful);
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, source));
+
+    auto const cells_begin = std::cbegin(source.cells());
+    auto const cells_end = std::cend(source.cells());
+
+    auto c_range = source.cluster_range();
+    ASSERT_EQ(c_range.first, cells_begin);
+    ASSERT_EQ(c_range.second, cells_end);
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128ClusterRangeDualThread) {
+    constexpr size_t fill_64bit_values = 345;
+    MockupData mockup_data = generateMockupData(fill_64bit_values);
+
+    constexpr size_t begin_capacity = 512;
+    HTAtomic128 source{begin_capacity};
+
+    bool all_inserted_successful = true;
+    for (size_t i = 0; i < mockup_data.size() && all_inserted_successful; ++i) {
+        all_inserted_successful = source.insert(mockup_data[i].first, mockup_data[i].second);
+    }
+    ASSERT_TRUE(all_inserted_successful);
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, source));
+
+    auto const cells_begin = std::cbegin(source.cells());
+    auto const cells_end = std::cend(source.cells());
+
+    auto c_range_t0 = source.cluster_range(2, 0);
+    ASSERT_EQ(c_range_t0.first, cells_begin);
+    ASSERT_TRUE(c_range_t0.second != cells_end);
+
+    auto c_range_t1 = source.cluster_range(2, 1);
+    ASSERT_TRUE(c_range_t1.first != cells_begin);
+    ASSERT_EQ(c_range_t1.second, cells_end);
+
+    ASSERT_EQ(c_range_t0.second, c_range_t1.first);
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128ClusterRangeQuadrupleThread) {
+    constexpr size_t fill_64bit_values = 345;
+    MockupData mockup_data = generateMockupData(fill_64bit_values);
+
+    constexpr size_t begin_capacity = 512;
+    HTAtomic128 source{begin_capacity};
+
+    bool all_inserted_successful = true;
+    for (size_t i = 0; i < mockup_data.size() && all_inserted_successful; ++i) {
+        all_inserted_successful = source.insert(mockup_data[i].first, mockup_data[i].second);
+    }
+    ASSERT_TRUE(all_inserted_successful);
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, source));
+
+    auto const cells_begin = std::cbegin(source.cells());
+    auto const cells_end = std::cend(source.cells());
+
+    uint32_t const thread_count = 4;
+
+    auto c_range_t0 = source.cluster_range(thread_count, 0);
+    ASSERT_EQ(c_range_t0.first, cells_begin);
+    ASSERT_TRUE(c_range_t0.second != cells_end);
+
+    auto c_range_t1 = source.cluster_range(thread_count, 1);
+    ASSERT_TRUE(c_range_t1.first != cells_begin);
+    ASSERT_TRUE(c_range_t1.second != cells_end);
+    ASSERT_EQ(c_range_t0.second, c_range_t1.first);
+
+    auto c_range_t2 = source.cluster_range(thread_count, 2);
+    ASSERT_TRUE(c_range_t2.first != cells_begin);
+    ASSERT_TRUE(c_range_t2.second != cells_end);
+    ASSERT_EQ(c_range_t1.second, c_range_t2.first);
+
+    auto c_range_t3 = source.cluster_range(thread_count, 3);
+    ASSERT_TRUE(c_range_t3.first != cells_begin);
+    ASSERT_EQ(c_range_t3.second, cells_end);
+    ASSERT_EQ(c_range_t2.second, c_range_t3.first);
+}
+
+GTEST_TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128RoamingSequential) {
+    constexpr size_t fill_64bit_values = 23;
+    MockupData mockup_data = generateMockupData(fill_64bit_values);
+
+    constexpr size_t begin_capacity = 32;
+    HTAtomic128 ht_first{begin_capacity};
+
+    bool all_inserted_successful = true;
+    for (size_t i = 0; i < mockup_data.size() && all_inserted_successful; ++i) {
+        all_inserted_successful = ht_first.insert(mockup_data[i].first, mockup_data[i].second);
+    }
+
+    ASSERT_TRUE(all_inserted_successful);
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht_first));
+
+    constexpr size_t next_capacity = begin_capacity << 1;
+    HTAtomic128 ht_second{next_capacity};
+
+    ht_first.roam(ht_second);
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht_second));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128RoamingDualThread) {
+    Aux::setNumberOfThreads(2);
+
+    constexpr size_t fill_64bit_values = 23;
+    MockupData mockup_data = generateMockupData(fill_64bit_values);
+
+    constexpr size_t begin_capacity = 32;
+    HTAtomic128 ht_first{begin_capacity};
+
+    bool all_inserted_successful = insert_data(ht_first, mockup_data);
+
+    ASSERT_TRUE(all_inserted_successful);
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht_first));
+
+    constexpr size_t next_capacity = begin_capacity << 1;
+    HTAtomic128 ht_second{next_capacity};
+
+#pragma omp parallel
+    { ht_first.roam(ht_second, 2, omp_get_thread_num()); }
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht_second));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128BigRoaming) {
+    Aux::setNumberOfThreads(4);
+
+    constexpr size_t fill_64bit_values = 10254;
+    MockupData mockup_data = generateMockupData(fill_64bit_values);
+
+    constexpr size_t begin_capacity = 16384u; //
+    HTAtomic128 ht_first{begin_capacity};
+
+    bool all_inserted_successful = insert_data(ht_first, mockup_data);
+
+    ASSERT_TRUE(all_inserted_successful);
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht_first));
+
+    constexpr size_t next_capacity = begin_capacity << 1;
+    HTAtomic128 ht_second{next_capacity};
+
+#pragma omp parallel
+    { ht_first.roam(ht_second, 4, omp_get_thread_num()); }
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht_second));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128HTHandleHTRoamingSingleThread) {
+    MockupData const mockup_data = generateMockupData();
+    std::mt19937 generator;
+
+    Aux::setNumberOfThreads(1);
+
+    std::unique_ptr<HTAtomic128> source =
+        std::make_unique<HTAtomic128>(Aux::ParallelHashMap::ht_begin_capacity);
+    std::unique_ptr<HTAtomic128> target;
+
+    std::atomic_uint32_t busy_bitset{0u};
+    std::atomic_bool request_growth{false};
+
+    HTSyncData sync_data{
+        source, target, busy_bitset, request_growth, 1, Aux::getCurrentNumberOfThreads(), 2};
+    HTHandle handle{sync_data};
+
+    bool const all_inserted_successful = insert_data(handle, mockup_data);
+
+    ASSERT_TRUE(all_inserted_successful);
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, handle.hashtable()));
+
+    ASSERT_EQ(handle.hashtable().global_occupancy(), mockup_data.size());
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128HTHandleHTRoamingDualThread) {
+    MockupData const mockup_data = generateMockupData();
+    std::mt19937 generator;
+
+    Aux::setNumberOfThreads(2);
+
+    std::unique_ptr<HTAtomic128> source =
+        std::make_unique<HTAtomic128>(Aux::ParallelHashMap::ht_begin_capacity);
+    std::unique_ptr<HTAtomic128> target;
+
+    std::atomic_uint32_t busy_bitset{0u};
+    std::atomic_bool request_growth{false};
+    std::vector<bool> successful_inserts({true, true});
+#pragma omp parallel
+    {
+        int const thread_id = omp_get_thread_num();
+        HTSyncData sync_data{
+            source,    target, busy_bitset, request_growth, Aux::getCurrentNumberOfThreads(),
+            thread_id, 2};
+        HTHandle handle{sync_data};
+
+        auto mockup_data_begin = std::begin(mockup_data);
+        std::advance(mockup_data_begin, thread_id == 0 ? 0 : mockup_data.size() / 2);
+
+        auto mockup_data_end = std::begin(mockup_data);
+        std::advance(mockup_data_end, thread_id == 0 ? mockup_data.size() / 2 : mockup_data.size());
+
+        for (auto it = mockup_data_begin; it != mockup_data_end; ++it) {
+            successful_inserts[thread_id] =
+                successful_inserts[thread_id] && handle.insert(it->first, it->second);
+        }
+    }
+    ASSERT_TRUE(successful_inserts[0]);
+    ASSERT_TRUE(successful_inserts[1]);
+
+    HTAtomic128 &ht = *source.get();
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht));
+
+    ASSERT_EQ(ht.global_occupancy(), mockup_data.size());
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTAtomic128HTHandleHTRoamingDualThreadRoaming) {
+    MockupData const mockup_data = generateMockupData();
+    std::mt19937 generator;
+
+    Aux::setNumberOfThreads(2);
+
+    std::unique_ptr<HTAtomic128> source = std::make_unique<HTAtomic128>(32u);
+    std::unique_ptr<HTAtomic128> target;
+
+    size_t const mockup_data_share = mockup_data.size() / 2;
+
+    std::atomic_uint32_t busy_bitset{0u};
+    std::atomic_bool request_growth{false};
+    std::vector<bool> successful_inserts({true, true});
+
+#pragma omp parallel
+    {
+        int const thread_id = omp_get_thread_num();
+        HTSyncData sync_data{source, target, busy_bitset, request_growth, 2, thread_id, 2};
+        HTHandle handle{sync_data};
+
+        auto begin = std::begin(mockup_data);
+        std::advance(begin, mockup_data_share * thread_id);
+
+        auto end = begin;
+
+        if (thread_id == 1) {
+            end = std::end(mockup_data);
+        } else {
+            std::advance(end, mockup_data_share);
+        }
+
+        bool all_inserted_successful = true;
+        for (auto it = begin; it != end; it++) {
+            successful_inserts[thread_id] =
+                successful_inserts[thread_id] && handle.insert(it->first, it->second);
+        }
+    }
+    ASSERT_TRUE(successful_inserts[0]);
+    ASSERT_TRUE(successful_inserts[1]);
+
+    HTAtomic128 &ht_2 = *source.get();
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, ht_2));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTCustodianConstructor) {
+    Aux::setNumberOfThreads(1);
+
+    // Swap
+
+    Aux::ParallelHashMap phm_a{32};
+    Aux::ParallelHashMap phm_b{32};
+
+    MockupData mockup_data = generateMockupData();
+
+    auto handle_a = phm_a.make_handle();
+    auto handle_b = phm_b.make_handle();
+
+    ASSERT_TRUE(handle_a->insert(mockup_data[0].first, mockup_data[0].second));
+    ASSERT_TRUE(handle_b->insert(mockup_data[1].first, mockup_data[1].second));
+
+    swap(phm_a, phm_b);
+
+    auto handle_a_new = phm_a.make_handle();
+    auto handle_b_new = phm_b.make_handle();
+
+    ASSERT_TRUE(handle_a_new->find(mockup_data[1].first) == mockup_data[1].second);
+    ASSERT_TRUE(handle_b_new->find(mockup_data[0].first) == mockup_data[0].second);
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTCustodianCopyConstructor) {
+    Aux::ParallelHashMap phm_a;
+    auto mockup_data = generateMockupData();
+
+    auto handle_a = phm_a.make_handle();
+
+    bool all_inserted_successful = insert_data(*handle_a.get(), mockup_data);
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, handle_a->hashtable()));
+
+    Aux::ParallelHashMap phm_b(phm_a);
+
+    auto handle_b = phm_b.make_handle();
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, handle_b->hashtable()));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTCustodianMoveConstructor) {
+
+    Aux::ParallelHashMap phm_a;
+    auto mockup_data = generateMockupData();
+
+    auto handle_a = phm_a.make_handle();
+
+    bool all_inserted_successful = insert_data(*handle_a.get(), mockup_data);
+
+    Aux::ParallelHashMap phm_b(std::move(phm_a));
+
+    auto handle_b = phm_b.make_handle();
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, handle_b->hashtable()));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTCustodianCopyAssignment) {
+    Aux::ParallelHashMap phm_a;
+    auto mockup_data = generateMockupData();
+
+    auto handle_a = phm_a.make_handle();
+
+    bool all_inserted_successful = insert_data(*handle_a.get(), mockup_data);
+
+    Aux::ParallelHashMap phm_b;
+    phm_b = phm_a;
+
+    auto handle_b = phm_b.make_handle();
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, handle_b->hashtable()));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTCustodianSingleThread) {
+    Aux::setNumberOfThreads(1);
+
+    Aux::ParallelHashMap phm{32};
+
+    constexpr size_t fill_64bit_values = 10254;
+    MockupData mockup_data = generateMockupData(fill_64bit_values);
+
+#pragma omp parallel num_threads(1) shared(phm)
+    {
+        auto handle = phm.make_handle();
+        for (auto it = std::cbegin(mockup_data); it != std::cend(mockup_data); ++it) {
+            handle->insert(it->first, it->second);
+        }
+    }
+
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, *phm.current_table()));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTCustodianDualThread) {
+    Aux::setNumberOfThreads(2);
+
+    Aux::ParallelHashMap phm{32};
+
+    constexpr size_t fill_64bit_values = 10254;
+    MockupData mockup_data = generateMockupData(fill_64bit_values);
+    std::vector<bool> successful_inserts({true, true});
+
+#pragma omp parallel num_threads(2) shared(phm, mockup_data)
+    {
+        uint32_t const thread_id = omp_get_thread_num();
+        auto handle = phm.make_handle();
+
+        auto local_begin = std::cbegin(mockup_data);
+        size_t const elements_per_thread = mockup_data.size() / 2;
+
+        if (thread_id != 0) {
+            std::advance(local_begin, thread_id * elements_per_thread);
+        }
+
+        auto local_end = local_begin;
+
+        if (thread_id == 1) {
+            local_end = std::cend(mockup_data);
+        } else {
+            std::advance(local_end, (thread_id + 1) * elements_per_thread);
+        }
+
+        for (auto it = local_begin; it != local_end && successful_inserts[thread_id]; ++it) {
+            successful_inserts[thread_id] = handle->insert(it->first, it->second);
+        }
+    }
+
+    ASSERT_TRUE(successful_inserts[0]);
+    ASSERT_TRUE(successful_inserts[1]);
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, *phm.current_table()));
+}
+
+TEST_F(AuxParallelGrowingHTGTest, testHTCustodianQuadrupleThread) {
+    Aux::setNumberOfThreads(4);
+
+    Aux::ParallelHashMap phm{32};
+
+    constexpr size_t fill_64bit_values = 10254;
+    MockupData mockup_data = generateMockupData(fill_64bit_values);
+    std::vector<bool> successful_inserts({true, true, true, true});
+
+#pragma omp parallel num_threads(4) shared(phm, mockup_data)
+    {
+        uint32_t const thread_id = omp_get_thread_num();
+        auto handle = phm.make_handle();
+
+        auto local_begin = std::cbegin(mockup_data);
+        size_t const elements_per_thread = mockup_data.size() / 4;
+
+        if (thread_id != 0) {
+            std::advance(local_begin, thread_id * elements_per_thread);
+        }
+
+        auto local_end = local_begin;
+
+        if (thread_id == 3) {
+            local_end = std::cend(mockup_data);
+        } else {
+            std::advance(local_end, elements_per_thread);
+        }
+
+        for (auto it = local_begin; it != local_end; ++it) {
+            successful_inserts[thread_id] = handle->insert(it->first, it->second);
+        }
+    }
+
+    ASSERT_TRUE(successful_inserts[0]);
+    ASSERT_TRUE(successful_inserts[1]);
+    ASSERT_TRUE(successful_inserts[2]);
+    ASSERT_TRUE(successful_inserts[3]);
+    ASSERT_TRUE(checkEntriesForMockupData(mockup_data, *phm.current_table()));
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/auxiliary/test/CMakeLists.txt
+++ b/networkit/cpp/auxiliary/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 networkit_add_test(auxiliary AuxGTest)
 networkit_add_test(auxiliary SparseVectorGTest)
+networkit_add_test(auxiliary AuxParallelHashMapGTest)
 
 networkit_add_benchmark(auxiliary AuxRandomBenchmark)
 


### PR DESCRIPTION
This is a slightly converted version of the parallel hashtable as implemented by @c-bebop for `d2hb`. `ParallelHashMap` supports `insert`, `update` and `find` and supports both concurrent access and inserts/updates.

For this PR I added `dwcas` for arm64 architecture, originally the datastructure only supported `x86_64`.