### PR TITLE
Remove unused headers in folders generators and geometric

### DIFF
--- a/include/networkit/generators/ChungLuGeneratorAlamEtAl.hpp
+++ b/include/networkit/generators/ChungLuGeneratorAlamEtAl.hpp
@@ -9,7 +9,6 @@
 #ifndef NETWORKIT_GENERATORS_CHUNG_LU_GENERATOR_ALAM_ET_AL_HPP_
 #define NETWORKIT_GENERATORS_CHUNG_LU_GENERATOR_ALAM_ET_AL_HPP_
 
-#include <networkit/generators/StaticDegreeSequenceGenerator.hpp>
 #include <networkit/generators/StaticGraphGenerator.hpp>
 
 namespace NetworKit {

--- a/include/networkit/generators/ConfigurationModel.hpp
+++ b/include/networkit/generators/ConfigurationModel.hpp
@@ -1,7 +1,6 @@
 #ifndef NETWORKIT_GENERATORS_CONFIGURATION_MODEL_HPP_
 #define NETWORKIT_GENERATORS_CONFIGURATION_MODEL_HPP_
 
-#include <set>
 #include <vector>
 #include <networkit/generators/StaticDegreeSequenceGenerator.hpp>
 

--- a/include/networkit/generators/DynamicDGSParser.hpp
+++ b/include/networkit/generators/DynamicDGSParser.hpp
@@ -8,12 +8,10 @@
 #ifndef NETWORKIT_GENERATORS_DYNAMIC_DGS_PARSER_HPP_
 #define NETWORKIT_GENERATORS_DYNAMIC_DGS_PARSER_HPP_
 
-#include <iterator>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include <networkit/auxiliary/StringTools.hpp>
 #include <networkit/generators/DynamicGraphSource.hpp>
 #include <networkit/structures/Partition.hpp>
 

--- a/include/networkit/generators/DynamicDorogovtsevMendesGenerator.hpp
+++ b/include/networkit/generators/DynamicDorogovtsevMendesGenerator.hpp
@@ -8,7 +8,6 @@
 #ifndef NETWORKIT_GENERATORS_DYNAMIC_DOROGOVTSEV_MENDES_GENERATOR_HPP_
 #define NETWORKIT_GENERATORS_DYNAMIC_DOROGOVTSEV_MENDES_GENERATOR_HPP_
 
-#include <networkit/auxiliary/Random.hpp>
 #include <networkit/generators/DynamicGraphGenerator.hpp>
 
 namespace NetworKit {

--- a/include/networkit/generators/DynamicHyperbolicGenerator.hpp
+++ b/include/networkit/generators/DynamicHyperbolicGenerator.hpp
@@ -8,8 +8,6 @@
 #ifndef NETWORKIT_GENERATORS_DYNAMIC_HYPERBOLIC_GENERATOR_HPP_
 #define NETWORKIT_GENERATORS_DYNAMIC_HYPERBOLIC_GENERATOR_HPP_
 
-#include <map>
-
 #include <networkit/generators/DynamicGraphGenerator.hpp>
 #include <networkit/generators/quadtree/Quadtree.hpp>
 

--- a/include/networkit/generators/HyperbolicGenerator.hpp
+++ b/include/networkit/generators/HyperbolicGenerator.hpp
@@ -13,7 +13,6 @@
 
 #include <networkit/auxiliary/Timer.hpp>
 #include <networkit/generators/StaticGraphGenerator.hpp>
-#include <networkit/generators/quadtree/Quadtree.hpp>
 #include <networkit/geometric/HyperbolicSpace.hpp>
 
 namespace NetworKit {

--- a/include/networkit/generators/quadtree/QuadNode.hpp
+++ b/include/networkit/generators/quadtree/QuadNode.hpp
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include <networkit/auxiliary/Log.hpp>
-#include <networkit/auxiliary/Parallel.hpp>
 #include <networkit/geometric/HyperbolicSpace.hpp>
 
 using std::cos;

--- a/include/networkit/generators/quadtree/QuadtreeCartesianEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadtreeCartesianEuclid.hpp
@@ -9,7 +9,6 @@
 #define NETWORKIT_GENERATORS_QUADTREE_QUADTREE_CARTESIAN_EUCLID_HPP_
 
 #include <cmath>
-#include <memory>
 #include <omp.h>
 #include <vector>
 

--- a/include/networkit/generators/quadtree/QuadtreePolarEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadtreePolarEuclid.hpp
@@ -9,7 +9,6 @@
 #define NETWORKIT_GENERATORS_QUADTREE_QUADTREE_POLAR_EUCLID_HPP_
 
 #include <cmath>
-#include <memory>
 #include <omp.h>
 #include <vector>
 

--- a/include/networkit/geometric/Point2DWithIndex.hpp
+++ b/include/networkit/geometric/Point2DWithIndex.hpp
@@ -9,10 +9,7 @@
 #define NETWORKIT_GEOMETRIC_POINT2_D_WITH_INDEX_HPP_
 
 #include <cassert>
-#include <cinttypes>
 #include <cmath>
-#include <cstdint>
-#include <vector>
 
 #include <networkit/Globals.hpp>
 

--- a/networkit/cpp/generators/ConfigurationModel.cpp
+++ b/networkit/cpp/generators/ConfigurationModel.cpp
@@ -3,10 +3,6 @@
 #include <networkit/generators/HavelHakimiGenerator.hpp>
 #include <networkit/graph/Graph.hpp>
 
-#include <chrono>
-#include <iostream>
-#include <thread>
-
 namespace NetworKit {
 
 ConfigurationModel::ConfigurationModel(const std::vector<count> &sequence)

--- a/networkit/cpp/generators/DynamicDGSParser.cpp
+++ b/networkit/cpp/generators/DynamicDGSParser.cpp
@@ -9,6 +9,7 @@
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Parallel.hpp>
+#include <networkit/auxiliary/StringTools.hpp>
 #include <networkit/generators/DynamicDGSParser.hpp>
 
 namespace NetworKit {


### PR DESCRIPTION
In this PR unused headers in the sub-folders 'generators' and 'geometric' are removed. 