### PR TITLE
Fix bugs in ParallelLeiden

### DIFF
--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -733,10 +733,6 @@ cdef class ParallelLeiden(CommunityDetector):
 	def __cinit__(self, Graph G not None, int iterations = 3, bool_t randomize = True, double gamma = 1):
 		self._G = G
 		self._this = new _ParallelLeiden(G._this,iterations,randomize,gamma)
-		from warnings import warn
-		warn("The current implementation might produce results, which do not follow the guarantees "
-		"from the Leiden algorithm. See documentation for more details: "
-		"https://networkit.github.io/dev-docs/python_api/community.html#ParallelLeiden")
 
 cdef extern from "<networkit/community/LouvainMapEquation.hpp>":
 	cdef cppclass _LouvainMapEquation "NetworKit::LouvainMapEquation"(_CommunityDetectionAlgorithm):

--- a/networkit/cpp/community/ParallelLeiden.cpp
+++ b/networkit/cpp/community/ParallelLeiden.cpp
@@ -231,7 +231,7 @@ void ParallelLeiden::parallelMove(const Graph &graph) {
                     if (0 > maxDelta) { // move node to empty community
                         singleton++;
                         bestCommunity = upperBound++;
-                        if (bestCommunity >= communityVolumes.capacity()) {
+                        if (bestCommunity >= communityVolumes.size()) {
                             // Wait until all other threads yielded, then increase vector size
                             // Chances are this will never happen. Ever. Seriously...
                             bool expected = false;

--- a/networkit/cpp/community/ParallelLeiden.cpp
+++ b/networkit/cpp/community/ParallelLeiden.cpp
@@ -26,7 +26,7 @@ void ParallelLeiden::run() {
             handler.assureRunning();
             parallelMove(*currentGraph);
             // If each community consists of exactly one node we're done, i.e. when |V(G)| = |P|
-            if (currentGraph->numberOfNodes() != result.numberOfSubsets()) {
+            if (currentGraph->numberOfNodes() == result.numberOfSubsets()) {
                 break;
             }
             handler.assureRunning();
@@ -60,6 +60,7 @@ void ParallelLeiden::calculateVolumes(const Graph &graph) {
     // Vol(G) is then 2*|E|
     communityVolumes.clear();
     communityVolumes.resize(result.upperBound() + VECTOR_OVERSIZE);
+    inverseGraphVolume = 0.0; // Reset to 0 before accumulation
     if (graph.isWeighted()) {
         std::vector<double> threadVolumes(omp_get_max_threads());
         graph.parallelForNodes([&](node a) {


### PR DESCRIPTION
- code inconsistent with the comment
- missed initialization

Also removed the warning, based on a comparison vs GVE Leiden

```
================================================================================
RESULTS SUMMARY
================================================================================
Algorithm Performance:
  leiden-communities-openmp Leiden:  9.0327s
  NetworkIt Leiden:                  9.1313s

Performance Comparison:
  leiden-communities-openmp vs NetworkIt Leiden:  1.01x

Community Detection Results:
  leiden-communities-openmp Leiden:  4504 communities, modularity 0.743539
  NetworkIt Leiden:                  2283 communities, modularity 0.788739

Quality Comparison:
  Modularity difference (LC vs NK Leiden):  0.045199
```

Related to: #1244   