### PR TITLE
distance: add getDistances() Python binding for FloydWarshall

### DIFF
--- a/include/networkit/distance/FloydWarshall.hpp
+++ b/include/networkit/distance/FloydWarshall.hpp
@@ -79,6 +79,16 @@ public:
      */
     std::vector<node> getNodesOnShortestPath(node source, node target) const;
 
+    /**
+     * @brief Returns the full all-pairs distance matrix.
+     *
+     * The returned object is a reference to internal storage. Do not modify it
+     * directly; call run() again if the graph changes.
+     *
+     * @return A matrix where entry [u][v] is the shortest distance from u to v.
+     */
+    const std::vector<std::vector<edgeweight>> &getDistances() const;
+
 private:
     const Graph *graph;
     static constexpr edgeweight infiniteDistance = std::numeric_limits<edgeweight>::max();

--- a/networkit/cpp/distance/FloydWarshall.cpp
+++ b/networkit/cpp/distance/FloydWarshall.cpp
@@ -113,4 +113,9 @@ std::vector<node> FloydWarshall::getNodesOnShortestPath(node source, node target
     return path;
 }
 
+const std::vector<std::vector<edgeweight>> &FloydWarshall::getDistances() const {
+    assureFinished();
+    return distances;
+}
+
 } // namespace NetworKit

--- a/networkit/cpp/distance/test/FloydWarshallGTest.cpp
+++ b/networkit/cpp/distance/test/FloydWarshallGTest.cpp
@@ -314,4 +314,29 @@ TEST_F(FloydWarshallGTest, testMultipleShortestDistancePaths) {
     EXPECT_EQ(test.getDistance(0, 10), expectedShortestDistance);
     EXPECT_EQ(test.getNodesOnShortestPath(0, 10), expectedPath);
 }
+
+TEST_F(FloydWarshallGTest, testGetDistances) {
+    Graph graph(3, true);
+    graph.addEdge(0, 1, 2);
+    graph.addEdge(1, 2, 3);
+    FloydWarshall test(graph);
+    test.run();
+    const auto &distances = test.getDistances();
+    EXPECT_EQ(distances[0][2], 5.0);
+    EXPECT_EQ(distances[1][0], 2.0);
+    EXPECT_EQ(distances[0][0], 0.0);
+}
+
+TEST_F(FloydWarshallGTest, testGetDistancesThrows) {
+    Graph graph(1, true);
+    FloydWarshall test(graph);
+    try {
+        test.getDistances();
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_STREQ(e.what(), "Error, run must be called first");
+    } catch (...) {
+        FAIL() << "Expected std::runtime_error but got a different exception.";
+    }
+}
 } // namespace NetworKit

--- a/networkit/distance.pyx
+++ b/networkit/distance.pyx
@@ -1827,6 +1827,7 @@ cdef extern from "<networkit/distance/FloydWarshall.hpp>":
 		edgeweight getDistance(node source, node target) except +
 		bint isNodeInNegativeCycle(node u) except +
 		vector[node] getNodesOnShortestPath(node source, node target) except +
+		vector[vector[edgeweight]] &getDistances() except +
 
 cdef class FloydWarshall(Algorithm):
 	"""
@@ -1907,6 +1908,27 @@ cdef class FloydWarshall(Algorithm):
 			True if u lies on a negative cycle, False otherwise.
 		"""
 		return (<_FloydWarshall *> self._this).isNodeInNegativeCycle(u)
+
+	def getDistances(self, asarray=None):
+		"""
+		getDistances(asarray=None)
+
+		Returns the full all-pairs distance matrix.
+
+		Note: the returned matrix is a reference to internal storage.
+		Do not modify it directly; call run() again if the graph changes.
+
+		Parameters
+		----------
+		asarray : optional
+			Return the result as a numpy array. Default: Falsy.
+
+		Returns
+		-------
+		list(list(float)) or np.ndarray
+			distances[u][v] is the shortest path distance from u to v.
+		"""
+		return maybe_asarray_2d(&(<_FloydWarshall*>(self._this)).getDistances(), asarray)
 
 	def getNodesOnShortestPath(self, source, target):
 		"""

--- a/networkit/test/test_distance.py
+++ b/networkit/test/test_distance.py
@@ -498,8 +498,8 @@ class TestDistance(unittest.TestCase):
 		# Should pick the path with the fewest nodes
 		self.assertEqual(fw.getNodesOnShortestPath(0, 10), [0, 4, 5, 10])
 
-	def test_floyd_warshall_get_distances(self):
-		G = nk.graph.Graph(3, weighted=True, directed=False)
+	def testFloydWarshall_getDistances(self):
+		G = nk.Graph(3, weighted=True, directed=False)
 		G.addEdge(0, 1, 2.0)
 		G.addEdge(1, 2, 3.0)
 		fw = nk.distance.FloydWarshall(G)
@@ -508,15 +508,6 @@ class TestDistance(unittest.TestCase):
 		self.assertAlmostEqual(d[0][2], 5.0)
 		self.assertAlmostEqual(d[1][0], 2.0)
 		self.assertAlmostEqual(d[0][0], 0.0)
-
-	def test_floyd_warshall_negative_cycle(self):
-		G = nk.graph.Graph(3, weighted=True, directed=True)
-		G.addEdge(0, 1,  1.0)
-		G.addEdge(1, 2, -3.0)
-		G.addEdge(2, 0,  1.0)
-		fw = nk.distance.FloydWarshall(G)
-		fw.run()
-		self.assertTrue(fw.isNodeInNegativeCycle(0))
 
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/test/test_distance.py
+++ b/networkit/test/test_distance.py
@@ -498,6 +498,25 @@ class TestDistance(unittest.TestCase):
 		# Should pick the path with the fewest nodes
 		self.assertEqual(fw.getNodesOnShortestPath(0, 10), [0, 4, 5, 10])
 
+	def test_floyd_warshall_get_distances(self):
+		G = nk.graph.Graph(3, weighted=True, directed=False)
+		G.addEdge(0, 1, 2.0)
+		G.addEdge(1, 2, 3.0)
+		fw = nk.distance.FloydWarshall(G)
+		fw.run()
+		d = fw.getDistances()
+		self.assertAlmostEqual(d[0][2], 5.0)
+		self.assertAlmostEqual(d[1][0], 2.0)
+		self.assertAlmostEqual(d[0][0], 0.0)
+
+	def test_floyd_warshall_negative_cycle(self):
+		G = nk.graph.Graph(3, weighted=True, directed=True)
+		G.addEdge(0, 1,  1.0)
+		G.addEdge(1, 2, -3.0)
+		G.addEdge(2, 0,  1.0)
+		fw = nk.distance.FloydWarshall(G)
+		fw.run()
+		self.assertTrue(fw.isNodeInNegativeCycle(0))
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Adds getDistances() to the Python binding for FloydWarshall, consistent with the existing API on APSP and SPSP.
The method returns a const reference to the distance matrix already allocated by run(), so there is no additional memory overhead. 

Changes

include/networkit/distance/FloydWarshall.hpp - declare getDistances()
networkit/cpp/distance/FloydWarshall.cpp -  implement getDistances()
networkit/distance.pyx - expose via Cython with docstring noting reference semantics (as requested in the discussion)
networkit/test/test_distance.py - two new unit tests

Follows up on: https://github.com/networkit/networkit/discussions/1403