### PR TITLE
Fix error when generating C++ doc strings (exhale)

### DIFF
--- a/include/networkit/graph/AdjListGraph.hpp
+++ b/include/networkit/graph/AdjListGraph.hpp
@@ -380,14 +380,14 @@ private:
      */
 
     // Return void when the callable does not have an Nth parameter.
-    template <typename TraitsT, size_t N, typename Enable = void>
+    template <typename TraitsT, size_t N, bool InRange = (N < TraitsT::arity)>
     struct SafeArg {
         using type = void;
     };
 
     // Enable this specialization only when N is in range.
     template <typename TraitsT, size_t N>
-    struct SafeArg<TraitsT, N, typename std::enable_if<(N < TraitsT::arity)>::type> {
+    struct SafeArg<TraitsT, N, true> {
         using type = typename TraitsT::template arg<N>::type;
     };
 


### PR DESCRIPTION
CI on master currently shows failures for the documentation build (see issue #1434).

Reason: Doxygen emits that comparison as part of the template name, and Exhale's (plugin for C++ doc generation) template parser counts the '<' in `N < TraitsT::arity` as a template opener. That gives Exhale an unbalanced template string, causing the 3 '<' and 2 '>' error.

The current fix leaves the logic of the code as is; however, it changes the detection for Exhale.