### PR TITLE
Update codestyle according to clang  22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,13 +490,15 @@ jobs:
   style-guide-compliance-build:
     name: "Linux (default): code-style"
     runs-on: ubuntu-22.04
+    env:
+      LLVM_VERSION: 22
     steps:
       - name: Install prerequisites
         run: |
-          curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/jammy llvm-toolchain-jammy-17 main" | sudo tee /etc/apt/sources.list.d/llvm17.list
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          echo "deb http://apt.llvm.org/jammy llvm-toolchain-jammy-${LLVM_VERSION} main" | sudo tee /etc/apt/sources.list.d/llvm${LLVM_VERSION}.list
           sudo apt-get update
-          sudo apt-get install clang-format-17 python3-yaml
+          sudo apt-get install clang-format-${LLVM_VERSION} python3-yaml
       - name: Checkout networkit
         uses: actions/checkout@v5
         with:
@@ -506,4 +508,4 @@ jobs:
           set -e
           ./check_code.sh -v
         env:
-          NETWORKIT_OVERRIDE_CLANG_FORMAT: "clang-format-17"
+          NETWORKIT_OVERRIDE_CLANG_FORMAT: "clang-format-${{ env.LLVM_VERSION }}"

--- a/extrafiles/tooling/nktooling/__init__.py
+++ b/extrafiles/tooling/nktooling/__init__.py
@@ -7,7 +7,7 @@ import subprocess
 READONLY = True
 VERBOSE = False
 SHOW_DIFFS = True
