### PR TITLE
Add C++ SimRank edge scoring algorithm

### DIFF
--- a/include/networkit/edgescores/SimRankScore.hpp
+++ b/include/networkit/edgescores/SimRankScore.hpp
@@ -15,13 +15,13 @@ namespace NetworKit {
 
 class SimRankScore final : public EdgeScore<double> {
 public:
-    SimRankScore(const Graph &G, double damping = 0.9, count maxIterations = 100,
+    SimRankScore(const Graph &G, double similarityPropagationFactor = 0.9, count maxIterations = 100,
                  double tolerance = 1e-4);
 
     void run() override;
 
 private:
-    double damping;
+    double similarityPropagationFactor;
     count maxIterations;
     double tolerance;
 

--- a/include/networkit/edgescores/SimRankScore.hpp
+++ b/include/networkit/edgescores/SimRankScore.hpp
@@ -1,13 +1,18 @@
-//
-// Created by andreas on 01.05.26.
-//
+/*  SimRankScore.hpp
+ *
+ *  Created on: 01.05.2026
+ *  Authors: Andreas Scharf (andreas.b.scharf@gmail.com)
+ *
+ */
 
-#ifndef NETWORKIT_SIMRANKSCORE_H
-#define NETWORKIT_SIMRANKSCORE_H
+#ifndef NETWORKIT_EDGESCORES_SIMRANK_SCORE_HPP
+#define NETWORKIT_EDGESCORES_SIMRANK_SCORE_HPP
 
 #include <networkit/edgescores/EdgeScore.hpp>
 #include <networkit/graph/Graph.hpp>
+
 namespace NetworKit {
+
 class SimRankScore final : public EdgeScore<double> {
 public:
     SimRankScore(const Graph &G, double damping = 0.9, count maxIterations = 100,
@@ -22,5 +27,6 @@ private:
 
     count iterations;
 };
+
 } // namespace NetworKit
-#endif // NETWORKIT_SIMRANKSCORE_H
+#endif // NETWORKIT_EDGESCORES_SIMRANK_SCORE_HPP

--- a/include/networkit/edgescores/SimRankScore.hpp
+++ b/include/networkit/edgescores/SimRankScore.hpp
@@ -5,28 +5,67 @@
  *
  */
 
-#ifndef NETWORKIT_EDGESCORES_SIMRANK_SCORE_HPP
-#define NETWORKIT_EDGESCORES_SIMRANK_SCORE_HPP
+#ifndef NETWORKIT_EDGESCORES_SIM_RANK_SCORE_HPP_
+#define NETWORKIT_EDGESCORES_SIM_RANK_SCORE_HPP_
 
 #include <networkit/edgescores/EdgeScore.hpp>
 #include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
+/**
+ * Computes a SimRank similarity score for each edge of the input graph.
+ *
+ * The score assigned to an edge (u, v) is the SimRank similarity between
+ * its endpoints u and v.
+ *
+ * This implementation follows the classical iterative SimRank recurrence:
+ * two nodes are similar if their neighbors/predecessors are similar.
+ *
+ * The result is stored as one score per edge id in scoreData.
+ *
+ * Requires indexed edges, i.e. G.indexEdges() must have been called before run().
+ */
 class SimRankScore final : public EdgeScore<double> {
 public:
-    SimRankScore(const Graph &G, double similarityPropagationFactor = 0.9, count maxIterations = 100,
-                 double tolerance = 1e-4);
-
+    /**
+     * Constructs a SimRank edge-score algorithm.
+     *
+     * @param G The input graph.
+     * @param similarityPropagationFactor Factor in [0, 1] that scales the contribution
+     *        of neighboring node-pair similarities in each SimRank iteration.
+     *        Larger values preserve more propagated similarity.
+     * @param maxIterations Maximum number of iterations.
+     * @param tolerance Convergence tolerance for the maximum absolute score change
+     *        between two consecutive iterations.
+     *
+     * @throws std::invalid_argument if similarityPropagationFactor is not in [0, 1].
+     * @throws std::invalid_argument if maxIterations is 0.
+     * @throws std::invalid_argument if tolerance is negative.
+     */
+    SimRankScore(const Graph &G, double similarityPropagationFactor = 0.9,
+                 count maxIterations = 100, double tolerance = 1e-4);
+    /**
+     * Computes one SimRank score per indexed edge.
+     *
+     * After run(), scores can be accessed through:
+     * - scores()
+     * - score(edgeid)
+     * - score(u, v)
+     *
+     * @throws std::runtime_error if the graph has no indexed edges.
+     *         Call G.indexEdges() before running the algorithm.
+     * @throws std::overflow_error if the internal pairwise score matrix would
+     *         exceed the supported index range.
+     */
     void run() override;
 
 private:
     double similarityPropagationFactor;
     count maxIterations;
     double tolerance;
-
     count iterations;
 };
 
 } // namespace NetworKit
-#endif // NETWORKIT_EDGESCORES_SIMRANK_SCORE_HPP
+#endif // NETWORKIT_EDGESCORES_SIM_RANK_SCORE_HPP_

--- a/include/networkit/edgescores/SimRankScore.hpp
+++ b/include/networkit/edgescores/SimRankScore.hpp
@@ -1,0 +1,26 @@
+//
+// Created by andreas on 01.05.26.
+//
+
+#ifndef NETWORKIT_SIMRANKSCORE_H
+#define NETWORKIT_SIMRANKSCORE_H
+
+#include <networkit/edgescores/EdgeScore.hpp>
+#include <networkit/graph/Graph.hpp>
+namespace NetworKit {
+class SimRankScore final : public EdgeScore<double> {
+public:
+    SimRankScore(const Graph &G, double damping = 0.9, count maxIterations = 100,
+                 double tolerance = 1e-4);
+
+    void run() override;
+
+private:
+    double damping;
+    count maxIterations;
+    double tolerance;
+
+    count iterations;
+};
+} // namespace NetworKit
+#endif // NETWORKIT_SIMRANKSCORE_H

--- a/include/networkit/edgescores/SimRankScore.hpp
+++ b/include/networkit/edgescores/SimRankScore.hpp
@@ -64,7 +64,6 @@ private:
     double similarityPropagationFactor;
     count maxIterations;
     double tolerance;
-    count iterations;
 };
 
 } // namespace NetworKit

--- a/networkit/cpp/edgescores/CMakeLists.txt
+++ b/networkit/cpp/edgescores/CMakeLists.txt
@@ -9,6 +9,7 @@ networkit_add_module(edgescores
     GeometricMeanScore.cpp
     PrefixJaccardScore.cpp
     TriangleEdgeScore.cpp
+    SimRankScore.cpp
     )
 
 networkit_module_link_modules(edgescores

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -13,7 +13,7 @@ SimRankScore::SimRankScore(const Graph &G, double similarityPropagationFactor, c
     : EdgeScore<double>(G), similarityPropagationFactor(similarityPropagationFactor), maxIterations(maxIterations), tolerance(tolerance), iterations(0)
 {
     if (similarityPropagationFactor < 0.0 || similarityPropagationFactor > 1.0) {
-        throw std::invalid_argument("damping must be in the range [0,1]");
+        throw std::invalid_argument("similarityPropagationFactor must be in the range [0,1]");
     }
 
     if (maxIterations == 0) {
@@ -26,6 +26,31 @@ SimRankScore::SimRankScore(const Graph &G, double similarityPropagationFactor, c
 }
 
 void SimRankScore::run() {
+    if (!G->hasEdgeIds()) {
+        throw std::runtime_error("Graph must have edge IDs for SimRank calculation");
+    }
+
+    const index n = G->upperNodeIdBound();
+
+    if (n != 0 && n > std::numeric_limits<index>::max() / n) {
+        throw std::overflow_error("SimRankScore matrix size overflows");
+    }
+
+    const index matrixSize = n * n;
+
+    auto matrixIndex = [n](node u, node v) -> index {
+        return u * n + v;
+    };
+
+    std::vector<double> oldScore(matrixSize, 0.0);
+    std::vector<double> newScore(matrixSize, 0.0);
+
+    G->forEdges([&](node u) {
+       oldScore[matrixIndex(u, u)] = 1.0;
+    });
+    iterations = 0;
+
+
     hasFinished();
 }
 

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -1,5 +1,5 @@
 /*  SimRankScore.cpp
-*
+ *
  *  Created on: 01.05.2026
  *  Authors: Andreas Scharf (andreas.b.scharf@gmail.com)
  *
@@ -9,9 +9,10 @@
 
 namespace NetworKit {
 
-SimRankScore::SimRankScore(const Graph &G, double similarityPropagationFactor, count maxIterations, double tolerance)
-    : EdgeScore<double>(G), similarityPropagationFactor(similarityPropagationFactor), maxIterations(maxIterations), tolerance(tolerance), iterations(0)
-{
+SimRankScore::SimRankScore(const Graph &G, double similarityPropagationFactor, count maxIterations,
+                           double tolerance)
+    : EdgeScore<double>(G), similarityPropagationFactor(similarityPropagationFactor),
+      maxIterations(maxIterations), tolerance(tolerance), iterations(0) {
     if (similarityPropagationFactor < 0.0 || similarityPropagationFactor > 1.0) {
         throw std::invalid_argument("similarityPropagationFactor must be in the range [0,1]");
     }
@@ -37,21 +38,64 @@ void SimRankScore::run() {
     }
 
     const index matrixSize = n * n;
+    double maxDifference = std::numeric_limits<double>::max();
 
-    auto matrixIndex = [n](node u, node v) -> index {
-        return u * n + v;
-    };
+    auto matrixIndex = [n](node u, node v) -> index { return u * n + v; };
 
     std::vector<double> oldScore(matrixSize, 0.0);
     std::vector<double> newScore(matrixSize, 0.0);
 
-    G->forEdges([&](node u) {
-       oldScore[matrixIndex(u, u)] = 1.0;
-    });
+    G->forEdges([&](node u) { oldScore[matrixIndex(u, u)] = 1.0; });
+
     iterations = 0;
+    for (count iter = 0; iter < maxIterations; ++iter) {
+        std::fill(newScore.begin(), newScore.end(), 0.0);
 
+        G->forNodes([&](node u) { newScore[matrixIndex(u, u)] = 1.0; });
+        double iterationMaxDifference = 0.0;
+        G->forNodes([&](node u) {
+            const count degreeU = G->degreeIn(u);
+            G->forNodes([&](node v) {
+                if (u == v) {
+                    return;
+                }
+                const count degreeV = G->degreeIn(v);
+                double value = 0.0;
+                if (degreeU > 0 && degreeV > 0) {
+                    double sum = 0.0;
+                    if (G->isDirected()) {
+                        for (node a : G->inNeighborRange(u)) {
+                            for (node b : G->inNeighborRange(v)) {
+                                sum += oldScore[matrixIndex(a, b)];
+                            }
+                        }
+                    } else {
+                        for (node a : G->neighborRange(u)) {
+                            for (node b : G->neighborRange(v)) {
+                                sum += oldScore[matrixIndex(a, b)];
+                            }
+                        }
+                    }
+                    value =
+                        similarityPropagationFactor * sum / static_cast<double>(degreeU * degreeV);
+                }
+                const auto index = matrixIndex(u, v);
+                newScore[index] = value;
+                iterationMaxDifference =
+                    std::max(iterationMaxDifference, std::abs(value - oldScore[index]));
+            });
+        });
+        oldScore.swap(newScore);
+        maxDifference = iterationMaxDifference;
+        iterations++;
 
-    hasFinished();
+        if (maxDifference < tolerance) {
+            break;
+        }
+    }
+    scoreData.assign(G->upperEdgeIdBound(), 0.0);
+    G->forEdges([&](node u, node v, edgeid eid) { scoreData[eid] = oldScore[matrixIndex(u, v)]; });
+    assureFinished();
 }
 
 } // namespace NetworKit

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -33,6 +33,9 @@ void SimRankScore::run() {
 
     const index n = G->upperNodeIdBound();
 
+    // This is practically unreachable in ordinary tests because constructing a graph
+    // with n >= 2^32 nodes usually fails first, but the check prevents n * n from
+    // wrapping before allocating the dense SimRank matrix.
     if (n != 0 && n > std::numeric_limits<index>::max() / n) {
         throw std::overflow_error("SimRankScore matrix size overflows");
     }

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -9,10 +9,10 @@
 
 namespace NetworKit {
 
-SimRankScore::SimRankScore(const Graph &G, double damping, count maxIterations, double tolerance)
-    : EdgeScore<double>(G), damping(damping), maxIterations(maxIterations), tolerance(tolerance), iterations(0)
+SimRankScore::SimRankScore(const Graph &G, double similarityPropagationFactor, count maxIterations, double tolerance)
+    : EdgeScore<double>(G), similarityPropagationFactor(similarityPropagationFactor), maxIterations(maxIterations), tolerance(tolerance), iterations(0)
 {
-    if (damping < 0.0 || damping > 1.0) {
+    if (similarityPropagationFactor < 0.0 || similarityPropagationFactor > 1.0) {
         throw std::invalid_argument("damping must be in the range [0,1]");
     }
 

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -5,9 +5,8 @@
  *
  */
 
+#include <networkit/auxiliary/NumericTools.hpp>
 #include <networkit/edgescores/SimRankScore.hpp>
-
-#include "networkit/auxiliary/NumericTools.hpp"
 
 namespace NetworKit {
 

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -39,16 +39,12 @@ void SimRankScore::run() {
 
     const index matrixSize = n * n;
 
-    auto matrixIndex = [n](node u, node v) -> index {
-        return u * n + v;
-    };
+    auto matrixIndex = [n](node u, node v) -> index { return u * n + v; };
 
     std::vector<double> oldScore(matrixSize, 0.0);
     std::vector<double> newScore(matrixSize, 0.0);
 
-    G->parallelForNodes([&](node u) {
-        oldScore[matrixIndex(u, u)] = 1.0;
-    });
+    G->parallelForNodes([&](node u) { oldScore[matrixIndex(u, u)] = 1.0; });
 
     iterations = 0;
     double maxDifference = std::numeric_limits<double>::max();
@@ -56,9 +52,7 @@ void SimRankScore::run() {
     for (count iter = 0; iter < maxIterations; ++iter) {
         std::fill(newScore.begin(), newScore.end(), 0.0);
 
-        G->parallelForNodes([&](node u) {
-            newScore[matrixIndex(u, u)] = 1.0;
-        });
+        G->parallelForNodes([&](node u) { newScore[matrixIndex(u, u)] = 1.0; });
 
         std::vector<double> threadMaxDifferences(omp_get_max_threads(), 0.0);
 
@@ -86,7 +80,7 @@ void SimRankScore::run() {
                 }
 
                 value = similarityPropagationFactor * sum
-                      / (static_cast<double>(degreeU) * static_cast<double>(degreeV));
+                        / (static_cast<double>(degreeU) * static_cast<double>(degreeV));
             }
 
             const auto uv = matrixIndex(u, v);
@@ -95,20 +89,16 @@ void SimRankScore::run() {
             newScore[uv] = value;
             newScore[vu] = value;
 
-            const double difference = std::max(
-                std::abs(value - oldScore[uv]),
-                std::abs(value - oldScore[vu])
-            );
+            const double difference =
+                std::max(std::abs(value - oldScore[uv]), std::abs(value - oldScore[vu]));
 
             const int tid = omp_get_thread_num();
-            threadMaxDifferences[tid] =
-                std::max(threadMaxDifferences[tid], difference);
+            threadMaxDifferences[tid] = std::max(threadMaxDifferences[tid], difference);
         });
 
         double iterationMaxDifference = 0.0;
         for (const double localDifference : threadMaxDifferences) {
-            iterationMaxDifference =
-                std::max(iterationMaxDifference, localDifference);
+            iterationMaxDifference = std::max(iterationMaxDifference, localDifference);
         }
 
         oldScore.swap(newScore);
@@ -122,9 +112,8 @@ void SimRankScore::run() {
 
     scoreData.assign(G->upperEdgeIdBound(), 0.0);
 
-    G->parallelForEdges([&](node u, node v, edgeid eid) {
-        scoreData[eid] = oldScore[matrixIndex(u, v)];
-    });
+    G->parallelForEdges(
+        [&](node u, node v, edgeid eid) { scoreData[eid] = oldScore[matrixIndex(u, v)]; });
 
     hasRun = true;
 }

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -12,7 +12,7 @@ namespace NetworKit {
 SimRankScore::SimRankScore(const Graph &G, double similarityPropagationFactor, count maxIterations,
                            double tolerance)
     : EdgeScore<double>(G), similarityPropagationFactor(similarityPropagationFactor),
-      maxIterations(maxIterations), tolerance(tolerance), iterations(0) {
+      maxIterations(maxIterations), tolerance(tolerance) {
     if (similarityPropagationFactor < 0.0 || similarityPropagationFactor > 1.0) {
         throw std::invalid_argument("similarityPropagationFactor must be in the range [0,1]");
     }
@@ -47,17 +47,20 @@ void SimRankScore::run() {
     std::vector<double> oldScore(matrixSize, 0.0);
     std::vector<double> newScore(matrixSize, 0.0);
 
-    G->parallelForNodes([&](node u) { oldScore[matrixIndex(u, u)] = 1.0; });
+    auto initDiagonal = [&](std::vector<double> &score) {
+        G->parallelForNodes([&](node u) { score[matrixIndex(u, u)] = 1.0; });
+    };
 
-    iterations = 0;
+    initDiagonal(oldScore);
+
     double maxDifference = std::numeric_limits<double>::max();
+    std::vector<double> threadMaxDifferences(omp_get_max_threads());
 
-    for (count iter = 0; iter < maxIterations; ++iter) {
-        std::fill(newScore.begin(), newScore.end(), 0.0);
+    for (count iterations = 0; iterations < maxIterations; ++iterations) {
+        std::ranges::fill(newScore.begin(), newScore.end(), 0.0);
+        std::ranges::fill(threadMaxDifferences, 0.0);
 
-        G->parallelForNodes([&](node u) { newScore[matrixIndex(u, u)] = 1.0; });
-
-        std::vector<double> threadMaxDifferences(omp_get_max_threads(), 0.0);
+        initDiagonal(newScore);
 
         G->parallelForNodePairs([&](node u, node v) {
             const count degreeU = G->isDirected() ? G->degreeIn(u) : G->degree(u);

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -7,6 +7,8 @@
 
 #include <networkit/edgescores/SimRankScore.hpp>
 
+#include "networkit/auxiliary/NumericTools.hpp"
+
 namespace NetworKit {
 
 SimRankScore::SimRankScore(const Graph &G, double similarityPropagationFactor, count maxIterations,
@@ -42,73 +44,71 @@ void SimRankScore::run() {
 
     const index matrixSize = n * n;
 
-    auto matrixIndex = [n](node u, node v) -> index { return u * n + v; };
+    const auto matrixIndex = [n](node u, node v) -> index { return u * n + v; };
 
     std::vector<double> oldScore(matrixSize, 0.0);
     std::vector<double> newScore(matrixSize, 0.0);
 
-    auto initDiagonal = [&](std::vector<double> &score) {
+    const auto initDiagonal = [&](std::vector<double> &score) {
         G->parallelForNodes([&](node u) { score[matrixIndex(u, u)] = 1.0; });
     };
 
     initDiagonal(oldScore);
 
-    double maxDifference = std::numeric_limits<double>::max();
     std::vector<double> threadMaxDifferences(omp_get_max_threads());
 
+    const auto computeSum = [&](node u, node v, auto &&getRange) -> double {
+        double sum = 0.0;
+        for (node a : getRange(u)) {
+            for (node b : getRange(v)) {
+                sum += oldScore[matrixIndex(a, b)];
+            }
+        }
+        return sum;
+    };
+
+    const auto updateScoreAndDifference = [&](node u, node v, double sum, count degreeU,
+                                              count degreeV) {
+        double value = 0.0;
+        if (degreeU > 0 && degreeV > 0) {
+            value = similarityPropagationFactor * sum
+                    / (static_cast<double>(degreeU) * static_cast<double>(degreeV));
+        }
+
+        const auto uv = matrixIndex(u, v);
+        const auto vu = matrixIndex(v, u);
+
+        newScore[uv] = value;
+        newScore[vu] = value;
+
+        const double difference =
+            std::max(std::abs(value - oldScore[uv]), std::abs(value - oldScore[vu]));
+
+        const int tid = omp_get_thread_num();
+        threadMaxDifferences[tid] = std::max(threadMaxDifferences[tid], difference);
+    };
+
     for (count iterations = 0; iterations < maxIterations; ++iterations) {
-        std::ranges::fill(newScore.begin(), newScore.end(), 0.0);
+        std::ranges::fill(newScore, 0.0);
         std::ranges::fill(threadMaxDifferences, 0.0);
 
         initDiagonal(newScore);
-
-        G->parallelForNodePairs([&](node u, node v) {
-            const count degreeU = G->isDirected() ? G->degreeIn(u) : G->degree(u);
-            const count degreeV = G->isDirected() ? G->degreeIn(v) : G->degree(v);
-
-            double value = 0.0;
-
-            if (degreeU > 0 && degreeV > 0) {
-                double sum = 0.0;
-
-                if (G->isDirected()) {
-                    for (node a : G->inNeighborRange(u)) {
-                        for (node b : G->inNeighborRange(v)) {
-                            sum += oldScore[matrixIndex(a, b)];
-                        }
-                    }
-                } else {
-                    for (node a : G->neighborRange(u)) {
-                        for (node b : G->neighborRange(v)) {
-                            sum += oldScore[matrixIndex(a, b)];
-                        }
-                    }
-                }
-
-                value = similarityPropagationFactor * sum
-                        / (static_cast<double>(degreeU) * static_cast<double>(degreeV));
-            }
-
-            const auto uv = matrixIndex(u, v);
-            const auto vu = matrixIndex(v, u);
-
-            newScore[uv] = value;
-            newScore[vu] = value;
-
-            const double difference =
-                std::max(std::abs(value - oldScore[uv]), std::abs(value - oldScore[vu]));
-
-            const int tid = omp_get_thread_num();
-            threadMaxDifferences[tid] = std::max(threadMaxDifferences[tid], difference);
-        });
-
-        const double iterationMaxDifference = std::ranges::max(threadMaxDifferences);
+        if (G->isDirected()) {
+            G->parallelForNodePairs([&](node u, node v) {
+                const double sum = computeSum(u, v, [&](node w) { return G->inNeighborRange(w); });
+                updateScoreAndDifference(u, v, sum, G->degreeIn(u), G->degreeIn(v));
+            });
+        } else {
+            G->parallelForNodePairs([&](node u, node v) {
+                const double sum = computeSum(u, v, [&](node w) { return G->neighborRange(w); });
+                updateScoreAndDifference(u, v, sum, G->degree(u), G->degree(v));
+            });
+        }
 
         oldScore.swap(newScore);
-        maxDifference = iterationMaxDifference;
-        ++iterations;
 
-        if (maxDifference < tolerance) {
+        const double iterationMaxDifference = std::ranges::max(threadMaxDifferences);
+        if (iterationMaxDifference < tolerance) {
             break;
         }
     }

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -45,7 +45,7 @@ void SimRankScore::run() {
     std::vector<double> oldScore(matrixSize, 0.0);
     std::vector<double> newScore(matrixSize, 0.0);
 
-    G->forEdges([&](node u) { oldScore[matrixIndex(u, u)] = 1.0; });
+    G->forNodes([&](node u) { oldScore[matrixIndex(u, u)] = 1.0; });
 
     iterations = 0;
     for (count iter = 0; iter < maxIterations; ++iter) {
@@ -95,7 +95,7 @@ void SimRankScore::run() {
     }
     scoreData.assign(G->upperEdgeIdBound(), 0.0);
     G->forEdges([&](node u, node v, edgeid eid) { scoreData[eid] = oldScore[matrixIndex(u, v)]; });
-    assureFinished();
+    hasRun = true;
 }
 
 } // namespace NetworKit

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -99,10 +99,7 @@ void SimRankScore::run() {
             threadMaxDifferences[tid] = std::max(threadMaxDifferences[tid], difference);
         });
 
-        double iterationMaxDifference = 0.0;
-        for (const double localDifference : threadMaxDifferences) {
-            iterationMaxDifference = std::max(iterationMaxDifference, localDifference);
-        }
+        const double iterationMaxDifference = std::ranges::max(threadMaxDifferences);
 
         oldScore.swap(newScore);
         maxDifference = iterationMaxDifference;

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -1,0 +1,23 @@
+//
+// Created by andreas on 01.05.26.
+//
+#include <networkit/edgescores/SimRankScore.hpp>
+
+namespace NetworKit {
+
+SimRankScore::SimRankScore(const Graph &G, double damping, count maxIterations, double tolerance)
+    : EdgeScore<double>(G), damping(damping), maxIterations(maxIterations), tolerance(tolerance), iterations(0)
+{
+    if (damping < 0.0 || damping > 1.0) {
+        throw std::invalid_argument("damping must be in the range [0,1]");
+    }
+
+    if (maxIterations == 0) {
+        throw std::invalid_argument("maxIterations must be greater than 0");
+    }
+
+    if (tolerance < 0.0) {
+        throw std::invalid_argument("tolerance must be greater than or equal to 0");
+    }
+}
+} // namespace NetworKit

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -1,6 +1,10 @@
-//
-// Created by andreas on 01.05.26.
-//
+/*  SimRankScore.cpp
+*
+ *  Created on: 01.05.2026
+ *  Authors: Andreas Scharf (andreas.b.scharf@gmail.com)
+ *
+ */
+
 #include <networkit/edgescores/SimRankScore.hpp>
 
 namespace NetworKit {
@@ -20,4 +24,9 @@ SimRankScore::SimRankScore(const Graph &G, double damping, count maxIterations, 
         throw std::invalid_argument("tolerance must be greater than or equal to 0");
     }
 }
+
+void SimRankScore::run() {
+    hasFinished();
+}
+
 } // namespace NetworKit

--- a/networkit/cpp/edgescores/SimRankScore.cpp
+++ b/networkit/cpp/edgescores/SimRankScore.cpp
@@ -38,63 +38,94 @@ void SimRankScore::run() {
     }
 
     const index matrixSize = n * n;
-    double maxDifference = std::numeric_limits<double>::max();
 
-    auto matrixIndex = [n](node u, node v) -> index { return u * n + v; };
+    auto matrixIndex = [n](node u, node v) -> index {
+        return u * n + v;
+    };
 
     std::vector<double> oldScore(matrixSize, 0.0);
     std::vector<double> newScore(matrixSize, 0.0);
 
-    G->forNodes([&](node u) { oldScore[matrixIndex(u, u)] = 1.0; });
+    G->parallelForNodes([&](node u) {
+        oldScore[matrixIndex(u, u)] = 1.0;
+    });
 
     iterations = 0;
+    double maxDifference = std::numeric_limits<double>::max();
+
     for (count iter = 0; iter < maxIterations; ++iter) {
         std::fill(newScore.begin(), newScore.end(), 0.0);
 
-        G->forNodes([&](node u) { newScore[matrixIndex(u, u)] = 1.0; });
-        double iterationMaxDifference = 0.0;
-        G->forNodes([&](node u) {
-            const count degreeU = G->degreeIn(u);
-            G->forNodes([&](node v) {
-                if (u == v) {
-                    return;
-                }
-                const count degreeV = G->degreeIn(v);
-                double value = 0.0;
-                if (degreeU > 0 && degreeV > 0) {
-                    double sum = 0.0;
-                    if (G->isDirected()) {
-                        for (node a : G->inNeighborRange(u)) {
-                            for (node b : G->inNeighborRange(v)) {
-                                sum += oldScore[matrixIndex(a, b)];
-                            }
-                        }
-                    } else {
-                        for (node a : G->neighborRange(u)) {
-                            for (node b : G->neighborRange(v)) {
-                                sum += oldScore[matrixIndex(a, b)];
-                            }
+        G->parallelForNodes([&](node u) {
+            newScore[matrixIndex(u, u)] = 1.0;
+        });
+
+        std::vector<double> threadMaxDifferences(omp_get_max_threads(), 0.0);
+
+        G->parallelForNodePairs([&](node u, node v) {
+            const count degreeU = G->isDirected() ? G->degreeIn(u) : G->degree(u);
+            const count degreeV = G->isDirected() ? G->degreeIn(v) : G->degree(v);
+
+            double value = 0.0;
+
+            if (degreeU > 0 && degreeV > 0) {
+                double sum = 0.0;
+
+                if (G->isDirected()) {
+                    for (node a : G->inNeighborRange(u)) {
+                        for (node b : G->inNeighborRange(v)) {
+                            sum += oldScore[matrixIndex(a, b)];
                         }
                     }
-                    value =
-                        similarityPropagationFactor * sum / static_cast<double>(degreeU * degreeV);
+                } else {
+                    for (node a : G->neighborRange(u)) {
+                        for (node b : G->neighborRange(v)) {
+                            sum += oldScore[matrixIndex(a, b)];
+                        }
+                    }
                 }
-                const auto index = matrixIndex(u, v);
-                newScore[index] = value;
-                iterationMaxDifference =
-                    std::max(iterationMaxDifference, std::abs(value - oldScore[index]));
-            });
+
+                value = similarityPropagationFactor * sum
+                      / (static_cast<double>(degreeU) * static_cast<double>(degreeV));
+            }
+
+            const auto uv = matrixIndex(u, v);
+            const auto vu = matrixIndex(v, u);
+
+            newScore[uv] = value;
+            newScore[vu] = value;
+
+            const double difference = std::max(
+                std::abs(value - oldScore[uv]),
+                std::abs(value - oldScore[vu])
+            );
+
+            const int tid = omp_get_thread_num();
+            threadMaxDifferences[tid] =
+                std::max(threadMaxDifferences[tid], difference);
         });
+
+        double iterationMaxDifference = 0.0;
+        for (const double localDifference : threadMaxDifferences) {
+            iterationMaxDifference =
+                std::max(iterationMaxDifference, localDifference);
+        }
+
         oldScore.swap(newScore);
         maxDifference = iterationMaxDifference;
-        iterations++;
+        ++iterations;
 
         if (maxDifference < tolerance) {
             break;
         }
     }
+
     scoreData.assign(G->upperEdgeIdBound(), 0.0);
-    G->forEdges([&](node u, node v, edgeid eid) { scoreData[eid] = oldScore[matrixIndex(u, v)]; });
+
+    G->parallelForEdges([&](node u, node v, edgeid eid) {
+        scoreData[eid] = oldScore[matrixIndex(u, v)];
+    });
+
     hasRun = true;
 }
 

--- a/networkit/cpp/edgescores/test/CMakeLists.txt
+++ b/networkit/cpp/edgescores/test/CMakeLists.txt
@@ -2,4 +2,5 @@ networkit_add_test(edgescores ChibaNishizekiQuadrangleEdgeScoreGTest)
 networkit_add_test(edgescores ChibaNishizekiTriangleEdgeScoreGTest)
 networkit_add_test(edgescores EdgeScoreGTest)
 networkit_add_test(edgescores EdgeScoreAsWeightGTest)
+networkit_add_test(edgescores SimRankScoreGTest)
 

--- a/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
+++ b/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
@@ -63,4 +63,99 @@ TEST_F(SimRankScoreGTest, testConstructorRejectsNegativeTolerance) {
     EXPECT_THROW(SimRankScore score(G, 0.9, 100, -1e-4), std::invalid_argument);
 }
 
+TEST_F(SimRankScoreGTest, testRunRequiresIndexedEdges) {
+    Graph G(2, false, false);
+    G.addEdge(0, 1);
+
+    SimRankScore simrank(G);
+
+    EXPECT_THROW(simrank.run(), std::runtime_error);
+}
+
+TEST_F(SimRankScoreGTest, testScoresUnavailableBeforeRun) {
+    Graph G(2, false, false);
+    G.addEdge(0, 1);
+    G.indexEdges();
+
+    SimRankScore simrank(G);
+
+    EXPECT_ANY_THROW(simrank.scores());
+    EXPECT_ANY_THROW(simrank.score(0));
+    EXPECT_ANY_THROW(simrank.score(0, 1));
+}
+
+TEST_F(SimRankScoreGTest, testRunProducesOneScorePerIndexedEdge) {
+    Graph G(3, false, false, true);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+
+    SimRankScore simrank(G);
+    simrank.run();
+
+    EXPECT_EQ(simrank.scores().size(), G.upperEdgeIdBound());
+}
+
+TEST_F(SimRankScoreGTest, testSingleUndirectedEdgeHasZeroSimRankScore) {
+    Graph G(2, false, false);
+    G.addEdge(0, 1);
+    G.indexEdges();
+
+    SimRankScore simrank(G, 0.9, 100, 1e-12);
+    simrank.run();
+
+    EXPECT_NEAR(simrank.score(0, 1), 0.0, 1e-12);
+}
+
+TEST_F(SimRankScoreGTest, testPathOfLengthTwoHasZeroEdgeScores) {
+    Graph G(3, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+    G.indexEdges();
+
+    SimRankScore simrank(G, 0.9, 100, 1e-12);
+    simrank.run();
+
+    EXPECT_NEAR(simrank.score(0, 1), 0.0, 1e-12);
+    EXPECT_NEAR(simrank.score(1, 2), 0.0, 1e-12);
+}
+
+TEST_F(SimRankScoreGTest, testTriangleHasPositiveEqualEdgeScores) {
+    Graph G(3, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+    G.addEdge(0, 2);
+    G.indexEdges();
+
+    SimRankScore simrank(G, 0.5, 100, 1e-12);
+    simrank.run();
+
+    const double expected = 0.2;
+
+    EXPECT_NEAR(simrank.score(0, 1), expected, 1e-10);
+    EXPECT_NEAR(simrank.score(1, 2), expected, 1e-10);
+    EXPECT_NEAR(simrank.score(0, 2), expected, 1e-10);
+}
+
+TEST_F(SimRankScoreGTest, testScoresAreStableAcrossRepeatedRun) {
+    Graph G(3, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+    G.addEdge(0, 2);
+    G.indexEdges();
+
+    SimRankScore simrank(G, 0.5, 100, 1e-12);
+
+    simrank.run();
+    const auto firstScores = simrank.scores();
+
+    simrank.run();
+    const auto secondScores = simrank.scores();
+
+    EXPECT_EQ(firstScores.size(), secondScores.size());
+
+    for (index i = 0; i < firstScores.size(); ++i) {
+        EXPECT_NEAR(firstScores[i], secondScores[i], 1e-12);
+    }
+}
+
 } // namespace NetworKit

--- a/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
+++ b/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <networkit/edgescores/SimRankScore.hpp>
+#include <networkit/graph/Graph.hpp>
+
+namespace NetworKit {
+
+class SimRankScoreGTest : public ::testing::Test {};
+
+TEST_F(SimRankScoreGTest, testConstructorAcceptsValidParameters) {
+    Graph G(3, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+
+    EXPECT_NO_THROW({
+        SimRankScore score(G, 0.9, 100, 1e-4);
+    });
+}
+
+TEST_F(SimRankScoreGTest, testConstructorAcceptsDefaultParameters) {
+    Graph G(3, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+
+    EXPECT_NO_THROW({
+        SimRankScore score(G);
+    });
+}
+
+TEST_F(SimRankScoreGTest, testConstructorDoesNotMarkAlgorithmAsRun) {
+    Graph G(3, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+
+    SimRankScore score(G);
+
+    EXPECT_THROW(score.scores(), std::runtime_error);
+    EXPECT_THROW(score.score(0), std::runtime_error);
+    EXPECT_THROW(score.score(0, 1), std::runtime_error);
+}
+
+TEST_F(SimRankScoreGTest, testConstructorRejectsNegativeDamping) {
+    Graph G(3, false, false);
+
+    EXPECT_THROW(SimRankScore score(G, -0.1, 100, 1e-4), std::invalid_argument);
+}
+
+TEST_F(SimRankScoreGTest, testConstructorRejectsDampingGreaterThanOne) {
+    Graph G(3, false, false);
+
+    EXPECT_THROW(SimRankScore score(G, 1.1, 100, 1e-4), std::invalid_argument);
+}
+
+TEST_F(SimRankScoreGTest, testConstructorRejectsZeroMaxIterations) {
+    Graph G(3, false, false);
+
+    EXPECT_THROW(SimRankScore score(G, 0.9, 0, 1e-4), std::invalid_argument);
+}
+
+TEST_F(SimRankScoreGTest, testConstructorRejectsNegativeTolerance) {
+    Graph G(3, false, false);
+
+    EXPECT_THROW(SimRankScore score(G, 0.9, 100, -1e-4), std::invalid_argument);
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
+++ b/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
@@ -12,9 +12,7 @@ TEST_F(SimRankScoreGTest, testConstructorAcceptsValidParameters) {
     G.addEdge(0, 1);
     G.addEdge(1, 2);
 
-    EXPECT_NO_THROW({
-        SimRankScore score(G, 0.9, 100, 1e-4);
-    });
+    EXPECT_NO_THROW({ SimRankScore score(G, 0.9, 100, 1e-4); });
 }
 
 TEST_F(SimRankScoreGTest, testConstructorAcceptsDefaultParameters) {
@@ -22,9 +20,7 @@ TEST_F(SimRankScoreGTest, testConstructorAcceptsDefaultParameters) {
     G.addEdge(0, 1);
     G.addEdge(1, 2);
 
-    EXPECT_NO_THROW({
-        SimRankScore score(G);
-    });
+    EXPECT_NO_THROW({ SimRankScore score(G); });
 }
 
 TEST_F(SimRankScoreGTest, testConstructorDoesNotMarkAlgorithmAsRun) {

--- a/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
+++ b/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
@@ -174,4 +174,78 @@ TEST_F(SimRankScoreGTest, testTriangleWithTailHasExpectedEdgeScores) {
     EXPECT_NEAR(simrank.score(0, 2), 65.0 / 423.0, 1e-10);
     EXPECT_NEAR(simrank.score(2, 3), 26.0 / 423.0, 1e-10);
 }
+
+TEST_F(SimRankScoreGTest, testResultsDoNotDependOnNumberOfThreads) {
+#ifndef _OPENMP
+    GTEST_SKIP() << "OpenMP is not enabled";
+#else
+    const int previousThreads = omp_get_max_threads();
+
+    Graph G(6, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(3, 4);
+    G.addEdge(4, 5);
+    G.addEdge(1, 5);
+    G.addEdge(0, 4);
+    G.indexEdges();
+
+    omp_set_num_threads(1);
+    SimRankScore singleThreaded(G, 0.7, 100, 1e-12);
+    singleThreaded.run();
+    const auto singleThreadedScores = singleThreaded.scores();
+
+    omp_set_num_threads(4);
+    SimRankScore multiThreaded(G, 0.7, 100, 1e-12);
+    multiThreaded.run();
+    const auto multiThreadedScores = multiThreaded.scores();
+
+    omp_set_num_threads(previousThreads);
+
+    EXPECT_EQ(singleThreadedScores.size(), multiThreadedScores.size());
+
+    for (index i = 0; i < singleThreadedScores.size(); ++i) {
+        EXPECT_NEAR(singleThreadedScores[i], multiThreadedScores[i], 1e-12);
+    }
+#endif
+}
+
+TEST_F(SimRankScoreGTest, testRepeatedParallelRunsProduceSameScores) {
+#ifdef _OPENMP
+    const int previousThreads = omp_get_max_threads();
+    omp_set_num_threads(4);
+#endif
+
+    Graph G(6, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(3, 4);
+    G.addEdge(4, 5);
+    G.addEdge(1, 5);
+    G.addEdge(0, 4);
+    G.indexEdges();
+
+    SimRankScore reference(G, 0.7, 100, 1e-12);
+    reference.run();
+    const auto referenceScores = reference.scores();
+
+    for (index run = 0; run < 20; ++run) {
+        SimRankScore simrank(G, 0.7, 100, 1e-12);
+        simrank.run();
+
+        EXPECT_EQ(referenceScores.size(), simrank.scores().size());
+
+        for (index i = 0; i < referenceScores.size(); ++i) {
+            EXPECT_NEAR(referenceScores[i], simrank.scores()[i], 1e-12);
+        }
+    }
+
+#ifdef _OPENMP
+    omp_set_num_threads(previousThreads);
+#endif
+}
 } // namespace NetworKit

--- a/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
+++ b/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
@@ -158,4 +158,20 @@ TEST_F(SimRankScoreGTest, testScoresAreStableAcrossRepeatedRun) {
     }
 }
 
+TEST_F(SimRankScoreGTest, testTriangleWithTailHasExpectedEdgeScores) {
+    Graph G(4, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+    G.addEdge(0, 2);
+    G.addEdge(2, 3);
+    G.indexEdges();
+
+    SimRankScore simrank(G, 0.5, 100, 1e-12);
+    simrank.run();
+
+    EXPECT_NEAR(simrank.score(0, 1), 79.0 / 423.0, 1e-10);
+    EXPECT_NEAR(simrank.score(1, 2), 65.0 / 423.0, 1e-10);
+    EXPECT_NEAR(simrank.score(0, 2), 65.0 / 423.0, 1e-10);
+    EXPECT_NEAR(simrank.score(2, 3), 26.0 / 423.0, 1e-10);
+}
 } // namespace NetworKit

--- a/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
+++ b/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <networkit/edgescores/SimRankScore.hpp>
 #include <networkit/graph/Graph.hpp>
@@ -147,7 +148,7 @@ TEST_F(SimRankScoreGTest, testScoresAreStableAcrossRepeatedRun) {
     simrank.run();
     const auto secondScores = simrank.scores();
 
-  EXPECT_THAT(firstScores, Pointwise(DoubleNear(1e-12), secondScores));
+  EXPECT_THAT(firstScores, testing::Pointwise(testing::DoubleNear(1e-12), secondScores));
 }
 
 TEST_F(SimRankScoreGTest, testTriangleWithTailHasExpectedEdgeScores) {

--- a/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
+++ b/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <networkit/edgescores/SimRankScore.hpp>
 #include <networkit/graph/Graph.hpp>
@@ -81,6 +81,26 @@ TEST_F(SimRankScoreGTest, testScoresUnavailableBeforeRun) {
     EXPECT_ANY_THROW(simrank.score(0, 1));
 }
 
+TEST_F(SimRankScoreGTest, testRunAcceptsEmptyGraph) {
+    Graph G(0, false, false);
+    G.indexEdges();
+
+    SimRankScore score(G);
+
+    EXPECT_NO_THROW(score.run());
+    EXPECT_THAT(score.scores(), testing::IsEmpty());
+}
+
+TEST_F(SimRankScoreGTest, testRunAcceptsSingleNodeGraph) {
+    Graph G(1, false, false);
+    G.indexEdges();
+
+    SimRankScore score(G);
+
+    EXPECT_NO_THROW(score.run());
+    EXPECT_THAT(score.scores(), testing::IsEmpty());
+}
+
 TEST_F(SimRankScoreGTest, testRunProducesOneScorePerIndexedEdge) {
     Graph G(3, false, false, true);
     G.addEdge(0, 1);
@@ -148,7 +168,7 @@ TEST_F(SimRankScoreGTest, testScoresAreStableAcrossRepeatedRun) {
     simrank.run();
     const auto secondScores = simrank.scores();
 
-  EXPECT_THAT(firstScores, testing::Pointwise(testing::DoubleNear(1e-12), secondScores));
+    EXPECT_THAT(firstScores, testing::Pointwise(testing::DoubleNear(1e-12), secondScores));
 }
 
 TEST_F(SimRankScoreGTest, testTriangleWithTailHasExpectedEdgeScores) {
@@ -212,48 +232,9 @@ TEST_F(SimRankScoreGTest, testResultsDoNotDependOnNumberOfThreads) {
 
     omp_set_num_threads(previousThreads);
 
-    EXPECT_EQ(singleThreadedScores.size(), multiThreadedScores.size());
-
-    for (index i = 0; i < singleThreadedScores.size(); ++i) {
-        EXPECT_NEAR(singleThreadedScores[i], multiThreadedScores[i], 1e-12);
-    }
+    EXPECT_THAT(singleThreadedScores,
+                testing::Pointwise(testing::DoubleNear(1e-12), multiThreadedScores));
 #endif
 }
 
-TEST_F(SimRankScoreGTest, testRepeatedParallelRunsProduceSameScores) {
-#ifdef _OPENMP
-    const int previousThreads = omp_get_max_threads();
-    omp_set_num_threads(4);
-#endif
-
-    Graph G(6, false, false);
-    G.addEdge(0, 1);
-    G.addEdge(0, 2);
-    G.addEdge(1, 2);
-    G.addEdge(2, 3);
-    G.addEdge(3, 4);
-    G.addEdge(4, 5);
-    G.addEdge(1, 5);
-    G.addEdge(0, 4);
-    G.indexEdges();
-
-    SimRankScore reference(G, 0.7, 100, 1e-12);
-    reference.run();
-    const auto referenceScores = reference.scores();
-
-    for (index run = 0; run < 20; ++run) {
-        SimRankScore simrank(G, 0.7, 100, 1e-12);
-        simrank.run();
-
-        EXPECT_EQ(referenceScores.size(), simrank.scores().size());
-
-        for (index i = 0; i < referenceScores.size(); ++i) {
-            EXPECT_NEAR(referenceScores[i], simrank.scores()[i], 1e-12);
-        }
-    }
-
-#ifdef _OPENMP
-    omp_set_num_threads(previousThreads);
-#endif
-}
 } // namespace NetworKit

--- a/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
+++ b/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
@@ -88,7 +88,7 @@ TEST_F(SimRankScoreGTest, testRunProducesOneScorePerIndexedEdge) {
     SimRankScore simrank(G);
     simrank.run();
 
-    EXPECT_EQ(simrank.scores().size(), G.upperEdgeIdBound());
+    EXPECT_THAT(simrank.scores(), testing::SizeIs(G.upperEdgeIdBound()));
 }
 
 TEST_F(SimRankScoreGTest, testSingleUndirectedEdgeHasZeroSimRankScore) {
@@ -147,11 +147,7 @@ TEST_F(SimRankScoreGTest, testScoresAreStableAcrossRepeatedRun) {
     simrank.run();
     const auto secondScores = simrank.scores();
 
-    EXPECT_EQ(firstScores.size(), secondScores.size());
-
-    for (index i = 0; i < firstScores.size(); ++i) {
-        EXPECT_NEAR(firstScores[i], secondScores[i], 1e-12);
-    }
+  EXPECT_THAT(firstScores, Pointwise(DoubleNear(1e-12), secondScores));
 }
 
 TEST_F(SimRankScoreGTest, testTriangleWithTailHasExpectedEdgeScores) {

--- a/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
+++ b/networkit/cpp/edgescores/test/SimRankScoreGTest.cpp
@@ -171,6 +171,21 @@ TEST_F(SimRankScoreGTest, testTriangleWithTailHasExpectedEdgeScores) {
     EXPECT_NEAR(simrank.score(2, 3), 26.0 / 423.0, 1e-10);
 }
 
+TEST_F(SimRankScoreGTest, testDirectedGraphUsesInNeighbors) {
+    Graph G(3, false, true);
+
+    G.addEdge(0, 1);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+
+    G.indexEdges();
+
+    SimRankScore simRank(G, 0.8, 1, 0.0);
+    simRank.run();
+
+    EXPECT_NEAR(simRank.score(G.edgeId(1, 2)), 0.4, 1e-12);
+}
+
 TEST_F(SimRankScoreGTest, testResultsDoNotDependOnNumberOfThreads) {
 #ifndef _OPENMP
     GTEST_SKIP() << "OpenMP is not enabled";


### PR DESCRIPTION
This PR adds the C++ implementation for the SimRank-based edge scoring part of #1381.

It introduces `SimRankScore`, an `EdgeScore<double>` implementation that assigns each indexed edge `(u, v)` the SimRank similarity between its endpoints.

The implementation follows the iterative SimRank recurrence: two nodes are considered similar if their neighbors are similar. For directed graphs, in-neighbors/predecessors are used; for undirected graphs, ordinary neighbors are used.

Let `z = G.upperNodeIdBound()` and `m` be the number of edges. The implementation uses `O(z^2)` space for the pairwise score matrices plus `O(m)` for `scoreData`. The dense worst-case runtime is `O(k * z^4)`, where `k` is the number of iterations.

The implementation is parallelized with OpenMP where feasible: diagonal initialization, pairwise score updates, and final edge-score extraction are parallelized. The convergence check uses thread-local maximum differences followed by a reduction.

In follow-up PRs, I plan to add the Python API and investigate performance improvements.
This PR does not yet close #1381 because the Python API is still missing.