### PR TITLE
Fix crash when writing empty graph in NetworkitBinaryWriter

### DIFF
--- a/include/networkit/io/NetworkitBinaryGraph.hpp
+++ b/include/networkit/io/NetworkitBinaryGraph.hpp
@@ -19,17 +19,17 @@ namespace nkbg {
 
 struct Header {
     char magic[8];
-    uint64_t checksum;
-    uint64_t features;
-    uint64_t nodes;
-    uint64_t chunks;
-    uint64_t offsetBaseData;
-    uint64_t offsetAdjLists;
-    uint64_t offsetAdjTranspose;
-    uint64_t offsetWeightLists;
-    uint64_t offsetWeightTranspose;
-    uint64_t offsetAdjIdLists;
-    uint64_t offsetAdjIdTranspose;
+    uint64_t checksum{};
+    uint64_t features{};
+    uint64_t nodes{};
+    uint64_t chunks{};
+    uint64_t offsetBaseData{};
+    uint64_t offsetAdjLists{};
+    uint64_t offsetAdjTranspose{};
+    uint64_t offsetWeightLists{};
+    uint64_t offsetWeightTranspose{};
+    uint64_t offsetAdjIdLists{};
+    uint64_t offsetAdjIdTranspose{};
 };
 
 enum class WeightFormat : int { NONE = 0, VARINT = 1, SIGNED_VARINT = 2, DOUBLE = 3, FLOAT = 4 };

--- a/include/networkit/io/NetworkitBinaryWriter.hpp
+++ b/include/networkit/io/NetworkitBinaryWriter.hpp
@@ -57,11 +57,11 @@ public:
     std::vector<uint8_t> writeToBuffer(const Graph &G);
 
 private:
+    static constexpr const char *FILE_FORMAT = "nkbg003";
     count chunks;
     NetworkitBinaryWeights weightsType;
     NetworkitBinaryEdgeIDs edgeIndex;
     bool preserveEdgeIndex;
-
     template <class T>
     void writeData(T &outStream, const Graph &G);
 };

--- a/networkit/cpp/io/NetworkitBinaryReader.cpp
+++ b/networkit/cpp/io/NetworkitBinaryReader.cpp
@@ -84,7 +84,6 @@ Graph NetworkitBinaryReader::readData(const T &source) {
     };
 
     readHeader();
-
     nodes = header.nodes;
     DEBUG("# nodes here = ", nodes);
     chunks = header.chunks;
@@ -95,8 +94,12 @@ Graph NetworkitBinaryReader::readData(const T &source) {
         weighted = true;
     }
     Graph G(nodes, weighted, directed);
+
     if (indexed)
         G.indexEdges();
+    if (nodes == 0) {
+        return G;
+    }
     // Read base data.
     std::vector<uint8_t> nodeFlags;
     const char *baseIt = startIt + header.offsetBaseData;

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -161,6 +161,7 @@ void NetworkitBinaryWriter::writeData(T &outStream, const Graph &G) {
         outStream.write(reinterpret_cast<char *>(&zero), sizeof(zero));
         return;
     }
