### PR TITLE
Add python API for SimRank.

### DIFF
--- a/networkit/sparsification.pyx
+++ b/networkit/sparsification.pyx
@@ -1624,3 +1624,49 @@ class ConstantScore():
 			The input graph.
 		"""
 		return self.constValue
+
+cdef extern from "networkit/edgescores/SimRankScore.hpp" namespace "NetworKit":
+	cdef cppclass _SimRankScore "NetworKit::SimRankScore"(_EdgeScore[double]):
+		_SimRankScore(
+			const _Graph& G,
+			double similarityPropagationFactor,
+			count maxIterations,
+			double tolerance
+		) except +
+
+cdef class SimRankScore(EdgeScore):
+	"""
+	SimRankScore(G, similarityPropagationFactor=0.8, maxIterations=20, tolerance=1e-4)
+
+	Computes a SimRank-based edge score. The score of an edge is the SimRank
+	similarity of its two endpoints.
+
+	Parameters
+	----------
+	G : networkit.Graph
+		The input graph. The graph must have indexed edges.
+	similarityPropagationFactor : float, optional
+		SimRank decay factor. Must be in [0, 1].
+	maxIterations : int, optional
+		Maximum number of iterations. Must be greater than zero.
+	tolerance : float, optional
+		Convergence tolerance. Must be non-negative.
+	"""
+
+	def __cinit__(
+		self,
+		Graph G not None,
+		double similarityPropagationFactor=0.8,
+		count maxIterations=20,
+		double tolerance=1e-4
+	):
+		self._G = G
+		self._this = new _SimRankScore(
+			G._this,
+			similarityPropagationFactor,
+			maxIterations,
+			tolerance
+		)
+
+	cdef bool_t isDoubleValue(self):
+		return True

--- a/networkit/test/test_sparsification.py
+++ b/networkit/test/test_sparsification.py
@@ -41,5 +41,95 @@ class TestSparsification(unittest.TestCase):
 			self.assertGreaterEqual(ratio, minExpectedRatio)
 			self.assertLessEqual(ratio, maxExpectedRatio)
 
+	def testSimRankScoreRejectsInvalidSimilarityPropagationFactor(self):
+		G = Graph(3, False, False)
+
+		with self.assertRaises(ValueError):
+			sparsification.SimRankScore(G, 1.1, 100, 1e-4)
+
+		with self.assertRaises(ValueError):
+			sparsification.SimRankScore(G, -0.1, 100, 1e-4)
+
+	def testSimRankScoreRejectsZeroMaxIterations(self):
+		G = Graph(3, False, False)
+
+		with self.assertRaises(ValueError):
+			sparsification.SimRankScore(G, 0.9, 0, 1e-4)
+
+	def testSimRankScoreRejectsNegativeTolerance(self):
+		G = Graph(3, False, False)
+
+		with self.assertRaises(ValueError):
+			sparsification.SimRankScore(G, 0.9, 100, -1e-4)
+
+	def testSimRankScoreRunRequiresIndexedEdges(self):
+		G = Graph(2, False, False)
+		G.addEdge(0, 1)
+
+		simrank = sparsification.SimRankScore(G)
+
+		with self.assertRaises(RuntimeError):
+			simrank.run()
+
+	def testSimRankScoreScoresUnavailableBeforeRun(self):
+		G = Graph(2, False, False)
+		G.addEdge(0, 1)
+		G.indexEdges()
+
+		simrank = sparsification.SimRankScore(G)
+
+		with self.assertRaises(RuntimeError):
+			simrank.scores()
+
+		with self.assertRaises(RuntimeError):
+			simrank.score(0)
+
+		with self.assertRaises(RuntimeError):
+			simrank.score(0, 1)
+
+	def testSimRankScoreRunAcceptsEmptyGraph(self):
+		G = Graph(0, False, False)
+		G.indexEdges()
+
+		simrank = sparsification.SimRankScore(G)
+		simrank.run()
+
+		self.assertEqual(simrank.scores(), [])
+
+	def testSimRankScoreProducesExpectedTriangleScores(self):
+		G = Graph(3, False, False)
+		G.addEdge(0, 1)
+		G.addEdge(1, 2)
+		G.addEdge(0, 2)
+		G.indexEdges()
+
+		simrank = sparsification.SimRankScore(G, 0.5, 100, 1e-12)
+		simrank.run()
+
+		scores = simrank.scores()
+
+		self.assertEqual(len(scores), G.upperEdgeIdBound())
+
+		for eid in range(G.upperEdgeIdBound()):
+			self.assertAlmostEqual(simrank.score(eid), scores[eid])
+
+		expected = 0.2
+
+		for u, v in [(0, 1), (1, 2), (0, 2)]:
+			eid = G.edgeId(u, v)
+			self.assertAlmostEqual(simrank.score(u, v), expected, delta=1e-10)
+			self.assertAlmostEqual(simrank.score(eid), expected, delta=1e-10)
+	def testSimRankScoreDirectedGraphUsesInNeighbors(self):
+		G = Graph(3, False, True)
+		G.addEdge(0, 1)
+		G.addEdge(0, 2)
+		G.addEdge(1, 2)
+		G.indexEdges()
+
+		simrank = sparsification.SimRankScore(G, 0.8, 1, 0.0)
+		simrank.run()
+
+		self.assertAlmostEqual(simrank.score(G.edgeId(1, 2)), 0.4, delta=1e-12)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/networkit/test/test_sparsification.py
+++ b/networkit/test/test_sparsification.py
@@ -119,6 +119,7 @@ class TestSparsification(unittest.TestCase):
 			eid = G.edgeId(u, v)
 			self.assertAlmostEqual(simrank.score(u, v), expected, delta=1e-10)
 			self.assertAlmostEqual(simrank.score(eid), expected, delta=1e-10)
+
 	def testSimRankScoreDirectedGraphUsesInNeighbors(self):
 		G = Graph(3, False, True)
 		G.addEdge(0, 1)


### PR DESCRIPTION
This PR adds the Python/Cython API for `SimRankScore`.

It follows up on the C++ implementation added in #1406 and exposes the existing `SimRankScore` implementation through the Python `networkit.sparsification` module.

`SimRankScore` is exposed as an `EdgeScore` implementation and forwards the Python constructor arguments to the existing C++ implementation.

This completes the Python API part of #1381.