### PR TITLE
Add unit tests for Aux::SortedList

### DIFF
--- a/include/networkit/auxiliary/SortedList.hpp
+++ b/include/networkit/auxiliary/SortedList.hpp
@@ -28,7 +28,7 @@ class SortedList {
 private:
     std::vector<std::pair<uint64_t, double>> elements;
     std::vector<uint64_t> position;
-    uint64_t virtualSize{};
+    uint64_t virtualSize;
     const uint64_t size;
     const uint64_t maxKey;
 

--- a/include/networkit/auxiliary/SortedList.hpp
+++ b/include/networkit/auxiliary/SortedList.hpp
@@ -11,8 +11,6 @@
 #include <algorithm>
 #include <vector>
 
-#include <networkit/auxiliary/Log.hpp>
-
 namespace Aux {
 /*
  * Keeps a sorted list of pairs with at most k elements.
@@ -30,7 +28,7 @@ class SortedList {
 private:
     std::vector<std::pair<uint64_t, double>> elements;
     std::vector<uint64_t> position;
-    uint64_t virtualSize;
+    uint64_t virtualSize{};
     const uint64_t size;
     const uint64_t maxKey;
 

--- a/networkit/cpp/auxiliary/test/CMakeLists.txt
+++ b/networkit/cpp/auxiliary/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 networkit_add_test(auxiliary AuxGTest)
 networkit_add_test(auxiliary SparseVectorGTest)
+networkit_add_test(auxiliary SortedListGTest)
 
 networkit_add_benchmark(auxiliary AuxRandomBenchmark)
 

--- a/networkit/cpp/auxiliary/test/SortedListGTest.cpp
+++ b/networkit/cpp/auxiliary/test/SortedListGTest.cpp
@@ -11,23 +11,23 @@ namespace Networkit {
 
 class SortedListGTest : public testing::Test {};
 
-TEST(SortedListGTest, testBasicInsertionSortedOrder) {
+TEST_F(SortedListGTest, testBasicInsertionSortedOrder) {
     Aux::SortedList list(3, 10);
 
     list.insert(1, 5.0);
     list.insert(2, 7.0);
     list.insert(3, 6.0);
 
-    EXPECT_EQ(list.getSize(), 3u);
-    EXPECT_EQ(list.getElement(0), 2u);
+    EXPECT_EQ(list.getSize(), 3);
+    EXPECT_EQ(list.getElement(0), 2);
     EXPECT_EQ(list.getValue(0), 7.0);
-    EXPECT_EQ(list.getElement(1), 3u);
+    EXPECT_EQ(list.getElement(1), 3);
     EXPECT_EQ(list.getValue(1), 6.0);
-    EXPECT_EQ(list.getElement(2), 1u);
+    EXPECT_EQ(list.getElement(2), 1);
     EXPECT_EQ(list.getValue(2), 5.0);
 }
 
-TEST(SortedListGTest, testInsertExistingElementWithHigherValue) {
+TEST_F(SortedListGTest, testInsertExistingElementWithHigherValue) {
     Aux::SortedList list(3, 10);
 
     list.insert(4, 3.0);
@@ -36,61 +36,61 @@ TEST(SortedListGTest, testInsertExistingElementWithHigherValue) {
 
     list.insert(4, 6.0);
 
-    EXPECT_EQ(list.getSize(), 3u);
+    EXPECT_EQ(list.getSize(), 3);
 
-    EXPECT_EQ(list.getElement(0), 4u);
+    EXPECT_EQ(list.getElement(0), 4);
     EXPECT_EQ(list.getValue(0), 6.0);
-    EXPECT_EQ(list.getElement(1), 6u);
+    EXPECT_EQ(list.getElement(1), 6);
     EXPECT_EQ(list.getValue(1), 5.0);
-    EXPECT_EQ(list.getElement(2), 5u);
+    EXPECT_EQ(list.getElement(2), 5);
     EXPECT_EQ(list.getValue(2), 4.0);
 }
 
-TEST(SortedListGTest, testExceedingCapacityKeepsTopK) {
+TEST_F(SortedListGTest, testExceedingCapacityKeepsTopK) {
     Aux::SortedList list(3, 10);
 
     list.insert(1, 1.0);
     list.insert(2, 2.0);
     list.insert(3, 3.0);
-    EXPECT_EQ(list.getElement(2), 1u);
-    EXPECT_EQ(list.getSize(), 3u);
+    EXPECT_EQ(list.getElement(2), 1);
+    EXPECT_EQ(list.getSize(), 3);
 
     list.insert(4, 4.0); // Should evict (1, 1.0)
-    EXPECT_EQ(list.getSize(), 3u);
-    EXPECT_NE(list.getElement(2), 1u);
-    EXPECT_EQ(list.getElement(2), 2u);
+    EXPECT_EQ(list.getSize(), 3);
+    EXPECT_NE(list.getElement(2), 1);
+    EXPECT_EQ(list.getElement(2), 2);
 }
 
-TEST(SortedListGTest, testDuplicateInsertSameElement) {
+TEST_F(SortedListGTest, testDuplicateInsertSameElement) {
     Aux::SortedList list(3, 10);
 
     list.insert(1, 5.0);
     list.insert(2, 6.0);
     list.insert(1, 7.0);
 
-    EXPECT_EQ(list.getSize(), 3u);
-    EXPECT_EQ(list.getElement(0), 1u);
+    EXPECT_EQ(list.getSize(), 3);
+    EXPECT_EQ(list.getElement(0), 1);
     EXPECT_EQ(list.getValue(0), 7.0);
-    EXPECT_EQ(list.getElement(1), 2u);
+    EXPECT_EQ(list.getElement(1), 2);
     EXPECT_EQ(list.getValue(1), 6.0);
-    EXPECT_EQ(list.getElement(2), 1u);
+    EXPECT_EQ(list.getElement(2), 1);
     EXPECT_EQ(list.getValue(2), 5.0);
 }
 
-TEST(SortedListGTest, testClear) {
+TEST_F(SortedListGTest, testClear) {
     Aux::SortedList list(3, 10);
     list.insert(1, 10.0);
     list.insert(2, 9.0);
     list.clear();
 
-    EXPECT_EQ(list.getSize(), 0u);
+    EXPECT_EQ(list.getSize(), 0);
     list.insert(3, 8.0);
-    EXPECT_EQ(list.getSize(), 1u);
-    EXPECT_EQ(list.getElement(0), 3u);
+    EXPECT_EQ(list.getSize(), 1);
+    EXPECT_EQ(list.getElement(0), 3);
     EXPECT_EQ(list.getValue(0), 8.0);
 }
 
-TEST(SortedListGTest, testInsertingOutOfRangeKeyThrows) {
+TEST_F(SortedListGTest, testInsertingOutOfRangeKeyThrows) {
     EXPECT_THROW(Aux::SortedList(5, 3), std::runtime_error);
 }
 

--- a/networkit/cpp/auxiliary/test/SortedListGTest.cpp
+++ b/networkit/cpp/auxiliary/test/SortedListGTest.cpp
@@ -1,0 +1,97 @@
+/*
+* SortedListGTest.cpp
+ *
+ *  Created on: 17.07.2025
+ *      Author: Andreas Scharf (andreas.b.scharf@gmail.com)
+ */
+
+#include <gtest/gtest.h>
+#include <networkit/auxiliary/SortedList.hpp>
+namespace Networkit {
+
+TEST(SortedListTest, testBasicInsertionSortedOrder) {
+    Aux::SortedList sl(3, 10);
+
+    sl.insert(1, 5.0);
+    sl.insert(2, 7.0);
+    sl.insert(3, 6.0);
+
+    EXPECT_EQ(sl.getSize(), 3u);
+    EXPECT_EQ(sl.getElement(0), 2u);
+    EXPECT_EQ(sl.getValue(0), 7.0);
+    EXPECT_EQ(sl.getElement(1), 3u);
+    EXPECT_EQ(sl.getValue(1), 6.0);
+    EXPECT_EQ(sl.getElement(2), 1u);
+    EXPECT_EQ(sl.getValue(2), 5.0);
+}
+
+TEST(SortedListTest, UpdateExistingElementHigherValue) {
+    Aux::SortedList sl(3, 10);
+
+    sl.insert(4, 3.0);
+    sl.insert(5, 4.0);
+    sl.insert(6, 5.0);
+
+    sl.insert(4, 6.0);
+
+    EXPECT_EQ(sl.getElement(0), 4u);
+    EXPECT_EQ(sl.getValue(0), 6.0);
+    EXPECT_EQ(sl.getSize(), 3u);
+}
+
+TEST(SortedListTest, ExceedingCapacityOnlyKeepsTopK) {
+    Aux::SortedList sl(3, 10);
+
+    sl.insert(1, 1.0);
+    sl.insert(2, 2.0);
+    sl.insert(3, 3.0);
+    EXPECT_EQ(sl.getElement(2), 1u);
+    EXPECT_EQ(sl.getSize(), 3u);
+
+    sl.insert(4, 4.0);  // Should evict (1, 1.0)
+    EXPECT_EQ(sl.getSize(), 3u);
+    EXPECT_NE(sl.getElement(2), 1u);
+    EXPECT_EQ(sl.getElement(2), 2u);
+}
+
+TEST(SortedListTest, DuplicateInsertSameValueIgnoredPosition) {
+    Aux::SortedList sl(3, 10);
+
+    sl.insert(1, 5.0);
+    sl.insert(2, 6.0);
+    sl.insert(1, 7.0);
+
+    EXPECT_EQ(sl.getSize(), 3u);
+    EXPECT_EQ(sl.getElement(0), 1u);
+    EXPECT_EQ(sl.getValue(0), 7.0);
+    EXPECT_EQ(sl.getElement(1), 2u);
+    EXPECT_EQ(sl.getValue(1), 6.0);
+    EXPECT_EQ(sl.getElement(2), 1u);
+    EXPECT_EQ(sl.getValue(2), 5.0);
+}
+
+TEST(SortedListTest, ClearEmptiesAll) {
+    Aux::SortedList sl(3, 10);
+    sl.insert(1, 10.0);
+    sl.insert(2, 9.0);
+    sl.clear();
+
+    EXPECT_EQ(sl.getSize(), 0u);
+    sl.insert(3, 8.0);
+    EXPECT_EQ(sl.getSize(), 1u);
+    EXPECT_EQ(sl.getElement(0), 3u);
+}
+
+TEST(SortedListTest, InsertingOutOfRangeKeyThrows) {
+    EXPECT_THROW(Aux::SortedList(5, 3), std::runtime_error);
+}
+
+TEST(SortedListTest, InsertingNonMonotonicValueIgnored) {
+    Aux::SortedList sl(3, 10);
+
+    sl.insert(2, 5.0);
+    sl.insert(2, 3.0);
+    EXPECT_EQ(sl.getElement(0), 2u);
+    EXPECT_EQ(sl.getValue(0), 5.0);
+}
+}

--- a/networkit/cpp/auxiliary/test/SortedListGTest.cpp
+++ b/networkit/cpp/auxiliary/test/SortedListGTest.cpp
@@ -1,5 +1,5 @@
 /*
-* SortedListGTest.cpp
+ * SortedListGTest.cpp
  *
  *  Created on: 17.07.2025
  *      Author: Andreas Scharf (andreas.b.scharf@gmail.com)
@@ -9,89 +9,89 @@
 #include <networkit/auxiliary/SortedList.hpp>
 namespace Networkit {
 
-TEST(SortedListTest, testBasicInsertionSortedOrder) {
-    Aux::SortedList sl(3, 10);
+class SortedListGTest : public testing::Test {};
 
-    sl.insert(1, 5.0);
-    sl.insert(2, 7.0);
-    sl.insert(3, 6.0);
+TEST(SortedListGTest, testBasicInsertionSortedOrder) {
+    Aux::SortedList list(3, 10);
 
-    EXPECT_EQ(sl.getSize(), 3u);
-    EXPECT_EQ(sl.getElement(0), 2u);
-    EXPECT_EQ(sl.getValue(0), 7.0);
-    EXPECT_EQ(sl.getElement(1), 3u);
-    EXPECT_EQ(sl.getValue(1), 6.0);
-    EXPECT_EQ(sl.getElement(2), 1u);
-    EXPECT_EQ(sl.getValue(2), 5.0);
+    list.insert(1, 5.0);
+    list.insert(2, 7.0);
+    list.insert(3, 6.0);
+
+    EXPECT_EQ(list.getSize(), 3u);
+    EXPECT_EQ(list.getElement(0), 2u);
+    EXPECT_EQ(list.getValue(0), 7.0);
+    EXPECT_EQ(list.getElement(1), 3u);
+    EXPECT_EQ(list.getValue(1), 6.0);
+    EXPECT_EQ(list.getElement(2), 1u);
+    EXPECT_EQ(list.getValue(2), 5.0);
 }
 
-TEST(SortedListTest, UpdateExistingElementHigherValue) {
-    Aux::SortedList sl(3, 10);
+TEST(SortedListGTest, testInsertExistingElementWithHigherValue) {
+    Aux::SortedList list(3, 10);
 
-    sl.insert(4, 3.0);
-    sl.insert(5, 4.0);
-    sl.insert(6, 5.0);
+    list.insert(4, 3.0);
+    list.insert(5, 4.0);
+    list.insert(6, 5.0);
 
-    sl.insert(4, 6.0);
+    list.insert(4, 6.0);
 
-    EXPECT_EQ(sl.getElement(0), 4u);
-    EXPECT_EQ(sl.getValue(0), 6.0);
-    EXPECT_EQ(sl.getSize(), 3u);
+    EXPECT_EQ(list.getSize(), 3u);
+
+    EXPECT_EQ(list.getElement(0), 4u);
+    EXPECT_EQ(list.getValue(0), 6.0);
+    EXPECT_EQ(list.getElement(1), 6u);
+    EXPECT_EQ(list.getValue(1), 5.0);
+    EXPECT_EQ(list.getElement(2), 5u);
+    EXPECT_EQ(list.getValue(2), 4.0);
 }
 
-TEST(SortedListTest, ExceedingCapacityOnlyKeepsTopK) {
-    Aux::SortedList sl(3, 10);
+TEST(SortedListGTest, testExceedingCapacityKeepsTopK) {
+    Aux::SortedList list(3, 10);
 
-    sl.insert(1, 1.0);
-    sl.insert(2, 2.0);
-    sl.insert(3, 3.0);
-    EXPECT_EQ(sl.getElement(2), 1u);
-    EXPECT_EQ(sl.getSize(), 3u);
+    list.insert(1, 1.0);
+    list.insert(2, 2.0);
+    list.insert(3, 3.0);
+    EXPECT_EQ(list.getElement(2), 1u);
+    EXPECT_EQ(list.getSize(), 3u);
 
-    sl.insert(4, 4.0);  // Should evict (1, 1.0)
-    EXPECT_EQ(sl.getSize(), 3u);
-    EXPECT_NE(sl.getElement(2), 1u);
-    EXPECT_EQ(sl.getElement(2), 2u);
+    list.insert(4, 4.0); // Should evict (1, 1.0)
+    EXPECT_EQ(list.getSize(), 3u);
+    EXPECT_NE(list.getElement(2), 1u);
+    EXPECT_EQ(list.getElement(2), 2u);
 }
 
-TEST(SortedListTest, DuplicateInsertSameValueIgnoredPosition) {
-    Aux::SortedList sl(3, 10);
+TEST(SortedListGTest, testDuplicateInsertSameElement) {
+    Aux::SortedList list(3, 10);
 
-    sl.insert(1, 5.0);
-    sl.insert(2, 6.0);
-    sl.insert(1, 7.0);
+    list.insert(1, 5.0);
+    list.insert(2, 6.0);
+    list.insert(1, 7.0);
 
-    EXPECT_EQ(sl.getSize(), 3u);
-    EXPECT_EQ(sl.getElement(0), 1u);
-    EXPECT_EQ(sl.getValue(0), 7.0);
-    EXPECT_EQ(sl.getElement(1), 2u);
-    EXPECT_EQ(sl.getValue(1), 6.0);
-    EXPECT_EQ(sl.getElement(2), 1u);
-    EXPECT_EQ(sl.getValue(2), 5.0);
+    EXPECT_EQ(list.getSize(), 3u);
+    EXPECT_EQ(list.getElement(0), 1u);
+    EXPECT_EQ(list.getValue(0), 7.0);
+    EXPECT_EQ(list.getElement(1), 2u);
+    EXPECT_EQ(list.getValue(1), 6.0);
+    EXPECT_EQ(list.getElement(2), 1u);
+    EXPECT_EQ(list.getValue(2), 5.0);
 }
 
-TEST(SortedListTest, ClearEmptiesAll) {
-    Aux::SortedList sl(3, 10);
-    sl.insert(1, 10.0);
-    sl.insert(2, 9.0);
-    sl.clear();
+TEST(SortedListGTest, testClear) {
+    Aux::SortedList list(3, 10);
+    list.insert(1, 10.0);
+    list.insert(2, 9.0);
+    list.clear();
 
-    EXPECT_EQ(sl.getSize(), 0u);
-    sl.insert(3, 8.0);
-    EXPECT_EQ(sl.getSize(), 1u);
-    EXPECT_EQ(sl.getElement(0), 3u);
+    EXPECT_EQ(list.getSize(), 0u);
+    list.insert(3, 8.0);
+    EXPECT_EQ(list.getSize(), 1u);
+    EXPECT_EQ(list.getElement(0), 3u);
+    EXPECT_EQ(list.getValue(0), 8.0);
 }
 
-TEST(SortedListTest, InsertingOutOfRangeKeyThrows) {
+TEST(SortedListGTest, testInsertingOutOfRangeKeyThrows) {
     EXPECT_THROW(Aux::SortedList(5, 3), std::runtime_error);
 }
 
-TEST(SortedListTest, InsertingNonMonotonicValueIgnored) {
-    Aux::SortedList sl(3, 10);
-
-    sl.insert(2, 5.0);
-    sl.insert(2, 3.0);
-    EXPECT_EQ(sl.getElement(0), 2u);
-    EXPECT_EQ(sl.getValue(0), 5.0);
-}
-}
+} // namespace Networkit


### PR DESCRIPTION
## Summary

This PR adds a test suite for the internal `Aux::SortedList` class. It covers:
- Insertion and ranking behavior
- Reinsertion with higher values (monotonic updates)
- Capacity handling and eviction
- `clear()` behavior

No production code was changed. Tests assume values for the same key are strictly increasing, based on implementation comments.