+
     if (nodes < chunks) {
         chunks = nodes;
         INFO("reducing chunks to ", chunks, " chunks");

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -154,12 +154,11 @@ void NetworkitBinaryWriter::writeData(T &outStream, const Graph &G) {
 
     count nodes = G.numberOfNodes();
     if (nodes == 0) {
-        // build header.features etc. as you do now…
         strncpy(header.magic, "nkbg003", 8);
         setFeatures();
         writeHeader();
         uint64_t zero = 0;
-        outStream.write(reinterpret_cast<char *>(&zero), sizeof(zero)); // adjListSize
+        outStream.write(reinterpret_cast<char *>(&zero), sizeof(zero));
         return;
     }
     if (nodes < chunks) {

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -154,7 +154,7 @@ void NetworkitBinaryWriter::writeData(T &outStream, const Graph &G) {
 
     count nodes = G.numberOfNodes();
     if (nodes == 0) {
-        strncpy(header.magic, "nkbg003", 8);
+        strncpy(header.magic, FILE_FORMAT, 8);
         setFeatures();
         writeHeader();
         uint64_t zero = 0;
@@ -278,7 +278,7 @@ void NetworkitBinaryWriter::writeData(T &outStream, const Graph &G) {
         transpIndexOffsets.push_back(transpIndexSize);
     }
     // Write header.
-    strncpy(header.magic, "nkbg003", 8);
+    strncpy(header.magic, FILE_FORMAT, 8);
     header.checksum = 0;
     setFeatures();
     header.nodes = nodes;

--- a/networkit/cpp/io/NetworkitBinaryWriter.cpp
+++ b/networkit/cpp/io/NetworkitBinaryWriter.cpp
@@ -153,6 +153,15 @@ void NetworkitBinaryWriter::writeData(T &outStream, const Graph &G) {
     };
 
     count nodes = G.numberOfNodes();
+    if (nodes == 0) {
+        // build header.features etc. as you do now…
+        strncpy(header.magic, "nkbg003", 8);
+        setFeatures();
+        writeHeader();
+        uint64_t zero = 0;
+        outStream.write(reinterpret_cast<char *>(&zero), sizeof(zero)); // adjListSize
+        return;
+    }
     if (nodes < chunks) {
         chunks = nodes;
         INFO("reducing chunks to ", chunks, " chunks");

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -1449,6 +1449,22 @@ TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraph) {
     EXPECT_EQ(graph.numberOfEdges(), graph_read.numberOfEdges());
     EXPECT_EQ(graph.isWeighted(), graph_read.isWeighted());
     EXPECT_EQ(graph.isDirected(), graph_read.isDirected());
+    EXPECT_EQ(graph.hasEdgeIds(), graph_read.hasEdgeIds());
+}
+
+TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraphWithIndexes) {
+    Graph graph(0, true, false, true);
+    NetworkitBinaryWriter writer;
+    std::filesystem::path const path = "output/empty_graph.nkb";
+    writer.write(graph, path.c_str());
+
+    NetworkitBinaryReader reader;
+    Graph graph_read = reader.read(path.c_str());
+    EXPECT_EQ(graph.numberOfNodes(), graph_read.numberOfNodes());
+    EXPECT_EQ(graph.numberOfEdges(), graph_read.numberOfEdges());
+    EXPECT_EQ(graph.isWeighted(), graph_read.isWeighted());
+    EXPECT_EQ(graph.isDirected(), graph_read.isDirected());
+    EXPECT_EQ(graph.hasEdgeIds(), graph_read.hasEdgeIds());
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -5,6 +5,7 @@
  *      Author: Christian Staudt (christian.staudt@kit.edu)
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <array>
@@ -1422,6 +1423,13 @@ TEST_F(IOGTest, testMatrixMarketReaderIntegerWeights) {
     });
 }
 
+MATCHER_P(GraphFeaturesEqual, expected, "Graph matches expected features") {
+    return arg.numberOfNodes() == expected.numberOfNodes()
+           && arg.numberOfEdges() == expected.numberOfEdges()
+           && arg.isWeighted() == expected.isWeighted() && arg.isDirected() == expected.isDirected()
+           && arg.hasEdgeIds() == expected.hasEdgeIds();
+}
+
 TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraph) {
     Graph graph(0, false, true);
     NetworkitBinaryWriter writer;
@@ -1430,11 +1438,7 @@ TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraph) {
 
     NetworkitBinaryReader reader;
     Graph graph_read = reader.read(path.string());
-    EXPECT_EQ(graph.numberOfNodes(), graph_read.numberOfNodes());
-    EXPECT_EQ(graph.numberOfEdges(), graph_read.numberOfEdges());
-    EXPECT_EQ(graph.isWeighted(), graph_read.isWeighted());
-    EXPECT_EQ(graph.isDirected(), graph_read.isDirected());
-    EXPECT_EQ(graph.hasEdgeIds(), graph_read.hasEdgeIds());
+    EXPECT_THAT(graph_read, GraphFeaturesEqual(graph));
 }
 
 TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraphWithIndexes) {
@@ -1445,11 +1449,6 @@ TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraphWithIndexes) {
 
     NetworkitBinaryReader reader;
     Graph graph_read = reader.read(path.string());
-    EXPECT_EQ(graph.numberOfNodes(), graph_read.numberOfNodes());
-    EXPECT_EQ(graph.numberOfEdges(), graph_read.numberOfEdges());
-    EXPECT_EQ(graph.isWeighted(), graph_read.isWeighted());
-    EXPECT_EQ(graph.isDirected(), graph_read.isDirected());
-    EXPECT_EQ(graph.hasEdgeIds(), graph_read.hasEdgeIds());
+    EXPECT_THAT(graph_read, GraphFeaturesEqual(graph));
 }
-
 } /* namespace NetworKit */

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -1427,10 +1427,10 @@ TEST_F(IOGTest, testGraphToolBinaryEmptyFileCanBeRead) {
     Graph graph(0, false, true);
     GraphToolBinaryWriter writer;
     std::filesystem::path const path = "output/empty_graph.gt";
-    writer.write(graph, path.c_str());
+    writer.write(graph, path.string());
 
     GraphToolBinaryReader reader;
-    Graph graph_read = reader.read(path.c_str());
+    Graph graph_read = reader.read(path.string());
     EXPECT_EQ(graph.numberOfNodes(), graph_read.numberOfNodes());
     EXPECT_EQ(graph.numberOfEdges(), graph_read.numberOfEdges());
     EXPECT_EQ(graph.isWeighted(), graph_read.isWeighted());
@@ -1441,10 +1441,10 @@ TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraph) {
     Graph graph(0, false, true);
     NetworkitBinaryWriter writer;
     std::filesystem::path const path = "output/empty_graph.nkb";
-    writer.write(graph, path.c_str());
+    writer.write(graph, path.string());
 
     NetworkitBinaryReader reader;
-    Graph graph_read = reader.read(path.c_str());
+    Graph graph_read = reader.read(path.string());
     EXPECT_EQ(graph.numberOfNodes(), graph_read.numberOfNodes());
     EXPECT_EQ(graph.numberOfEdges(), graph_read.numberOfEdges());
     EXPECT_EQ(graph.isWeighted(), graph_read.isWeighted());
@@ -1456,10 +1456,10 @@ TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraphWithIndexes) {
     Graph graph(0, true, false, true);
     NetworkitBinaryWriter writer;
     std::filesystem::path const path = "output/empty_graph.nkb";
-    writer.write(graph, path.c_str());
+    writer.write(graph, path.string());
 
     NetworkitBinaryReader reader;
-    Graph graph_read = reader.read(path.c_str());
+    Graph graph_read = reader.read(path.string());
     EXPECT_EQ(graph.numberOfNodes(), graph_read.numberOfNodes());
     EXPECT_EQ(graph.numberOfEdges(), graph_read.numberOfEdges());
     EXPECT_EQ(graph.isWeighted(), graph_read.isWeighted());

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <chrono>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <limits>
@@ -1420,6 +1421,34 @@ TEST_F(IOGTest, testMatrixMarketReaderIntegerWeights) {
         EXPECT_TRUE(G_from_csr.hasEdge(u, v));
         EXPECT_EQ(G_from_csr.weight(u, v), w);
     });