-CLANG_FORMAT_VERSION = 17
+CLANG_FORMAT_VERSION = 22
 
 def setup(args = None):
 	"""

--- a/include/networkit/auxiliary/IncrementalUniformRandomSelector.hpp
+++ b/include/networkit/auxiliary/IncrementalUniformRandomSelector.hpp
@@ -24,7 +24,7 @@ public:
     /**
      * Initialize the random select for one element.
      */
-    IncrementalUniformRandomSelector() : counter(1){};
+    IncrementalUniformRandomSelector() : counter(1) {};
 
     /**
      * Add the next element.

--- a/include/networkit/generators/quadtree/Quadtree.hpp
+++ b/include/networkit/generators/quadtree/Quadtree.hpp
@@ -213,7 +213,9 @@ public:
 #pragma omp parallel
         {
 #pragma omp single nowait
-            { root.reindex(0); }
+            {
+                root.reindex(0);
+            }
         }
     }
 

--- a/include/networkit/generators/quadtree/QuadtreeCartesianEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadtreeCartesianEuclid.hpp
@@ -127,7 +127,9 @@ public:
 #pragma omp parallel
         {
 #pragma omp single nowait
-            { root.reindex(0); }
+            {
+                root.reindex(0);
+            }
         }
     }
 

--- a/include/networkit/generators/quadtree/QuadtreePolarEuclid.hpp
+++ b/include/networkit/generators/quadtree/QuadtreePolarEuclid.hpp
@@ -123,7 +123,9 @@ public:
 #pragma omp parallel
         {
 #pragma omp single nowait
-            { root.reindex(0); }
+            {
+                root.reindex(0);
+            }
         }
     }
 

--- a/include/networkit/graph/Attributes.hpp
+++ b/include/networkit/graph/Attributes.hpp
@@ -151,7 +151,7 @@ public:
 
 private:
     std::vector<T> values; // the real attribute storage
-};                         // class AttributeStorage<NodeOrEdge, Base, T>
+}; // class AttributeStorage<NodeOrEdge, Base, T>
 
 template <typename NodeOrEdge, typename GraphType, typename T, bool isConst>
 class Attribute {

--- a/include/networkit/graph/EdgeIterators.hpp
+++ b/include/networkit/graph/EdgeIterators.hpp
@@ -180,7 +180,7 @@ class EdgeWeightTRange {
 public:
     EdgeWeightTRange(const GraphType<NodeT, EdgeWeightT> &G) : G(&G) {}
 
-    EdgeWeightTRange() : G(nullptr){};
+    EdgeWeightTRange() : G(nullptr) {};
 
     ~EdgeWeightTRange() = default;
 

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -480,7 +480,7 @@ public:
     public:
         NeighborRange(const AdjListGraph &G, NodeT u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborRange() : G(nullptr){};
+        NeighborRange() : G(nullptr) {};
 
         NeighborIterator begin() const {
             assert(G);
@@ -512,7 +512,7 @@ public:
     public:
         NeighborWeightRange(const AdjListGraph &G, NodeT u) : G(&G), u(u) { assert(G.hasNode(u)); };
 
-        NeighborWeightRange() : G(nullptr){};
+        NeighborWeightRange() : G(nullptr) {};
 
         NeighborWeightIterator begin() const {
             assert(G);
@@ -727,7 +727,7 @@ public:
           inEdgeIds(other.inEdgeIds), outEdgeIds(other.outEdgeIds),
           // call special constructors to copy attribute maps
           nodeAttributeMap(other.nodeAttributeMap, this),
-          edgeAttributeMap(other.edgeAttributeMap, this){};
+          edgeAttributeMap(other.edgeAttributeMap, this) {};
 
     /** move constructor */
     AdjListGraph(AdjListGraph &&other) noexcept

--- a/include/networkit/graph/GraphBuilder.hpp
+++ b/include/networkit/graph/GraphBuilder.hpp
@@ -58,8 +58,8 @@ class GraphBuilder {
         node source;
         node destination;
         // HalfEdge(node source, node destination);
-        HalfEdge(){};
-        HalfEdge(node source, node destination) : source(source), destination(destination){};
+        HalfEdge() {};
+        HalfEdge(node source, node destination) : source(source), destination(destination) {};
     };
 
     std::vector<std::vector<std::vector<HalfEdge>>>

--- a/include/networkit/graph/NodeIterators.hpp
+++ b/include/networkit/graph/NodeIterators.hpp
@@ -107,7 +107,7 @@ class NodeRangeBase {
 public:
     NodeRangeBase(const GraphType<NodeT, EdgeWeightT> &G) : G(&G) {}
 
-    NodeRangeBase() : G(nullptr){};
+    NodeRangeBase() : G(nullptr) {};
 
     ~NodeRangeBase() = default;
 

--- a/include/networkit/graph/RandomMaximumSpanningForest.hpp
+++ b/include/networkit/graph/RandomMaximumSpanningForest.hpp
@@ -118,7 +118,7 @@ private:
                                && (u > other.u || (u == other.u && v > other.v)))));
         };
         weightedEdge(node u, node v, double attribute, edgeid eid = 0)
-            : attribute(attribute), u(u), v(v), eid(eid), rand(Aux::Random::integer()){};
+            : attribute(attribute), u(u), v(v), eid(eid), rand(Aux::Random::integer()) {};
     };
 
     const Graph &G;

--- a/include/networkit/graph/UnionMaximumSpanningForest.hpp
+++ b/include/networkit/graph/UnionMaximumSpanningForest.hpp
@@ -111,7 +111,7 @@ private:
                        && (u > other.u || (u == other.u && v > other.v)));
         };
         weightedEdge(node u, node v, edgeweight attribute, edgeid eid = 0)
-            : attribute(attribute), u(u), v(v), eid(eid){};
+            : attribute(attribute), u(u), v(v), eid(eid) {};
     };
 
     const Graph *G;

--- a/include/networkit/io/NetworkitBinaryReader.hpp
+++ b/include/networkit/io/NetworkitBinaryReader.hpp
@@ -37,7 +37,7 @@ namespace NetworKit {
 class NetworkitBinaryReader final : public GraphReader {
 
 public:
-    NetworkitBinaryReader(){};
+    NetworkitBinaryReader() {};
 
     Graph read(std::string_view path) override;
     Graph readFromBuffer(const std::vector<uint8_t> &data);

--- a/include/networkit/layout/LayoutAlgorithm.hpp
+++ b/include/networkit/layout/LayoutAlgorithm.hpp
@@ -22,9 +22,9 @@ class LayoutAlgorithm {
 
 public:
     LayoutAlgorithm(const Graph &G)
-        : G(G){
+        : G(G) {
 
-        };
+          };
 
     virtual void run() = 0;
 

--- a/include/networkit/structures/LocalCommunity.hpp
+++ b/include/networkit/structures/LocalCommunity.hpp
@@ -54,9 +54,9 @@ public:
             throw std::runtime_error("Decreasing value that is missing");
         }
 
-        OptionalValue(const ValueType &){};
+        OptionalValue(const ValueType &) {};
 
-        OptionalValue(){};
+        OptionalValue() {};
     };
 
     template <typename ValueType>
@@ -89,9 +89,9 @@ public:
             return *this;
         }
 
-        OptionalValue(const ValueType &v) : value(v){};
+        OptionalValue(const ValueType &v) : value(v) {};
 
-        OptionalValue() : value(){};
+        OptionalValue() : value() {};
 
         ValueType value;
     };

--- a/networkit/cpp/centrality/GroupClosenessGrowShrink.cpp
+++ b/networkit/cpp/centrality/GroupClosenessGrowShrink.cpp
@@ -15,15 +15,18 @@ GroupClosenessGrowShrink::GroupClosenessGrowShrink(const Graph &G, const std::ve
                                                    bool extended, count insertions,
                                                    count maxIterations)
     : G(&G),
-      weightedImpl{G.isWeighted() ? std::make_unique<
-                       GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<edgeweight>>(
-                       G, group, extended, insertions, maxIterations)
-                                  : nullptr},
-      unweightedImpl{G.isWeighted()
-                         ? nullptr
-                         : std::make_unique<
-                             GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<count>>(
-                             G, group, extended, insertions, maxIterations)} {}
+      weightedImpl{
+          G.isWeighted()
+              ? std::make_unique<
+                    GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<edgeweight>>(
+                    G, group, extended, insertions, maxIterations)
+              : nullptr},
+      unweightedImpl{
+          G.isWeighted()
+              ? nullptr
+              : std::make_unique<
+                    GroupClosenessGrowShrinkDetails::GroupClosenessGrowShrinkImpl<count>>(
+                    G, group, extended, insertions, maxIterations)} {}
 
 GroupClosenessGrowShrink::~GroupClosenessGrowShrink() = default;
 

--- a/networkit/cpp/community/LouvainMapEquation.cpp
+++ b/networkit/cpp/community/LouvainMapEquation.cpp
@@ -212,7 +212,9 @@ count LouvainMapEquation::synchronousLocalMoving(std::vector<node> &nodes, count
 
 #ifndef NDEBUG
 #pragma omp single
-            { checkUpdatedCutsAndVolumesAgainstRecomputation(); }
+            {
+                checkUpdatedCutsAndVolumesAgainstRecomputation();
+            }
 // don't start the next round of moves, before the old ones were validated
 #pragma omp barrier
 #endif

--- a/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
+++ b/networkit/cpp/distance/NeighborhoodFunctionHeuristic.cpp
@@ -20,8 +20,8 @@ namespace NetworKit {
 NeighborhoodFunctionHeuristic::NeighborhoodFunctionHeuristic(const Graph &G, count nSamples,
                                                              SelectionStrategy strategy)
     : Algorithm(), G(&G),
-      nSamples(!nSamples ? (count)std::ceil(
-                   std::max((double)0.15f * G.numberOfNodes(), std::sqrt(G.numberOfEdges())))
+      nSamples(!nSamples ? (count)std::ceil(std::max((double)0.15f * G.numberOfNodes(),
+                                                     std::sqrt(G.numberOfEdges())))
                          : nSamples),
       strategy(strategy) {
 

--- a/networkit/cpp/distance/test/DistanceGTest.cpp
+++ b/networkit/cpp/distance/test/DistanceGTest.cpp
@@ -96,24 +96,24 @@ TEST_F(DistanceGTest, testAStarInvalidSourceNode) {
     Graph G(5);
     std::vector<double> distanceHeu = {1.0, 2.0, 3.0, 4.0, 5.0};
 
-    EXPECT_THROW({ AStar astar(G, distanceHeu, /*invalid_source*/ 6, /*target*/ 0); },
-                 std::runtime_error);
+    EXPECT_THROW(
+        { AStar astar(G, distanceHeu, /*invalid_source*/ 6, /*target*/ 0); }, std::runtime_error);
 }
 
 TEST_F(DistanceGTest, testAStarInvalidTargetNode) {
     Graph G(5);
     std::vector<double> distanceHeu = {1.0, 2.0, 3.0, 4.0, 5.0};
 
-    EXPECT_THROW({ AStar astar(G, distanceHeu, /*source*/ 0, /*invalid_target*/ 6); },
-                 std::runtime_error);
+    EXPECT_THROW(
+        { AStar astar(G, distanceHeu, /*source*/ 0, /*invalid_target*/ 6); }, std::runtime_error);
 }
 
 TEST_F(DistanceGTest, testAStarConstructorThrowsMismatchHeuristicAndNodeCount) {
     Graph G(5);
     std::vector<double> distanceHeu = {1.0, 2.0}; // size mismatch (2 instead of 5)
 
-    EXPECT_THROW({ AStar astar_bad(G, distanceHeu, /*source*/ 0, /*target*/ 1); },
-                 std::runtime_error);
+    EXPECT_THROW(
+        { AStar astar_bad(G, distanceHeu, /*source*/ 0, /*target*/ 1); }, std::runtime_error);
 }
 
 TEST_F(DistanceGTest, testAStar) {
@@ -188,10 +188,12 @@ TEST_F(DistanceGTest, testAStar) {
 TEST_F(DistanceGTest, testAlgebraicDistanceContructorThrowsForInvalidOmegaValues) {
     Graph G(5, true, false);
 
-    EXPECT_THROW({ AlgebraicDistance AGD(G, 10UL, 30UL, /* invalid_omega*/ 1.1, 0UL, true); },
-                 std::invalid_argument);
-    EXPECT_THROW({ AlgebraicDistance AGD(G, 10UL, 30UL, /* invalid_omega*/ -0.3, 0UL, true); },
-                 std::invalid_argument);
+    EXPECT_THROW(
+        { AlgebraicDistance AGD(G, 10UL, 30UL, /* invalid_omega*/ 1.1, 0UL, true); },
+        std::invalid_argument);
+    EXPECT_THROW(
+        { AlgebraicDistance AGD(G, 10UL, 30UL, /* invalid_omega*/ -0.3, 0UL, true); },
+        std::invalid_argument);
 }
 
 TEST_F(DistanceGTest, testAlgebraicDistanceContructorThrowsForEdgecoresWithoutEdgeIds) {
@@ -776,8 +778,9 @@ TEST_P(DistanceGTest, testSPSPWithUnreachableTarget) {
 TEST_F(DistanceGTest, testMultiTargetBFSThrowsInvalidSourceWithTargetRange) {
     Graph G(5);
     std::vector<node> targets = {0, 1, 2, 3};
-    EXPECT_THROW({ MultiTargetBFS astar(G, /*invalid_source*/ 6, targets.begin(), targets.end()); },
-                 std::runtime_error);
+    EXPECT_THROW(
+        { MultiTargetBFS astar(G, /*invalid_source*/ 6, targets.begin(), targets.end()); },
+        std::runtime_error);
 }
 
 TEST_F(DistanceGTest, testMultiTargetBFSThrowsWithOneInvalidTargetInTargetRange) {

--- a/networkit/cpp/edgescores/PrefixJaccardScore.cpp
+++ b/networkit/cpp/edgescores/PrefixJaccardScore.cpp
@@ -30,7 +30,7 @@ void PrefixJaccardScore<AttributeT>::run() {
         AttributeT att;
         count rank;
 
-        RankedEdge(node u, AttributeT att, count rank) : u(u), att(att), rank(rank){};
+        RankedEdge(node u, AttributeT att, count rank) : u(u), att(att), rank(rank) {};
 
         bool operator<(const RankedEdge &other) const {
             return std::tie(rank, att, u) < std::tie(other.rank, other.att, other.u);

--- a/networkit/cpp/generators/test/GeneratorsGTest.cpp
+++ b/networkit/cpp/generators/test/GeneratorsGTest.cpp
@@ -1113,9 +1113,8 @@ TEST_F(GeneratorsGTest, testStaticDegreeSequenceGenerator) {
     for (int iter = 0; iter < 100; ++iter) {
         const auto n = distr_num_nodes(prng);
         std::vector<count> seq(n);
-        std::generate(seq.begin(), seq.end(), [&] {
-            return std::uniform_int_distribution<count>{0, n - 1}(prng);
-        });
+        std::generate(seq.begin(), seq.end(),
+                      [&] { return std::uniform_int_distribution<count>{0, n - 1}(prng); });
 
         HavelHakimiGenerator gen(seq, true);
         const auto isRealizable = gen.isRealizable();

--- a/networkit/cpp/io/GraphToolBinaryWriter.cpp
+++ b/networkit/cpp/io/GraphToolBinaryWriter.cpp
@@ -47,7 +47,7 @@ uint8_t GraphToolBinaryWriter::getAdjacencyWidth(uint64_t n) {
 
 void GraphToolBinaryWriter::writeHeader(std::ofstream &file) {
     uint8_t header[8] = {0xe2, 0x9b, 0xbe, 0x20, 0x67, 0x74, 0x01, 0x00};
-    header[7] |= (uint8_t) !this->littleEndianness;
+    header[7] |= (uint8_t)!this->littleEndianness;
     file.write((char *)header, 8);
 }
 

--- a/networkit/cpp/matching/test/MatcherGTest.cpp
+++ b/networkit/cpp/matching/test/MatcherGTest.cpp
@@ -330,9 +330,8 @@ TEST_F(MatcherGTest, testDynBSuitorRemoveEdges) {
     dbsm.run();
 
     std::vector<GraphEvent> events;
-    G.forEdges([&](node u, node v) {
-        events.emplace_back(GraphEvent{GraphEvent::EDGE_REMOVAL, u, v});
-    });
+    G.forEdges(
+        [&](node u, node v) { events.emplace_back(GraphEvent{GraphEvent::EDGE_REMOVAL, u, v}); });
 
     for (auto &e : events) {
         G.removeEdge(e.u, e.v);

--- a/networkit/cpp/randomization/CurveballImpl.hpp
+++ b/networkit/cpp/randomization/CurveballImpl.hpp
@@ -198,7 +198,9 @@ private:
             adjList.insertNeighbour(b, a);
             return;
         }
-        { adjList.insertNeighbour(a, b); }
+        {
+            adjList.insertNeighbour(a, b);
+        }
     }
 };
 

--- a/networkit/cpp/scd/LocalDegreeDirectedGraph.hpp
+++ b/networkit/cpp/scd/LocalDegreeDirectedGraph.hpp
@@ -211,8 +211,7 @@ public:
      */
     template <typename F>
     void forTrianglesOf(node u, F callback) {
-        forTrianglesOf(
-            u, [](node, edgeweight) {}, callback);
+        forTrianglesOf(u, [](node, edgeweight) {}, callback);
     }
 
     /**

--- a/networkit/cpp/scd/LocalTightnessExpansion.cpp
+++ b/networkit/cpp/scd/LocalTightnessExpansion.cpp
@@ -66,7 +66,7 @@ private:
 public:
     LocalGraph(const Graph &g, NodeAddedCallbackType nodeAddedCallback)
         : LocalDegreeDirectedGraph<is_weighted, InnerNodeAddedCallback<NodeAddedCallbackType>>(
-            g, InnerNodeAddedCallback<NodeAddedCallbackType>{nodeAddedCallback, triangleSum}) {
+              g, InnerNodeAddedCallback<NodeAddedCallbackType>{nodeAddedCallback, triangleSum}) {
         if (g.isWeighted() != is_weighted) {
             throw std::runtime_error("Error, weighted/unweighted status of input graph does not "
                                      "match is_weighted template parameter");

--- a/networkit/cpp/viz/MaxentStress.cpp
+++ b/networkit/cpp/viz/MaxentStress.cpp
@@ -504,9 +504,8 @@ void MaxentStress::computeKnownDistances(const count k, const GraphDistance grap
     case EDGE_WEIGHT:
         // add edges to known distances
         G->parallelForNodes([&](node u) {
-            G->forNeighborsOf(u, [&](node v, edgeweight w) {
-                knownDistances[u].push_back({v, w});
-            });
+            G->forNeighborsOf(u,
+                              [&](node v, edgeweight w) { knownDistances[u].push_back({v, w}); });
             // add k-neighborhood
             if (k > 1) { // 1-neighborhood are adjacent vertices that are already added above
                 addKNeighborhoodOfVertex(u, k);

--- a/networkit/cpp/viz/test/VizGTest.cpp
+++ b/networkit/cpp/viz/test/VizGTest.cpp
@@ -33,9 +33,8 @@ TEST_F(VizGTest, testPostscriptWriterOnRandomGraph) {
     std::vector<Point2D> coordinates(G.upperNodeIdBound());
 
     // create coordinates
-    G.forNodes([&](node u) {
-        coordinates[u] = {Aux::Random::probability(), Aux::Random::probability()};
-    });
+    G.forNodes(
+        [&](node u) { coordinates[u] = {Aux::Random::probability(), Aux::Random::probability()}; });
 
     // write graph to file
     std::string path = "output/testGraph.eps";


### PR DESCRIPTION
It is a preliminary step before raising clang's version from 17 to 22. It currently affects only clang-format, including CI and a local formatting tool `./extrafiles/tooling/CppClangFormat.py`.

There are no changes neither in logic nor semantics, only codestyle changes.  I have split this out into a separate PR, because of the large number of affected files.