### PR TITLE
Doc: Remove hint towards errornuous results of ParallelLeiden.

### DIFF
--- a/include/networkit/community/ParallelLeiden.hpp
+++ b/include/networkit/community/ParallelLeiden.hpp
@@ -14,12 +14,7 @@ namespace NetworKit {
 class ParallelLeiden final : public CommunityDetectionAlgorithm {
 public:
     /**
-     * @note As reported by Sahu et. al in "GVE-Leiden: Fast Leiden Algorithm for Community
-     * Detection in Shared Memory Setting", the current implementation in NetworKit might create a
-     * small fraction of disconnected communities. Since this violates the guarantees from the
-     * original algorithm, ParallelLeiden should be used with caution. In addition the modularity
-     * value of the resulting partition / clustering can be lower compared to other Leiden
-     * implementations and even Louvain.
+     * Parallel Leiden algorithm for community detection.
      *
      * @param graph A networkit graph
      * @param iterations Number of Leiden Iterations to be run

--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -711,13 +711,6 @@ cdef class ParallelLeiden(CommunityDetector):
 
 	Parallel Leiden Algorithm.
 
-    As reported by Sahu et. al in "GVE-Leiden: Fast Leiden Algorithm for Community
-    Detection in Shared Memory Setting", the current implementation in NetworKit might create a
-    small fraction of disconnected communities. Since this violates the guarantees from the
-    original algorithm, ParallelLeiden should be used with caution. In addition the modularity 
-	value of the resulting partition / clustering can be lower compared to other Leiden 
-	implementations and even Louvain.
-
 	Parameters
 	----------
 	G : networkit.Graph


### PR DESCRIPTION
The error has been fixed in #1328.