### PR TITLE
Clean-up headers in subfolders starting with 'c'.

### DIFF
--- a/include/networkit/centrality/ApproxElectricalCloseness.hpp
+++ b/include/networkit/centrality/ApproxElectricalCloseness.hpp
@@ -9,10 +9,8 @@
 #ifndef NETWORKIT_CENTRALITY_APPROX_ELECTRICAL_CLOSENESS_HPP_
 #define NETWORKIT_CENTRALITY_APPROX_ELECTRICAL_CLOSENESS_HPP_
 
-#include <cmath>
 #include <memory>
 #include <random>
-#include <unordered_map>
 #include <vector>
 
 #include <networkit/centrality/Centrality.hpp>

--- a/include/networkit/centrality/ComplexPaths.hpp
+++ b/include/networkit/centrality/ComplexPaths.hpp
@@ -20,7 +20,6 @@
 #ifndef NETWORKIT_CENTRALITY_COMPLEX_PATHS_HPP_
 #define NETWORKIT_CENTRALITY_COMPLEX_PATHS_HPP_
 
-#include <random>
 #include <vector>
 
 #include <networkit/base/Algorithm.hpp>

--- a/include/networkit/centrality/CoreDecomposition.hpp
+++ b/include/networkit/centrality/CoreDecomposition.hpp
@@ -8,8 +8,6 @@
 #ifndef NETWORKIT_CENTRALITY_CORE_DECOMPOSITION_HPP_
 #define NETWORKIT_CENTRALITY_CORE_DECOMPOSITION_HPP_
 
-#include <list>
-#include <string>
 #include <vector>
 
 #include <networkit/centrality/Centrality.hpp>

--- a/include/networkit/centrality/DynApproxBetweenness.hpp
+++ b/include/networkit/centrality/DynApproxBetweenness.hpp
@@ -14,10 +14,8 @@
 #include <networkit/distance/DynSSSP.hpp>
 #include <networkit/dynamics/GraphEvent.hpp>
 
-#include <algorithm>
 #include <cmath>
 #include <memory>
