### PR TITLE
helpers.pyx: Fix 32-bit overflow for internal variables

### DIFF
--- a/networkit/helpers.pyx
+++ b/networkit/helpers.pyx
@@ -157,7 +157,7 @@ cdef asarray_2d(vector[vector[element_t]]* nested):
 	cdef:
 		element_t[:] values
 		element_t* target
-		int num_rows, num_cols
+		size_t num_rows, num_cols
 
 	# Return an empty matrix if there are no rows.
 	num_rows = nested.size()


### PR DESCRIPTION
This PR fixes #1366.

Basically, the `int` type of the internal size counter is degraded to 32 bits. The reported issue can be reproduced (given the code in #1366) on macOS 15.7. With the change, the type is aligned with the return type of `nested.size()`. `size_t` is still implementation-defined; however, given the standard, it is at least `unsigned` and normally 64 bits on modern machines. With the change, the snippet from the referenced issue now works. The 2D ndarray uses roughly 20 GB of memory.