### PR TITLE
Expose isBipartite to python

### DIFF
--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <span>
+#include <queue>
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -1,6 +1,6 @@
 #include <algorithm>
-#include <span>
 #include <queue>
+#include <span>
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/Random.hpp>

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <queue>
 #include <span>
 
 #include <networkit/auxiliary/Log.hpp>

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -44,6 +44,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	node augmentGraph(_Graph G) except + nogil
 	pair[_Graph, node] createAugmentedGraph(_Graph G) except + nogil
 	void randomizeWeights(_Graph G) except + nogil
+	bool_t isBipartite(_Graph G) except + nogil
 
 cdef class GraphTools:
 
@@ -715,3 +716,22 @@ cdef class GraphTools:
 			The input graph.
 		"""
 		randomizeWeights(G._this)
+
+	@staticmethod
+	def isBipartite(Graph G):
+		"""
+		isBipartite(G)
+
+		Checks whether the input graph is bipartite.
+
+		Parameters
+		----------
+		G : networkit.Graph
+			The input graph. Must be undirected.
+
+		Returns
+		-------
+		bool
+			True if the graph is bipartite, False otherwise.
+		"""
+		return isBipartite(G._this)

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -578,7 +578,115 @@ class TestGraphTools(unittest.TestCase):
 				self.assertLessEqual(v2, v1)
 				self.assertLessEqual(v3, v1)			
 
-	
+	def testIsBipartiteDirectedGraphThrows(self):
+		G = nk.Graph(0, False, True)
+		with self.assertRaises(RuntimeError):
+			nk.graphtools.isBipartite(G)
+
+	def testIsBipartiteEmptyGraph(self):
+		G = nk.Graph()
+		self.assertTrue(nk.graphtools.isBipartite(G))
+
+	def testIsBipartiteSingleNodeGraphs(self):
+		for n in range(1, 10):
+			G = nk.Graph(n)
+			self.assertTrue(nk.graphtools.isBipartite(G))
+
+	def testIsBipartiteBinaryTreeGraphs(self):
+		def binaryTree(numNodes):
+			G = nk.Graph(numNodes, True, False)
+			for i in range(numNodes):
+				leftChild = 2 * i + 1
+				rightChild = 2 * i + 2
+				if leftChild < numNodes:
+					G.addEdge(i, leftChild, float(i))
+				if rightChild < numNodes:
+					G.addEdge(i, rightChild, float(i))
+			return G
+
+		for n in range(1, 10):
+			G = binaryTree(n)
+			self.assertTrue(nk.graphtools.isBipartite(G))
+
+	def testIsBipartiteCompleteGraphs(self):
+		def completeGraph(numNodes):
+			G = nk.Graph(numNodes, True, False)
+			for i in range(numNodes):
+				for j in range(i + 1, numNodes):
+					G.addEdge(i, j, float(j * (j + 1)))
+			return G
+
+		for n in range(3, 11):
+			G = completeGraph(n)
+			self.assertFalse(nk.graphtools.isBipartite(G))
+
+	def testIsBipartiteCompleteBipartiteGraphK3_3(self):
+		G = nk.Graph(6)
+		G.addEdge(0, 3)
+		G.addEdge(0, 4)
+		G.addEdge(0, 5)
+		G.addEdge(1, 3)
+		G.addEdge(1, 4)
+		G.addEdge(1, 5)
+		G.addEdge(2, 3)
+		G.addEdge(2, 4)
+		G.addEdge(2, 5)
+
+		self.assertTrue(nk.graphtools.isBipartite(G))
+
+	def testIsBipartiteDeleteNode(self):
+		G = nk.Graph(7)
+		G.addEdge(0, 3)
+		G.addEdge(0, 4)
+		G.addEdge(0, 5)
+		G.addEdge(1, 3)
+		G.addEdge(1, 4)
+		G.addEdge(1, 5)
+		G.addEdge(2, 3)
+		G.addEdge(2, 4)
+		G.addEdge(2, 5)
+
+		# make graph non-bipartite
+		G.addEdge(0, 6)
+		G.addEdge(5, 6)
+
+		self.assertFalse(nk.graphtools.isBipartite(G))
+
+		# remove node 6 to make graph bipartite again -> K_{3,3}
+		G.removeNode(6)
+		self.assertTrue(nk.graphtools.isBipartite(G))
+
+	def testIsBipartiteDeleteAndRestoreNodes(self):
+		G = nk.Graph(4)
+		G.addEdge(0, 1)
+		G.addEdge(0, 2)
+		G.addEdge(0, 3)
+		G.addEdge(1, 2)
+		G.addEdge(1, 3)
+		G.addEdge(2, 3)
+
+		self.assertFalse(nk.graphtools.isBipartite(G))
+
+		G.removeNode(1)
+		self.assertFalse(nk.graphtools.isBipartite(G))
+
+		G.restoreNode(1)
+		self.assertFalse(nk.graphtools.isBipartite(G))
+
+		G.removeNode(2)
+		self.assertTrue(nk.graphtools.isBipartite(G))
+
+	def testIsBipartiteGrid5x5DistArchGraph(self):
+		G = nk.readGraph("input/grid-5x5-dist-arch.graph", nk.Format.METIS)
+		self.assertTrue(nk.graphtools.isBipartite(G))
+
+	def testIsBipartiteAirfoil1Graph(self):
+		G = nk.readGraph("input/airfoil1.graph", nk.Format.METIS)
+		self.assertFalse(nk.graphtools.isBipartite(G))
+
+	def testIsBipartiteHepThGraph(self):
+		G = nk.readGraph("input/hep-th.graph", nk.Format.METIS)
+		self.assertFalse(nk.graphtools.isBipartite(G))
 
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -584,41 +584,45 @@ class TestGraphTools(unittest.TestCase):
 			nk.graphtools.isBipartite(G)
 
 	def testIsBipartiteEmptyGraph(self):
-		G = nk.Graph()
+		self.assertTrue(nk.graphtools.isBipartite(nk.Graph()))
+
+	def testIsBipartiteSingletonNodesGraph(self):
+		self.assertTrue(nk.graphtools.isBipartite(nk.Graph(1)))
+		self.assertTrue(nk.graphtools.isBipartite(nk.Graph(2)))
+		self.assertTrue(nk.graphtools.isBipartite(nk.Graph(3)))
+
+	def testIsBipartiteBinaryTreeGraph(self):
+		# 7-nodes binary tree:
+		#        0
+		#      /   \
+		#     1     2
+		#    / \   / \
+		#   3   4 5   6
+		G = nk.Graph(7)
+
+		G.addEdge(0, 1)
+		G.addEdge(0, 2)
+
+		G.addEdge(1, 3)
+		G.addEdge(1, 4)
+
+		G.addEdge(2, 5)
+		G.addEdge(2, 6)
+
 		self.assertTrue(nk.graphtools.isBipartite(G))
 
-	def testIsBipartiteSingleNodeGraphs(self):
-		for n in range(1, 10):
-			G = nk.Graph(n)
-			self.assertTrue(nk.graphtools.isBipartite(G))
+	def testIsBipartiteCompleteGraph(self):
+		# Complete graph K3:
+		#   0
+		#  / \
+		# 1---2
+		G = nk.Graph(3)
 
-	def testIsBipartiteBinaryTreeGraphs(self):
-		def binaryTree(numNodes):
-			G = nk.Graph(numNodes, True, False)
-			for i in range(numNodes):
-				leftChild = 2 * i + 1
-				rightChild = 2 * i + 2
-				if leftChild < numNodes:
-					G.addEdge(i, leftChild, float(i))
-				if rightChild < numNodes:
-					G.addEdge(i, rightChild, float(i))
-			return G
+		G.addEdge(0, 1)
+		G.addEdge(0, 2)
+		G.addEdge(1, 2)
 
-		for n in range(1, 10):
-			G = binaryTree(n)
-			self.assertTrue(nk.graphtools.isBipartite(G))
-
-	def testIsBipartiteCompleteGraphs(self):
-		def completeGraph(numNodes):
-			G = nk.Graph(numNodes, True, False)
-			for i in range(numNodes):
-				for j in range(i + 1, numNodes):
-					G.addEdge(i, j, float(j * (j + 1)))
-			return G
-
-		for n in range(3, 11):
-			G = completeGraph(n)
-			self.assertFalse(nk.graphtools.isBipartite(G))
+		self.assertFalse(nk.graphtools.isBipartite(G))
 
 	def testIsBipartiteCompleteBipartiteGraphK3_3(self):
 		G = nk.Graph(6)


### PR DESCRIPTION
Expose `GraphTools::isBipartite` in the Python API via Cython bindings and add
Python tests for the new functionality.