### PR TITLE
Update Python version requirement 3.9 -> 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ As both a production tool and a research testbed for algorithm engineering, Netw
 
 #### Python Module
 
-**For most users**, NetworKit can be installed directly via package managers with no additional requirements other than Python 3.9+.
+**For most users**, NetworKit can be installed directly via package managers with no additional requirements other than Python 3.10+.
 
 | Package Manager | Command |
 |-----------------|---------|
@@ -191,7 +191,7 @@ Building from source requires:
 
 - **C++ Compiler**: [g++] (&gt;= 10.0), [clang++] (&gt;= 11.0), or MSVC (&gt;= 14.30)
 - **OpenMP**: For parallelism (usually included with compiler)
-- **Python**: 3.9 or higher with development libraries
+- **Python**: 3.10 or higher with development libraries
   - Debian/Ubuntu: `apt-get install python3-dev`
   - RHEL/CentOS: `dnf install python3-devel`
   - Windows: [Official installer](https://www.python.org/downloads/windows/)

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -18,10 +18,10 @@ def run_notebook(path):
     proc = ExecutePreprocessor(timeout=600, kernel_name='python3')
     proc.allow_errors = True
 
-    # For Python >= 3.8 on Windows, the Preprocessor throws a NotImplementedError
+    # On Windows, the Preprocessor throws a NotImplementedError
     # This check is inserted as a workaround
     # See: https://github.com/jupyter/nbconvert/issues/1372
-    if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
+    if sys.platform.startswith('win'):
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
     proc.preprocess(nb, {'metadata': {'path': dirname}})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "networkit"
 dynamic = ["version"]
 description = "NetworKit is a toolbox for high-performance network analysis"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "License.txt"}
 keywords =["graph algorithm", "network analysis", "social network"]
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 #!/usr/bin/python3
 
-import shutil
 import sys
+
+if sys.version_info < (3, 10):
+    print("ERROR: NetworKit requires Python 3.10 or later.")
+    sys.exit(1)
+
+import shutil
 import sysconfig
 import os
 from Cython.Build import cythonize
@@ -12,10 +17,6 @@ buildDirectory = "build/build_python"
 ninja_available = False
 enable_osx_crossbuild = False
 build_tests = False
-
-if sys.version_info.major < 3:
-    print("ERROR: NetworKit requires Python 3.")
-    sys.exit(1)
 
 if "CXX" in os.environ:
     cmakeCompiler = os.environ["CXX"]
@@ -313,6 +314,7 @@ setup(
     package_data={"networkit.profiling": ["html/*", "latex/*", "description/*"]},
     keywords=version.keywords,
     platforms=version.platforms,
+    python_requires=version.python_requires,
     classifiers=version.classifiers,
     cmdclass={"build_ext": build_ext},
     ext_modules=cythonize(["networkit/*pyx"], compiler_directives=compiler_directives),

--- a/version.py
+++ b/version.py
@@ -30,6 +30,8 @@ keywords = ["graph algorithm", "network analysis", "social network"]
 
 platforms = "any"
 
+python_requires = ">=3.10"
+
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",


### PR DESCRIPTION
  This PR moves Python from 3.9 to 3.10 as the minimum supported version.

  Changes made:

  - Updated package metadata in `pyproject.toml` from
  `requires-python = ">=3.9"` to `>=3.10`.
  - Added `python_requires = ">=3.10"` to `version.py`, and correspondingly `version.python_requires` in `setup.py`.
  - Updated `setup.py` check to reject Python versions older than 3.10 at the very beginning.
  - Updated README.md accordingly.
  - Simplified the notebook check workaround for Windows by removing the redundant ">= 3.8"  version check, since all  supported Python versions are now 3.10+.

  ### Already Up To Date

  Surprisingly, the CI and wheels already met Python 3.10+ requirement, so no changes needed there.