### PR TITLE
Trigger CI on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,6 @@ on:
     branches:
       - master
   push:
-    branches:
-      - master
 
 # Default parameters for all builds.
 env:


### PR DESCRIPTION
This change triggers CI on forks, allowing developers to verify branch builds and catch failures without having to open a new PR.