### PR TITLE
Adding cmake to build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ changelog = "https://github.com/networkit/networkit/blob/master/CHANGES.md"
 [build-system]
 requires = [
   "cython",
+  "cmake",
   "numpy",
   "scipy<1.17.0",
   "setuptools",


### PR DESCRIPTION
Adding cmake here solves cmake error while compiling from source.
  File "/home/user/venv/network/bin/cmake", line 3, in <module>
          from cmake import cmake
      ModuleNotFoundError: No module named 'cmake'
      cmake returned an error, exiting setup.py