### PR TITLE
New Algorithm: dynamic approx electrical closeness

### DIFF
--- a/include/networkit/centrality/ApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/ApproxElectricalCloseness.hpp
@@ -30,13 +30,13 @@ class ApproxElectricalCloseness final : public Centrality {
 public:
     /**
      * Approximates the electrical closeness of all the vertices of the graph by approximating the
-     * diagonal of the laplacian's pseudoinverse of @a G. Every element of the diagonal is
-     * guaranteed to have a maximum absolute error of @a epsilon. Based on "Approximation of the
-     * Diagonal of a Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al., ESA
-     * 2020. The algorithm does two steps: solves a linear system and samples uniform spanning trees
-     * (USTs). The parameter @a kappa balances the tolerance of solver for the linear system and the
-     * number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver converges
-     * faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
+     * diagonal of the laplacian's pseudoinverse of @a G. Every element of the diagonal has
+     * a maximum absolute error of @a epsilon with probability (1-(1/n)). Based on "Approximation of
+     * the Diagonal of a Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al.,
+     * ESA 2020. The algorithm does two steps: solves a linear system and samples uniform spanning
+     * trees (USTs). The parameter @a kappa balances the tolerance of solver for the linear system
+     * and the number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver
+     * converges faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
      *
      * @param G The input graph.
      * @param epsilon Maximum absolute error of the elements in the diagonal.

--- a/include/networkit/centrality/ApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/ApproxElectricalCloseness.hpp
@@ -88,6 +88,19 @@ private:
         VISITED
     };
 
+    struct Tree {
+        std::vector<node> parent;
+        std::vector<node> sibling;
+        std::vector<node> child;
+
+        std::vector<count> tVisit;
+        std::vector<count> tFinish;
+
+        Tree(count n) : parent(n, none), sibling(n), child(n), tVisit(n), tFinish(n) {}
+    };
+
+    std::vector<Tree> bfsTrees;
+
     // Used to mark the status of each node, one vector per thread
     std::vector<std::vector<NodeStatus>> statusGlobal;
 
@@ -95,9 +108,6 @@ private:
 
     // Nodes in each biconnected components sorted by their degree.
     std::vector<std::vector<node>> sequences;
-
-    // Pointers to the parent of the UST, one vector per thread
-    std::vector<std::vector<node>> parentGlobal;
 
     // Index of the parent component of the current component (after the topological order has been
     // determined)
@@ -115,9 +125,6 @@ private:
     // Pseudo-inverse diagonal
     std::vector<double> diagonal;
 
-    // Timestamps for DFS
-    std::vector<std::vector<count>> tVisitGlobal, tFinishGlobal;
-
     // Random number generators
     std::vector<std::mt19937_64> generators;
     std::vector<std::uniform_int_distribution<index>> degDist;
@@ -127,11 +134,7 @@ private:
 
     // Nodes sequences: Wilson's algorithm runs faster if we start the random walks following a
     // specific sequence of nodes. In this function we compute those sequences.
-    void computeNodeSequence();
-
-    // Adjacency list for trees: additional data structure to speed-up the DFS
-    std::vector<std::vector<node>> ustChildPtrGlobal;
-    std::vector<std::vector<node>> ustSiblingPtrGlobal;
+    void computeNodeSequence(node pivot = none);
 
     void computeBFSTree();
     void sampleUST();
@@ -145,9 +148,9 @@ private:
 #ifdef NETWORKIT_SANITY_CHECKS
     // Debugging methods
     void checkBFSTree() const;
-    void checkUST() const;
-    void checkTwoNodesSequence(const std::vector<node> &sequence) const;
-    void checkTimeStamps() const;
+    void checkUST(const Tree &tree) const;
+    void checkTwoNodesSequence(const std::vector<node> &sequence, std::vector<node> &parent) const;
+    void checkTimeStamps(const Tree &tree) const;
 #endif // NETWORKIT_SANITY_CHECKS
 };
 

--- a/include/networkit/centrality/ApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/ApproxElectricalCloseness.hpp
@@ -109,7 +109,7 @@ protected:
     // Used to mark the status of each node, one vector per thread
     std::vector<std::vector<NodeStatus>> statusGlobal;
 
-    std::unique_ptr<BiconnectedComponents> bccPtr;
+    BiconnectedComponents bcc;
 
     // Nodes in each biconnected components sorted by their degree.
     std::vector<std::vector<node>> sequences;

--- a/include/networkit/centrality/ApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/ApproxElectricalCloseness.hpp
@@ -47,7 +47,20 @@ public:
     ApproxElectricalCloseness(const Graph &G, double epsilon = 0.1, double kappa = 0.3);
 
     /**
-     * Constructor to set @a delta (the approximation probability) manually.
+     * Approximates the electrical closeness of all the vertices of the graph by approximating the
+     * diagonal of the laplacian's pseudoinverse of @a G. Every element of the diagonal has
+     * a maximum absolute error of @a epsilon with probability (1-(1/n)). Based on "Approximation of
+     * the Diagonal of a Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al.,
+     * ESA 2020. The algorithm does two steps: solves a linear system and samples uniform spanning
+     * trees (USTs). The parameter @a kappa balances the tolerance of solver for the linear system
+     * and the number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver
+     * converges faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
+     *
+     * @param G The input graph.
+     * @param epsilon Maximum absolute error of the elements in the diagonal.
+     * @param kappa Balances the tolerance of the solver for the linear system and the number of
+     * USTs to be sampled.
+     * @param delta approximation probability.
      */
     ApproxElectricalCloseness(const Graph &G, double epsilon, double kappa, double delta);
 
@@ -137,7 +150,7 @@ protected:
     // Topological order of the biconnected components
     std::vector<index> topOrder;
 
-    // Non-normalized approx effective resistance, one per thread.
+    // normalized approx effective resistance, one per thread.
     std::vector<std::vector<double>> approxEffResistanceGlobal;
 
     // Pseudo-inverse diagonal

--- a/include/networkit/centrality/ApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/ApproxElectricalCloseness.hpp
@@ -25,7 +25,7 @@ namespace NetworKit {
 /**
  * @ingroup centrality
  */
-class ApproxElectricalCloseness final : public Centrality {
+class ApproxElectricalCloseness : public Centrality {
 
 public:
     /**
@@ -73,7 +73,7 @@ public:
      */
     std::vector<double> computeExactDiagonal(double tol = 1e-9) const;
 
-private:
+protected:
     const double epsilon, delta, kappa;
     node root = 0;
     count rootEcc;
@@ -119,8 +119,7 @@ private:
     std::vector<index> topOrder;
 
     // Non-normalized approx effective resistance, one per thread.
-    // Values could be negative, so we use signed integers.
-    std::vector<std::vector<int64_t>> approxEffResistanceGlobal;
+    std::vector<std::vector<double>> approxEffResistanceGlobal;
 
     // Pseudo-inverse diagonal
     std::vector<double> diagonal;
@@ -139,7 +138,7 @@ private:
     void computeBFSTree();
     void sampleUST();
     void dfsUST();
-    void aggregateUST();
+    void aggregateUST(double weight = 1.0);
 
     node approxMinEccNode();
 

--- a/include/networkit/centrality/ApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/ApproxElectricalCloseness.hpp
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <networkit/algebraic/CSRMatrix.hpp>
 #include <networkit/centrality/Centrality.hpp>
 #include <networkit/components/BiconnectedComponents.hpp>
 #include <networkit/distance/Diameter.hpp>
@@ -80,8 +81,21 @@ public:
 
 protected:
     const double epsilon, delta, kappa;
+    double tol;
     node root = 0;
     count rootEcc;
+    count numberOfUSTs;
+
+    // These members are artifacts from running the algorithm. In the static algorithm, these
+    // members are cleared after running the algorithm to release memory; in the dynamic algorithm,
+    // they are kept to allow updates.
+
+    // laplacian matrix of the graph.
+    CSRMatrix laplacian;
+    // lpinv column of root
+    Vector rootCol;
+    // Resistance of node with root
+    std::vector<double> resistanceToRoot;
 
     // #of BFSs used to estimate a vertex with low eccentricity.
     static constexpr uint32_t sweeps = 10;
@@ -146,6 +160,9 @@ protected:
     void aggregateUST(double weight = 1.0);
 
     node approxMinEccNode();
+
+    void aggregateResults();
+    void solveColumnAndSampleUSTs();
 
     count computeNumberOfUSTs() const;
 

--- a/include/networkit/centrality/ApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/ApproxElectricalCloseness.hpp
@@ -45,6 +45,11 @@ public:
      */
     ApproxElectricalCloseness(const Graph &G, double epsilon = 0.1, double kappa = 0.3);
 
+    /**
+     * Constructor to set @a delta (the approximation probability) manually.
+     */
+    ApproxElectricalCloseness(const Graph &G, double epsilon, double kappa, double delta);
+
     ~ApproxElectricalCloseness() override = default;
 
     /**

--- a/include/networkit/centrality/DynApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/DynApproxElectricalCloseness.hpp
@@ -1,0 +1,201 @@
+/*
+ * DynApproxElectricalCloseness.hpp
+ *
+ *  Created on: 19.04.2023
+ *     Authors: Matthias Görg <goergmat@informatik.hu-berlin.de>
+ *              Maria Predari <predarimaria@gmail.com>
+ *              Lukas Berner <Lukas.Berner@hu-berlin.de>
+ */
+
+#ifndef NETWORKIT_CENTRALITY_DYN_APPROX_ELECTRICAL_CLOSENESS_HPP_
+#define NETWORKIT_CENTRALITY_DYN_APPROX_ELECTRICAL_CLOSENESS_HPP_
+
+#include <cmath>
+#include <memory>
+#include <random>
+#include <unordered_map>
+#include <vector>
+
+#include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/base/DynAlgorithm.hpp>
+#include <networkit/centrality/Centrality.hpp>
+#include <networkit/components/BiconnectedComponents.hpp>
+#include <networkit/distance/Diameter.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+/**
+ * @ingroup centrality
+ */
+class DynApproxElectricalCloseness final : public Centrality, public DynAlgorithm {
+
+public:
+    /**
+     * Approximates the electrical closeness of all the vertices of the graph by approximating the
+     * diagonal of the laplacian's pseudoinverse of @a G. Every element of the diagonal has
+     * a maximum absolute error of @a epsilon with probability (1-(1/n)). Based on "Approximation of
+     * the Diagonal of a Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al.,
+     * ESA 2020. The algorithm does two steps: solves a linear system and samples uniform spanning
+     * trees (USTs). The parameter @a kappa balances the tolerance of solver for the linear system
+     * and the number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver
+     * converges faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
+     *
+     * @note This dynamic algorithm supports addition of arbitrary edges and deletion of edges which
+     * are not in the bfs tree sourced from the pivot node. The algorithm depends on G having a
+     * single connected component - edge deletions which disconnect the graph are not supported.
+     * @note Batch updates are not supported.
+     *
+     * @param G The input graph.
+     * @param epsilon Maximum absolute error of the elements in the diagonal.
+     * @param kappa Balances the tolerance of the solver for the linear system and the number of
+     * @param pivot The pivot node. If none, a node with small approximate
+     * eccentricity will be chosen. USTs to be sampled.
+     */
+    DynApproxElectricalCloseness(const Graph &G, double epsilon = 0.1, double kappa = 0.3,
+                                 node pivot = none);
+
+    /**
+     * Constructor to set @a delta (the approximation probability) manually.
+     */
+    DynApproxElectricalCloseness(const Graph &G, double epsilon, double kappa, node pivot,
+                                 double delta);
+
+    /** copy constructor that copies internal data structures, but still references the same graph
+     * as @a other */
+    DynApproxElectricalCloseness(const DynApproxElectricalCloseness &other) = default;
+
+    ~DynApproxElectricalCloseness() override = default;
+
+    /**
+     * Run the algorithm.
+     */
+    void run() override;
+
+    /**
+     * update - to be called after the graph has been updated.
+     * Supports arbitrary edge additions.
+     * Supports edge deletions for edges which are not on the bfs tree of the pivot node. Removing
+     * the edge may not disconnect the graph.
+     */
+    void update(GraphEvent e) override;
+
+    /**
+     * @note batch updates are not supported.
+     */
+    void updateBatch(const std::vector<GraphEvent> &) override {
+        throw std::runtime_error("Error: batch updates are not supported.");
+    }
+
+    /**
+     * Return an epsilon-approximation of the diagonal of the laplacian's pseudoinverse.
+     *
+     * @return Approximation of the diagonal of the laplacian's pseudoinverse.
+     */
+    const std::vector<double> &getDiagonal() const {
+        assureFinished();
+        return diagonal;
+    }
+
+    inline NetworKit::count getUstCount() { return numberOfUSTs; }
+
+private:
+    const double epsilon, delta, kappa;
+    double tol;
+    count numberOfUSTs;
+    node root = 0;
+    const node pivot;
+    count rootEcc;
+    NetworKit::CSRMatrix laplacian;
+
+    // #of BFSs used to estimate a vertex with low eccentricity.
+    static constexpr uint32_t sweeps = 10;
+
+    enum class NodeStatus : unsigned char {
+        NOT_IN_COMPONENT,
+        IN_SPANNING_TREE,
+        NOT_VISITED,
+        VISITED
+    };
+
+    struct Tree {
+        std::vector<node> parent;
+        std::vector<node> sibling;
+        std::vector<node> child;
+
+        std::vector<count> tVisit;
+        std::vector<count> tFinish;
+        bool timesComputed = false;
+    };
+
+    // Used to mark the status of each node, one vector per thread
+    std::vector<std::vector<NodeStatus>> statusGlobal;
+
+    BiconnectedComponents bcc;
+
+    // Nodes in each biconnected components sorted by their degree.
+    std::vector<std::vector<node>> sequences;
+
+    // Shortest path tree
+    Tree bfsTree;
+
+    // Index of the parent component of the current component (after the topological order has been
+    // determined)
+    std::vector<index> biParent;
+    // Node within the bionnected component that points to the node in the parent component
+    std::vector<node> biAnchor;
+
+    // Topological order of the biconencted components
+    std::vector<index> topOrder;
+
+    // approx effective resistance, summed contribution per tree, one per thread.
+    std::vector<std::vector<double>> approxEffResistanceGlobal;
+
+    // Pseudo-inverse diagonal
+    std::vector<double> diagonal;
+
+    // Resistance of node with root
+    std::vector<double> resistanceToRoot;
+
+    // lpinv column of root
+    Vector rootCol;
+
+    // Least common ancestor vectors, per thread
+    std::vector<std::vector<node>> lcaGlobal;
+
+    // Random number generators
+    std::vector<std::mt19937_64> generators;
+    std::vector<std::uniform_int_distribution<index>> degDist;
+
+    // Nodes sequences: Wilson's algorithm runs faster if we start the random walks following a
+    // specific sequence of nodes. In this function we compute those sequences.
+    void computeNodeSequence();
+
+    void setDFSTimes(Tree &tree);
+
+    void computeBFSTree();
+    void sampleUST(Tree &result);
+    void sampleUSTWithEdge(Tree &result, node a, node b);
+
+    void aggregateUST(Tree &tree, double weight);
+
+    void edgeAdded(node a, node b);
+
+    void edgeRemoved(node a, node b);
+
+    node approxMinEccNode();
+
+    count computeNumberOfUSTs() const;
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    // Debugging methods
+    void checkBFSTree() const;
+    void checkUST(const Tree &tree) const;
+    void checkTwoNodesSequence(const std::vector<node> &sequence, std::vector<node> &parent) const;
+    void checkTimeStamps(const Tree &tree) const;
+#endif // NETWORKIT_SANITY_CHECKS
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_CENTRALITY_DYN_APPROX_ELECTRICAL_CLOSENESS_HPP_

--- a/include/networkit/centrality/DynApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/DynApproxElectricalCloseness.hpp
@@ -56,7 +56,26 @@ public:
                                  node pivot = none);
 
     /**
-     * Constructor to set @a delta (the approximation probability) manually.
+     * Approximates the electrical closeness of all the vertices of the graph by approximating the
+     * diagonal of the laplacian's pseudoinverse of @a G. Every element of the diagonal has
+     * a maximum absolute error of @a epsilon with probability (1-(1/n)). Based on "Approximation of
+     * the Diagonal of a Laplacian’s Pseudoinverse for Complex Network Analysis", Angriman et al.,
+     * ESA 2020. The algorithm does two steps: solves a linear system and samples uniform spanning
+     * trees (USTs). The parameter @a kappa balances the tolerance of solver for the linear system
+     * and the number of USTs to be sampled. A high value of @a kappa raises the tolerance (solver
+     * converges faster) but more USTs need to be sampled, vice versa for a low value of @a kappa.
+     *
+     * @note This dynamic algorithm supports addition of arbitrary edges and deletion of edges which
+     * are not in the bfs tree sourced from the pivot node. The algorithm depends on G having a
+     * single connected component - edge deletions which disconnect the graph are not supported.
+     * @note Batch updates are not supported.
+     *
+     * @param G The input graph.
+     * @param epsilon Maximum absolute error of the elements in the diagonal.
+     * @param kappa Balances the tolerance of the solver for the linear system and the number of
+     * @param pivot The pivot node. If none, a node with small approximate
+     * eccentricity will be chosen. USTs to be sampled.
+     * @param delta approximation probability.
      */
     DynApproxElectricalCloseness(const Graph &G, double epsilon, double kappa, node pivot,
                                  double delta);

--- a/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
@@ -480,6 +480,8 @@ void ApproxElectricalCloseness::aggregateUST(double weight) {
 }
 
 void ApproxElectricalCloseness::run() {
+    hasRun = false;
+
     // Preprocessing
     computeNodeSequence();
     computeBFSTree();

--- a/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
@@ -19,9 +19,9 @@
 
 namespace NetworKit {
 
-ApproxElectricalCloseness::ApproxElectricalCloseness(const Graph &G, double epsilon, double kappa)
-    : Centrality(G), epsilon(epsilon), delta(1.0 / static_cast<double>(G.numberOfNodes())),
-      kappa(kappa), bccPtr(new BiconnectedComponents(G)) {
+ApproxElectricalCloseness::ApproxElectricalCloseness(const Graph &G, double epsilon, double kappa,
+                                                     double delta)
+    : Centrality(G), epsilon(epsilon), delta(delta), kappa(kappa), bcc(G) {
 
     if (G.isDirected())
         throw std::runtime_error("Error: the input graph must be undirected.");
@@ -50,6 +50,9 @@ ApproxElectricalCloseness::ApproxElectricalCloseness(const Graph &G, double epsi
     G.forNodes([&](node u) { degDist.emplace_back(0, G.degree(u) - 1); });
     bfsParent.resize(n, none);
 }
+
+ApproxElectricalCloseness::ApproxElectricalCloseness(const Graph &G, double epsilon, double kappa)
+    : ApproxElectricalCloseness(G, epsilon, kappa, 1.0 / static_cast<double>(G.numberOfNodes())) {}
 
 count ApproxElectricalCloseness::computeNumberOfUSTs() const {
     return rootEcc * rootEcc

--- a/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/ApproxElectricalCloseness.cpp
@@ -121,7 +121,6 @@ void ApproxElectricalCloseness::computeNodeSequence(node pivot) {
     auto &status = statusGlobal[0];
 
     // Compute the biconnected components
-    auto &bcc = *bccPtr;
     bcc.run();
     auto components = bcc.getComponents();
 
@@ -276,7 +275,7 @@ void ApproxElectricalCloseness::sampleUST() {
         // parent component.
         auto updateParentOfAnchor = [&]() -> void {
             for (const node v : G.neighborRange(curAnchor)) {
-                const auto &vComps = bccPtr->getComponentsOfNode(v);
+                const auto &vComps = bcc.getComponentsOfNode(v);
                 if (vComps.find(biParent[componentIndex]) != vComps.end()) {
                     parent[curAnchor] = v;
                     break;

--- a/networkit/cpp/centrality/CMakeLists.txt
+++ b/networkit/cpp/centrality/CMakeLists.txt
@@ -11,6 +11,7 @@ networkit_add_module(centrality
     CoreDecomposition.cpp
     DegreeCentrality.cpp
     DynApproxBetweenness.cpp
+    DynApproxElectricalCloseness.cpp
     DynBetweenness.cpp
     DynBetweennessOneNode.cpp
     DynKatzCentrality.cpp
@@ -40,7 +41,7 @@ networkit_add_module(centrality
     SpanningEdgeCentrality.cpp
     TopCloseness.cpp
     TopHarmonicCloseness.cpp
-    )
+)
 
 networkit_module_link_modules(centrality
         algebraic

--- a/networkit/cpp/centrality/CMakeLists.txt
+++ b/networkit/cpp/centrality/CMakeLists.txt
@@ -44,16 +44,17 @@ networkit_add_module(centrality
 )
 
 networkit_module_link_modules(centrality
-        algebraic
-        auxiliary
-        components
-        distance
-        dyn_distance
-        dynamics
-        graph
-        linkprediction
-        reachability
-        structures
-    )
+    algebraic
+    auxiliary
+    components
+    distance
+    dyn_distance
+    dynamics
+    graph
+    linkprediction
+    reachability
+    structures
+    numerics
+)
 
 add_subdirectory(test)

--- a/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
@@ -25,35 +25,9 @@ namespace NetworKit {
 
 DynApproxElectricalCloseness::DynApproxElectricalCloseness(const Graph &G, double epsilon,
                                                            double kappa, node pivot, double delta)
-    : Centrality(G), epsilon(epsilon), delta(delta), kappa(kappa), pivot(pivot),
-      bcc(BiconnectedComponents(G)) {
-
-    if (G.isDirected())
-        throw std::runtime_error("Error: the input graph must be undirected.");
-
-    if (G.isWeighted())
-        throw std::runtime_error("Error: the input graph must be unweighted.");
-
-    if (G.numberOfNodes() < 2)
-        throw std::runtime_error("Error: the graph should have at leasts two vertices");
-
-    if (G.upperNodeIdBound() != G.numberOfNodes())
-        throw std::runtime_error("Error, graph is not compact. Use getCompactedGraph in GraphTools "
-                                 "before using this algorithm.");
+    : ApproxElectricalCloseness(G, epsilon, kappa, delta), pivot(pivot) {
 
     const count n = G.upperNodeIdBound(), threads = omp_get_max_threads();
-    statusGlobal.resize(threads, std::vector<NodeStatus>(n, NodeStatus::NOT_VISITED));
-    approxEffResistanceGlobal.resize(threads, std::vector<double>(n));
-    scoreData.resize(n);
-    diagonal.resize(n);
-    resistanceToRoot.resize(n);
-    generators.reserve(threads);
-    for (omp_index i = 0; i < threads; ++i)
-        generators.emplace_back(Aux::Random::getURNG());
-
-    degDist.reserve(G.upperNodeIdBound());
-    G.forNodes([&](node u) { degDist.emplace_back(0, G.degree(u) - 1); });
-
     lcaGlobal.resize(threads, std::vector<node>(n, none));
 }
 
@@ -62,393 +36,17 @@ DynApproxElectricalCloseness::DynApproxElectricalCloseness(const Graph &G, doubl
     : DynApproxElectricalCloseness(G, epsilon, kappa, pivot,
                                    1.0 / static_cast<double>(G.numberOfNodes())) {}
 
-count DynApproxElectricalCloseness::computeNumberOfUSTs() const {
-    return rootEcc * rootEcc
-           * static_cast<count>(
-               std::ceil(std::log(2.0 * static_cast<double>(G.numberOfEdges()) / delta)
-                         / (2.0 * epsilon * epsilon * (1. - kappa) * (1. - kappa))));
-}
-
-node DynApproxElectricalCloseness::approxMinEccNode() {
-    auto &status = statusGlobal[0];
-    std::vector<count> distance(G.upperNodeIdBound());
-    std::vector<count> eccLowerBound(G.upperNodeIdBound());
-
-    auto maxDegreeNode = [&]() -> node {
-        node maxDegNode = 0;
-        count maxDeg = 0;
-        G.forNodes([&](const node u) {
-            const auto degU = G.degree(u);
-            if (degU > maxDeg) {
-                maxDeg = degU;
-                maxDegNode = u;
-            }
-        });
-        return maxDegNode;
-    };
-
-    auto doBFS = [&](const node source) -> node {
-        std::queue<node> q;
-        q.push(source);
-        status[source] = NodeStatus::VISITED;
-        distance[source] = 0;
-        node farthest = 0;
-
-        do {
-            const node u = q.front();
-            q.pop();
-            eccLowerBound[u] = std::max(eccLowerBound[u], distance[u]);
-            farthest = u;
-
-            G.forNeighborsOf(u, [&](const node v) {
-                if (status[v] == NodeStatus::NOT_VISITED) {
-                    q.push(v);
-                    status[v] = NodeStatus::VISITED;
-                    distance[v] = distance[u] + 1;
-                }
-            });
-
-        } while (!q.empty());
-
-        std::fill(status.begin(), status.end(), NodeStatus::NOT_VISITED);
-        return farthest;
-    };
-
-    node source = maxDegreeNode();
-
-    for (uint32_t i = 0; i < sweeps; ++i)
-        source = doBFS(source);
-
-    // Return node with minimum ecc lower bound
-    return static_cast<node>(std::min_element(eccLowerBound.begin(), eccLowerBound.end())
-                             - eccLowerBound.begin());
-}
-
-void DynApproxElectricalCloseness::computeNodeSequence() {
-    // We use thread 0's vector
-    auto &status = statusGlobal[0];
-
-    // Compute the biconnected components
-    bcc.run();
-    auto components = bcc.getComponents();
-
-    std::queue<node> queue;
-    std::vector<node> curSequence;
-
-    for (const auto &curComponent : components) {
-        // Biconnected components with 2 vertices can be handled trivially.
-        if (curComponent.size() == 2) {
-            sequences.push_back({curComponent[0], curComponent[1]});
-            continue;
-        }
-
-        // We take the node with highest degree in the component as source
-        node source = curComponent[0];
-        for (node u : curComponent) {
-            source = G.degree(u) > G.degree(source) ? u : source;
-            status[u] = NodeStatus::VISITED;
-        }
-
-        // Start a BFS from source to determine the order of the nodes.
-        // Later, we need to re-explore the graph again, so in the beginning we mark all nodes to be
-        // visited as VISITED, and we set them as NOT_VISITED during the BFS. This avoids a call to
-        // std::fill.
-        queue.push(source);
-        status[source] = NodeStatus::NOT_VISITED;
-
-        do {
-            const node u = queue.front();
-            queue.pop();
-            curSequence.push_back(u);
-            G.forNeighborsOf(u, [&](node v) {
-                if (status[v] == NodeStatus::VISITED) {
-                    status[v] = NodeStatus::NOT_VISITED;
-                    queue.push(v);
-                }
-            });
-        } while (!queue.empty());
-
-        sequences.push_back(std::move(curSequence));
-        curSequence.clear();
-    }
-
-    // Set the root to the highest degree node within the largest biconnected component
-    if (pivot == none)
-        root = approxMinEccNode();
-    else
-        root = pivot;
-
-    biAnchor.resize(bcc.numberOfComponents(), none);
-    biParent.resize(bcc.numberOfComponents(), none);
-
-#ifdef NETWORKIT_SANITY_CHECKS
-    G.forNodes([&](node u) { assert(status[u] == NodeStatus::NOT_VISITED); });
-#endif
-
-    // Topological order of biconnected components: tree of biconnected components starting from the
-    // root's biconnected component. If the root is in multiple biconnected components, arbitrarily
-    // select one of them.
-    std::queue<std::pair<node, index>> q;
-    const auto &rootComps = bcc.getComponentsOfNode(root);
-    q.push({root, *(rootComps.begin())});
-
-    topOrder.reserve(bcc.numberOfComponents());
-    topOrder.insert(topOrder.begin(), rootComps.begin(), rootComps.end());
-
-    std::vector<count> distance(G.upperNodeIdBound());
-    status[root] = NodeStatus::VISITED;
-    rootEcc = 0;
-
-    do {
-        const auto front = q.front();
-        q.pop();
-        G.forNeighborsOf(front.first, [&](const node v) {
-            if (status[v] == NodeStatus::NOT_VISITED) {
-                distance[v] = distance[front.first] + 1;
-                rootEcc = std::max(rootEcc, distance[v]);
-                const auto &vComps = bcc.getComponentsOfNode(v);
-                for (const node vComponentIndex : vComps) {
-                    // Check if a new biconnected components has been found.
-                    if (vComponentIndex != front.second && biAnchor[vComponentIndex] == none
-                        && rootComps.find(vComponentIndex) == rootComps.end()) {
-                        // The anchor cannot be the root, because the anchor does not have a parent.
-                        // We handle biAnchor = none cases later.
-                        biAnchor[vComponentIndex] = (v == root) ? none : v;
-                        biParent[vComponentIndex] = front.second;
-                        topOrder.push_back(vComponentIndex);
-                    }
-                }
-                q.push({v, *(vComps.begin())});
-                status[v] = NodeStatus::VISITED;
-            }
-        });
-    } while (!q.empty());
-
-#ifdef NETWORKIT_SANITY_CHECKS
-    G.forNodes([&](node u) { assert(status[u] == NodeStatus::VISITED); });
-    assert(topOrder.size() == bcc.numberOfComponents());
-    assert(std::unordered_set<index>(topOrder.begin(), topOrder.end()).size()
-           == bcc.numberOfComponents());
-#endif
-}
-
-void DynApproxElectricalCloseness::computeBFSTree() {
-    // Using thread 0's vector
-    auto &status = statusGlobal[0];
-    auto n = G.numberOfNodes();
-    bfsTree.parent.resize(n);
-    bfsTree.child.resize(n);
-    bfsTree.sibling.resize(n);
-    std::fill(status.begin(), status.end(), NodeStatus::NOT_VISITED);
-    std::fill(bfsTree.parent.begin(), bfsTree.parent.end(), none);
-    std::fill(bfsTree.child.begin(), bfsTree.child.end(), none);
-    std::fill(bfsTree.sibling.begin(), bfsTree.sibling.end(), none);
-
-    std::queue<node> queue;
-    queue.push(root);
-    status[root] = NodeStatus::VISITED;
-
-    do {
-        const node currentNode = queue.front();
-        queue.pop();
-        node previous = none;
-        node first = none;
-        G.forNeighborsOf(currentNode, [&](const node v) {
-            if (status[v] == NodeStatus::NOT_VISITED) {
-                status[v] = NodeStatus::VISITED;
-                queue.push(v);
-                bfsTree.parent[v] = currentNode;
-                if (previous != none) {
-                    bfsTree.sibling[previous] = v;
-                }
-                previous = v;
-                if (first == none) {
-                    bfsTree.child[currentNode] = v;
-                    first = v;
-                }
-            }
-        });
-    } while (!queue.empty());
-
-#ifdef NETWORKIT_SANITY_CHECKS
-    checkBFSTree();
-#endif
-}
-
-void DynApproxElectricalCloseness::sampleUST(Tree &result) {
-    // Getting thread-local vectors
-    auto &status = statusGlobal[omp_get_thread_num()];
-    auto &parent = result.parent;
-    auto &childPtr = result.child;
-    auto &siblingPtr = result.sibling;
-
-    auto n = G.numberOfNodes();
-    parent.resize(n);
-    childPtr.resize(n);
-    siblingPtr.resize(n);
-    std::fill(status.begin(), status.end(), NodeStatus::NOT_IN_COMPONENT);
-    std::fill(parent.begin(), parent.end(), none);
-    std::fill(childPtr.begin(), childPtr.end(), none);
-    std::fill(siblingPtr.begin(), siblingPtr.end(), none);
-
-    auto &generator = generators[omp_get_thread_num()];
-
-    // Iterate over the biconnected components in their topological order.
-    for (const auto componentIndex : topOrder) {
-        // Current component, sorted by vertex degree.
-        const auto &sequence = sequences[componentIndex];
-        auto curAnchor = biAnchor[componentIndex];
-
-        // Finds the parent of the current anchor node i.e., the anchor's neighbor that is in the
-        // parent component.
-        auto updateParentOfAnchor = [&]() -> void {
-            for (const node v : G.neighborRange(curAnchor)) {
-                const auto &vComps = bcc.getComponentsOfNode(v);
-                if (vComps.find(biParent[componentIndex]) != vComps.end()) {
-                    parent[curAnchor] = v;
-                    break;
-                }
-            }
-            assert(parent[curAnchor] != none);
-        };
-
-        if (sequence.size() == 2) {
-            // Happens when the current component is the root component in the topological
-            // order. In this case, the root plays the anchor's role.
-            if (curAnchor == none) {
-                const node v = (sequence[0] == root) ? sequence[1] : sequence[0];
-                assert(sequence.front() == root || sequence.back() == root);
-                assert(v != root);
-                parent[v] = root;
-            } else {
-                const node v = (sequence[0] == curAnchor) ? sequence[1] : sequence[0];
-                assert(v != curAnchor);
-                assert(v != root);
-                parent[v] = curAnchor;
-                if (parent[curAnchor] == none)
-                    updateParentOfAnchor();
-            }
-#ifdef NETWORKIT_SANITY_CHECKS
-            checkTwoNodesSequence(sequence, parent);
-#endif
-            continue;
-        }
-
-        // We start building the spanning tree from the first node of the
-        // sequence.
-        // Root of the spanning tree
-        status[sequence[0]] = NodeStatus::IN_SPANNING_TREE;
-        const node curAnchorParent = (curAnchor != none) ? parent[curAnchor] : none;
-
-        // All the remaining nodes in the components need to be visited.
-        std::for_each(sequence.begin() + 1, sequence.end(),
-                      [&status](node u) { status[u] = NodeStatus::NOT_VISITED; });
-
-        count nodesInSpanningTree = 1;
-        // Iterate over the remaining nodes to create the spanning tree.
-        for (auto it = sequence.begin() + 1; it != sequence.end(); ++it) {
-            const node walkStart = *it;
-            if (status[walkStart] == NodeStatus::IN_SPANNING_TREE)
-                // Node already added to the spanning tree
-                continue;
-
-            node currentNode = walkStart;
-
-            // Start a new random walk from the current node.
-            do {
-                // Get a random neighbor within the component
-                node randomNeighbor;
-                do {
-                    randomNeighbor = G.getIthNeighbor(currentNode, degDist[currentNode](generator));
-                } while (status[randomNeighbor] == NodeStatus::NOT_IN_COMPONENT);
-
-                assert(randomNeighbor != none);
-                parent[currentNode] = randomNeighbor;
-                currentNode = randomNeighbor;
-
-            } while (status[currentNode] != NodeStatus::IN_SPANNING_TREE);
-
-            // Last node encountered in the random walk (it is in the spanning tree);
-            const node walkEnd = currentNode;
-            assert(status[walkEnd] == NodeStatus::IN_SPANNING_TREE);
-            // Add the random walk to the spanning tree; eventually, reverse the path if the
-            // anchor/root is encountered
-            for (currentNode = walkStart; currentNode != walkEnd;
-                 currentNode = parent[currentNode]) {
-
-                status[currentNode] = NodeStatus::IN_SPANNING_TREE;
-                ++nodesInSpanningTree;
-                if (currentNode == curAnchor || currentNode == root) {
-
-                    // Anchor of current component in the walk, we have to reverse the
-                    // parent pointers
-                    node next = parent[currentNode];
-                    node nextParent = none;
-                    node tmp = currentNode;
-                    do {
-                        status[next] = NodeStatus::IN_SPANNING_TREE;
-                        nextParent = parent[next];
-                        parent[next] = currentNode;
-                        currentNode = next;
-                        next = nextParent;
-                    } while (next != none);
-
-                    if (tmp == root)
-                        parent[root] = none;
-                    else if (parent[curAnchor] == none)
-                        // Not none if articulation node visited by the parent component before
-                        updateParentOfAnchor();
-                    else
-                        parent[curAnchor] = curAnchorParent;
-
-                    break;
-                }
-            }
-
-            if (nodesInSpanningTree == sequence.size())
-                break;
-        }
-
-        for (node u : sequence)
-            status[u] = NodeStatus::NOT_IN_COMPONENT;
-    }
-
-    count visitedNodes = 0;
-    for (node u : G.nodeRange()) {
-        while (status[u] == NodeStatus::NOT_IN_COMPONENT) {
-            status[u] = NodeStatus::NOT_VISITED;
-            ++visitedNodes;
-            node parentU = parent[u];
-            if (parent[u] != none) {
-                assert(siblingPtr[u] == none);
-                if (childPtr[parentU] != none)
-                    siblingPtr[u] = childPtr[parentU];
-                childPtr[parentU] = u;
-                u = parentU;
-            } else
-                break;
-        }
-        if (visitedNodes == G.numberOfNodes())
-            break;
-    }
-
-#ifdef NETWORKIT_SANITY_CHECKS
-    checkUST(result);
-#endif
-}
-
-void DynApproxElectricalCloseness::sampleUSTWithEdge(Tree &result, node a, node b) {
+void DynApproxElectricalCloseness::sampleUSTWithEdge(node a, node b) {
     auto n = G.numberOfNodes();
     assert(a < n && b < n);
 
-    auto &parent = result.parent;
-    auto &status = statusGlobal[omp_get_thread_num()];
-    auto &childPtr = result.child;
-    auto &siblingPtr = result.sibling;
+    auto &tree = bfsTrees[omp_get_thread_num()];
 
-    parent.resize(n, none);
-    childPtr.resize(n, none);
-    siblingPtr.resize(n, none);
+    auto &parent = tree.parent;
+    auto &status = statusGlobal[omp_get_thread_num()];
+    auto &childPtr = tree.child;
+    auto &siblingPtr = tree.sibling;
+
     std::fill(status.begin(), status.end(), NodeStatus::NOT_IN_COMPONENT);
     std::fill(parent.begin(), parent.end(), none);
     std::fill(childPtr.begin(), childPtr.end(), none);
@@ -530,94 +128,105 @@ void DynApproxElectricalCloseness::sampleUSTWithEdge(Tree &result, node a, node 
     }
 
 #ifdef NETWORKIT_SANITY_CHECKS
-    checkUST(result);
+    checkUST(tree);
 #endif
-}
-
-void DynApproxElectricalCloseness::setDFSTimes(Tree &tree) {
-    if (tree.timesComputed) {
-        return;
-    }
-    tree.tVisit.resize(G.numberOfNodes());
-    tree.tFinish.resize(G.numberOfNodes());
-
-    std::stack<std::pair<node, node>> stack;
-    stack.push({root, tree.child[root]});
-    count timestamp = 0;
-
-    do {
-        // v is a child of u that has not been visited yet.
-        const node u = stack.top().first;
-        const node v = stack.top().second;
-
-        if (v == none) {
-            stack.pop();
-            tree.tFinish[u] = ++timestamp;
-        } else {
-            stack.top().second = tree.sibling[v];
-            tree.tVisit[v] = ++timestamp;
-            stack.push({v, tree.child[v]});
-        }
-    } while (!stack.empty());
-
-    tree.timesComputed = true;
-}
-
-void DynApproxElectricalCloseness::aggregateUST(Tree &tree, double weight) {
-#ifdef NETWORKIT_SANITY_CHECKS
-    checkTimeStamps(tree);
-#endif
-
-    auto &approxEffResistance = approxEffResistanceGlobal[omp_get_thread_num()];
-    const auto &tVisit = tree.tVisit;
-    const auto &tFinish = tree.tFinish;
-    const auto &parent = tree.parent;
-
-    // Doing aggregation
-    G.forNodes([&](const node u) {
-        node p = bfsTree.parent[u];
-        node c = u;
-
-        auto goUp = [&]() -> void {
-            c = p;
-            p = bfsTree.parent[p];
-        };
-
-        while (p != none) {
-            // Edge in BSTree: e1 -> e2
-            node e1 = p, e2 = c;
-            bool reverse = false;
-            if (e1 != parent[e2]) {
-                if (e2 != parent[e1]) {
-                    goUp();
-                    continue;
-                }
-                std::swap(e1, e2);
-                reverse = true;
-            }
-
-            if (tVisit[u] >= tVisit[e2] && tFinish[u] <= tFinish[e2])
-                approxEffResistance[u] += reverse ? -weight : weight;
-
-            goUp();
-        }
-    });
 }
 
 void DynApproxElectricalCloseness::edgeAdded(node a, node b) {
     assert(G.hasEdge(a, b));
     assert(hasRun);
 
-    // Compute lpinv columns for a and b exactly.
     const count n = G.numberOfNodes();
     const double n_double = static_cast<double>(n);
 
-    /// double laa = laplacian(a, a), lab = laplacian(a, b), lba = laplacian(b, a), lbb =
-    /// laplacian(b, b);
+    // Compute lpinv columns for a and b exactly.
+
     laplacian.setValue(a, a, laplacian(a, a) + 1.);
     laplacian.setValue(b, b, laplacian(b, b) + 1.);
     laplacian.setValue(a, b, laplacian(a, b) - 1.);
     laplacian.setValue(b, a, laplacian(b, a) - 1.);
+
+    const auto [w, lpinvColA, lpinvColB] = computeColumnsExact(a, b);
+
+    solveRootAndResample(a, b, w);
+
+    // Aggregate results
+    Vector currentRoundResistanceApprox(n);
+
+    G.parallelForNodes([&](const node u) {
+        // Accumulate all results on first thread vector
+        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
+            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
+        currentRoundResistanceApprox[u] = approxEffResistanceGlobal[0][u];
+        resistanceToRoot[u] = (1. - w) * resistanceToRoot[u] + w * currentRoundResistanceApprox[u];
+        diagonal[u] = resistanceToRoot[u] - rootCol[root] + 2. * rootCol[u];
+    });
+
+    diagonal[root] = rootCol[root];
+    diagonal[a] = lpinvColA[a];
+    diagonal[b] = lpinvColB[b];
+    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.);
+
+    G.parallelForNodes(
+        [&](node u) { scoreData[u] = (n_double - 1.) / (n_double * diagonal[u] + trace); });
+}
+
+void DynApproxElectricalCloseness::edgeRemoved(node a, node b) {
+    assert(!G.hasEdge(a, b));
+    assert(hasRun);
+    assert(bfsParent[a] != b && bfsParent[b] != a);
+
+    const count n = G.numberOfNodes();
+    const double n_double = static_cast<double>(n);
+
+    // precond: this->laplacian is the laplacian of G' = G with edge (a,b)
+    //          this->G is the graph without edge (a,b)
+
+    // we need the following values:
+    //   r_G'(u,v) for all v, u=pivot - stored in this->resistanceToRoot
+    //   r_G'(a,b) - computed via columns/solver. requires old laplacian
+    //   E[F | e in t'] - computed via USTs with edge (a,b)
+    //   we need the u'th column of the pseudoinverse of L(G) for the diag formula
+
+    // Compute lpinv columns for a and b exactly. (for G', old laplacian)
+
+    const auto [w, lpinvColA, lpinvColB] = computeColumnsExact(a, b);
+
+    // compute u'th column of laplacian pseudoinverse for G
+
+    // update laplacian to G (remove edge (a,b))
+    laplacian.setValue(a, a, laplacian(a, a) - 1.);
+    laplacian.setValue(b, b, laplacian(b, b) - 1.);
+    laplacian.setValue(a, b, laplacian(a, b) + 1.);
+    laplacian.setValue(b, a, laplacian(b, a) + 1.);
+
+    solveRootAndResample(a, b, w);
+
+    // Aggregate results
+    Vector currentRoundResistanceApprox(n);
+
+    G.parallelForNodes([&](const node u) {
+        // Accumulate all results on first thread vector
+        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
+            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
+        currentRoundResistanceApprox[u] = approxEffResistanceGlobal[0][u]; // E[F | e in t']
+        resistanceToRoot[u] = // flipped formula compared to edgeAdded
+            (resistanceToRoot[u] - w * currentRoundResistanceApprox[u]) / (1. - w);
+        diagonal[u] = resistanceToRoot[u] - rootCol[root] + 2. * rootCol[u];
+    });
+
+    diagonal[root] = rootCol[root];
+    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.);
+
+    G.parallelForNodes(
+        [&](node u) { scoreData[u] = (n_double - 1.) / (n_double * diagonal[u] + trace); });
+}
+
+std::tuple<double, Vector, Vector> DynApproxElectricalCloseness::computeColumnsExact(node a,
+                                                                                     node b) {
+    // Compute lpinv columns for a and b exactly.
+    const count n = G.numberOfNodes();
+    const double n_double = static_cast<double>(n);
 
     ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg(tol);
     cg.setupConnected(laplacian);
@@ -646,109 +255,12 @@ void DynApproxElectricalCloseness::edgeAdded(node a, node b) {
     double w = lpinvColA[a] + lpinvColB[b] - 2. * lpinvColA[b];
     assert(0 <= w && w <= 1.);
 
-    Vector rhs(n);
-    G.forNodes([&](node u) { rhs[u] = -1.0 / n_double; });
-    rhs[root] += 1.;
-    Vector exactRootCol(n);
-    cg.solve(rhs, exactRootCol);
-    double sum = 0.;
-    G.forNodes([&](node u) { sum += exactRootCol[u]; });
-    exactRootCol -= sum / n_double;
-    rootCol = exactRootCol;
-
-    // Sample and aggregate USTs
-    count ustsCurrentRound = std::ceil(w * numberOfUSTs);
-    INFO("USTS: ", ustsCurrentRound);
-
-    for (auto &approxEffResistanceLocal : approxEffResistanceGlobal) {
-        std::fill(approxEffResistanceLocal.begin(), approxEffResistanceLocal.end(), 0.);
-    }
-
-    // update degDist
-    degDist[a] = std::uniform_int_distribution<index>(0, G.degree(a) - 1);
-    degDist[b] = std::uniform_int_distribution<index>(0, G.degree(b) - 1);
-
-#pragma omp parallel for
-    for (omp_index i = 0; i < ustsCurrentRound; ++i) {
-        Tree tree;
-        sampleUSTWithEdge(tree, a, b);
-        setDFSTimes(tree);
-        aggregateUST(tree, 1. / static_cast<double>(ustsCurrentRound));
-    }
-
-    // Aggregate results
-    Vector currentRoundResistanceApprox(n);
-
-    G.parallelForNodes([&](const node u) {
-        // Accumulate all results on first thread vector
-        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
-            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
-        currentRoundResistanceApprox[u] = approxEffResistanceGlobal[0][u];
-        resistanceToRoot[u] = (1. - w) * resistanceToRoot[u] + w * currentRoundResistanceApprox[u];
-        diagonal[u] = resistanceToRoot[u] - rootCol[root] + 2. * rootCol[u];
-    });
-
-    diagonal[root] = rootCol[root];
-    diagonal[a] = lpinvColA[a];
-    diagonal[b] = lpinvColB[b];
-    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.);
-
-    G.parallelForNodes(
-        [&](node u) { scoreData[u] = (n_double - 1.) / (n_double * diagonal[u] + trace); });
+    return {w, lpinvColA, lpinvColB};
 }
 
-void DynApproxElectricalCloseness::edgeRemoved(node a, node b) {
-    assert(!G.hasEdge(a, b));
-    assert(hasRun);
-    assert(bfsTree.parent[a] != b && bfsTree.parent[b] != a);
-
-    // precond: this->laplacian is the laplacian of G' = G with edge (a,b)
-    //          this->G is the graph without edge (a,b)
-
-    // we need the following values:
-    //   r_G'(u,v) for all v, u=pivot - stored in this->resistanceToRoot
-    //   r_G'(a,b) - computed via columns/solver. requires old laplacian
-    //   E[F | e in t'] - computed via USTs with edge (a,b)
-    //   we need the u'th column of the pseudoinverse of L(G) for the diag formula
-
-    // Compute lpinv columns for a and b exactly. (for G', old laplacian)
+void DynApproxElectricalCloseness::solveRootAndResample(node a, node b, double w) {
     const count n = G.numberOfNodes();
     const double n_double = static_cast<double>(n);
-
-    ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg_old(tol);
-    cg_old.setupConnected(laplacian);
-
-    Vector rhs_a(n), rhs_b(n), lpinvColA(n), lpinvColB(n);
-    G.forNodes([&](node u) {
-        rhs_a[u] = -1.0 / n_double;
-        rhs_b[u] = -1.0 / n_double;
-    });
-    rhs_a[a] += 1.;
-    rhs_b[b] += 1.;
-    auto status = cg_old.solve(rhs_a, lpinvColA);
-    assert(status.converged);
-    status = cg_old.solve(rhs_b, lpinvColB);
-    assert(status.converged);
-
-    double sum_a = 0., sum_b = 0.;
-    G.forNodes([&](node u) {
-        sum_a += lpinvColA[u];
-        sum_b += lpinvColB[u];
-    });
-    lpinvColA -= sum_a / n_double;
-    lpinvColB -= sum_b / n_double;
-
-    // update weights
-    double w = lpinvColA[a] + lpinvColB[b] - 2. * lpinvColA[b];
-    assert(0 <= w && w <= 1.);
-
-    // compute u'th column of laplacian pseudoinverse for G
-
-    // update laplacian to G (remove edge (a,b))
-    laplacian.setValue(a, a, laplacian(a, a) - 1.);
-    laplacian.setValue(b, b, laplacian(b, b) - 1.);
-    laplacian.setValue(a, b, laplacian(a, b) + 1.);
-    laplacian.setValue(b, a, laplacian(b, a) + 1.);
 
     ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg(tol);
     cg.setupConnected(laplacian);
@@ -777,32 +289,13 @@ void DynApproxElectricalCloseness::edgeRemoved(node a, node b) {
 
 #pragma omp parallel for
     for (omp_index i = 0; i < ustsCurrentRound; ++i) {
-        Tree tree;
-        sampleUSTWithEdge(tree, a,
-                          b); // edge (a,b) is not in G, but the sample function does not check this
+        sampleUSTWithEdge(a,
+                          b); // for removed edges: edge (a,b) is not in G, but the sample function
+                              // does not check this
                               // -> the UST is a UST in G' which is what we need here.
-        setDFSTimes(tree);
-        aggregateUST(tree, 1. / static_cast<double>(ustsCurrentRound));
+        dfsUST();
+        aggregateUST(1. / static_cast<double>(ustsCurrentRound));
     }
-
-    // Aggregate results
-    Vector currentRoundResistanceApprox(n);
-
-    G.parallelForNodes([&](const node u) {
-        // Accumulate all results on first thread vector
-        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
-            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
-        currentRoundResistanceApprox[u] = approxEffResistanceGlobal[0][u]; // E[F | e in t']
-        resistanceToRoot[u] = // flipped formula compared to edgeAdded
-            (resistanceToRoot[u] - w * currentRoundResistanceApprox[u]) / (1. - w);
-        diagonal[u] = resistanceToRoot[u] - rootCol[root] + 2. * rootCol[u];
-    });
-
-    diagonal[root] = rootCol[root];
-    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.);
-
-    G.parallelForNodes(
-        [&](node u) { scoreData[u] = (n_double - 1.) / (n_double * diagonal[u] + trace); });
 }
 
 void DynApproxElectricalCloseness::update(GraphEvent e) {
@@ -814,7 +307,7 @@ void DynApproxElectricalCloseness::update(GraphEvent e) {
         // re-compute some results from previous iterations (either reset the state and run() again,
         // or store all USTs and aggregate them again). for now, we throw an error in this case -
         // current planned use cases do not delete edges from the bfs tree.
-        if (bfsTree.parent[e.u] == e.v || bfsTree.parent[e.v] == e.u)
+        if (bfsParent[e.u] == e.v || bfsParent[e.v] == e.u)
             throw std::runtime_error("Error: Edge removal where the edge removed is in the "
                                      "bfsTree is not supported.");
         else
@@ -826,148 +319,16 @@ void DynApproxElectricalCloseness::update(GraphEvent e) {
 
 void DynApproxElectricalCloseness::run() {
     // Preprocessing
-    computeNodeSequence();
+    computeNodeSequence(pivot);
     computeBFSTree();
 
     numberOfUSTs = computeNumberOfUSTs();
     rootCol = Vector(G.numberOfNodes());
 
-    double weight = 1. / static_cast<double>(numberOfUSTs);
-
-#pragma omp parallel
-    {
-        // Thread 0 solves the linear system
-        if (omp_get_thread_num() == 0) {
-            const count n = G.numberOfNodes();
-
-            laplacian = CSRMatrix::laplacianMatrix(G);
-            Diameter diamAlgo(G, DiameterAlgo::ESTIMATED_RANGE, 0);
-            diamAlgo.run();
-            // Getting diameter upper bound
-            const auto diam = static_cast<double>(diamAlgo.getDiameter().second);
-            tol = epsilon * kappa
-                  / (std::sqrt(static_cast<double>((n * G.numberOfEdges())) * std::log(n)) * diam
-                     * 3.);
-            ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg(tol);
-            cg.setupConnected(laplacian);
-
-            Vector rhs(n);
-            G.forNodes([&](node u) { rhs[u] = -1.0 / static_cast<double>(n); });
-            rhs[root] += 1.;
-            cg.solve(rhs, rootCol);
-
-            double sum = 0.0;
-            G.forNodes([&](node u) { sum += rootCol[u]; });
-            rootCol -= sum / static_cast<double>(n);
-        }
-
-        // All threads sample and aggregate USTs in parallel
-#pragma omp for
-        for (omp_index i = 0; i < numberOfUSTs; ++i) {
-            Tree tree;
-            sampleUST(tree);
-            setDFSTimes(tree);
-            aggregateUST(tree, weight);
-        }
-    }
-
-    // Aggregating thread-local results
-    G.parallelForNodes([&](const node u) {
-        // Accumulate all results on thread 0 vector
-        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
-            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
-        resistanceToRoot[u] = approxEffResistanceGlobal[0][u];
-        diagonal[u] = resistanceToRoot[u] - rootCol[root] + 2. * rootCol[u];
-    });
-
-    diagonal[root] = rootCol[root];
-    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.);
-    const double n = G.numberOfNodes();
-
-    G.parallelForNodes([&](node u) { scoreData[u] = (n - 1.) / (n * diagonal[u] + trace); });
+    solveColumnAndSampleUSTs();
+    aggregateResults();
 
     hasRun = true;
 }
-
-#ifdef NETWORKIT_SANITY_CHECKS
-/*
- * Methods for sanity check.
- */
-void DynApproxElectricalCloseness::checkUST(const Tree &tree) const {
-    std::vector<bool> visitedNodes(G.upperNodeIdBound());
-    const auto &parent = tree.parent;
-    const auto &childPtr = tree.child;
-    const auto &siblingPtr = tree.sibling;
-
-    // To debug
-    G.forNodes([&](node u) {
-        if (childPtr[u] != none) {
-            assert(u == parent[childPtr[u]]);
-        }
-        if (siblingPtr[u] != none) {
-            assert(parent[u] == parent[siblingPtr[u]]);
-        }
-        if (u == root) {
-            assert(parent[u] == none);
-        } else {
-            assert(parent[u] != none);
-            std::fill(visitedNodes.begin(), visitedNodes.end(), 0);
-            visitedNodes[u] = 1;
-            do {
-                u = parent[u];
-                assert(!visitedNodes[u]);
-                visitedNodes[u] = 1;
-            } while (u != root);
-        }
-    });
-}
-
-void DynApproxElectricalCloseness::checkBFSTree() const {
-    G.forNodes([&](node u) {
-        if (u == root) {
-            assert(bfsTree.parent[u] == none);
-        } else {
-            std::vector<bool> visited(G.upperNodeIdBound());
-            do {
-                assert(!visited[u]);
-                visited[u] = true;
-                assert(bfsTree.parent[u] != none);
-                u = bfsTree.parent[u];
-            } while (u != root);
-        }
-    });
-}
-
-void DynApproxElectricalCloseness::checkTwoNodesSequence(const std::vector<node> &sequence,
-                                                         std::vector<node> &parent) const {
-    for (node u : sequence) {
-        if (u == root) {
-            assert(parent[u] == none);
-        } else {
-            std::vector<bool> visited(G.upperNodeIdBound());
-            visited[u] = true;
-            do {
-                u = parent[u];
-                assert(!visited[u]);
-                visited[u] = true;
-            } while (u != root);
-        }
-    }
-}
-
-void DynApproxElectricalCloseness::checkTimeStamps(const Tree &tree) const {
-    const auto &tVisit = tree.tVisit;
-    const auto &tFinish = tree.tFinish;
-    G.forNodes([&](const node u) {
-        assert(tVisit[u] < tFinish[u]);
-        if (u == root)
-            assert(tVisit[u] == 0);
-        else
-            assert(tVisit[u] > 0);
-        assert(tVisit[u] < 2 * G.numberOfNodes());
-    });
-}
-
-#endif // NETWORKIT_SANITY_CHECKS
 
 } // namespace NetworKit

--- a/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
@@ -152,7 +152,10 @@ void DynApproxElectricalCloseness::edgeAdded(node a, node b) {
     laplacian.setValue(a, b, laplacian(a, b) - 1.);
     laplacian.setValue(b, a, laplacian(b, a) - 1.);
 
-    const auto [w, lpinvColA, lpinvColB] = computeColumnsExact(a, b);
+    const auto [_w, _lpinvColA, _lpinvColB] = computeColumnsExact(a, b);
+    const double w = _w;
+    const Vector &lpinvColA = _lpinvColA;
+    const Vector &lpinvColB = _lpinvColB;
 
     solveRootAndResample(a, b, w);
 
@@ -196,7 +199,8 @@ void DynApproxElectricalCloseness::edgeRemoved(node a, node b) {
 
     // Compute lpinv columns for a and b exactly. (for G', old laplacian)
 
-    const auto [w, lpinvColA, lpinvColB] = computeColumnsExact(a, b);
+    const auto [_w, lpinvColA, lpinvColB] = computeColumnsExact(a, b);
+    const double w = _w;
 
     // compute u'th column of laplacian pseudoinverse for G
 

--- a/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
@@ -1,0 +1,973 @@
+/*
+ * DynApproxElectricalCloseness.cpp
+ *
+ *  Created on: 19.04.2023
+ *     Authors: Matthias Görg <goergmat@informatik.hu-berlin.de>
+ *              Maria Predari <predarimaria@gmail.com>
+ *              Lukas Berner <Lukas.Berner@hu-berlin.de>
+ */
+
+#include <algorithm>
+#include <numeric>
+#include <omp.h>
+#include <queue>
+
+#include <networkit/algebraic/CSRMatrix.hpp>
+#include <networkit/auxiliary/Random.hpp>
+#include <networkit/centrality/DynApproxElectricalCloseness.hpp>
+#include <networkit/numerics/ConjugateGradient.hpp>
+#include <networkit/numerics/LAMG/Lamg.hpp>
+#include <networkit/numerics/Preconditioner/DiagonalPreconditioner.hpp>
+
+#include <networkit/auxiliary/Log.hpp>
+
+namespace NetworKit {
+
+DynApproxElectricalCloseness::DynApproxElectricalCloseness(const Graph &G, double epsilon,
+                                                           double kappa, node pivot, double delta)
+    : Centrality(G), epsilon(epsilon), delta(delta), kappa(kappa), pivot(pivot),
+      bcc(BiconnectedComponents(G)) {
+
+    if (G.isDirected())
+        throw std::runtime_error("Error: the input graph must be undirected.");
+
+    if (G.isWeighted())
+        throw std::runtime_error("Error: the input graph must be unweighted.");
+
+    if (G.numberOfNodes() < 2)
+        throw std::runtime_error("Error: the graph should have at leasts two vertices");
+
+    if (G.upperNodeIdBound() != G.numberOfNodes())
+        throw std::runtime_error("Error, graph is not compact. Use getCompactedGraph in GraphTools "
+                                 "before using this algorithm.");
+
+    const count n = G.upperNodeIdBound(), threads = omp_get_max_threads();
+    statusGlobal.resize(threads, std::vector<NodeStatus>(n, NodeStatus::NOT_VISITED));
+    approxEffResistanceGlobal.resize(threads, std::vector<double>(n));
+    scoreData.resize(n);
+    diagonal.resize(n);
+    resistanceToRoot.resize(n);
+    generators.reserve(threads);
+    for (omp_index i = 0; i < threads; ++i)
+        generators.emplace_back(Aux::Random::getURNG());
+
+    degDist.reserve(G.upperNodeIdBound());
+    G.forNodes([&](node u) { degDist.emplace_back(0, G.degree(u) - 1); });
+
+    lcaGlobal.resize(threads, std::vector<node>(n, none));
+}
+
+DynApproxElectricalCloseness::DynApproxElectricalCloseness(const Graph &G, double epsilon,
+                                                           double kappa, node pivot)
+    : DynApproxElectricalCloseness(G, epsilon, kappa, pivot,
+                                   1.0 / static_cast<double>(G.numberOfNodes())) {}
+
+count DynApproxElectricalCloseness::computeNumberOfUSTs() const {
+    return rootEcc * rootEcc
+           * static_cast<count>(
+               std::ceil(std::log(2.0 * static_cast<double>(G.numberOfEdges()) / delta)
+                         / (2.0 * epsilon * epsilon * (1. - kappa) * (1. - kappa))));
+}
+
+node DynApproxElectricalCloseness::approxMinEccNode() {
+    auto &status = statusGlobal[0];
+    std::vector<count> distance(G.upperNodeIdBound());
+    std::vector<count> eccLowerBound(G.upperNodeIdBound());
+
+    auto maxDegreeNode = [&]() -> node {
+        node maxDegNode = 0;
+        count maxDeg = 0;
+        G.forNodes([&](const node u) {
+            const auto degU = G.degree(u);
+            if (degU > maxDeg) {
+                maxDeg = degU;
+                maxDegNode = u;
+            }
+        });
+        return maxDegNode;
+    };
+
+    auto doBFS = [&](const node source) -> node {
+        std::queue<node> q;
+        q.push(source);
+        status[source] = NodeStatus::VISITED;
+        distance[source] = 0;
+        node farthest = 0;
+
+        do {
+            const node u = q.front();
+            q.pop();
+            eccLowerBound[u] = std::max(eccLowerBound[u], distance[u]);
+            farthest = u;
+
+            G.forNeighborsOf(u, [&](const node v) {
+                if (status[v] == NodeStatus::NOT_VISITED) {
+                    q.push(v);
+                    status[v] = NodeStatus::VISITED;
+                    distance[v] = distance[u] + 1;
+                }
+            });
+
+        } while (!q.empty());
+
+        std::fill(status.begin(), status.end(), NodeStatus::NOT_VISITED);
+        return farthest;
+    };
+
+    node source = maxDegreeNode();
+
+    for (uint32_t i = 0; i < sweeps; ++i)
+        source = doBFS(source);
+
+    // Return node with minimum ecc lower bound
+    return static_cast<node>(std::min_element(eccLowerBound.begin(), eccLowerBound.end())
+                             - eccLowerBound.begin());
+}
+
+void DynApproxElectricalCloseness::computeNodeSequence() {
+    // We use thread 0's vector
+    auto &status = statusGlobal[0];
+
+    // Compute the biconnected components
+    bcc.run();
+    auto components = bcc.getComponents();
+
+    std::queue<node> queue;
+    std::vector<node> curSequence;
+
+    for (const auto &curComponent : components) {
+        // Biconnected components with 2 vertices can be handled trivially.
+        if (curComponent.size() == 2) {
+            sequences.push_back({curComponent[0], curComponent[1]});
+            continue;
+        }
+
+        // We take the node with highest degree in the component as source
+        node source = curComponent[0];
+        for (node u : curComponent) {
+            source = G.degree(u) > G.degree(source) ? u : source;
+            status[u] = NodeStatus::VISITED;
+        }
+
+        // Start a BFS from source to determine the order of the nodes.
+        // Later, we need to re-explore the graph again, so in the beginning we mark all nodes to be
+        // visited as VISITED, and we set them as NOT_VISITED during the BFS. This avoids a call to
+        // std::fill.
+        queue.push(source);
+        status[source] = NodeStatus::NOT_VISITED;
+
+        do {
+            const node u = queue.front();
+            queue.pop();
+            curSequence.push_back(u);
+            G.forNeighborsOf(u, [&](node v) {
+                if (status[v] == NodeStatus::VISITED) {
+                    status[v] = NodeStatus::NOT_VISITED;
+                    queue.push(v);
+                }
+            });
+        } while (!queue.empty());
+
+        sequences.push_back(std::move(curSequence));
+        curSequence.clear();
+    }
+
+    // Set the root to the highest degree node within the largest biconnected component
+    if (pivot == none)
+        root = approxMinEccNode();
+    else
+        root = pivot;
+
+    biAnchor.resize(bcc.numberOfComponents(), none);
+    biParent.resize(bcc.numberOfComponents(), none);
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    G.forNodes([&](node u) { assert(status[u] == NodeStatus::NOT_VISITED); });
+#endif
+
+    // Topological order of biconnected components: tree of biconnected components starting from the
+    // root's biconnected component. If the root is in multiple biconnected components, arbitrarily
+    // select one of them.
+    std::queue<std::pair<node, index>> q;
+    const auto &rootComps = bcc.getComponentsOfNode(root);
+    q.push({root, *(rootComps.begin())});
+
+    topOrder.reserve(bcc.numberOfComponents());
+    topOrder.insert(topOrder.begin(), rootComps.begin(), rootComps.end());
+
+    std::vector<count> distance(G.upperNodeIdBound());
+    status[root] = NodeStatus::VISITED;
+    rootEcc = 0;
+
+    do {
+        const auto front = q.front();
+        q.pop();
+        G.forNeighborsOf(front.first, [&](const node v) {
+            if (status[v] == NodeStatus::NOT_VISITED) {
+                distance[v] = distance[front.first] + 1;
+                rootEcc = std::max(rootEcc, distance[v]);
+                const auto &vComps = bcc.getComponentsOfNode(v);
+                for (const node vComponentIndex : vComps) {
+                    // Check if a new biconnected components has been found.
+                    if (vComponentIndex != front.second && biAnchor[vComponentIndex] == none
+                        && rootComps.find(vComponentIndex) == rootComps.end()) {
+                        // The anchor cannot be the root, because the anchor does not have a parent.
+                        // We handle biAnchor = none cases later.
+                        biAnchor[vComponentIndex] = (v == root) ? none : v;
+                        biParent[vComponentIndex] = front.second;
+                        topOrder.push_back(vComponentIndex);
+                    }
+                }
+                q.push({v, *(vComps.begin())});
+                status[v] = NodeStatus::VISITED;
+            }
+        });
+    } while (!q.empty());
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    G.forNodes([&](node u) { assert(status[u] == NodeStatus::VISITED); });
+    assert(topOrder.size() == bcc.numberOfComponents());
+    assert(std::unordered_set<index>(topOrder.begin(), topOrder.end()).size()
+           == bcc.numberOfComponents());
+#endif
+}
+
+void DynApproxElectricalCloseness::computeBFSTree() {
+    // Using thread 0's vector
+    auto &status = statusGlobal[0];
+    auto n = G.numberOfNodes();
+    bfsTree.parent.resize(n);
+    bfsTree.child.resize(n);
+    bfsTree.sibling.resize(n);
+    std::fill(status.begin(), status.end(), NodeStatus::NOT_VISITED);
+    std::fill(bfsTree.parent.begin(), bfsTree.parent.end(), none);
+    std::fill(bfsTree.child.begin(), bfsTree.child.end(), none);
+    std::fill(bfsTree.sibling.begin(), bfsTree.sibling.end(), none);
+
+    std::queue<node> queue;
+    queue.push(root);
+    status[root] = NodeStatus::VISITED;
+
+    do {
+        const node currentNode = queue.front();
+        queue.pop();
+        node previous = none;
+        node first = none;
+        G.forNeighborsOf(currentNode, [&](const node v) {
+            if (status[v] == NodeStatus::NOT_VISITED) {
+                status[v] = NodeStatus::VISITED;
+                queue.push(v);
+                bfsTree.parent[v] = currentNode;
+                if (previous != none) {
+                    bfsTree.sibling[previous] = v;
+                }
+                previous = v;
+                if (first == none) {
+                    bfsTree.child[currentNode] = v;
+                    first = v;
+                }
+            }
+        });
+    } while (!queue.empty());
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    checkBFSTree();
+#endif
+}
+
+void DynApproxElectricalCloseness::sampleUST(Tree &result) {
+    // Getting thread-local vectors
+    auto &status = statusGlobal[omp_get_thread_num()];
+    auto &parent = result.parent;
+    auto &childPtr = result.child;
+    auto &siblingPtr = result.sibling;
+
+    auto n = G.numberOfNodes();
+    parent.resize(n);
+    childPtr.resize(n);
+    siblingPtr.resize(n);
+    std::fill(status.begin(), status.end(), NodeStatus::NOT_IN_COMPONENT);
+    std::fill(parent.begin(), parent.end(), none);
+    std::fill(childPtr.begin(), childPtr.end(), none);
+    std::fill(siblingPtr.begin(), siblingPtr.end(), none);
+
+    auto &generator = generators[omp_get_thread_num()];
+
+    // Iterate over the biconnected components in their topological order.
+    for (const auto componentIndex : topOrder) {
+        // Current component, sorted by vertex degree.
+        const auto &sequence = sequences[componentIndex];
+        auto curAnchor = biAnchor[componentIndex];
+
+        // Finds the parent of the current anchor node i.e., the anchor's neighbor that is in the
+        // parent component.
+        auto updateParentOfAnchor = [&]() -> void {
+            for (const node v : G.neighborRange(curAnchor)) {
+                const auto &vComps = bcc.getComponentsOfNode(v);
+                if (vComps.find(biParent[componentIndex]) != vComps.end()) {
+                    parent[curAnchor] = v;
+                    break;
+                }
+            }
+            assert(parent[curAnchor] != none);
+        };
+
+        if (sequence.size() == 2) {
+            // Happens when the current component is the root component in the topological
+            // order. In this case, the root plays the anchor's role.
+            if (curAnchor == none) {
+                const node v = (sequence[0] == root) ? sequence[1] : sequence[0];
+                assert(sequence.front() == root || sequence.back() == root);
+                assert(v != root);
+                parent[v] = root;
+            } else {
+                const node v = (sequence[0] == curAnchor) ? sequence[1] : sequence[0];
+                assert(v != curAnchor);
+                assert(v != root);
+                parent[v] = curAnchor;
+                if (parent[curAnchor] == none)
+                    updateParentOfAnchor();
+            }
+#ifdef NETWORKIT_SANITY_CHECKS
+            checkTwoNodesSequence(sequence, parent);
+#endif
+            continue;
+        }
+
+        // We start building the spanning tree from the first node of the
+        // sequence.
+        // Root of the spanning tree
+        status[sequence[0]] = NodeStatus::IN_SPANNING_TREE;
+        const node curAnchorParent = (curAnchor != none) ? parent[curAnchor] : none;
+
+        // All the remaining nodes in the components need to be visited.
+        std::for_each(sequence.begin() + 1, sequence.end(),
+                      [&status](node u) { status[u] = NodeStatus::NOT_VISITED; });
+
+        count nodesInSpanningTree = 1;
+        // Iterate over the remaining nodes to create the spanning tree.
+        for (auto it = sequence.begin() + 1; it != sequence.end(); ++it) {
+            const node walkStart = *it;
+            if (status[walkStart] == NodeStatus::IN_SPANNING_TREE)
+                // Node already added to the spanning tree
+                continue;
+
+            node currentNode = walkStart;
+
+            // Start a new random walk from the current node.
+            do {
+                // Get a random neighbor within the component
+                node randomNeighbor;
+                do {
+                    randomNeighbor = G.getIthNeighbor(currentNode, degDist[currentNode](generator));
+                } while (status[randomNeighbor] == NodeStatus::NOT_IN_COMPONENT);
+
+                assert(randomNeighbor != none);
+                parent[currentNode] = randomNeighbor;
+                currentNode = randomNeighbor;
+
+            } while (status[currentNode] != NodeStatus::IN_SPANNING_TREE);
+
+            // Last node encountered in the random walk (it is in the spanning tree);
+            const node walkEnd = currentNode;
+            assert(status[walkEnd] == NodeStatus::IN_SPANNING_TREE);
+            // Add the random walk to the spanning tree; eventually, reverse the path if the
+            // anchor/root is encountered
+            for (currentNode = walkStart; currentNode != walkEnd;
+                 currentNode = parent[currentNode]) {
+
+                status[currentNode] = NodeStatus::IN_SPANNING_TREE;
+                ++nodesInSpanningTree;
+                if (currentNode == curAnchor || currentNode == root) {
+
+                    // Anchor of current component in the walk, we have to reverse the
+                    // parent pointers
+                    node next = parent[currentNode];
+                    node nextParent = none;
+                    node tmp = currentNode;
+                    do {
+                        status[next] = NodeStatus::IN_SPANNING_TREE;
+                        nextParent = parent[next];
+                        parent[next] = currentNode;
+                        currentNode = next;
+                        next = nextParent;
+                    } while (next != none);
+
+                    if (tmp == root)
+                        parent[root] = none;
+                    else if (parent[curAnchor] == none)
+                        // Not none if articulation node visited by the parent component before
+                        updateParentOfAnchor();
+                    else
+                        parent[curAnchor] = curAnchorParent;
+
+                    break;
+                }
+            }
+
+            if (nodesInSpanningTree == sequence.size())
+                break;
+        }
+
+        for (node u : sequence)
+            status[u] = NodeStatus::NOT_IN_COMPONENT;
+    }
+
+    count visitedNodes = 0;
+    for (node u : G.nodeRange()) {
+        while (status[u] == NodeStatus::NOT_IN_COMPONENT) {
+            status[u] = NodeStatus::NOT_VISITED;
+            ++visitedNodes;
+            node parentU = parent[u];
+            if (parent[u] != none) {
+                assert(siblingPtr[u] == none);
+                if (childPtr[parentU] != none)
+                    siblingPtr[u] = childPtr[parentU];
+                childPtr[parentU] = u;
+                u = parentU;
+            } else
+                break;
+        }
+        if (visitedNodes == G.numberOfNodes())
+            break;
+    }
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    checkUST(result);
+#endif
+}
+
+void DynApproxElectricalCloseness::sampleUSTWithEdge(Tree &result, node a, node b) {
+    auto n = G.numberOfNodes();
+    assert(a < n && b < n);
+
+    auto &parent = result.parent;
+    auto &status = statusGlobal[omp_get_thread_num()];
+    auto &childPtr = result.child;
+    auto &siblingPtr = result.sibling;
+
+    parent.resize(n, none);
+    childPtr.resize(n, none);
+    siblingPtr.resize(n, none);
+    std::fill(status.begin(), status.end(), NodeStatus::NOT_IN_COMPONENT);
+    std::fill(parent.begin(), parent.end(), none);
+    std::fill(childPtr.begin(), childPtr.end(), none);
+    std::fill(siblingPtr.begin(), siblingPtr.end(), none);
+
+    auto &generator = generators[omp_get_thread_num()];
+
+    // Initialize UST with only (a, b) in the tree.
+    parent[a] = b;
+    status[a] = NodeStatus::IN_SPANNING_TREE;
+    status[b] = NodeStatus::IN_SPANNING_TREE;
+    unsigned int nodesInSpanningTree = 2;
+
+    // The tree is generated using Wilson's algorithm, rooted in b.
+    // Afterwards reroot it to this->root.
+    for (const auto componentIndex : topOrder) {
+        const auto &sequence = sequences[componentIndex];
+        for (const auto walkStart : sequence) {
+            if (status[walkStart] == NodeStatus::IN_SPANNING_TREE) {
+                continue;
+            }
+
+            // Random Walk
+            node currentNode = walkStart;
+            do {
+                node randomNeighbor =
+                    G.getIthNeighbor(currentNode, degDist[currentNode](generator));
+
+                assert(randomNeighbor != none);
+                parent[currentNode] = randomNeighbor;
+                currentNode = randomNeighbor;
+
+            } while (status[currentNode] != NodeStatus::IN_SPANNING_TREE);
+
+            // Last node encountered in the random walk (it is in the spanning tree);
+            const node walkEnd = currentNode;
+            assert(status[walkEnd] == NodeStatus::IN_SPANNING_TREE);
+            // Add the random walk to the spanning tree;
+            for (currentNode = walkStart; currentNode != walkEnd;
+                 currentNode = parent[currentNode]) {
+
+                status[currentNode] = NodeStatus::IN_SPANNING_TREE;
+                ++nodesInSpanningTree;
+            }
+        }
+    }
+
+    assert(nodesInSpanningTree == n);
+
+    // Switch root from b to `root`.
+    node currentNode = root;
+    node next = parent[root];
+    while (next != none) {
+        node tmp = parent[next];
+        parent[next] = currentNode;
+        currentNode = next;
+        next = tmp;
+    }
+    parent[root] = none;
+
+    // Set child and sibling pointers
+    count visitedNodes = 0;
+    for (node u : G.nodeRange()) {
+        while (status[u] == NodeStatus::IN_SPANNING_TREE) {
+            status[u] = NodeStatus::NOT_VISITED;
+            ++visitedNodes;
+            node parentU = parent[u];
+            if (parentU != none) {
+                assert(siblingPtr[u] == none);
+                if (childPtr[parentU] != none)
+                    siblingPtr[u] = childPtr[parentU];
+                childPtr[parentU] = u;
+                u = parentU;
+            } else
+                break;
+        }
+        if (visitedNodes == G.numberOfNodes())
+            break;
+    }
+
+#ifdef NETWORKIT_SANITY_CHECKS
+    checkUST(result);
+#endif
+}
+
+void DynApproxElectricalCloseness::setDFSTimes(Tree &tree) {
+    if (tree.timesComputed) {
+        return;
+    }
+    tree.tVisit.resize(G.numberOfNodes());
+    tree.tFinish.resize(G.numberOfNodes());
+
+    std::stack<std::pair<node, node>> stack;
+    stack.push({root, tree.child[root]});
+    count timestamp = 0;
+
+    do {
+        // v is a child of u that has not been visited yet.
+        const node u = stack.top().first;
+        const node v = stack.top().second;
+
+        if (v == none) {
+            stack.pop();
+            tree.tFinish[u] = ++timestamp;
+        } else {
+            stack.top().second = tree.sibling[v];
+            tree.tVisit[v] = ++timestamp;
+            stack.push({v, tree.child[v]});
+        }
+    } while (!stack.empty());
+
+    tree.timesComputed = true;
+}
+
+void DynApproxElectricalCloseness::aggregateUST(Tree &tree, double weight) {
+#ifdef NETWORKIT_SANITY_CHECKS
+    checkTimeStamps(tree);
+#endif
+
+    auto &approxEffResistance = approxEffResistanceGlobal[omp_get_thread_num()];
+    const auto &tVisit = tree.tVisit;
+    const auto &tFinish = tree.tFinish;
+    const auto &parent = tree.parent;
+
+    // Doing aggregation
+    G.forNodes([&](const node u) {
+        node p = bfsTree.parent[u];
+        node c = u;
+
+        auto goUp = [&]() -> void {
+            c = p;
+            p = bfsTree.parent[p];
+        };
+
+        while (p != none) {
+            // Edge in BSTree: e1 -> e2
+            node e1 = p, e2 = c;
+            bool reverse = false;
+            if (e1 != parent[e2]) {
+                if (e2 != parent[e1]) {
+                    goUp();
+                    continue;
+                }
+                std::swap(e1, e2);
+                reverse = true;
+            }
+
+            if (tVisit[u] >= tVisit[e2] && tFinish[u] <= tFinish[e2])
+                approxEffResistance[u] += reverse ? -weight : weight;
+
+            goUp();
+        }
+    });
+}
+
+void DynApproxElectricalCloseness::edgeAdded(node a, node b) {
+    assert(G.hasEdge(a, b));
+    assert(hasRun);
+
+    // Compute lpinv columns for a and b exactly.
+    const count n = G.numberOfNodes();
+    const double n_double = static_cast<double>(n);
+
+    /// double laa = laplacian(a, a), lab = laplacian(a, b), lba = laplacian(b, a), lbb =
+    /// laplacian(b, b);
+    laplacian.setValue(a, a, laplacian(a, a) + 1.);
+    laplacian.setValue(b, b, laplacian(b, b) + 1.);
+    laplacian.setValue(a, b, laplacian(a, b) - 1.);
+    laplacian.setValue(b, a, laplacian(b, a) - 1.);
+
+    ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg(tol);
+    cg.setupConnected(laplacian);
+
+    Vector rhs_a(n), rhs_b(n), lpinvColA(n), lpinvColB(n);
+    G.forNodes([&](node u) {
+        rhs_a[u] = -1.0 / n_double;
+        rhs_b[u] = -1.0 / n_double;
+    });
+    rhs_a[a] += 1.;
+    rhs_b[b] += 1.;
+    auto status = cg.solve(rhs_a, lpinvColA);
+    assert(status.converged);
+    status = cg.solve(rhs_b, lpinvColB);
+    assert(status.converged);
+
+    double sum_a = 0., sum_b = 0.;
+    G.forNodes([&](node u) {
+        sum_a += lpinvColA[u];
+        sum_b += lpinvColB[u];
+    });
+    lpinvColA -= sum_a / n_double;
+    lpinvColB -= sum_b / n_double;
+
+    // update weights
+    double w = lpinvColA[a] + lpinvColB[b] - 2. * lpinvColA[b];
+    assert(0 <= w && w <= 1.);
+
+    Vector rhs(n);
+    G.forNodes([&](node u) { rhs[u] = -1.0 / n_double; });
+    rhs[root] += 1.;
+    Vector exactRootCol(n);
+    cg.solve(rhs, exactRootCol);
+    double sum = 0.;
+    G.forNodes([&](node u) { sum += exactRootCol[u]; });
+    exactRootCol -= sum / n_double;
+    rootCol = exactRootCol;
+
+    // Sample and aggregate USTs
+    count ustsCurrentRound = std::ceil(w * numberOfUSTs);
+    INFO("USTS: ", ustsCurrentRound);
+
+    for (auto &approxEffResistanceLocal : approxEffResistanceGlobal) {
+        std::fill(approxEffResistanceLocal.begin(), approxEffResistanceLocal.end(), 0.);
+    }
+
+    // update degDist
+    degDist[a] = std::uniform_int_distribution<index>(0, G.degree(a) - 1);
+    degDist[b] = std::uniform_int_distribution<index>(0, G.degree(b) - 1);
+
+#pragma omp parallel for
+    for (omp_index i = 0; i < ustsCurrentRound; ++i) {
+        Tree tree;
+        sampleUSTWithEdge(tree, a, b);
+        setDFSTimes(tree);
+        aggregateUST(tree, 1. / static_cast<double>(ustsCurrentRound));
+    }
+
+    // Aggregate results
+    Vector currentRoundResistanceApprox(n);
+
+    G.parallelForNodes([&](const node u) {
+        // Accumulate all results on first thread vector
+        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
+            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
+        currentRoundResistanceApprox[u] = approxEffResistanceGlobal[0][u];
+        resistanceToRoot[u] = (1. - w) * resistanceToRoot[u] + w * currentRoundResistanceApprox[u];
+        diagonal[u] = resistanceToRoot[u] - rootCol[root] + 2. * rootCol[u];
+    });
+
+    diagonal[root] = rootCol[root];
+    diagonal[a] = lpinvColA[a];
+    diagonal[b] = lpinvColB[b];
+    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.);
+
+    G.parallelForNodes(
+        [&](node u) { scoreData[u] = (n_double - 1.) / (n_double * diagonal[u] + trace); });
+}
+
+void DynApproxElectricalCloseness::edgeRemoved(node a, node b) {
+    assert(!G.hasEdge(a, b));
+    assert(hasRun);
+    assert(bfsTree.parent[a] != b && bfsTree.parent[b] != a);
+
+    // precond: this->laplacian is the laplacian of G' = G with edge (a,b)
+    //          this->G is the graph without edge (a,b)
+
+    // we need the following values:
+    //   r_G'(u,v) for all v, u=pivot - stored in this->resistanceToRoot
+    //   r_G'(a,b) - computed via columns/solver. requires old laplacian
+    //   E[F | e in t'] - computed via USTs with edge (a,b)
+    //   we need the u'th column of the pseudoinverse of L(G) for the diag formula
+
+    // Compute lpinv columns for a and b exactly. (for G', old laplacian)
+    const count n = G.numberOfNodes();
+    const double n_double = static_cast<double>(n);
+
+    ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg_old(tol);
+    cg_old.setupConnected(laplacian);
+
+    Vector rhs_a(n), rhs_b(n), lpinvColA(n), lpinvColB(n);
+    G.forNodes([&](node u) {
+        rhs_a[u] = -1.0 / n_double;
+        rhs_b[u] = -1.0 / n_double;
+    });
+    rhs_a[a] += 1.;
+    rhs_b[b] += 1.;
+    auto status = cg_old.solve(rhs_a, lpinvColA);
+    assert(status.converged);
+    status = cg_old.solve(rhs_b, lpinvColB);
+    assert(status.converged);
+
+    double sum_a = 0., sum_b = 0.;
+    G.forNodes([&](node u) {
+        sum_a += lpinvColA[u];
+        sum_b += lpinvColB[u];
+    });
+    lpinvColA -= sum_a / n_double;
+    lpinvColB -= sum_b / n_double;
+
+    // update weights
+    double w = lpinvColA[a] + lpinvColB[b] - 2. * lpinvColA[b];
+    assert(0 <= w && w <= 1.);
+
+    // compute u'th column of laplacian pseudoinverse for G
+
+    // update laplacian to G (remove edge (a,b))
+    laplacian.setValue(a, a, laplacian(a, a) - 1.);
+    laplacian.setValue(b, b, laplacian(b, b) - 1.);
+    laplacian.setValue(a, b, laplacian(a, b) + 1.);
+    laplacian.setValue(b, a, laplacian(b, a) + 1.);
+
+    ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg(tol);
+    cg.setupConnected(laplacian);
+
+    Vector rhs(n);
+    G.forNodes([&](node u) { rhs[u] = -1.0 / n_double; });
+    rhs[root] += 1.;
+    Vector exactRootCol(n);
+    cg.solve(rhs, exactRootCol);
+    double sum = 0.;
+    G.forNodes([&](node u) { sum += exactRootCol[u]; });
+    exactRootCol -= sum / n_double;
+    rootCol = exactRootCol;
+
+    // Sample and aggregate USTs
+    count ustsCurrentRound = std::ceil(w * numberOfUSTs);
+    INFO("USTS: ", ustsCurrentRound);
+
+    for (auto &approxEffResistanceLocal : approxEffResistanceGlobal) {
+        std::fill(approxEffResistanceLocal.begin(), approxEffResistanceLocal.end(), 0.);
+    }
+
+    // update degDist
+    degDist[a] = std::uniform_int_distribution<index>(0, G.degree(a) - 1);
+    degDist[b] = std::uniform_int_distribution<index>(0, G.degree(b) - 1);
+
+#pragma omp parallel for
+    for (omp_index i = 0; i < ustsCurrentRound; ++i) {
+        Tree tree;
+        sampleUSTWithEdge(tree, a,
+                          b); // edge (a,b) is not in G, but the sample function does not check this
+                              // -> the UST is a UST in G' which is what we need here.
+        setDFSTimes(tree);
+        aggregateUST(tree, 1. / static_cast<double>(ustsCurrentRound));
+    }
+
+    // Aggregate results
+    Vector currentRoundResistanceApprox(n);
+
+    G.parallelForNodes([&](const node u) {
+        // Accumulate all results on first thread vector
+        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
+            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
+        currentRoundResistanceApprox[u] = approxEffResistanceGlobal[0][u]; // E[F | e in t']
+        resistanceToRoot[u] = // flipped formula compared to edgeAdded
+            (resistanceToRoot[u] - w * currentRoundResistanceApprox[u]) / (1. - w);
+        diagonal[u] = resistanceToRoot[u] - rootCol[root] + 2. * rootCol[u];
+    });
+
+    diagonal[root] = rootCol[root];
+    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.);
+
+    G.parallelForNodes(
+        [&](node u) { scoreData[u] = (n_double - 1.) / (n_double * diagonal[u] + trace); });
+}
+
+void DynApproxElectricalCloseness::update(GraphEvent e) {
+    if (e.type == GraphEvent::EDGE_ADDITION)
+        edgeAdded(e.u, e.v);
+    else if (e.type == GraphEvent::EDGE_REMOVAL) {
+        // the deleted edge may be part of the bfsTree. If this is the case, we need a new one.
+        // Since all our computations depend on this exact tree (via aggregateUST), we need to
+        // re-compute some results from previous iterations (either reset the state and run() again,
+        // or store all USTs and aggregate them again). for now, we throw an error in this case -
+        // current planned use cases do not delete edges from the bfs tree.
+        if (bfsTree.parent[e.u] == e.v || bfsTree.parent[e.v] == e.u)
+            throw std::runtime_error("Error: Edge removal where the edge removed is in the "
+                                     "bfsTree is not supported.");
+        else
+            edgeRemoved(e.u, e.v);
+    } else
+        throw std::runtime_error(
+            "Error: Events other than EDGE_ADDITION and EDGE_REMOVAL are not supported.");
+}
+
+void DynApproxElectricalCloseness::run() {
+    // Preprocessing
+    computeNodeSequence();
+    computeBFSTree();
+
+    numberOfUSTs = computeNumberOfUSTs();
+    rootCol = Vector(G.numberOfNodes());
+
+    double weight = 1. / static_cast<double>(numberOfUSTs);
+
+#pragma omp parallel
+    {
+        // Thread 0 solves the linear system
+        if (omp_get_thread_num() == 0) {
+            const count n = G.numberOfNodes();
+
+            laplacian = CSRMatrix::laplacianMatrix(G);
+            Diameter diamAlgo(G, DiameterAlgo::ESTIMATED_RANGE, 0);
+            diamAlgo.run();
+            // Getting diameter upper bound
+            const auto diam = static_cast<double>(diamAlgo.getDiameter().second);
+            tol = epsilon * kappa
+                  / (std::sqrt(static_cast<double>((n * G.numberOfEdges())) * std::log(n)) * diam
+                     * 3.);
+            ConjugateGradient<CSRMatrix, DiagonalPreconditioner> cg(tol);
+            cg.setupConnected(laplacian);
+
+            Vector rhs(n);
+            G.forNodes([&](node u) { rhs[u] = -1.0 / static_cast<double>(n); });
+            rhs[root] += 1.;
+            cg.solve(rhs, rootCol);
+
+            double sum = 0.0;
+            G.forNodes([&](node u) { sum += rootCol[u]; });
+            rootCol -= sum / static_cast<double>(n);
+        }
+
+        // All threads sample and aggregate USTs in parallel
+#pragma omp for
+        for (omp_index i = 0; i < numberOfUSTs; ++i) {
+            Tree tree;
+            sampleUST(tree);
+            setDFSTimes(tree);
+            aggregateUST(tree, weight);
+        }
+    }
+
+    // Aggregating thread-local results
+    G.parallelForNodes([&](const node u) {
+        // Accumulate all results on thread 0 vector
+        for (count i = 1; i < approxEffResistanceGlobal.size(); ++i)
+            approxEffResistanceGlobal[0][u] += approxEffResistanceGlobal[i][u];
+        resistanceToRoot[u] = approxEffResistanceGlobal[0][u];
+        diagonal[u] = resistanceToRoot[u] - rootCol[root] + 2. * rootCol[u];
+    });
+
+    diagonal[root] = rootCol[root];
+    const double trace = std::accumulate(diagonal.begin(), diagonal.end(), 0.);
+    const double n = G.numberOfNodes();
+
+    G.parallelForNodes([&](node u) { scoreData[u] = (n - 1.) / (n * diagonal[u] + trace); });
+
+    hasRun = true;
+}
+
+#ifdef NETWORKIT_SANITY_CHECKS
+/*
+ * Methods for sanity check.
+ */
+void DynApproxElectricalCloseness::checkUST(const Tree &tree) const {
+    std::vector<bool> visitedNodes(G.upperNodeIdBound());
+    const auto &parent = tree.parent;
+    const auto &childPtr = tree.child;
+    const auto &siblingPtr = tree.sibling;
+
+    // To debug
+    G.forNodes([&](node u) {
+        if (childPtr[u] != none) {
+            assert(u == parent[childPtr[u]]);
+        }
+        if (siblingPtr[u] != none) {
+            assert(parent[u] == parent[siblingPtr[u]]);
+        }
+        if (u == root) {
+            assert(parent[u] == none);
+        } else {
+            assert(parent[u] != none);
+            std::fill(visitedNodes.begin(), visitedNodes.end(), 0);
+            visitedNodes[u] = 1;
+            do {
+                u = parent[u];
+                assert(!visitedNodes[u]);
+                visitedNodes[u] = 1;
+            } while (u != root);
+        }
+    });
+}
+
+void DynApproxElectricalCloseness::checkBFSTree() const {
+    G.forNodes([&](node u) {
+        if (u == root) {
+            assert(bfsTree.parent[u] == none);
+        } else {
+            std::vector<bool> visited(G.upperNodeIdBound());
+            do {
+                assert(!visited[u]);
+                visited[u] = true;
+                assert(bfsTree.parent[u] != none);
+                u = bfsTree.parent[u];
+            } while (u != root);
+        }
+    });
+}
+
+void DynApproxElectricalCloseness::checkTwoNodesSequence(const std::vector<node> &sequence,
+                                                         std::vector<node> &parent) const {
+    for (node u : sequence) {
+        if (u == root) {
+            assert(parent[u] == none);
+        } else {
+            std::vector<bool> visited(G.upperNodeIdBound());
+            visited[u] = true;
+            do {
+                u = parent[u];
+                assert(!visited[u]);
+                visited[u] = true;
+            } while (u != root);
+        }
+    }
+}
+
+void DynApproxElectricalCloseness::checkTimeStamps(const Tree &tree) const {
+    const auto &tVisit = tree.tVisit;
+    const auto &tFinish = tree.tFinish;
+    G.forNodes([&](const node u) {
+        assert(tVisit[u] < tFinish[u]);
+        if (u == root)
+            assert(tVisit[u] == 0);
+        else
+            assert(tVisit[u] > 0);
+        assert(tVisit[u] < 2 * G.numberOfNodes());
+    });
+}
+
+#endif // NETWORKIT_SANITY_CHECKS
+
+} // namespace NetworKit

--- a/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
@@ -328,6 +328,8 @@ void DynApproxElectricalCloseness::update(GraphEvent e) {
 }
 
 void DynApproxElectricalCloseness::run() {
+    hasRun = false;
+
     // Preprocessing
     computeNodeSequence(pivot);
     computeBFSTree();

--- a/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
@@ -37,8 +37,7 @@ DynApproxElectricalCloseness::DynApproxElectricalCloseness(const Graph &G, doubl
                                    1.0 / static_cast<double>(G.numberOfNodes())) {}
 
 void DynApproxElectricalCloseness::sampleUSTWithEdge(node a, node b) {
-    auto n = G.numberOfNodes();
-    assert(a < n && b < n);
+    assert(a < G.numberOfNodes() && b < G.numberOfNodes());
 
     auto &tree = bfsTrees[omp_get_thread_num()];
 
@@ -58,7 +57,10 @@ void DynApproxElectricalCloseness::sampleUSTWithEdge(node a, node b) {
     parent[a] = b;
     status[a] = NodeStatus::IN_SPANNING_TREE;
     status[b] = NodeStatus::IN_SPANNING_TREE;
+
+#ifdef NETWORKIT_SANITY_CHECKS
     unsigned int nodesInSpanningTree = 2;
+#endif
 
     // The tree is generated using Wilson's algorithm, rooted in b.
     // Afterwards reroot it to this->root.
@@ -89,12 +91,16 @@ void DynApproxElectricalCloseness::sampleUSTWithEdge(node a, node b) {
                  currentNode = parent[currentNode]) {
 
                 status[currentNode] = NodeStatus::IN_SPANNING_TREE;
+#ifdef NETWORKIT_SANITY_CHECKS
                 ++nodesInSpanningTree;
+#endif
             }
         }
     }
 
+#ifdef NETWORKIT_SANITY_CHECKS
     assert(nodesInSpanningTree == n);
+#endif
 
     // Switch root from b to `root`.
     node currentNode = root;

--- a/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
+++ b/networkit/cpp/centrality/DynApproxElectricalCloseness.cpp
@@ -99,7 +99,7 @@ void DynApproxElectricalCloseness::sampleUSTWithEdge(node a, node b) {
     }
 
 #ifdef NETWORKIT_SANITY_CHECKS
-    assert(nodesInSpanningTree == n);
+    assert(nodesInSpanningTree == G.numberOfNodes());
 #endif
 
     // Switch root from b to `root`.

--- a/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
+++ b/networkit/cpp/centrality/test/ApproxElectricalClosenessGTest.cpp
@@ -1,0 +1,180 @@
+/*
+ * ApproxElectricalClosenessGTest.cpp
+ *
+ *  Created on: 18.04.2023
+ *      Author: Lukas Berner <Lukas.Berner@hu-berlin.de>
+ */
+
+#include <gtest/gtest.h>
+
+#include <networkit/centrality/ApproxElectricalCloseness.hpp>
+#include <networkit/centrality/DynApproxElectricalCloseness.hpp>
+#include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/generators/ErdosRenyiGenerator.hpp>
+#include <networkit/generators/HyperbolicGenerator.hpp>
+#include <networkit/generators/StaticGraphGenerator.hpp>
+
+namespace NetworKit {
+
+class ApproxElectricalClosenessGTest
+    : public testing::TestWithParam<std::tuple<int, std::string, double>> {
+protected:
+    const count n_gen = 75;
+    const double er_prob = 0.15;
+
+    Graph generate(std::string generator) {
+        Graph G;
+        if (generator == "ER")
+            G = ErdosRenyiGenerator(n_gen, er_prob).generate();
+        else if (generator == "Hyperbolic")
+            G = HyperbolicGenerator(n_gen).generate();
+        else
+            throw std::logic_error("unkown generator");
+        G = ConnectedComponents::extractLargestConnectedComponent(G, true);
+        const count n = G.numberOfNodes();
+
+        // Create a biconnected component with size 2.
+        G.addNodes(2);
+        G.addEdge(n - 1, n);
+        G.addEdge(n, n + 1);
+
+        return G;
+    };
+
+    GraphEvent add_random_edge(Graph &G) {
+        node a, b;
+
+        do {
+            a = Aux::Random::integer(0, G.numberOfNodes() - 1);
+            b = Aux::Random::integer(0, G.numberOfNodes() - 1);
+        } while (G.hasEdge(a, b) || a == b);
+
+        G.addEdge(a, b);
+        return GraphEvent(GraphEvent::EDGE_ADDITION, a, b);
+    };
+
+    GraphEvent remove_random_edge(Graph &G, const node pivot = none) {
+        node a, b;
+
+        do {
+            a = Aux::Random::integer(0, G.numberOfNodes() - 1);
+            b = Aux::Random::integer(0, G.numberOfNodes() - 1);
+            if (a > b)
+                std::swap(a, b);
+        } while (!G.hasEdge(a, b) || a == pivot || b == pivot);
+
+        G.removeEdge(a, b);
+        return GraphEvent(GraphEvent::EDGE_REMOVAL, a, b);
+    };
+};
+
+INSTANTIATE_TEST_SUITE_P(InstantiationName, ApproxElectricalClosenessGTest,
+                         testing::Combine(testing::Values(1, 2, 3),            // seed
+                                          testing::Values("ER", "Hyperbolic"), // generator
+                                          testing::Values(0.1, 0.3, 0.5)       // eps
+                                          ));
+
+TEST_P(ApproxElectricalClosenessGTest, testApproxElectricalCloseness) {
+    auto [seed, generator, eps] = GetParam();
+    Aux::Random::setSeed(seed, true);
+    auto G = generate(generator);
+
+    ApproxElectricalCloseness apx(G, eps);
+    apx.run();
+    const auto diag = apx.getDiagonal();
+    const auto gt = apx.computeExactDiagonal(1e-12);
+    G.forNodes([&eps = eps, &gt, &diag](node u) { EXPECT_NEAR(diag[u], gt[u], eps); });
+    EXPECT_EQ(apx.scores().size(), G.numberOfNodes());
+}
+
+TEST_P(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_run) {
+    auto [seed, generator, eps] = GetParam();
+    Aux::Random::setSeed(seed, true);
+    auto G = generate(generator);
+
+    ApproxElectricalCloseness apx(G, eps);
+    DynApproxElectricalCloseness dapx(G, eps);
+    apx.run();
+    dapx.run();
+    const auto diag = apx.getDiagonal();
+    const auto ddiag = dapx.getDiagonal();
+    G.forNodes([&eps = eps, &ddiag, &diag](node u) {
+        EXPECT_NEAR(diag[u], ddiag[u], 2 * eps);
+    }); // 2 * eps because both have max abs error of eps
+    EXPECT_EQ(dapx.scores().size(), G.numberOfNodes());
+}
+
+TEST_P(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_EdgeAddition) {
+    auto [seed, generator, eps] = GetParam();
+    Aux::Random::setSeed(seed, true);
+    auto G = generate(generator);
+
+    DynApproxElectricalCloseness dapx(G, eps);
+    dapx.run();
+
+    for (int i = 0; i < 10; i++) {
+        auto event = add_random_edge(G);
+        dapx.update(event);
+    }
+
+    ApproxElectricalCloseness apx(G, eps);
+    apx.run();
+
+    const auto diag = apx.getDiagonal();
+    const auto ddiag = dapx.getDiagonal();
+    G.forNodes([&eps = eps, &ddiag, &diag](node u) { EXPECT_NEAR(diag[u], ddiag[u], 2 * eps); });
+    EXPECT_EQ(dapx.scores().size(), G.numberOfNodes());
+}
+
+TEST_P(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_EdgeDeletion) {
+    omp_set_num_threads(1);
+    auto [seed, generator, eps] = GetParam();
+    Aux::Random::setSeed(seed, true);
+    auto G = generate(generator);
+
+    // make sure that removing an edge does not disconnect the graph
+    auto star_node = G.addNode();
+    G.forNodes([&](node u) {
+        if (u != star_node)
+            G.addEdge(star_node, u);
+    });
+
+    DynApproxElectricalCloseness dapx(G, eps, 0.3, star_node);
+    dapx.run();
+
+    auto event = remove_random_edge(G, star_node);
+    dapx.update(event);
+
+    ApproxElectricalCloseness apx(G, eps);
+    apx.run();
+
+    const auto diag = apx.getDiagonal();
+    const auto ddiag = dapx.getDiagonal();
+    G.forNodes([&eps = eps, &ddiag, &diag](node u) { EXPECT_NEAR(diag[u], ddiag[u], 2 * eps); });
+    EXPECT_EQ(dapx.scores().size(), G.numberOfNodes());
+}
+
+TEST_P(ApproxElectricalClosenessGTest, testDynApproxElectricalCloseness_copy) {
+    auto [seed, generator, eps] = GetParam();
+    Aux::Random::setSeed(seed, true);
+    auto G = generate(generator);
+
+    DynApproxElectricalCloseness dapx(G, eps);
+    dapx.run();
+
+    auto event = add_random_edge(G);
+
+    // make copy
+    DynApproxElectricalCloseness dapx2 = dapx;
+
+    dapx2.update(event);
+    ApproxElectricalCloseness apx(G, eps);
+    apx.run();
+
+    const auto diag = apx.getDiagonal();
+    const auto ddiag2 = dapx2.getDiagonal();
+    G.forNodes([&eps = eps, &ddiag2, &diag](node u) { EXPECT_NEAR(diag[u], ddiag2[u], 2 * eps); });
+    EXPECT_EQ(dapx2.scores().size(), G.numberOfNodes());
+}
+
+} /* namespace NetworKit */

--- a/networkit/cpp/centrality/test/CMakeLists.txt
+++ b/networkit/cpp/centrality/test/CMakeLists.txt
@@ -8,4 +8,6 @@ networkit_add_test(centrality SpanningEdgeCentralityGTest
     graph io numerics)
 networkit_add_test(centrality TopClosenessGTest
     generators graph io)
+networkit_add_test(centrality ApproxElectricalClosenessGTest
+    auxiliary generators io structures algebraic)
 

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -1938,29 +1938,6 @@ TEST_P(CentralityGTest, testGedWalk) {
     }
 }
 
-TEST_F(CentralityGTest, testApproxElectricalCloseness) {
-    const double eps = 0.1;
-    const count n = 75;
-    for (int seed : {1, 2, 3}) {
-        Aux::Random::setSeed(seed, true);
-        auto G = HyperbolicGenerator(n, 10, 3).generate();
-        G = ConnectedComponents::extractLargestConnectedComponent(G, true);
-        auto new_n = G.numberOfNodes();
-
-        // Create a biconnected component with size 2.
-        G.addNodes(2);
-        G.addEdge(new_n - 1, new_n);
-        G.addEdge(new_n, new_n + 1);
-
-        ApproxElectricalCloseness apx(G);
-        apx.run();
-        const auto diag = apx.getDiagonal();
-        const auto gt = apx.computeExactDiagonal(1e-12);
-        G.forNodes([&](node u) { EXPECT_NEAR(diag[u], gt[u], eps); });
-        EXPECT_EQ(apx.scores().size(), G.numberOfNodes());
-    }
-}
-
 TEST_F(CentralityGTest, testGroupClosenessDirected) {
     // directed graphs are not supported
     Graph G(10, false, true);

--- a/networkit/test/test_centrality.py
+++ b/networkit/test/test_centrality.py
@@ -53,6 +53,92 @@ class TestCentrality(unittest.TestCase):
 			pinv = np.linalg.pinv(L).diagonal()
 			for u in g.iterNodes():
 				self.assertLessEqual(abs(apx[u] - pinv[u]), eps)
+
+	def testDynApproxElectricalCloseness_run(self):
+		eps = 0.1
+		nk.engineering.setSeed(1, True)
+		g = nk.generators.ErdosRenyiGenerator(50, 0.15, False).generate()
+		g = nk.components.ConnectedComponents(g).extractLargestConnectedComponent(g, True)
+		n = g.numberOfNodes()
+
+		# create a biconnected component with size 2
+		g.addNodes(2)
+		g.addEdge(n, n+1)
+		g.addEdge(n - 1, n)
+
+		dapx = nk.centrality.DynApproxElectricalCloseness(g, eps)
+		apx = nk.centrality.ApproxElectricalCloseness(g, eps)
+		dapx.run()
+		apx.run()
+		diag = apx.getDiagonal()
+		ddiag = dapx.getDiagonal()
+		for u in g.iterNodes():
+			self.assertLessEqual(abs(diag[u] - ddiag[u]), 2 * eps)
+
+	def testDynApproxElectricalCloseness_EdgeAddition(self):
+		eps = 0.1
+		nk.engineering.setSeed(1, True)
+		g = nk.generators.ErdosRenyiGenerator(50, 0.15, False).generate()
+		g = nk.components.ConnectedComponents(g).extractLargestConnectedComponent(g, True)
+		n = g.numberOfNodes()
+
+		# create a biconnected component with size 2
+		g.addNodes(2)
+		g.addEdge(n, n+1)
+		g.addEdge(n - 1, n)
+
+		dapx = nk.centrality.DynApproxElectricalCloseness(g, eps)
+		dapx.run()
+
+		for _ in range(10):
+			found = False
+			while not found:
+				[a, b] = nk.graphtools.randomNodes(g, 2)
+				if not g.hasEdge(a,b): found = True
+			g.addEdge(a,b, 1, True)
+			event = nk.dynamics.GraphEvent(nk.dynamics.GraphEventType.EDGE_ADDITION, a, b, 1)
+			dapx.update(event)
+
+		ddiag = dapx.getDiagonal()
+		diag = nk.centrality.ApproxElectricalCloseness(g).run().getDiagonal()
+		for u in g.iterNodes():
+			self.assertLessEqual(abs(diag[u] - ddiag[u]), 2 * eps)
+		self.assertEqual(g.numberOfNodes(), len(dapx.scores()))
+
+	def testDynApproxElectricalCloseness_EdgeDeletion(self):
+		eps = 0.1
+		nk.engineering.setSeed(1, True)
+		g = nk.generators.ErdosRenyiGenerator(75, 0.15, False).generate()
+		g = nk.components.ConnectedComponents(g).extractLargestConnectedComponent(g, True)
+		n = g.numberOfNodes()
+
+		# create a biconnected component with size 2
+		g.addNodes(2)
+		g.addEdge(n, n+1)
+		g.addEdge(n - 1, n)
+
+		# create star pivot node
+		star_node = g.addNode()
+		for node in g.iterNodes():
+			if node != star_node:
+				g.addEdge(star_node, node)
+
+		dapx = nk.centrality.DynApproxElectricalCloseness(g, eps, pivot=star_node)
+		dapx.run()
+
+		found = False
+		while not found:
+			[a, b] = nk.graphtools.randomNodes(g, 2)
+			if g.hasEdge(a,b) and a != star_node and b != star_node: found = True
+		g.removeEdge(a,b)
+		event = nk.dynamics.GraphEvent(nk.dynamics.GraphEventType.EDGE_REMOVAL, a, b, 1)
+
+		dapx.update(event)
+		ddiag = dapx.getDiagonal()
+		diag = nk.centrality.ApproxElectricalCloseness(g).run().getDiagonal()
+		for u in g.iterNodes():
+			self.assertLessEqual(abs(diag[u] - ddiag[u]), 2 * eps)
+		self.assertEqual(g.numberOfNodes(), len(dapx.scores()))
 	
 	def testApproxSpanningEdge(self):
 		nk.setSeed(42, False)


### PR DESCRIPTION
This PR is an updated version of #1097. 
Old description:


This algorithm is based on the ApproxElectricalCloseness algorithm in networkit.
The dynamic algorithm supports:

- edge addition. Algorithm details can be found in our recent paper (which I think is not published yet (?))
- edge deletion. Based on the same idea as edge addition, with small changes to the math / reordering some terms.

This implementation currently does not support arbitrary edge deletions: edges on the BFS tree from the pivot element u (which is used to approximate r(u,v) for all v) may not be deleted, because this would require a larger update computation. In principle, this is possible, but for our current use case this is not a problem. The code can easily be extended when the need arises.

Additional changes in this PR:

- updated the description of ApproxElectricalCloseness to a more accurate description of the results properties
- created a new GTest file which now contains the tests for the static and dynamic algorithm

