### PR TITLE
Fix CI for building wheels for macOS

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -143,7 +143,7 @@ jobs:
     strategy:
       matrix:
         buildplat:
-        - [macos-latest, arm64, NETWORKIT_OSX_CROSSBUILD=ON]
+        - [macos-15, arm64, NETWORKIT_OSX_CROSSBUILD=ON]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Several recent PR's are already affected by this issue.

The issue was that when landed on a runner with macOS 26, CI failed due to platform and deployment target incompatibility `MACOSX_DEPLOYMENT_TARGET='15.0'`.

Although the problem is independent of #1431, they were triggered by the same event: migration github's runners from macOS 15 to macOS 26.

Rather than in #1431 and #1432 where pinning to macOS 15 is temporary, I would keep wheel target as macOS 15 until we raise minimal supported version. 