-#include <omp.h>
 
 namespace NetworKit {
 

--- a/include/networkit/centrality/DynBetweenness.hpp
+++ b/include/networkit/centrality/DynBetweenness.hpp
@@ -8,7 +8,6 @@
 #ifndef NETWORKIT_CENTRALITY_DYN_BETWEENNESS_HPP_
 #define NETWORKIT_CENTRALITY_DYN_BETWEENNESS_HPP_
 
-#include <memory>
 #include <queue>
 
 #include <networkit/auxiliary/PrioQueue.hpp>

--- a/include/networkit/centrality/ForestCentrality.hpp
+++ b/include/networkit/centrality/ForestCentrality.hpp
@@ -9,8 +9,6 @@
 #define NETWORKIT_CENTRALITY_FOREST_CENTRALITY_HPP_
 
 #include <cmath>
-#include <functional>
-#include <omp.h>
 #include <random>
 #include <vector>
 

--- a/include/networkit/centrality/GroupDegree.hpp
+++ b/include/networkit/centrality/GroupDegree.hpp
@@ -8,9 +8,6 @@
 #ifndef NETWORKIT_CENTRALITY_GROUP_DEGREE_HPP_
 #define NETWORKIT_CENTRALITY_GROUP_DEGREE_HPP_
 
-#include <omp.h>
-#include <ranges>
-
 #include <networkit/auxiliary/BucketPQ.hpp>
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>

--- a/include/networkit/centrality/KadabraBetweenness.hpp
+++ b/include/networkit/centrality/KadabraBetweenness.hpp
@@ -12,7 +12,6 @@
 #include <atomic>
 #include <memory>
 #include <random>
-#include <ranges>
 #include <vector>
 
 #include <networkit/auxiliary/SortedList.hpp>

--- a/include/networkit/coarsening/ParallelPartitionCoarsening.hpp
+++ b/include/networkit/coarsening/ParallelPartitionCoarsening.hpp
@@ -8,7 +8,6 @@
 #ifndef NETWORKIT_COARSENING_PARALLEL_PARTITION_COARSENING_HPP_
 #define NETWORKIT_COARSENING_PARALLEL_PARTITION_COARSENING_HPP_
 
-#include <networkit/Globals.hpp>
 #include <networkit/coarsening/GraphCoarsening.hpp>
 #include <networkit/structures/Partition.hpp>
 

--- a/include/networkit/community/Conductance.hpp
+++ b/include/networkit/community/Conductance.hpp
@@ -8,8 +8,6 @@
 #ifndef NETWORKIT_COMMUNITY_CONDUCTANCE_HPP_
 #define NETWORKIT_COMMUNITY_CONDUCTANCE_HPP_
 
-#include <networkit/auxiliary/NumericTools.hpp>
-#include <networkit/community/EdgeCut.hpp>
 #include <networkit/community/QualityMeasure.hpp>
 
 namespace NetworKit {

--- a/include/networkit/community/DynamicNMIDistance.hpp
+++ b/include/networkit/community/DynamicNMIDistance.hpp
@@ -9,7 +9,6 @@
 #define NETWORKIT_COMMUNITY_DYNAMIC_NMI_DISTANCE_HPP_
 
 #include <networkit/community/DissimilarityMeasure.hpp>
-#include <networkit/community/NMIDistance.hpp>
 
 namespace NetworKit {
 

--- a/include/networkit/community/ParallelLeiden.hpp
+++ b/include/networkit/community/ParallelLeiden.hpp
@@ -1,23 +1,11 @@
 #ifndef NETWORKIT_COMMUNITY_PARALLEL_LEIDEN_HPP_
 #define NETWORKIT_COMMUNITY_PARALLEL_LEIDEN_HPP_
 
-#include <atomic>
-#include <condition_variable>
-#include <iomanip>
-#include <iostream>
 #include <mutex>
-#include <omp.h>
-#include <thread>
-#include <tlx/unused.hpp>
 #include <networkit/Globals.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
-#include <networkit/auxiliary/Parallelism.hpp>
 #include <networkit/auxiliary/SignalHandling.hpp>
-#include <networkit/auxiliary/Timer.hpp>
-#include <networkit/coarsening/ParallelPartitionCoarsening.hpp>
 #include <networkit/community/CommunityDetectionAlgorithm.hpp>
-#include <networkit/community/Modularity.hpp>
-#include <networkit/community/PLM.hpp>
 #include <networkit/graph/Graph.hpp>
 #include <networkit/structures/Partition.hpp>
 

--- a/include/networkit/components/ParallelConnectedComponents.hpp
+++ b/include/networkit/components/ParallelConnectedComponents.hpp
@@ -10,7 +10,6 @@
 
 #include <networkit/components/ComponentDecomposition.hpp>
 #include <networkit/graph/Graph.hpp>
-#include <networkit/structures/Partition.hpp>
 
 namespace NetworKit {
 

--- a/networkit/cpp/centrality/test/ApproxBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/ApproxBetweennessGTest.cpp
@@ -8,9 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <networkit/centrality/ApproxBetweenness.hpp>
-#include <networkit/centrality/Betweenness.hpp>
 #include <networkit/distance/Diameter.hpp>
-#include <networkit/generators/DorogovtsevMendesGenerator.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 
 namespace NetworKit {

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -15,7 +15,6 @@
 #include <networkit/centrality/DynApproxBetweenness.hpp>
 #include <networkit/centrality/DynBetweenness.hpp>
 #include <networkit/centrality/DynBetweennessOneNode.hpp>
-#include <networkit/generators/DorogovtsevMendesGenerator.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/graph/GraphTools.hpp>
 #include <networkit/io/METISGraphReader.hpp>

--- a/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
+++ b/networkit/cpp/coarsening/ParallelPartitionCoarsening.cpp
@@ -6,10 +6,7 @@
  */
 
 #include <numeric>
-#include <omp.h>
 
-#include <networkit/auxiliary/Log.hpp>
-#include <networkit/auxiliary/Timer.hpp>
 #include <networkit/coarsening/ParallelPartitionCoarsening.hpp>
 #include <networkit/graph/GraphBuilder.hpp>
 

--- a/networkit/cpp/community/Conductance.cpp
+++ b/networkit/cpp/community/Conductance.cpp
@@ -5,7 +5,9 @@
  *      Author: Henning
  */
 
+#include <networkit/auxiliary/NumericTools.hpp>
 #include <networkit/community/Conductance.hpp>
+#include <networkit/community/EdgeCut.hpp>
 
 namespace NetworKit {
 

--- a/networkit/cpp/community/LFM.cpp
+++ b/networkit/cpp/community/LFM.cpp
@@ -5,7 +5,6 @@
  *      Author: John Gelhausen
  */
 
-#include <iostream>
 #include <networkit/auxiliary/SignalHandling.hpp>
 #include <networkit/community/LFM.hpp>
 

--- a/networkit/cpp/community/NMIDistance.cpp
+++ b/networkit/cpp/community/NMIDistance.cpp
@@ -7,7 +7,6 @@
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/MissingMath.hpp>
-#include <networkit/auxiliary/NumericTools.hpp>
 #include <networkit/community/DynamicNMIDistance.hpp>
 #include <networkit/community/NMIDistance.hpp>
 #include <networkit/community/PartitionIntersection.hpp>

--- a/networkit/cpp/community/PLP.cpp
+++ b/networkit/cpp/community/PLP.cpp
@@ -5,8 +5,6 @@
  *      Author: Christian Staudt
  */
 
-#include <omp.h>
-
 #include <networkit/Globals.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>

--- a/networkit/cpp/community/ParallelLeiden.cpp
+++ b/networkit/cpp/community/ParallelLeiden.cpp
@@ -1,3 +1,7 @@
+#include <condition_variable>
+#include <tlx/unused.hpp>
+#include <networkit/auxiliary/Timer.hpp>
+#include <networkit/coarsening/ParallelPartitionCoarsening.hpp>
 #include <networkit/community/ParallelLeiden.hpp>
 
 namespace NetworKit {

--- a/networkit/cpp/community/test/CommunityGTest.cpp
+++ b/networkit/cpp/community/test/CommunityGTest.cpp
@@ -16,7 +16,6 @@
 #include <networkit/community/CoverHubDominance.hpp>
 #include <networkit/community/Coverage.hpp>
 #include <networkit/community/CutClustering.hpp>
-#include <networkit/community/DynamicNMIDistance.hpp>
 #include <networkit/community/EdgeCut.hpp>
 #include <networkit/community/GraphClusteringTools.hpp>
 #include <networkit/community/GraphStructuralRandMeasure.hpp>
@@ -41,7 +40,6 @@
 #include <networkit/community/SampledNodeStructuralRandMeasure.hpp>
 #include <networkit/community/StablePartitionNodes.hpp>
 #include <networkit/generators/ClusteredRandomGraphGenerator.hpp>
-#include <networkit/generators/DynamicBarabasiAlbertGenerator.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/generators/LFRGenerator.hpp>
 #include <networkit/graph/GraphTools.hpp>

--- a/networkit/cpp/community/test/LouvainMapEquationBenchmark.cpp
+++ b/networkit/cpp/community/test/LouvainMapEquationBenchmark.cpp
@@ -10,7 +10,6 @@
 #include <networkit/auxiliary/Timer.hpp>
 #include <networkit/community/LouvainMapEquation.hpp>
 #include <networkit/generators/ClusteredRandomGraphGenerator.hpp>
-#include <networkit/io/METISGraphReader.hpp>
 #include <networkit/io/SNAPGraphReader.hpp>
 
 namespace NetworKit {

--- a/networkit/cpp/components/BiconnectedComponents.cpp
+++ b/networkit/cpp/components/BiconnectedComponents.cpp
@@ -5,7 +5,6 @@
  * 		 Author: Eugenio Angriman
  */
 
-#include <cmath>
 #include <stack>
 
 #include <networkit/components/BiconnectedComponents.hpp>

--- a/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
@@ -19,8 +19,6 @@
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/distance/Diameter.hpp>
-#include <networkit/generators/DorogovtsevMendesGenerator.hpp>
-#include <networkit/generators/HavelHakimiGenerator.hpp>
 #include <networkit/io/EdgeListReader.hpp>
 #include <networkit/io/KONECTGraphReader.hpp>
 #include <networkit/io/METISGraphReader.hpp>


### PR DESCRIPTION
In this PR unused headers are removed from files located in the sub-folders
- centrality
- clique
- coarsening
- community
- components
- correlation

to improve maintainability and potentially reduce build times.

No production logic or test code has been touched.
