### PR TITLE
Cleanup headers in algebraic, auxiliary and base folder

### DIFF
--- a/include/networkit/algebraic/CSRGeneralMatrix.hpp
+++ b/include/networkit/algebraic/CSRGeneralMatrix.hpp
@@ -12,7 +12,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <iostream>
 #include <numeric>
 #include <omp.h>
 #include <ranges>

--- a/include/networkit/algebraic/DenseMatrix.hpp
+++ b/include/networkit/algebraic/DenseMatrix.hpp
@@ -9,7 +9,6 @@
 #define NETWORKIT_ALGEBRAIC_DENSE_MATRIX_HPP_
 
 #include <cassert>
-#include <iostream>
 #include <vector>
 
 #include <networkit/Globals.hpp>

--- a/include/networkit/algebraic/DynamicMatrix.hpp
+++ b/include/networkit/algebraic/DynamicMatrix.hpp
@@ -8,7 +8,6 @@
 #ifndef NETWORKIT_ALGEBRAIC_DYNAMIC_MATRIX_HPP_
 #define NETWORKIT_ALGEBRAIC_DYNAMIC_MATRIX_HPP_
 
-#include <iostream>
 
 #include <networkit/algebraic/AlgebraicGlobals.hpp>
 #include <networkit/algebraic/SparseAccumulator.hpp>

--- a/include/networkit/algebraic/DynamicMatrix.hpp
+++ b/include/networkit/algebraic/DynamicMatrix.hpp
@@ -8,7 +8,6 @@
 #ifndef NETWORKIT_ALGEBRAIC_DYNAMIC_MATRIX_HPP_
 #define NETWORKIT_ALGEBRAIC_DYNAMIC_MATRIX_HPP_
 
-
 #include <networkit/algebraic/AlgebraicGlobals.hpp>
 #include <networkit/algebraic/SparseAccumulator.hpp>
 #include <networkit/algebraic/Vector.hpp>

--- a/include/networkit/algebraic/GraphBLAS.hpp
+++ b/include/networkit/algebraic/GraphBLAS.hpp
@@ -8,7 +8,6 @@
 #ifndef NETWORKIT_ALGEBRAIC_GRAPH_BLAS_HPP_
 #define NETWORKIT_ALGEBRAIC_GRAPH_BLAS_HPP_
 
-#include <limits>
 #include <networkit/algebraic/AlgebraicGlobals.hpp>
 #include <networkit/algebraic/Semirings.hpp>
 #include <networkit/algebraic/SparseAccumulator.hpp>

--- a/include/networkit/algebraic/Vector.hpp
+++ b/include/networkit/algebraic/Vector.hpp
@@ -11,7 +11,6 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
-#include <numeric>
 #include <stdexcept>
 #include <vector>
 

--- a/include/networkit/auxiliary/ArrayTools.hpp
+++ b/include/networkit/auxiliary/ArrayTools.hpp
@@ -5,8 +5,6 @@
 #include <utility>
 #include <vector>
 
-#include <networkit/Globals.hpp>
-
 #include <tlx/math/integer_log2.hpp>
 
 namespace Aux {

--- a/include/networkit/auxiliary/BloomFilter.hpp
+++ b/include/networkit/auxiliary/BloomFilter.hpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include <networkit/Globals.hpp>
-#include <networkit/auxiliary/Log.hpp>
 
 namespace Aux {
 

--- a/include/networkit/auxiliary/FunctionTraits.hpp
+++ b/include/networkit/auxiliary/FunctionTraits.hpp
@@ -2,7 +2,6 @@
 #define NETWORKIT_AUXILIARY_FUNCTION_TRAITS_HPP_
 
 #include <tuple>
-#include <type_traits>
 
 namespace Aux {
 

--- a/include/networkit/auxiliary/NumberParsing.hpp
+++ b/include/networkit/auxiliary/NumberParsing.hpp
@@ -2,7 +2,6 @@
 #define NETWORKIT_AUXILIARY_NUMBER_PARSING_HPP_
 
 #include <algorithm>
-#include <cassert>
 #include <cctype>
 #include <cstdint>
 #include <limits>

--- a/include/networkit/auxiliary/SignalHandling.hpp
+++ b/include/networkit/auxiliary/SignalHandling.hpp
@@ -1,7 +1,6 @@
 #ifndef NETWORKIT_AUXILIARY_SIGNAL_HANDLING_HPP_
 #define NETWORKIT_AUXILIARY_SIGNAL_HANDLING_HPP_
 
-#include <cstdint>
 #include <exception>
 
 namespace Aux {

--- a/include/networkit/base/Algorithm.hpp
+++ b/include/networkit/base/Algorithm.hpp
@@ -3,7 +3,6 @@
 #define NETWORKIT_BASE_ALGORITHM_HPP_
 
 #include <stdexcept>
-#include <string>
 
 namespace NetworKit {
 

--- a/include/networkit/base/DynAlgorithm.hpp
+++ b/include/networkit/base/DynAlgorithm.hpp
@@ -1,8 +1,6 @@
 #ifndef NETWORKIT_BASE_DYN_ALGORITHM_HPP_
 #define NETWORKIT_BASE_DYN_ALGORITHM_HPP_
 
-#include <stdexcept>
-#include <string>
 #include <networkit/dynamics/GraphEvent.hpp>
 
 namespace NetworKit {

--- a/networkit/cpp/auxiliary/Log.cpp
+++ b/networkit/cpp/auxiliary/Log.cpp
@@ -3,7 +3,6 @@
 #include <ctime>
 #include <fstream>
 #include <iomanip>
-#include <ios>
 #include <iostream>
 #include <mutex>
 #include <string>

--- a/networkit/cpp/auxiliary/Parallelism.cpp
+++ b/networkit/cpp/auxiliary/Parallelism.cpp
@@ -1,4 +1,3 @@
-#include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Parallelism.hpp>
 
 // OpenMP

--- a/networkit/cpp/auxiliary/Random.cpp
+++ b/networkit/cpp/auxiliary/Random.cpp
@@ -7,7 +7,6 @@
 
 #include <atomic>
 #include <cmath>
-#include <limits>
 #include <omp.h>
 
 #include <networkit/GlobalState.hpp>


### PR DESCRIPTION
In this PR unused headers are removed from files located in the sub-folders
- `algebraic`
- `auxilliary`
- `base`
to improve maintainability and potentially reduce build times.

No production logic or test code has been touched.