+}
+
+TEST_F(IOGTest, testGraphToolBinaryEmptyFileCanBeRead) {
+    Graph graph(0, false, true);
+    GraphToolBinaryWriter writer;
+    std::filesystem::path const path = "output/empty_graph.gt";
+    writer.write(graph, path.c_str());
+
+    GraphToolBinaryReader reader;
+    Graph graph_read = reader.read(path.c_str());
+    EXPECT_EQ(graph.numberOfNodes(), graph_read.numberOfNodes());
+    EXPECT_EQ(graph.numberOfEdges(), graph_read.numberOfEdges());
+    EXPECT_EQ(graph.isWeighted(), graph_read.isWeighted());
+    EXPECT_EQ(graph.isDirected(), graph_read.isDirected());
+}
+
+TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraph) {
+    Graph graph(0, false, true);
+    NetworkitBinaryWriter writer;
+    std::filesystem::path const path = "output/empty_graph.nkb";
+    writer.write(graph, path.c_str());
+
+    NetworkitBinaryReader reader;
+    Graph graph_read = reader.read(path.c_str());
+    EXPECT_EQ(graph.numberOfNodes(), graph_read.numberOfNodes());
+    EXPECT_EQ(graph.numberOfEdges(), graph_read.numberOfEdges());
+    EXPECT_EQ(graph.isWeighted(), graph_read.isWeighted());
+    EXPECT_EQ(graph.isDirected(), graph_read.isDirected());
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -49,7 +49,6 @@
 #include <networkit/io/PartitionReader.hpp>
 #include <networkit/io/PartitionWriter.hpp>
 #include <networkit/io/RBMatrixReader.hpp>
-#include <networkit/io/SNAPEdgeListPartitionReader.hpp>
 #include <networkit/io/SNAPGraphReader.hpp>
 #include <networkit/io/SNAPGraphWriter.hpp>
 #include <networkit/io/ThrillGraphBinaryReader.hpp>
@@ -1423,24 +1422,10 @@ TEST_F(IOGTest, testMatrixMarketReaderIntegerWeights) {
     });
 }
 
