### PR TITLE
Add unit tests for Aux::Spinlock.

### DIFF
--- a/networkit/cpp/auxiliary/test/CMakeLists.txt
+++ b/networkit/cpp/auxiliary/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 networkit_add_test(auxiliary AuxGTest)
 networkit_add_test(auxiliary SparseVectorGTest)
+networkit_add_test(auxiliary SpinLockGTest)
 
 networkit_add_benchmark(auxiliary AuxRandomBenchmark)
 

--- a/networkit/cpp/auxiliary/test/SpinLockGTest.cpp
+++ b/networkit/cpp/auxiliary/test/SpinLockGTest.cpp
@@ -1,0 +1,52 @@
+/*
+ * SpinLockGTest.cpp
+ *
+ *  Created on: 18.07.2025
+ *      Author: Andreas Scharf (andreas.b.scharf@gmail.com)
+ */
+
+#include <thread>
+#include <gtest/gtest.h>
+#include <networkit/auxiliary/SpinLock.hpp>
+
+class SpinlockGTest : public testing::Test {};
+
+namespace NetworKit {
+
+TEST_F(SpinlockGTest, testSpinLockSingleThread) {
+    Aux::Spinlock lock;
+    EXPECT_NO_THROW({
+        lock.lock();
+        lock.unlock();
+    });
+}
+
+TEST_F(SpinlockGTest, testSpinLockUnderContention) {
+    Aux::Spinlock lock;
+
+    int counter = 0;
+    constexpr int incrementsPerThread = 10000;
+    const unsigned int numberOfThreads = std::thread::hardware_concurrency();
+
+    auto worker = [&]() {
+        for (int i = 0; i < incrementsPerThread; ++i) {
+            lock.lock();
+            ++counter;
+            lock.unlock();
+        }
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(numberOfThreads);
+    for (unsigned int i = 0; i < numberOfThreads; ++i) {
+        threads.emplace_back(worker);
+    }
+
+    for (auto &t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(counter, numberOfThreads * incrementsPerThread);
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/auxiliary/test/SpinLockGTest.cpp
+++ b/networkit/cpp/auxiliary/test/SpinLockGTest.cpp
@@ -36,11 +36,8 @@ TEST_F(SpinlockGTest, testSpinLockUnderContention) {
         }
     };
 
-    std::vector<std::thread> threads;
-    threads.reserve(numberOfThreads);
-    for (unsigned int i = 0; i < numberOfThreads; ++i) {
-        threads.emplace_back(worker);
-    }
+    std::vector<std::thread> threads(numberOfThreads);
+    std::ranges::iota(threads, 0);
 
     for (auto &t : threads) {
         t.join();

--- a/networkit/cpp/auxiliary/test/SpinLockGTest.cpp
+++ b/networkit/cpp/auxiliary/test/SpinLockGTest.cpp
@@ -36,11 +36,12 @@ TEST_F(SpinlockGTest, testSpinLockUnderContention) {
         }
     };
 
-    std::vector<std::thread> threads(numberOfThreads);
-    std::ranges::iota(threads, 0);
-
+    std::vector<std::thread> threads;
+    for (unsigned int i = 0; i < numberOfThreads; ++i) {
+        threads.emplace_back(worker);
+    }
     for (std::thread &thread : threads) {
-        t.join();
+        thread.join();
     }
 
     EXPECT_EQ(counter, numberOfThreads * incrementsPerThread);

--- a/networkit/cpp/auxiliary/test/SpinLockGTest.cpp
+++ b/networkit/cpp/auxiliary/test/SpinLockGTest.cpp
@@ -39,7 +39,7 @@ TEST_F(SpinlockGTest, testSpinLockUnderContention) {
     std::vector<std::thread> threads(numberOfThreads);
     std::ranges::iota(threads, 0);
 
-    for (auto &t : threads) {
+    for (std::thread &thread : threads) {
         t.join();
     }
 


### PR DESCRIPTION
## Summary

This PR adds a test suite for the internal `Aux::Spinlock` class. No production code was changed. 