### PR TITLE
Migrate SSSP to templates

### DIFF
--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -12,7 +12,7 @@
 
 #include <networkit/auxiliary/Multiprecision.hpp>
 #include <networkit/base/Algorithm.hpp>
-#include <networkit/graph/Graph.hpp>
+#include <networkit/graph/AdjListGraph.hpp>
 
 namespace NetworKit {
 
@@ -20,11 +20,15 @@ namespace NetworKit {
  * @ingroup distance
  * Abstract base class for single-source shortest path algorithms.
  */
-class SSSP : public Algorithm {
+template <class GraphT>
+class SingleSourceShortestPaths : public Algorithm {
+    using NodeT = typename GraphT::NodeT;
+    using EdgeWeightT = typename GraphT::EdgeWeightT;
+    static constexpr NodeT nullNodeId = NullNodeId<NodeT>;
 
 public:
     /**
-     * Creates the SSSP class for @a G and source @a s.
+     * Creates the SingleSourceShortestPaths class for @a G and source @a s.
      *
      * @param G The graph.
      * @param source The source node.
@@ -34,10 +38,10 @@ public:
      * increasing distance from the source.
      * @param target The target node.
      */
-    SSSP(const Graph &G, node source, bool storePaths = true,
-         bool storeNodesSortedByDistance = false, node target = none);
+    SingleSourceShortestPaths(const GraphT &G, NodeT source, bool storePaths = true,
+                              bool storeNodesSortedByDistance = false, NodeT target = nullNodeId);
 
-    ~SSSP() override = default;
+    ~SingleSourceShortestPaths() override = default;
 
     /** Computes the shortest paths from the source to all other nodes. */
     void run() override = 0;
@@ -49,21 +53,26 @@ public:
      * @return The weighted distances from the source node to any other node in
      * the graph.
      */
-    const std::vector<edgeweight> &getDistances();
+    const std::vector<EdgeWeightT> &getDistances() { return distances; }
 
     /**
      * Returns the distance from the source node to @a t.
      * @param  t Target node.
      * @return The distance from source to target node @a t.
      */
-    edgeweight distance(node t) const;
+    EdgeWeightT distance(NodeT t) const { return distances[t]; }
 
     /**
      * Returns the number of shortest paths between the source node and @a t.
      * @param  t Target node.
      * @return The number of shortest paths between source and @a t.
      */
-    bigfloat numberOfPaths(node t) const;
+    bigfloat numberOfPaths(NodeT t) const {
+        if (!storePaths) {
+            throw std::runtime_error("number of paths have not been stored");
+        }
+        return npaths[t];
+    }
 
     /**
      * Returns the number of shortest paths between the source node and @a t
@@ -71,7 +80,7 @@ public:
      * @param  t Target node.
      * @return The number of shortest paths between source and @a t.
      */
-    double _numberOfPaths(node t) const;
+    double _numberOfPaths(NodeT t) const;
 
     /**
      * Returns the predecessor nodes of @a t on all shortest paths from source
@@ -80,7 +89,12 @@ public:
      * @return The predecessors of @a t on all shortest paths from source to @a
      * t.
      */
-    const std::vector<node> &getPredecessors(node t) const;
+    const std::vector<NodeT> &getPredecessors(NodeT t) const {
+        if (!storePaths) {
+            throw std::runtime_error("predecessors have not been stored");
+        }
+        return previous[t];
+    }
 
     /**
      * Returns a shortest path from source to @a t and an empty path if source
@@ -91,7 +105,7 @@ public:
      * @a t, otherwise the path is reversed.
      * @return A shortest path from source to @a t or an empty path.
      */
-    std::vector<node> getPath(node t, bool forward = true) const;
+    std::vector<NodeT> getPath(NodeT t, bool forward = true) const;
 
     /**
      * Returns all shortest paths from source to @a t and an empty set if source
@@ -102,10 +116,10 @@ public:
      * @a t, otherwise the path is reversed.
      * @return All shortest paths from source node to target node @a t.
      */
-    std::set<std::vector<node>> getPaths(node t, bool forward = true) const;
+    std::set<std::vector<NodeT>> getPaths(NodeT t, bool forward = true) const;
 
     /* Returns the number of shortest paths to node t.*/
-    bigfloat getNumberOfPaths(node t) const;
+    bigfloat getNumberOfPaths(NodeT t) const { return npaths[t]; }
 
     /**
      * Returns a vector of nodes ordered in increasing distance from the source.
@@ -116,7 +130,7 @@ public:
      *
      * @return vector of nodes ordered in increasing distance from the source
      */
-    const std::vector<node> &getNodesSortedByDistance() const;
+    const std::vector<NodeT> &getNodesSortedByDistance() const;
 
     /**
      * Returns the number of nodes reached by the source.
@@ -133,7 +147,7 @@ public:
      *
      * @param newSource The new source node.
      */
-    void setSource(node newSource) {
+    void setSource(NodeT newSource) {
         if (!G->hasNode(newSource))
             throw std::runtime_error("Error: node not in the graph.");
         source = newSource;
@@ -142,14 +156,14 @@ public:
     /**
      * Sets a new target.
      */
-    void setTarget(node newTarget) {
+    void setTarget(NodeT newTarget) {
         if (!G->hasNode(newTarget))
             throw std::runtime_error("Error: node not in the graph.");
         target = newTarget;
     }
 
     /**
-     * Returns the sum of distances from the source node node to the reached
+     * Returns the sum of distances from the source node to the reached
      * nodes.
      */
     double getSumOfDistances() const {
@@ -158,16 +172,16 @@ public:
     }
 
 protected:
-    const Graph *G;
-    node source;
-    node target;
+    const GraphT *G;
+    NodeT source;
+    NodeT target;
     double sumDist;
     count reachedNodes;
-    std::vector<edgeweight> distances;
-    std::vector<std::vector<node>> previous; // predecessors on shortest path
+    std::vector<EdgeWeightT> distances;
+    std::vector<std::vector<NodeT>> previous; // predecessors on shortest path
     std::vector<bigfloat> npaths;
 
-    std::vector<node> nodesSortedByDistance;
+    std::vector<NodeT> nodesSortedByDistance;
 
     bool storePaths;                 //!< if true, paths are reconstructable and the number of
                                      //!< paths is stored
@@ -176,18 +190,8 @@ protected:
                                      //!< the source
 };
 
-inline edgeweight SSSP::distance(node t) const {
-    return distances[t];
-}
-
-inline bigfloat SSSP::numberOfPaths(node t) const {
-    if (!storePaths) {
-        throw std::runtime_error("number of paths have not been stored");
-    }
-    return npaths[t];
-}
-
-inline double SSSP::_numberOfPaths(node t) const {
+template <class GraphT>
+inline double SingleSourceShortestPaths<GraphT>::_numberOfPaths(NodeT t) const {
     if (!storePaths) {
         throw std::runtime_error("number of paths have not been stored");
     }
@@ -200,17 +204,10 @@ inline double SSSP::_numberOfPaths(node t) const {
     return res;
 }
 
-inline const std::vector<node> &SSSP::getPredecessors(node t) const {
-    if (!storePaths) {
-        throw std::runtime_error("predecessors have not been stored");
-    }
-    return previous[t];
-}
-
-inline bigfloat SSSP::getNumberOfPaths(node t) const {
-    return npaths[t];
-}
+using SSSP = SingleSourceShortestPaths<AdjListGraph<node, edgeweight>>;
 
 } /* namespace NetworKit */
+
+#include <networkit/distance/SSSPImpl.hpp>
 
 #endif // NETWORKIT_DISTANCE_SSSP_HPP_

--- a/include/networkit/distance/SSSPImpl.hpp
+++ b/include/networkit/distance/SSSPImpl.hpp
@@ -1,10 +1,14 @@
 /*
- * SSSP.cpp
+ * SSSPImpl.hpp
  *
  *  Created on: 15.04.2014
  *      Author: cls
  */
 
+#ifndef NETWORKIT_DISTANCE_SSSP_IMPL_HPP_
+#define NETWORKIT_DISTANCE_SSSP_IMPL_HPP_
+
+#include <algorithm>
 #include <stack>
 
 #include <networkit/auxiliary/Log.hpp>
@@ -12,25 +16,25 @@
 
 namespace NetworKit {
 
-SSSP::SSSP(const Graph &G, node source, bool storePaths, bool storeNodesSortedByDistance,
-           node target)
+template <class GraphT>
+SingleSourceShortestPaths<GraphT>::SingleSourceShortestPaths(const GraphT &G, NodeT source,
+                                                             bool storePaths,
+                                                             bool storeNodesSortedByDistance,
+                                                             NodeT target)
     : Algorithm(), G(&G), source(source), target(target), storePaths(storePaths),
       storeNodesSortedByDistance(storeNodesSortedByDistance) {}
 
-const std::vector<edgeweight> &SSSP::getDistances() {
-    return distances;
-}
-
-std::vector<node> SSSP::getPath(node t, bool forward) const {
+template <class GraphT>
+auto SingleSourceShortestPaths<GraphT>::getPath(NodeT t, bool forward) const -> std::vector<NodeT> {
     if (!storePaths) {
         throw std::runtime_error("paths have not been stored");
     }
-    std::vector<node> path;
+    std::vector<NodeT> path;
     if (previous[t].empty()) { // t is not reachable from source
         WARN("there is no path from ", source, " to ", t);
         return path;
     }
-    node v = t;
+    NodeT v = t;
     while (v != source) {
         path.push_back(v);
         v = previous[v].front();
@@ -38,28 +42,30 @@ std::vector<node> SSSP::getPath(node t, bool forward) const {
     path.push_back(source);
 
     if (forward) {
-        std::reverse(path.begin(), path.end());
+        std::ranges::reverse(path);
     }
     return path;
 }
 
-std::set<std::vector<node>> SSSP::getPaths(node t, bool forward) const {
+template <class GraphT>
+auto SingleSourceShortestPaths<GraphT>::getPaths(NodeT t, bool forward) const
+    -> std::set<std::vector<NodeT>> {
 
-    std::set<std::vector<node>> paths;
+    std::set<std::vector<NodeT>> paths;
     if (previous[t].empty()) { // t is not reachable from source
         WARN("there is no path from ", source, " to ", t);
         return paths;
     }
 
-    std::vector<node> targetPredecessors = previous[t];
+    std::vector<NodeT> targetPredecessors = previous[t];
 
 #pragma omp parallel for schedule(dynamic)
     for (omp_index i = 0; i < static_cast<omp_index>(targetPredecessors.size()); ++i) {
 
-        std::stack<std::vector<node>> stack;
-        std::vector<std::vector<node>> currPaths;
+        std::stack<std::vector<NodeT>> stack;
+        std::vector<std::vector<NodeT>> currPaths;
 
-        node pred = targetPredecessors[i];
+        NodeT pred = targetPredecessors[i];
         if (pred == source) {
             currPaths.push_back({t, pred});
         } else {
@@ -68,7 +74,7 @@ std::set<std::vector<node>> SSSP::getPaths(node t, bool forward) const {
 
         while (!stack.empty()) {
 
-            node topPathLastNode = stack.top().back();
+            NodeT topPathLastNode = stack.top().back();
 
             if (topPathLastNode == source) {
                 currPaths.push_back(stack.top());
@@ -76,13 +82,13 @@ std::set<std::vector<node>> SSSP::getPaths(node t, bool forward) const {
                 continue;
             }
 
-            std::vector<node> topPath = stack.top();
+            std::vector<NodeT> topPath = stack.top();
             stack.pop();
 
-            std::vector<node> currPredecessors = previous[topPath.back()];
+            std::vector<NodeT> currPredecessors = previous[topPath.back()];
 
-            for (node currPredecessor : currPredecessors) {
-                std::vector<node> suffix(topPath);
+            for (NodeT currPredecessor : currPredecessors) {
+                std::vector<NodeT> suffix(topPath);
                 suffix.push_back(currPredecessor);
                 stack.push(suffix);
             }
@@ -93,18 +99,20 @@ std::set<std::vector<node>> SSSP::getPaths(node t, bool forward) const {
     }
 
     if (forward) {
-        std::set<std::vector<node>> reversedPaths;
-        for (std::vector<node> path : paths) {
-            std::reverse(std::begin(path), std::end(path));
+        std::set<std::vector<NodeT>> reversedPaths;
+        for (std::vector<NodeT> path : paths) {
+            std::ranges::reverse(path);
             reversedPaths.insert(path);
         }
-        paths = reversedPaths;
+        std::swap(paths, reversedPaths);
     }
 
     return paths;
 }
 
-const std::vector<node> &SSSP::getNodesSortedByDistance() const {
+template <class GraphT>
+auto SingleSourceShortestPaths<GraphT>::getNodesSortedByDistance() const
+    -> const std::vector<NodeT> & {
     if (!storeNodesSortedByDistance) {
         throw std::runtime_error("Nodes sorted by distance have not been stored. Set "
                                  "storeNodesSortedByDistance in the constructor to true to enable "
@@ -116,3 +124,5 @@ const std::vector<node> &SSSP::getNodesSortedByDistance() const {
 }
 
 } /* namespace NetworKit */
+
+#endif // NETWORKIT_DISTANCE_SSSP_IMPL_HPP_

--- a/include/networkit/graph/AdjListGraph.hpp
+++ b/include/networkit/graph/AdjListGraph.hpp
@@ -52,8 +52,13 @@ class CurveballMaterialization;
  * @ingroup graph
  * A graph (with optional weights) and parallel iterator methods.
  */
-template <GraphNode NodeT, GraphEdgeWeight EdgeWeightT>
+template <GraphNode NodeType, GraphEdgeWeight EdgeWeightType>
 class AdjListGraph final {
+public:
+    using NodeT = NodeType;
+    using EdgeWeightT = EdgeWeightType;
+
+private:
     // graph attributes
     //!< current number of nodes
     count n;
@@ -109,7 +114,6 @@ class AdjListGraph final {
 
     static constexpr NodeT nullNodeId = NullNodeId<NodeT>;
 
-private:
     AttributeMap<PerNode, AdjListGraph> nodeAttributeMap;
     AttributeMap<PerEdge, AdjListGraph> edgeAttributeMap;
 

--- a/networkit/cpp/distance/CMakeLists.txt
+++ b/networkit/cpp/distance/CMakeLists.txt
@@ -25,7 +25,6 @@ networkit_add_module(distance
     PrunedLandmarkLabeling.cpp
     ReverseBFS.cpp
     SPSP.cpp
-    SSSP.cpp
     Volume.cpp
     )
 


### PR DESCRIPTION
SSSP is used as base class for algorithms such as BFS and Dijkstra, which will be migrated in future PRs. As mentioned in #1415, for backward compatibility we rename SSSP to SingleSourceShortestPaths and introduce an SSSP alias based on `AdjListGraph<node, edgeweight>`.

Further, add aliases for `NodeT` and `EdgeWeightT` in `AdjListGraph`, which are necessary for accessing them in `SingleSourceShortestPaths`.