-TEST_F(IOGTest, testGraphToolBinaryEmptyFileCanBeRead) {
-    Graph graph(0, false, true);
-    GraphToolBinaryWriter writer;
-    std::filesystem::path const path = "output/empty_graph.gt";
-    writer.write(graph, path.string());
-
-    GraphToolBinaryReader reader;
-    Graph graph_read = reader.read(path.string());
-    EXPECT_EQ(graph.numberOfNodes(), graph_read.numberOfNodes());
-    EXPECT_EQ(graph.numberOfEdges(), graph_read.numberOfEdges());
-    EXPECT_EQ(graph.isWeighted(), graph_read.isWeighted());
-    EXPECT_EQ(graph.isDirected(), graph_read.isDirected());
-}
-
 TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraph) {
     Graph graph(0, false, true);
     NetworkitBinaryWriter writer;
-    std::filesystem::path const path = "output/empty_graph.nkb";
+    const std::filesystem::path path = "output/empty_graph.nkb";
     writer.write(graph, path.string());
 
     NetworkitBinaryReader reader;
@@ -1455,7 +1440,7 @@ TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraph) {
 TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraphWithIndexes) {
     Graph graph(0, true, false, true);
     NetworkitBinaryWriter writer;
-    std::filesystem::path const path = "output/empty_graph.nkb";
+    const std::filesystem::path path = "output/empty_graph.nkb";
     writer.write(graph, path.string());
 
     NetworkitBinaryReader reader;

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -1432,23 +1432,19 @@ MATCHER_P(GraphFeaturesEqual, expected, "Graph matches expected features") {
 
 TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraph) {
     Graph graph(0, false, true);
-    NetworkitBinaryWriter writer;
     const std::filesystem::path path = "output/empty_graph.nkb";
-    writer.write(graph, path.string());
+    NetworkitBinaryWriter{}.write(graph, path.string());
 
-    NetworkitBinaryReader reader;
-    Graph graph_read = reader.read(path.string());
+    const Graph graph_read = NetworkitBinaryReader{}.read(path.string());
     EXPECT_THAT(graph_read, GraphFeaturesEqual(graph));
 }
 
 TEST_F(IOGTest, testNetworkitBinaryWriteReadEmptyGraphWithIndexes) {
     Graph graph(0, true, false, true);
-    NetworkitBinaryWriter writer;
     const std::filesystem::path path = "output/empty_graph.nkb";
-    writer.write(graph, path.string());
+    NetworkitBinaryWriter{}.write(graph, path.string());
 
-    NetworkitBinaryReader reader;
-    Graph graph_read = reader.read(path.string());
+    const Graph graph_read = NetworkitBinaryReader{}.read(path.string());
     EXPECT_THAT(graph_read, GraphFeaturesEqual(graph));
 }
 } /* namespace NetworKit */


### PR DESCRIPTION
This PR fixes a crash when writing an empty graph (numberOfNodes() == 0) using NetworkitBinaryWriter.
Closes [#909](https://github.com/networkit/networkit/issues/909).

## Root Cause
When serializing an empty graph, the internal logic attempted to compute offset values based on the number of chunks. However, if nodes == 0, then chunks == 0, and expressions like (chunks - 1) underflowed due to unsigned arithmetic. This led to corrupted headers and potential segmentation faults during read/write operations.

## Fix
This PR addresses the issue by:
- Zero-initializing all uint64_t fields of the header using brace initialization
- Explicitly handling the empty graph case at the beginning of NetworkitBinaryWriter::writeData():

