### PR TITLE
return by value + test to confirm the fix 

### DIFF
--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -50,7 +50,7 @@ cdef extern from "<networkit/community/CommunityDetectionAlgorithm.hpp>":
 
 	cdef cppclass _CommunityDetectionAlgorithm "NetworKit::CommunityDetectionAlgorithm"(_Algorithm):
 		_CommunityDetectionAlgorithm(const _Graph &_G)
-		_Partition &getPartition() except +
+		_Partition getPartition() except +
 
 cdef class CommunityDetector(Algorithm):
 	""" 

--- a/networkit/test/test_community.py
+++ b/networkit/test/test_community.py
@@ -248,11 +248,22 @@ class TestCommunity(unittest.TestCase):
 
 	def testPLMProlong(self):
 		PLM = nk.community.PLM(self.L)
-		PLM.run()	
-		PLMP = PLM.getPartition()		
+		PLM.run()
+		PLMP = PLM.getPartition()
 		coarse = PLM.coarsen(self.L, PLMP)
 		part = PLM.prolong(coarse[0], PLMP, self.L, coarse[1])
 		self.assertDictEqual(part.subsetSizeMap(), {0:9})
+
+	def testPLMGetPartitionIdempotent(self):
+		plm = nk.community.PLM(self.L)
+		plm.run()
+		p1 = plm.getPartition()
+		p2 = plm.getPartition()
+		self.assertGreater(p1.numberOfElements(), 0)
+		self.assertEqual(p1.numberOfElements(), p2.numberOfElements())
+		self.assertEqual(p1.numberOfSubsets(), p2.numberOfSubsets())
+		for u in self.L.iterNodes():
+			self.assertEqual(p1.subsetOf(u), p2.subsetOf(u))
 
 	def testLouvainMapEquation(self):
 		LME = nk.community.LouvainMapEquation(self.L)


### PR DESCRIPTION
This PR addresses Issue #949 

In Issue #949, the following scenario is reported: If we run an instance of PLM and use PLM.getPartition() twice in a row, the second call yields different results. In particular, the second call returns an empty partition. 

Here's my opinion on where the problem is: 
In the C++ declaration of `getPartition` we return a const reference to a partition object (to be precise: result): 
`virtual const Partition &getPartition() const;`
However, in the Cython binding we find the following: 
The Cython binding declared the return value also as a reference. The problem with this is the following: 
When we call getPartition() via Python, in community.pyx, we call 
`return Partition().setThis((<_CommunityDetectionAlgorithm*>(self._this)).getPartition())`
 `Partition()` calls `__cinit__`, which creates an empty partition. 
In `setThis` we then use std::swap, which means that `result` now holds the empty partition and the Python wrapper owns the real partition. Every subsequent call then swaps empty partitions with empty partitions.

The (quick) fix is then to declare the Cython return by value. With this, `other` is then a local copy instead of a reference to result. If we use `swap` then, it doesn't influence `result`. 

I know this might not be the performance optimal fix, but it is already used in similar scenarios such as in community.pyx: `getCover()`, so I thought I stick with this pattern. Let me know if another fix is preferred.  

There is also a new test to make sure that `getPartition()` is idempotent now. 

Co-developed with Claude (Claude Code).