### PR TITLE
graph: prevent edge callback crash for invalid nodes.

### DIFF
--- a/networkit/graph.pyx
+++ b/networkit/graph.pyx
@@ -766,6 +766,9 @@ cdef class Graph:
 			Any callable object that takes the parameter tuple(int, int, float, int).
 			Parameter list refering to (node id, node id, edge weight, edge id).
 		"""
+		if not self._this.hasNode(u):
+			raise RuntimeError("Cannot iterate over edges of non-existing node {}".format(u))
+
 		cdef EdgeCallBackWrapper* wrapper
 		try:
 			wrapper = new EdgeCallBackWrapper(callback)
@@ -790,6 +793,9 @@ cdef class Graph:
 			Any callable object that takes the parameter tuple(int, int, float, int).
 			Parameter list refering to (node id, node id, edge weight, edge id).
 		"""
+		if not self._this.hasNode(u):
+			raise RuntimeError("Cannot iterate over in-edges of non-existing node {}".format(u))
+
 		cdef EdgeCallBackWrapper* wrapper
 		try:
 			wrapper = new EdgeCallBackWrapper(callback)

--- a/networkit/test/test_graph.py
+++ b/networkit/test/test_graph.py
@@ -672,6 +672,65 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(un.getUMSF().numberOfEdges(), 5)
         self.assertTrue(un.inUMST(0, 1))
 
+    def testForInEdgesOfInvalidNodeRaises(self):
+        G = nk.Graph(2, directed=True)
+        G.addEdge(0, 1)
+
+        def edgeFunc(*args):
+            self.fail("Callback should not be called for a non-existing node")
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "Cannot iterate over in-edges of non-existing node 912",
+        ):
+            G.forInEdgesOf(912, edgeFunc)
+
+
+    def testForInEdgesOfRemovedNodeRaises(self):
+        G = nk.Graph(3, directed=True)
+        G.addEdge(0, 1)
+        G.addEdge(2, 1)
+
+        G.removeNode(1)
+
+        def edgeFunc(*args):
+            self.fail("Callback should not be called for a removed node")
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "Cannot iterate over in-edges of non-existing node 1",
+        ):
+            G.forInEdgesOf(1, edgeFunc)
+
+    def testForEdgesOfInvalidNodeRaises(self):
+        G = nk.Graph(2)
+        G.addEdge(0, 1)
+
+        def edgeFunc(*args):
+            self.fail("Callback should not be called for a non-existing node")
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "Cannot iterate over edges of non-existing node 912",
+        ):
+            G.forEdgesOf(912, edgeFunc)
+
+
+    def testForEdgesOfRemovedNodeRaises(self):
+        G = nk.Graph(3)
+        G.addEdge(0, 2)
+
+        G.removeNode(1)
+
+        def edgeFunc(*args):
+            self.fail("Callback should not be called for a removed node")
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "Cannot iterate over edges of non-existing node 1",
+        ):
+            G.forEdgesOf(1, edgeFunc)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes a crash in the Python API when `Graph.forEdgesOf` or `Graph.forInEdgesOf` is called with a non-existing node.

Invalid or removed nodes now raise a RuntimeError instead of reaching unchecked C++ adjacency access.

Fixes #1419