### PR TITLE
Improve LoggingTimer Test Coverage and Structure

### DIFF
--- a/networkit/cpp/auxiliary/test/AuxGTest.cpp
+++ b/networkit/cpp/auxiliary/test/AuxGTest.cpp
@@ -15,7 +15,6 @@
 #include <array>
 #include <chrono>
 #include <fstream>
-#include <iostream>
 #include <limits>
 #include <numeric>
 #include <set>
@@ -38,37 +37,6 @@
 namespace NetworKit {
 
 class AuxGTest : public testing::Test {};
-
-TEST_F(AuxGTest, testTimer) {
-    Aux::LoggingTimer ltimer(
-        "LogginTimer",
-        Aux::Log::LogLevel::TRACE); // only enabled if test is execut with raised loglevel
-
-    Aux::StartedTimer timer;
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    const auto ms = timer.elapsedMilliseconds();
-    const auto us = timer.elapsedMicroseconds();
-    const auto ns = timer.elapsedNanoseconds();
-
-    ASSERT_GE(ms, 5);
-    ASSERT_GE(us, 5000);
-    ASSERT_GE(ns, 5000000);
-
-    timer.stop();
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    const auto ms2 = timer.elapsedMilliseconds();
-    const auto us2 = timer.elapsedMicroseconds();
-    const auto ns2 = timer.elapsedNanoseconds();
-
-    ASSERT_GE(ms2, 5);
-    ASSERT_GE(us2, 5000);
-    ASSERT_GE(ns2, 5000000);
-
-    ASSERT_LE(ms2, us2 / 1000 + 1);
-    ASSERT_LE(us2, ns2 / 1000 + 1);
-}
 
 TEST_F(AuxGTest, produceRandomIntegers) {
     Aux::Random::setSeed(1, false);

--- a/networkit/cpp/auxiliary/test/CMakeLists.txt
+++ b/networkit/cpp/auxiliary/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 networkit_add_test(auxiliary AuxGTest)
 networkit_add_test(auxiliary SparseVectorGTest)
 networkit_add_test(auxiliary SortedListGTest)
+networkit_add_test(auxiliary LoggingTimerGTest)
 
 networkit_add_benchmark(auxiliary AuxRandomBenchmark)
 

--- a/networkit/cpp/auxiliary/test/LoggingTimerGTest.cpp
+++ b/networkit/cpp/auxiliary/test/LoggingTimerGTest.cpp
@@ -5,6 +5,7 @@
  *      Author: Andreas Scharf (andreas.b.scharf@gmail.com)
  */
 
+#include <thread>
 #include <gtest/gtest.h>
 #include <networkit/auxiliary/Timer.hpp>
 

--- a/networkit/cpp/auxiliary/test/LoggingTimerGTest.cpp
+++ b/networkit/cpp/auxiliary/test/LoggingTimerGTest.cpp
@@ -64,7 +64,7 @@ TEST_F(LoggingTimerTest, testStartedTimerElapsedValuesAfterStop) {
 
 TEST_F(LoggingTimerTest, testStartedTimerStartAndStopTimeValid) {
     Aux::StartedTimer timer;
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     timer.stop();
     EXPECT_LE(timer.startTime(), timer.stopTime());
 }

--- a/networkit/cpp/auxiliary/test/LoggingTimerGTest.cpp
+++ b/networkit/cpp/auxiliary/test/LoggingTimerGTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <thread>
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <networkit/auxiliary/Timer.hpp>
 
@@ -30,8 +31,7 @@ TEST_F(LoggingTimerTest, testLogsWhenLabelIsUsed) {
         Aux::LoggingTimer timer("test-timer", Aux::Log::LogLevel::TRACE);
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
-    const std::string output = getCapturedOutput();
-    EXPECT_NE(output.find("Timer \"test-timer\" ran for"), std::string::npos);
+    EXPECT_THAT(getCapturedOutput(), testing::HasSubstr("Timer \"test-timer\" ran for"));
 }
 
 TEST_F(LoggingTimerTest, testLogsWhenLabelIsNotUsed) {
@@ -40,21 +40,16 @@ TEST_F(LoggingTimerTest, testLogsWhenLabelIsNotUsed) {
         Aux::LoggingTimer timer("", Aux::Log::LogLevel::DEBUG);
         std::this_thread::sleep_for(std::chrono::milliseconds(3));
     }
-    const std::string output = getCapturedOutput();
-    EXPECT_NE(output.find("Timer ran for"), std::string::npos);
+    EXPECT_THAT(getCapturedOutput(), testing::HasSubstr("Timer ran for"));
 }
 
 TEST_F(LoggingTimerTest, testStartedTimerElapsedValuesBeforeStop) {
     Aux::StartedTimer timer;
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
-    const auto ms = timer.elapsedMilliseconds();
-    const auto us = timer.elapsedMicroseconds();
-    const auto ns = timer.elapsedNanoseconds();
-
-    EXPECT_GE(ms, 5);
-    EXPECT_GE(us, 5000);
-    EXPECT_GE(ns, 5000000);
+    EXPECT_GE(timer.elapsedMilliseconds(), 5);
+    EXPECT_GE(timer.elapsedMicroseconds(), 5000);
+    EXPECT_GE(timer.elapsedNanoseconds(), 5000000);
 }
 
 TEST_F(LoggingTimerTest, testStartedTimerElapsedValuesAfterStop) {
@@ -63,25 +58,13 @@ TEST_F(LoggingTimerTest, testStartedTimerElapsedValuesAfterStop) {
     timer.stop();
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-    const auto ms2 = timer.elapsedMilliseconds();
-    const auto us2 = timer.elapsedMicroseconds();
-    const auto ns2 = timer.elapsedNanoseconds();
-
-    EXPECT_GE(ms2, 5);
-    EXPECT_GE(us2, 5000);
-    EXPECT_GE(ns2, 5000000);
-
-    EXPECT_LE(ms2, us2 / 1000 + 1);
-    EXPECT_LE(us2, ns2 / 1000 + 1);
+    EXPECT_LE(timer.elapsedMilliseconds(), timer.elapsedMicroseconds() / 1000 + 1);
+    EXPECT_LE(timer.elapsedMicroseconds(), timer.elapsedNanoseconds() / 1000 + 1);
 }
 
 TEST_F(LoggingTimerTest, testStartedTimerStartAndStopTimeValid) {
     Aux::StartedTimer timer;
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     timer.stop();
-
-    const auto start = timer.startTime();
-    const auto stop = timer.stopTime();
-
-    EXPECT_LE(start, stop);
+    EXPECT_LE(timer.startTime(), timer.stopTime());
 }

--- a/networkit/cpp/auxiliary/test/LoggingTimerGTest.cpp
+++ b/networkit/cpp/auxiliary/test/LoggingTimerGTest.cpp
@@ -1,0 +1,86 @@
+/*
+ * SortedListGTest.cpp
+ *
+ *  Created on: 22.07.2025
+ *      Author: Andreas Scharf (andreas.b.scharf@gmail.com)
+ */
+
+#include <gtest/gtest.h>
+#include <networkit/auxiliary/Timer.hpp>
+
+class LoggingTimerTest : public ::testing::Test {
+protected:
+    std::streambuf *originalCerrBuf;
+    std::stringstream capturedOutput;
+
+    void SetUp() override {
+        originalCerrBuf = std::cerr.rdbuf();
+        std::cerr.rdbuf(capturedOutput.rdbuf());
+    }
+
+    void TearDown() override { std::cerr.rdbuf(originalCerrBuf); }
+
+    std::string getCapturedOutput() { return capturedOutput.str(); }
+};
+
+TEST_F(LoggingTimerTest, testLogsWhenLabelIsUsed) {
+    Aux::Log::setLogLevel("TRACE");
+    {
+        Aux::LoggingTimer timer("test-timer", Aux::Log::LogLevel::TRACE);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    const std::string output = getCapturedOutput();
+    EXPECT_NE(output.find("Timer \"test-timer\" ran for"), std::string::npos);
+}
+
+TEST_F(LoggingTimerTest, testLogsWhenLabelIsNotUsed) {
+    Aux::Log::setLogLevel("DEBUG");
+    {
+        Aux::LoggingTimer timer("", Aux::Log::LogLevel::DEBUG);
+        std::this_thread::sleep_for(std::chrono::milliseconds(3));
+    }
+    const std::string output = getCapturedOutput();
+    EXPECT_NE(output.find("Timer ran for"), std::string::npos);
+}
+
+TEST_F(LoggingTimerTest, testStartedTimerElapsedValuesBeforeStop) {
+    Aux::StartedTimer timer;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    const auto ms = timer.elapsedMilliseconds();
+    const auto us = timer.elapsedMicroseconds();
+    const auto ns = timer.elapsedNanoseconds();
+
+    EXPECT_GE(ms, 5);
+    EXPECT_GE(us, 5000);
+    EXPECT_GE(ns, 5000000);
+}
+
+TEST_F(LoggingTimerTest, testStartedTimerElapsedValuesAfterStop) {
+    Aux::StartedTimer timer;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    timer.stop();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    const auto ms2 = timer.elapsedMilliseconds();
+    const auto us2 = timer.elapsedMicroseconds();
+    const auto ns2 = timer.elapsedNanoseconds();
+
+    EXPECT_GE(ms2, 5);
+    EXPECT_GE(us2, 5000);
+    EXPECT_GE(ns2, 5000000);
+
+    EXPECT_LE(ms2, us2 / 1000 + 1);
+    EXPECT_LE(us2, ns2 / 1000 + 1);
+}
+
+TEST_F(LoggingTimerTest, testStartedTimerStartAndStopTimeValid) {
+    Aux::StartedTimer timer;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    timer.stop();
+
+    const auto start = timer.startTime();
+    const auto stop = timer.stopTime();
+
+    EXPECT_LE(start, stop);
+}


### PR DESCRIPTION
## Summary

This PR improves test coverage for the `Aux::Timer` and `Aux::LoggingTimer` components.
### Changes made
- **Closed coverage gaps** in the `Timer` and `LoggingTimer` APIs
- **Moved** the existing `testTimer` from `AuxGTest.cpp` into a new file: `LoggingTimerGTest.cpp`
- **Split** the original `testTimer` into multiple smaller test cases
