### PR TITLE
Remove redundant map lookup

### DIFF
--- a/networkit/cpp/generators/DynamicDGSParser.cpp
+++ b/networkit/cpp/generators/DynamicDGSParser.cpp
@@ -178,8 +178,6 @@ void DynamicDGSParser::evaluateClusterings(const std::string &path, const Partit
         clusterMappings[normalizedID].reserve(100000);
 
         for (const std::string &category : currentNodeCategories) {
-            clusterMappings[normalizedID].find(category);
-
             const auto got = clusterMappings[normalizedID].find(category);
 
             if (got == clusterMappings[normalizedID].end()) {


### PR DESCRIPTION
This is likely the result of a wrong merge, the result of `find` is not used and the same lookup is performed in the instruction below.