### PR TITLE
Using C++20 concepts to constrain NodeT and EdgeWeightT.

### DIFF
--- a/include/networkit/graph/AdjListGraph.hpp
+++ b/include/networkit/graph/AdjListGraph.hpp
@@ -35,15 +35,13 @@
 #include <networkit/graph/Attributes.hpp>
 #include <networkit/graph/EdgeIterators.hpp>
 #include <networkit/graph/EdgeUtils.hpp>
+#include <networkit/graph/GraphConcepts.hpp>
 #include <networkit/graph/NeighborIterators.hpp>
 #include <networkit/graph/NodeIterators.hpp>
 
 #include <tlx/define/deprecated.hpp>
 
 namespace NetworKit {
-
-template <typename T>
-concept GraphEdgeWeight = std::integral<T> || std::floating_point<T>;
 
 // forward declaration to randomization/CurveballImpl.hpp
 namespace CurveballDetails {
@@ -54,7 +52,7 @@ class CurveballMaterialization;
  * @ingroup graph
  * A graph (with optional weights) and parallel iterator methods.
  */
-template <std::integral NodeT, GraphEdgeWeight EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 class AdjListGraph final {
     // graph attributes
     //!< current number of nodes

--- a/include/networkit/graph/AdjListGraph.hpp
+++ b/include/networkit/graph/AdjListGraph.hpp
@@ -1343,7 +1343,7 @@ public:
      * Get an upper bound for the node ids in the graph.
      * @return An upper bound for the node ids.
      */
-    index upperNodeIdBound() const noexcept { return z; }
+    NodeT upperNodeIdBound() const noexcept { return z; }
 
     /**
      * Check for invalid graph states, such as multi-edges.

--- a/include/networkit/graph/AdjListGraph.hpp
+++ b/include/networkit/graph/AdjListGraph.hpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cassert>
+#include <concepts>
 #include <functional>
 #include <numeric>
 #include <omp.h>
@@ -41,6 +42,9 @@
 
 namespace NetworKit {
 
+template <typename T>
+concept GraphEdgeWeight = std::integral<T> || std::floating_point<T>;
+
 // forward declaration to randomization/CurveballImpl.hpp
 namespace CurveballDetails {
 class CurveballMaterialization;
@@ -50,10 +54,8 @@ class CurveballMaterialization;
  * @ingroup graph
  * A graph (with optional weights) and parallel iterator methods.
  */
-template <class NodeT, class EdgeWeightT>
+template <std::integral NodeT, GraphEdgeWeight EdgeWeightT>
 class AdjListGraph final {
-    static_assert(std::is_integral_v<NodeT>, "NodeT must be an integer type.");
-    static_assert(std::is_arithmetic_v<EdgeWeightT>, "EdgeWeightT must be a numeric type.");
     // graph attributes
     //!< current number of nodes
     count n;

--- a/include/networkit/graph/AdjListGraphImpl.hpp
+++ b/include/networkit/graph/AdjListGraphImpl.hpp
@@ -1551,7 +1551,7 @@ bool AdjListGraph<NodeT, EdgeWeightT>::checkConsistency() const {
     return noMultiEdges && correctNodeUpperbound && correctNumberOfEdges;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 AdjListGraph<NodeT, EdgeWeightT> AdjListGraph<NodeT, EdgeWeightT>::fromCSR(
     std::span<const index> rowIdxView, std::span<const index> columnIdxView,
     std::span<const double> nonZerosView, bool directed, bool isWeighted) {
@@ -1715,7 +1715,7 @@ AdjListGraph<NodeT, EdgeWeightT> AdjListGraph<NodeT, EdgeWeightT>::fromCSR(
     return graph;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 AdjListGraph<NodeT, EdgeWeightT>
 AdjListGraph<NodeT, EdgeWeightT>::_fromCSRRaw(const index *rowIdxPtr, std::size_t rowIdxSize,
                                               const index *columnIdxPtr, std::size_t columnIdxSize,

--- a/include/networkit/graph/AdjListGraphImpl.hpp
+++ b/include/networkit/graph/AdjListGraphImpl.hpp
@@ -5,7 +5,7 @@ namespace NetworKit {
 
 /* NODE ITERATORS */
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::forNodes(
     L handle) const { // NOLINT(performance-unnecessary-value-param)
@@ -16,7 +16,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::forNodes(
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::parallelForNodes(
     L handle) const { // NOLINT(performance-unnecessary-value-param)
@@ -28,7 +28,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::parallelForNodes(
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename C, typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::forNodesWhile(
     C condition, L handle) const { // NOLINT(performance-unnecessary-value-param)
@@ -42,7 +42,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::forNodesWhile(
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::forNodesInRandomOrder(
     L handle) const { // NOLINT(performance-unnecessary-value-param)
@@ -55,7 +55,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::forNodesInRandomOrder(
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::balancedParallelForNodes(
     L handle) const { // NOLINT(performance-unnecessary-value-param)
@@ -68,7 +68,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::balancedParallelForNodes(
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::forNodePairs(
     L handle) const { // NOLINT(performance-unnecessary-value-param)
@@ -83,7 +83,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::forNodePairs(
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::parallelForNodePairs(
     L handle) const { // NOLINT(performance-unnecessary-value-param)
@@ -101,7 +101,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::parallelForNodePairs(
 
 /* EDGE ITERATORS */
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline void AdjListGraph<NodeT, EdgeWeightT>::forOutEdgesOfImpl(NodeT u, L handle) const {
     for (index i = 0; i < outEdges[u].size(); ++i) {
@@ -114,7 +114,7 @@ inline void AdjListGraph<NodeT, EdgeWeightT>::forOutEdgesOfImpl(NodeT u, L handl
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline void AdjListGraph<NodeT, EdgeWeightT>::forInEdgesOfImpl(NodeT u, L handle) const {
     if (graphIsDirected) {
@@ -134,7 +134,7 @@ inline void AdjListGraph<NodeT, EdgeWeightT>::forInEdgesOfImpl(NodeT u, L handle
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline void AdjListGraph<NodeT, EdgeWeightT>::forEdgeImpl(L handle) const {
     for (NodeT u = 0; u < z; ++u) {
@@ -142,7 +142,7 @@ inline void AdjListGraph<NodeT, EdgeWeightT>::forEdgeImpl(L handle) const {
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline void AdjListGraph<NodeT, EdgeWeightT>::parallelForEdgesImpl(L handle) const {
 #pragma omp parallel for schedule(guided)
@@ -151,7 +151,7 @@ inline void AdjListGraph<NodeT, EdgeWeightT>::parallelForEdgesImpl(L handle) con
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <bool graphIsDirected, bool hasWeights, bool graphHasEdgeIds, typename L>
 inline double AdjListGraph<NodeT, EdgeWeightT>::parallelSumForEdgesImpl(L handle) const {
     double sum = 0.0;
@@ -173,7 +173,7 @@ inline double AdjListGraph<NodeT, EdgeWeightT>::parallelSumForEdgesImpl(L handle
     return sum;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::forEdges(L handle) const {
     switch (weighted + 2 * directed + 4 * edgesIndexed) {
@@ -211,7 +211,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::forEdges(L handle) const {
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::parallelForEdges(L handle) const {
     switch (weighted + 2 * directed + 4 * edgesIndexed) {
@@ -251,13 +251,13 @@ void AdjListGraph<NodeT, EdgeWeightT>::parallelForEdges(L handle) const {
 
 /* NEIGHBORHOOD ITERATORS */
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::forNeighborsOf(NodeT u, L handle) const {
     forEdgesOf(u, handle);
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::forEdgesOf(NodeT u, L handle) const {
     switch (weighted + 2 * edgesIndexed) {
@@ -279,13 +279,13 @@ void AdjListGraph<NodeT, EdgeWeightT>::forEdgesOf(NodeT u, L handle) const {
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::forInNeighborsOf(NodeT u, L handle) const {
     forInEdgesOf(u, handle);
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 void AdjListGraph<NodeT, EdgeWeightT>::forInEdgesOf(NodeT u, L handle) const {
     switch (weighted + 2 * directed + 4 * edgesIndexed) {
@@ -325,7 +325,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::forInEdgesOf(NodeT u, L handle) const {
 
 /* REDUCTION ITERATORS */
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 double AdjListGraph<NodeT, EdgeWeightT>::parallelSumForNodes(
     L handle) const { // NOLINT(performance-unnecessary-value-param)
@@ -341,7 +341,7 @@ double AdjListGraph<NodeT, EdgeWeightT>::parallelSumForNodes(
     return sum;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename L>
 double AdjListGraph<NodeT, EdgeWeightT>::parallelSumForEdges(L handle) const {
     double sum = 0.0;
@@ -385,7 +385,7 @@ double AdjListGraph<NodeT, EdgeWeightT>::parallelSumForEdges(L handle) const {
 
 /* EDGE MODIFIERS */
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename Condition>
 std::pair<count, count>
 AdjListGraph<NodeT, EdgeWeightT>::removeAdjacentEdges(NodeT u, Condition condition, bool edgesIn) {
@@ -420,7 +420,7 @@ AdjListGraph<NodeT, EdgeWeightT>::removeAdjacentEdges(NodeT u, Condition conditi
     return {removedEdges, removedSelfLoops};
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <typename Lambda>
 void AdjListGraph<NodeT, EdgeWeightT>::sortNeighbors(NodeT u, Lambda lambda) {
     if ((degreeIn(u) < 2) && (degree(u) < 2)) {
@@ -466,7 +466,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::sortNeighbors(NodeT u, Lambda lambda) {
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 template <class Lambda>
 void AdjListGraph<NodeT, EdgeWeightT>::sortEdges(Lambda lambda) {
 
@@ -534,7 +534,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::sortEdges(Lambda lambda) {
 
 /** CONSTRUCTORS **/
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 AdjListGraph<NodeT, EdgeWeightT>::AdjListGraph(count n, bool weighted, bool directed,
                                                bool edgesIndexed)
     : n(n), m(0), storedNumberOfSelfLoops(0), z(n), omega(0), t(0),
@@ -557,7 +557,7 @@ AdjListGraph<NodeT, EdgeWeightT>::AdjListGraph(count n, bool weighted, bool dire
       inEdgeIds(edgesIndexed && directed ? n : 0), outEdgeIds(edgesIndexed ? n : 0),
       nodeAttributeMap(this), edgeAttributeMap(this) {}
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 AdjListGraph<NodeT, EdgeWeightT>::AdjListGraph(
     std::initializer_list<WeightedEdgeT<NodeT, EdgeWeightT>> edges)
     : AdjListGraph(0, true) {
@@ -576,7 +576,7 @@ AdjListGraph<NodeT, EdgeWeightT>::AdjListGraph(
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::preallocateUndirected(NodeT u, size_t size) {
     assert(!directed);
     assert(exists[u]);
@@ -589,13 +589,13 @@ void AdjListGraph<NodeT, EdgeWeightT>::preallocateUndirected(NodeT u, size_t siz
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::preallocateDirected(NodeT u, size_t outSize, size_t inSize) {
     preallocateDirectedOutEdges(u, outSize);
     preallocateDirectedInEdges(u, inSize);
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::preallocateDirectedOutEdges(NodeT u, size_t outSize) {
     assert(directed);
     assert(exists[u]);
@@ -609,7 +609,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::preallocateDirectedOutEdges(NodeT u, size
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::preallocateDirectedInEdges(NodeT u, size_t inSize) {
     assert(directed);
     assert(exists[u]);
@@ -624,7 +624,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::preallocateDirectedInEdges(NodeT u, size_
 }
 /** PRIVATE HELPERS **/
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 index AdjListGraph<NodeT, EdgeWeightT>::indexInInEdgeArray(NodeT v, NodeT u) const {
     if (!directed) {
         return indexInOutEdgeArray(v, u);
@@ -638,7 +638,7 @@ index AdjListGraph<NodeT, EdgeWeightT>::indexInInEdgeArray(NodeT v, NodeT u) con
     return none;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 index AdjListGraph<NodeT, EdgeWeightT>::indexInOutEdgeArray(NodeT u, NodeT v) const {
     for (index i = 0; i < outEdges[u].size(); ++i) {
         NodeT x = outEdges[u][i];
@@ -651,7 +651,7 @@ index AdjListGraph<NodeT, EdgeWeightT>::indexInOutEdgeArray(NodeT u, NodeT v) co
 
 /** EDGE IDS **/
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::indexEdges(bool force) {
     if (edgesIndexed && !force)
         return;
@@ -708,7 +708,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::indexEdges(bool force) {
                          // needs to create edge ids
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 edgeid AdjListGraph<NodeT, EdgeWeightT>::edgeId(NodeT u, NodeT v) const {
     if (!edgesIndexed) {
         throw std::runtime_error("edges have not been indexed - call indexEdges first");
@@ -724,7 +724,7 @@ edgeid AdjListGraph<NodeT, EdgeWeightT>::edgeId(NodeT u, NodeT v) const {
 
 /** GRAPH INFORMATION **/
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::shrinkToFit() {
     exists.shrink_to_fit();
 
@@ -749,7 +749,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::shrinkToFit() {
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::compactEdges() {
     this->parallelForNodes([&](NodeT u) {
         if (degreeOut(u) == 0) {
@@ -805,7 +805,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::compactEdges() {
     });
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::sortEdges() {
     std::vector<std::vector<NodeT>> targetAdjacencies(upperNodeIdBound());
     std::vector<std::vector<EdgeWeightT>> targetWeight;
@@ -867,7 +867,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::sortEdges() {
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 EdgeWeightT
 AdjListGraph<NodeT, EdgeWeightT>::computeWeightedDegree(NodeT u, bool inDegree,
                                                         bool countSelfLoopsTwice) const {
@@ -900,7 +900,7 @@ AdjListGraph<NodeT, EdgeWeightT>::computeWeightedDegree(NodeT u, bool inDegree,
 
 /** NODE MODIFIERS **/
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 NodeT AdjListGraph<NodeT, EdgeWeightT>::addNode() {
     NodeT v = z; // node gets maximum id
     ++z;         // increment node range
@@ -926,7 +926,7 @@ NodeT AdjListGraph<NodeT, EdgeWeightT>::addNode() {
     return v;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 NodeT AdjListGraph<NodeT, EdgeWeightT>::addNodes(count numberOfNewNodes) {
     if (numberOfNewNodes < 10) {
         // benchmarks suggested, it's cheaper to call 10 time emplace_back than resizing.
@@ -959,7 +959,7 @@ NodeT AdjListGraph<NodeT, EdgeWeightT>::addNodes(count numberOfNewNodes) {
     return z - 1;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::removeNode(NodeT v) {
     assert(v < z);
     assert(exists[v]);
@@ -982,7 +982,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::removeNode(NodeT v) {
     --n;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::restoreNode(NodeT v) {
     assert(v < z);
     assert(!exists[v]);
@@ -993,13 +993,13 @@ void AdjListGraph<NodeT, EdgeWeightT>::restoreNode(NodeT v) {
 
 /** NODE PROPERTIES **/
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 EdgeWeightT AdjListGraph<NodeT, EdgeWeightT>::weightedDegree(NodeT u,
                                                              bool countSelfLoopsTwice) const {
     return computeWeightedDegree(u, false, countSelfLoopsTwice);
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 EdgeWeightT AdjListGraph<NodeT, EdgeWeightT>::weightedDegreeIn(NodeT u,
                                                                bool countSelfLoopsTwice) const {
     return computeWeightedDegree(u, true, countSelfLoopsTwice);
@@ -1007,7 +1007,7 @@ EdgeWeightT AdjListGraph<NodeT, EdgeWeightT>::weightedDegreeIn(NodeT u,
 
 /** EDGE MODIFIERS **/
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 bool AdjListGraph<NodeT, EdgeWeightT>::addEdge(NodeT u, NodeT v, EdgeWeightT ew,
                                                bool checkForMultiEdges) {
     assert(u < z);
@@ -1065,7 +1065,7 @@ bool AdjListGraph<NodeT, EdgeWeightT>::addEdge(NodeT u, NodeT v, EdgeWeightT ew,
     return true;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 bool AdjListGraph<NodeT, EdgeWeightT>::addPartialEdge(Unsafe, NodeT u, NodeT v, EdgeWeightT ew,
                                                       uint64_t index, bool checkForMultiEdges) {
     assert(u < z);
@@ -1090,7 +1090,7 @@ bool AdjListGraph<NodeT, EdgeWeightT>::addPartialEdge(Unsafe, NodeT u, NodeT v, 
     return true;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 bool AdjListGraph<NodeT, EdgeWeightT>::addPartialOutEdge(Unsafe, NodeT u, NodeT v, EdgeWeightT ew,
                                                          uint64_t index, bool checkForMultiEdges) {
     assert(u < z);
@@ -1115,7 +1115,7 @@ bool AdjListGraph<NodeT, EdgeWeightT>::addPartialOutEdge(Unsafe, NodeT u, NodeT 
     return true;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 bool AdjListGraph<NodeT, EdgeWeightT>::addPartialInEdge(Unsafe, NodeT u, NodeT v, EdgeWeightT ew,
                                                         uint64_t index, bool checkForMultiEdges) {
     assert(u < z);
@@ -1145,7 +1145,7 @@ void erase(NodeT u, index idx, std::vector<std::vector<T>> &vec) {
     vec[u].pop_back();
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::removeEdge(NodeT u, NodeT v) {
     assert(u < z);
     assert(exists[u]);
@@ -1289,7 +1289,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::removeEdge(NodeT u, NodeT v) {
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::removeAllEdges() {
     parallelForNodes([&](const NodeT u) {
         removePartialOutEdges(unsafe, u);
@@ -1301,7 +1301,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::removeAllEdges() {
     m = 0;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::removeSelfLoops() {
     parallelForNodes([&](const NodeT u) {
         auto isSelfLoop = [u](const NodeT v) { return u == v; };
@@ -1315,7 +1315,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::removeSelfLoops() {
     storedNumberOfSelfLoops = 0;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::removeMultiEdges() {
     count removedEdges = 0;
     count removedSelfLoops = 0;
@@ -1343,7 +1343,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::removeMultiEdges() {
     storedNumberOfSelfLoops -= removedSelfLoops;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::swapEdge(NodeT s1, NodeT t1, NodeT s2, NodeT t2) {
     index s1t1 = indexInOutEdgeArray(s1, t1);
     if (s1t1 == none)
@@ -1380,7 +1380,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::swapEdge(NodeT s1, NodeT t1, NodeT s2, No
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 bool AdjListGraph<NodeT, EdgeWeightT>::hasEdge(NodeT u, NodeT v) const noexcept {
     if (u >= z || v >= z) {
         return false;
@@ -1396,7 +1396,7 @@ bool AdjListGraph<NodeT, EdgeWeightT>::hasEdge(NodeT u, NodeT v) const noexcept 
 
 /** EDGE ATTRIBUTES **/
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 EdgeWeightT AdjListGraph<NodeT, EdgeWeightT>::weight(NodeT u, NodeT v) const {
     index vi = indexInOutEdgeArray(u, v);
     if (vi == none) {
@@ -1406,7 +1406,7 @@ EdgeWeightT AdjListGraph<NodeT, EdgeWeightT>::weight(NodeT u, NodeT v) const {
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::setWeight(NodeT u, NodeT v, EdgeWeightT ew) {
     if (!weighted) {
         throw std::runtime_error("Cannot set edge weight in unweighted graph.");
@@ -1430,7 +1430,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::setWeight(NodeT u, NodeT v, EdgeWeightT e
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::increaseWeight(NodeT u, NodeT v, EdgeWeightT ew) {
     if (!weighted) {
         throw std::runtime_error("Cannot increase edge weight in unweighted graph.");
@@ -1453,13 +1453,13 @@ void AdjListGraph<NodeT, EdgeWeightT>::increaseWeight(NodeT u, NodeT v, EdgeWeig
     }
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::setWeightAtIthNeighbor(Unsafe, NodeT u, index i,
                                                               EdgeWeightT ew) {
     outEdgeWeights[u][i] = ew;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 void AdjListGraph<NodeT, EdgeWeightT>::setWeightAtIthInNeighbor(Unsafe, NodeT u, index i,
                                                                 EdgeWeightT ew) {
     inEdgeWeights[u][i] = ew;
@@ -1467,14 +1467,14 @@ void AdjListGraph<NodeT, EdgeWeightT>::setWeightAtIthInNeighbor(Unsafe, NodeT u,
 
 /** SUMS **/
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 EdgeWeightT AdjListGraph<NodeT, EdgeWeightT>::totalEdgeWeight() const noexcept {
     if (weighted)
         return parallelSumForEdges([](NodeT, NodeT, EdgeWeightT ew) { return ew; });
     return numberOfEdges() * defaultEdgeWeightT;
 }
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 bool AdjListGraph<NodeT, EdgeWeightT>::checkConsistency() const {
     // check for multi-edges
     std::vector<NodeT> lastSeen(z, nullNodeId);

--- a/include/networkit/graph/EdgeIterators.hpp
+++ b/include/networkit/graph/EdgeIterators.hpp
@@ -11,11 +11,12 @@
 
 #include <networkit/Globals.hpp>
 #include <networkit/graph/EdgeUtils.hpp>
+#include <networkit/graph/GraphConcepts.hpp>
 #include <networkit/graph/NodeIterators.hpp>
 
 namespace NetworKit {
 
-template <class GraphType, class NodeT, class EdgeWeightT>
+template <class GraphType, GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 class EdgeIteratorBase {
 protected:
     const GraphType *G;
@@ -82,14 +83,14 @@ public:
 template <class T>
 struct is_weighted_edge_specialization : std::false_type {};
 
-template <class NodeT, class EdgeWeightT>
+template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 struct is_weighted_edge_specialization<WeightedEdgeT<NodeT, EdgeWeightT>> : std::true_type {};
 
 /**
  * Class to iterate over the edges of the given graph type. If the graph is undirected, operator*()
  * returns the edges (u, v) s.t. u <= v.
  */
-template <class GraphType, class NodeT, class EdgeWeightT, class IterEdgeWeightT>
+template <class GraphType, GraphNode NodeT, GraphEdgeWeight EdgeWeightT, class IterEdgeWeightT>
 class EdgeWeightTIterator : public EdgeIteratorBase<GraphType, NodeT, EdgeWeightT> {
     using EdgeIteratorBase<GraphType, NodeT, EdgeWeightT>::nodeIter;
     using EdgeIteratorBase<GraphType, NodeT, EdgeWeightT>::G;
@@ -169,7 +170,7 @@ public:
 /**
  * Wrapper class to iterate over a range of the edges.
  */
-template <class GraphType, class NodeT, class EdgeWeightT, class IterEdgeWeightT>
+template <class GraphType, GraphNode NodeT, GraphEdgeWeight EdgeWeightT, class IterEdgeWeightT>
 class EdgeWeightTRange {
 
     const GraphType *G;

--- a/include/networkit/graph/GraphConcepts.hpp
+++ b/include/networkit/graph/GraphConcepts.hpp
@@ -5,8 +5,8 @@
  *
  */
 
-#ifndef NETWORKIT_GRAPH_CONCEPTS_HPP_
-#define NETWORKIT_GRAPH_CONCEPTS_HPP_
+#ifndef NETWORKIT_GRAPH_GRAPH_CONCEPTS_HPP_
+#define NETWORKIT_GRAPH_GRAPH_CONCEPTS_HPP_
 
 #include <concepts>
 #include <type_traits>
@@ -20,4 +20,4 @@ concept GraphEdgeWeight = std::integral<T> || std::floating_point<T>;
 
 } // namespace NetworKit
 
-#endif // NETWORKIT_GRAPH_CONCEPTS_HPP_
+#endif // NETWORKIT_GRAPH_GRAPH_CONCEPTS_HPP_

--- a/include/networkit/graph/GraphConcepts.hpp
+++ b/include/networkit/graph/GraphConcepts.hpp
@@ -10,6 +10,7 @@
 
 #include <concepts>
 #include <type_traits>
+
 namespace NetworKit {
 
 template <typename T>

--- a/include/networkit/graph/GraphConcepts.hpp
+++ b/include/networkit/graph/GraphConcepts.hpp
@@ -9,7 +9,6 @@
 #define NETWORKIT_GRAPH_GRAPH_CONCEPTS_HPP_
 
 #include <concepts>
-#include <type_traits>
 
 namespace NetworKit {
 

--- a/include/networkit/graph/GraphConcepts.hpp
+++ b/include/networkit/graph/GraphConcepts.hpp
@@ -1,0 +1,23 @@
+/*  GraphConcepts.hpp
+ *
+ *  Created on: 05.07.2026
+ *  Authors: Andreas Scharf (andreas.b.scharf@gmail.com)
+ *
+ */
+
+#ifndef NETWORKIT_GRAPH_CONCEPTS_HPP_
+#define NETWORKIT_GRAPH_CONCEPTS_HPP_
+
+#include <concepts>
+#include <type_traits>
+namespace NetworKit {
+
+template <typename T>
+concept GraphNode = std::integral<T>;
+
+template <typename T>
+concept GraphEdgeWeight = std::integral<T> || std::floating_point<T>;
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_GRAPH_CONCEPTS_HPP_

--- a/include/networkit/graph/NodeIterators.hpp
+++ b/include/networkit/graph/NodeIterators.hpp
@@ -11,13 +11,14 @@
 #include <iterator>
 
 #include <networkit/Globals.hpp>
+#include <networkit/graph/GraphConcepts.hpp>
 
 namespace NetworKit {
 
 /**
  * Class to iterate over the nodes of a graph.
  */
-template <class GraphType, class NodeT, class EdgeWeightT>
+template <class GraphType, GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 class NodeIteratorBase {
 
     const GraphType *G;
@@ -99,7 +100,7 @@ public:
 /**
  * Wrapper class to iterate over a range of the nodes of a graph.
  */
-template <class GraphType, class NodeT, class EdgeWeightT>
+template <class GraphType, GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
 class NodeRangeBase {
 
     const GraphType *G;

--- a/networkit/cpp/graph/test/AdjListGraphGTest.cpp
+++ b/networkit/cpp/graph/test/AdjListGraphGTest.cpp
@@ -35,7 +35,36 @@ TYPED_TEST_P(AdjListGraphGTest, testDefaultConstructor) {
     EXPECT_EQ(G.isDirected(), TypeParam::directed);
 }
 
-REGISTER_TYPED_TEST_SUITE_P(AdjListGraphGTest, testDefaultConstructor);
+TYPED_TEST_P(AdjListGraphGTest, testNodeAndEdgeIterators) {
+    using Graph = AdjListGraph<typename TestFixture::NodeT, typename TestFixture::EdgeWeightT>;
+    using NodeT = typename TestFixture::NodeT;
+    using EdgeWeightT = typename TestFixture::EdgeWeightT;
+
+    Graph G(4, TypeParam::weighted, TypeParam::directed);
+    G.addEdge(NodeT{0}, NodeT{1}, EdgeWeightT{2});
+    G.addEdge(NodeT{1}, NodeT{2}, EdgeWeightT{3});
+
+    count nodes = 0;
+    for ([[maybe_unused]] const auto u : G.nodeRange()) {
+        ++nodes;
+    }
+
+    count edges = 0;
+    for ([[maybe_unused]] const auto edge : G.edgeRange()) {
+        ++edges;
+    }
+
+    count weightedEdges = 0;
+    for ([[maybe_unused]] const auto edge : G.edgeWeightRange()) {
+        ++weightedEdges;
+    }
+
+    EXPECT_EQ(nodes, 4u);
+    EXPECT_EQ(edges, 2u);
+    EXPECT_EQ(weightedEdges, 2u);
+}
+
+REGISTER_TYPED_TEST_SUITE_P(AdjListGraphGTest, testDefaultConstructor, testNodeAndEdgeIterators);
 
 using AdjListTestTypes = ::testing::Types<
     AdjListConfig<node, edgeweight, false, false>, AdjListConfig<node, edgeweight, true, false>,

--- a/networkit/cpp/graph/test/AdjListGraphGTest.cpp
+++ b/networkit/cpp/graph/test/AdjListGraphGTest.cpp
@@ -1,10 +1,21 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <vector>
 
 #include <networkit/Globals.hpp>
 #include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 namespace {
+
+MATCHER_P2(EdgeEq, expectedU, expectedV, "") {
+    return arg.u == expectedU && arg.v == expectedV;
+}
+
+MATCHER_P3(WeightedEdgeEq, expectedU, expectedV, expectedWeight, "") {
+    return arg.u == expectedU && arg.v == expectedV && arg.weight == expectedWeight;
+}
 
 /**
  * Configuration for AdjListGraph tests, combining type and value parameterization.
@@ -36,6 +47,8 @@ TYPED_TEST_P(AdjListGraphGTest, testDefaultConstructor) {
 }
 
 TYPED_TEST_P(AdjListGraphGTest, testNodeAndEdgeIterators) {
+    using ::testing::ElementsAre;
+
     using Graph = AdjListGraph<typename TestFixture::NodeT, typename TestFixture::EdgeWeightT>;
     using NodeT = typename TestFixture::NodeT;
     using EdgeWeightT = typename TestFixture::EdgeWeightT;
@@ -44,24 +57,18 @@ TYPED_TEST_P(AdjListGraphGTest, testNodeAndEdgeIterators) {
     G.addEdge(NodeT{0}, NodeT{1}, EdgeWeightT{2});
     G.addEdge(NodeT{1}, NodeT{2}, EdgeWeightT{3});
 
-    count nodes = 0;
-    for ([[maybe_unused]] const auto u : G.nodeRange()) {
-        ++nodes;
-    }
+    const std::vector<NodeT> nodes(G.nodeRange().begin(), G.nodeRange().end());
+    EXPECT_THAT(nodes, ElementsAre(NodeT{0}, NodeT{1}, NodeT{2}, NodeT{3}));
 
-    count edges = 0;
-    for ([[maybe_unused]] const auto edge : G.edgeRange()) {
-        ++edges;
-    }
+    const std::vector<EdgeT<NodeT>> edges(G.edgeRange().begin(), G.edgeRange().end());
+    EXPECT_THAT(edges, ElementsAre(EdgeEq(NodeT{0}, NodeT{1}), EdgeEq(NodeT{1}, NodeT{2})));
 
-    count weightedEdges = 0;
-    for ([[maybe_unused]] const auto edge : G.edgeWeightRange()) {
-        ++weightedEdges;
-    }
-
-    EXPECT_EQ(nodes, 4u);
-    EXPECT_EQ(edges, 2u);
-    EXPECT_EQ(weightedEdges, 2u);
+    const EdgeWeightT firstWeight = TypeParam::weighted ? EdgeWeightT{2} : EdgeWeightT{1};
+    const EdgeWeightT secondWeight = TypeParam::weighted ? EdgeWeightT{3} : EdgeWeightT{1};
+    const std::vector<WeightedEdgeT<NodeT, EdgeWeightT>> weightedEdges(G.edgeWeightRange().begin(),
+                                                                       G.edgeWeightRange().end());
+    EXPECT_THAT(weightedEdges, ElementsAre(WeightedEdgeEq(NodeT{0}, NodeT{1}, firstWeight),
+                                           WeightedEdgeEq(NodeT{1}, NodeT{2}, secondWeight)));
 }
 
 REGISTER_TYPED_TEST_SUITE_P(AdjListGraphGTest, testDefaultConstructor, testNodeAndEdgeIterators);

--- a/networkit/cpp/graph/test/CMakeLists.txt
+++ b/networkit/cpp/graph/test/CMakeLists.txt
@@ -8,7 +8,7 @@ networkit_add_test(graph TopologicalSortGTest)
 networkit_add_test(graph AttributeGTest graph)
 networkit_add_test(graph AdjListGraphGTest graph)
 networkit_add_test(graph DHBGraphGTest generators)
+networkit_add_test(graph GraphConceptsGTest graph)
 
 networkit_add_benchmark(graph Graph2Benchmark)
 networkit_add_benchmark(graph GraphBenchmark auxiliary)
-

--- a/networkit/cpp/graph/test/GraphConceptsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphConceptsGTest.cpp
@@ -1,0 +1,35 @@
+/*  GraphConceptsGTest.hpp
+ *
+ *  Created on: 05.07.2026
+ *  Authors: Andreas Scharf (andreas.b.scharf@gmail.com)
+ *
+ */
+
+#include <string>
+#include <gtest/gtest.h>
+#include <networkit/Globals.hpp>
+#include <networkit/graph/GraphConcepts.hpp>
+
+namespace NetworKit {
+
+TEST(GraphConceptsGTest, testGraphNodeConstraints) {
+    static_assert(GraphNode<node>);
+    static_assert(GraphNode<int>);
+    static_assert(GraphNode<uint32_t>);
+    static_assert(GraphNode<bool>);
+    static_assert(!GraphNode<double>);
+
+    SUCCEED();
+}
+
+TEST(GraphConceptsGTest, testGraphEdgeWeightConstraints) {
+    static_assert(GraphEdgeWeight<edgeweight>);
+    static_assert(GraphEdgeWeight<int>);
+    static_assert(GraphEdgeWeight<double>);
+    static_assert(GraphEdgeWeight<bool>);
+    static_assert(!GraphEdgeWeight<std::string>);
+
+    SUCCEED();
+}
+
+} // namespace NetworKit


### PR DESCRIPTION
## Proposal: constrain `AdjListGraph` template parameters with C++20 concepts

This PR is part of this [proposal](https://github.com/networkit/networkit/issues/1415) and replaces the existing `static_assert` checks in `AdjListGraph` with C++20 template constraints.

Current constraints:
- `NodeT` must satisfy `std::integral`
- `EdgeWeightT` must satisfy the new `GraphEdgeWeight` concept, currently defined as integral or floating point

This makes the type contract visible directly at the template declaration instead of inside the class body.

One consequence is that every out-of-class member definition now also carries the constrained template head:
```cpp
template <std::integral NodeT, GraphEdgeWeight EdgeWeightT>
```
This is more explicit, but also adds some repetition throughout `Graph.hpp`.

A further advantage of named concepts is that graph-related type requirements can be defined once and reused consistently by graph implementations and generic algorithms. This also makes them easier to refine centrally in the future. For example, if `bool` should not be accepted as a node or edge-weight type, dedicated GraphNode and GraphEdgeWeight concepts could express that rule, and algorithms using those concepts would automatically follow it.

@angriman @fabratu What do you think about this direction? Is the clearer template contract worth the additional verbosity in the out-of-class definitions?


