### PR TITLE
Fix stale paths bug in DynBetweenness

### DIFF
--- a/networkit/cpp/centrality/DynApproxBetweenness.cpp
+++ b/networkit/cpp/centrality/DynApproxBetweenness.cpp
@@ -165,10 +165,10 @@ void DynApproxBetweenness::updateBatch(std::span<const GraphEvent> batch) {
         for (node z : sampledPaths[i]) {
             scoreData[z] -= 1 / (double)r;
         }
+        sampledPaths[i].clear();
         if (sssp[i]->distance(v[i]) == infDist) // Skip unreachable node v[i]
             continue;
         // sample a new shortest path
-        sampledPaths[i].clear();
         node t = v[i];
         while (t != u[i]) {
             // sample z in P_u(t) with probability sigma_uz / sigma_us

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -5,6 +5,8 @@
  *      Author: ebergamini, cls
  */
 
+#include <span>
+
 #include <gtest/gtest.h>
 
 #include <networkit/auxiliary/Log.hpp>
@@ -23,18 +25,21 @@ namespace NetworKit {
 
 class DynBetweennessGTest : public testing::TestWithParam<std::pair<bool, bool>> {
 protected:
+    void SetUp() override { Aux::Random::setSeed(42, false); }
+
     bool isDirected() const noexcept { return GetParam().first; };
     bool isWeighted() const noexcept { return GetParam().second; };
     Graph generateSmallGraph() const;
 
     static constexpr double epsilon = 0.1, delta = 0.1;
 
-    void compareAgainstBaseline(const Graph &G, const std::vector<double> &apxScores,
-                                const std::vector<double> &exactScores, double normalized = false,
-                                double err = epsilon) const {
+    void compareAgainstBaseline(const Graph &G, std::span<const double> apxScores,
+                                std::span<const double> exactScores,
+                                bool normalized = false) const {
         const auto n = static_cast<double>(G.numberOfNodes());
-        const auto normFactor = normalized ? n * (n - 1) : 1.;
-        G.forNodes([&](node u) { EXPECT_NEAR(apxScores[u], exactScores[u] / normFactor, err); });
+        const double normFactor = normalized ? n * (n - 1) : 1.;
+        G.forNodes(
+            [&](node u) { EXPECT_NEAR(apxScores[u], exactScores[u] / normFactor, epsilon); });
     }
 
     std::pair<node, node> getNonAdjacentNodes(const Graph &G) const {
@@ -76,7 +81,6 @@ Graph DynBetweennessGTest::generateSmallGraph() const {
     }
 
     if (isWeighted()) {
-        Aux::Random::setSeed(42, false);
         GraphTools::randomizeWeights(G);
     }
     return G;
@@ -113,7 +117,6 @@ TEST_P(DynBetweennessGTest, runDynApproxBetweennessSmallGraphEdgeDeletion) {
 }
 
 TEST_P(DynBetweennessGTest, testDynApproxBetweenessGeneratedGraph) {
-    Aux::Random::setSeed(42, false);
     ErdosRenyiGenerator generator(100, 0.25, isDirected());
     Graph G = generator.generate();
     if (isWeighted()) {
@@ -135,11 +138,9 @@ TEST_P(DynBetweennessGTest, testDynApproxBetweenessGeneratedGraph) {
 }
 
 TEST_P(DynBetweennessGTest, runDynApproxBetweenessGeneratedGraphEdgeDeletion) {
-    Aux::Random::setSeed(42, false);
     ErdosRenyiGenerator generator(100, 0.25, isDirected());
     Graph G = generator.generate();
     if (isWeighted()) {
-        Aux::Random::setSeed(42, false);
         GraphTools::randomizeWeights(G);
     }
 
@@ -197,8 +198,6 @@ TEST_F(DynBetweennessGTest, runDynVsStaticEdgeDeletion) {
 }
 
 TEST_F(DynBetweennessGTest, runDynVsStaticCaseInsertDirected) {
-    Aux::Random::setSeed(0, false);
-
     for (count n = 2; n <= 25; n++)
         for (count t = 0; t < 100; t++) {
             auto g = ErdosRenyiGenerator(n, 0.3, true).generate();
@@ -223,10 +222,8 @@ TEST_F(DynBetweennessGTest, runDynVsStaticCaseInsertDirected) {
 }
 
 TEST_F(DynBetweennessGTest, runDynVsStaticCaseInsertUndirected) {
-    Aux::Random::setSeed(0, false);
-
-    for (count n = 2; n <= 25; n++)
-        for (count t = 0; t < 100; t++) {
+    for (count n = 2; n <= 25; ++n)
+        for (count t = 0; t < 100; ++t) {
             auto g = ErdosRenyiGenerator(n, 0.3, false).generate();
             if (g.numberOfEdges() == g.numberOfNodes() * (g.numberOfNodes() - 1) / 2)
                 continue;


### PR DESCRIPTION
`DynApproxBetweenness::updateBatch` fails to clear the old sampled path when a node pair becomes unreachable after a graph update. This can lead to "stale" paths and thus wrong score subtractions in subsequent updates. For this reason,`DynApproxBetweenness` tests randomly fail like in this example: <img width="1209" height="408" alt="Screenshot 2026-05-23 at 01 30 56" src="https://github.com/user-attachments/assets/651b2348-ba14-4d87-9a2c-96f6079bf8a0" />

Moving `sampledPaths[i].clear()` before the reachability check fixes the issue.

Also, add a fixed random seed at tests startup to reduce flakiness and other minor improvements.
