### PR TITLE
CI: Remove condition on coverage upload.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,11 +357,11 @@ jobs:
           coverage run -m unittest discover -v networkit/test
           coverage report
           coveralls --merge=core_build/networkit_cpp.json --output=$COVERALLS_DUMP_FILE
-      - name: Upload coverage
-        run: |
-          cd ${{ github.workspace }}
-          . pyenv/bin/activate
-          python3 ${{ github.workspace }}/.github/workflows/scripts/upload_coverage.py
+      - name: Upload coverage to coveralls.io
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.COVERALLS_DUMP_FILE }}
 
   linux-build-leak:
     name: "Linux (gcc-10): leak checks"


### PR DESCRIPTION
The goal of this PR is to enable coverage reports on PRs directly.

Update: It seems this is working now by switching from a manual upload to the corresponding GitHub action. The covered lines are precisely what Coveralls reports for the repo on master. Note that the badge on the main page is only dependent on the master branch, so builds on PRs should not influence the coverage reported overall.