### PR TITLE
Performance improvement for BucketPriorityQueue

### DIFF
--- a/include/networkit/auxiliary/BucketPriorityQueue.hpp
+++ b/include/networkit/auxiliary/BucketPriorityQueue.hpp
@@ -49,13 +49,13 @@ private:
     std::vector<ValueType> bucketHead;
     std::vector<ValueType> previous;
     std::vector<ValueType> next;
-    std::vector<BucketIndex> myBucket;     // keeps track of current bucket for each value
-    KeyType currentMinKey;                 // current min key
-    KeyType currentMaxKey;                 // current max key
-    KeyType minAdmissibleKey;              // minimum admissible key
-    KeyType maxAdmissibleKey;              // maximum admissible key
-    count numElems;                        // number of elements stored
-    KeyType offset;                        // offset from minAdmissibleKeys to 0
+    std::vector<BucketIndex> myBucket; // keeps track of current bucket for each value
+    KeyType currentMinKey;             // current min key
+    KeyType currentMaxKey;             // current max key
+    KeyType minAdmissibleKey;          // minimum admissible key
+    KeyType maxAdmissibleKey;          // maximum admissible key
+    count numElems;                    // number of elements stored
+    KeyType offset;                    // offset from minAdmissibleKeys to 0
 
     static index valueToIndex(ValueType value) {
         if constexpr (std::is_signed_v<ValueType>) {

--- a/include/networkit/auxiliary/BucketPriorityQueue.hpp
+++ b/include/networkit/auxiliary/BucketPriorityQueue.hpp
@@ -11,7 +11,6 @@
 #include <concepts>
 #include <cstdint>
 #include <limits>
-#include <list>
 #include <span>
 #include <stdexcept>
 #include <type_traits>
@@ -41,30 +40,15 @@ concept IntegralValue = std::integral<T> && !std::same_as<std::remove_cvref_t<T>
 template <SignedIntegral KeyType = int64_t, IntegralValue ValueType = index>
 class BucketPriorityQueue : public PrioQueue<KeyType, ValueType> {
 private:
-    using Bucket = std::list<ValueType>;
     using BucketIndex = index;
 
     static constexpr KeyType noneKey = std::numeric_limits<KeyType>::max();
     static constexpr ValueType noneValue = std::numeric_limits<ValueType>::max();
     static constexpr BucketIndex noneBucket = std::numeric_limits<BucketIndex>::max();
 
-    std::vector<Bucket> buckets; // the actual buckets
-    inline static Bucket dummyBucket{};
-    inline static const typename Bucket::iterator invalidPtr = dummyBucket.end();
-
-    struct OptionalIterator {
-        bool valid;
-        typename Bucket::iterator iter;
-
-        void reset() {
-            valid = false;
-            iter = invalidPtr;
-        }
-        OptionalIterator() { reset(); }
-        OptionalIterator(bool valid, typename Bucket::iterator iter) : valid(valid), iter(iter) {}
-    };
-
-    std::vector<OptionalIterator> nodePtr; // keeps track of node positions
+    std::vector<ValueType> bucketHead;
+    std::vector<ValueType> previous;
+    std::vector<ValueType> next;
     std::vector<BucketIndex> myBucket;     // keeps track of current bucket for each value
     KeyType currentMinKey;                 // current min key
     KeyType currentMaxKey;                 // current max key
@@ -72,6 +56,19 @@ private:
     KeyType maxAdmissibleKey;              // maximum admissible key
     count numElems;                        // number of elements stored
     KeyType offset;                        // offset from minAdmissibleKeys to 0
+
+    static index valueToIndex(ValueType value) {
+        if constexpr (std::is_signed_v<ValueType>) {
+            assert(value >= 0);
+        }
+        return static_cast<index>(value);
+    }
+
+    static void assureCapacityFitsValueType(uint64_t capacity) {
+        if (capacity > static_cast<uint64_t>(noneValue)) {
+            throw std::invalid_argument("capacity cannot be represented by ValueType");
+        }
+    }
 
     /**
      * Constructor. Not to be used, only here for overriding.

--- a/include/networkit/auxiliary/BucketPriorityQueueImpl.hpp
+++ b/include/networkit/auxiliary/BucketPriorityQueueImpl.hpp
@@ -168,12 +168,14 @@ void BucketPriorityQueue<KeyType, ValueType>::remove(const ValueType &value) {
             currentMaxKey = std::numeric_limits<KeyType>::min();
         } else {
             // adjust max pointer if necessary
-            while (bucketHead[currentMaxKey + offset] == noneValue && currentMaxKey > currentMinKey) {
+            while (bucketHead[currentMaxKey + offset] == noneValue
+                   && currentMaxKey > currentMinKey) {
                 --currentMaxKey;
             }
 
             // adjust min pointer if necessary
-            while (bucketHead[currentMinKey + offset] == noneValue && currentMinKey < currentMaxKey) {
+            while (bucketHead[currentMinKey + offset] == noneValue
+                   && currentMinKey < currentMaxKey) {
                 ++currentMinKey;
             }
         }

--- a/include/networkit/auxiliary/BucketPriorityQueueImpl.hpp
+++ b/include/networkit/auxiliary/BucketPriorityQueueImpl.hpp
@@ -19,10 +19,14 @@ void BucketPriorityQueue<KeyType, ValueType>::construct(uint64_t capacity) {
         throw std::invalid_argument("minAdmissibleKey cannot be larger than maxAdmissibleKey");
     }
 
+    assureCapacityFitsValueType(capacity);
+
     // init
-    buckets.resize(maxAdmissibleKey - minAdmissibleKey + 1);
-    nodePtr.resize(capacity);
+    bucketHead.assign(maxAdmissibleKey - minAdmissibleKey + 1, noneValue);
     myBucket.assign(capacity, noneBucket);
+    previous.assign(capacity, noneValue);
+    next.assign(capacity, noneValue);
+
     currentMinKey = noneKey;
     currentMaxKey = std::numeric_limits<KeyType>::min();
     numElems = 0;
@@ -57,15 +61,20 @@ template <SignedIntegral KeyType, IntegralValue ValueType>
 void BucketPriorityQueue<KeyType, ValueType>::insert(KeyType key, ValueType value) {
     assert(minAdmissibleKey <= key && key <= maxAdmissibleKey);
 
-    const auto valueIdx = static_cast<index>(value);
-    if constexpr (std::is_signed_v<ValueType>) {
-        assert(value >= 0);
-    }
-    assert(valueIdx < nodePtr.size());
+    const auto valueIdx = valueToIndex(value);
+    assert(valueIdx < myBucket.size());
+    assert(myBucket[valueIdx] == noneBucket);
 
     const auto bucketIdx = static_cast<BucketIndex>(key + offset);
-    buckets[bucketIdx].push_front(value);
-    nodePtr[valueIdx] = OptionalIterator{true, buckets[bucketIdx].begin()};
+    const ValueType oldHead = bucketHead[bucketIdx];
+    next[valueIdx] = oldHead;
+    previous[valueIdx] = noneValue;
+
+    if (oldHead != noneValue) {
+        previous[valueToIndex(oldHead)] = value;
+    }
+    bucketHead[bucketIdx] = value;
+
     myBucket[valueIdx] = bucketIdx;
     ++numElems;
 
@@ -83,7 +92,7 @@ std::pair<KeyType, ValueType> BucketPriorityQueue<KeyType, ValueType>::getMin() 
     if (empty())
         return {noneKey, noneValue};
     else
-        return {currentMinKey, buckets[currentMinKey + offset].front()};
+        return {currentMinKey, bucketHead[currentMinKey + offset]};
 }
 
 template <SignedIntegral KeyType, IntegralValue ValueType>
@@ -91,7 +100,7 @@ std::pair<KeyType, ValueType> BucketPriorityQueue<KeyType, ValueType>::extractMi
     if (empty())
         return {noneKey, noneValue};
 
-    ValueType result = buckets[currentMinKey + offset].front();
+    ValueType result = bucketHead[currentMinKey + offset];
 
     // store currentMinKey because remove(result) will change it
     KeyType oldMinKey = currentMinKey;
@@ -121,7 +130,7 @@ bool BucketPriorityQueue<KeyType, ValueType>::contains(const ValueType &value) c
     if constexpr (std::is_signed_v<ValueType>) {
         assert(value >= 0);
     }
-    return valueIdx < nodePtr.size() && nodePtr[valueIdx].valid;
+    return valueIdx < myBucket.size() && myBucket[valueIdx] != noneBucket;
 }
 
 template <SignedIntegral KeyType, IntegralValue ValueType>
@@ -130,13 +139,26 @@ void BucketPriorityQueue<KeyType, ValueType>::remove(const ValueType &value) {
     if constexpr (std::is_signed_v<ValueType>) {
         assert(value >= 0);
     }
-    assert(valueIdx < nodePtr.size());
+    assert(valueIdx < myBucket.size());
 
     if (myBucket[valueIdx] != noneBucket) {
         // remove from appropriate bucket
-        BucketIndex bucketIdx = myBucket[valueIdx];
-        buckets[bucketIdx].erase(nodePtr[valueIdx].iter);
-        nodePtr[valueIdx].reset();
+        const BucketIndex bucketIdx = myBucket[valueIdx];
+        const ValueType previousValue = previous[valueIdx];
+        const ValueType nextValue = next[valueIdx];
+
+        if (previousValue != noneValue) {
+            next[valueToIndex(previousValue)] = nextValue;
+        } else {
+            bucketHead[bucketIdx] = nextValue;
+        }
+
+        if (nextValue != noneValue) {
+            previous[valueToIndex(nextValue)] = previousValue;
+        }
+
+        previous[valueIdx] = noneValue;
+        next[valueIdx] = noneValue;
         myBucket[valueIdx] = noneBucket;
         --numElems;
 
@@ -146,12 +168,12 @@ void BucketPriorityQueue<KeyType, ValueType>::remove(const ValueType &value) {
             currentMaxKey = std::numeric_limits<KeyType>::min();
         } else {
             // adjust max pointer if necessary
-            while (buckets[currentMaxKey + offset].empty() && currentMaxKey > currentMinKey) {
+            while (bucketHead[currentMaxKey + offset] == noneValue && currentMaxKey > currentMinKey) {
                 --currentMaxKey;
             }
 
             // adjust min pointer if necessary
-            while (buckets[currentMinKey + offset].empty() && currentMinKey < currentMaxKey) {
+            while (bucketHead[currentMinKey + offset] == noneValue && currentMinKey < currentMaxKey) {
                 ++currentMinKey;
             }
         }

--- a/networkit/cpp/auxiliary/test/BucketPriorityQueueGTest.cpp
+++ b/networkit/cpp/auxiliary/test/BucketPriorityQueueGTest.cpp
@@ -78,6 +78,30 @@ TYPED_TEST_P(BucketPriorityQueueGTest, testChangeKeyAndRemove) {
     EXPECT_THAT(prioQ, IsEmpty());
 }
 
+TYPED_TEST_P(BucketPriorityQueueGTest, testRemoveElementsWithSameKey) {
+    using KeyType = typename TestFixture::KeyType;
+    using ValueType = typename TestFixture::ValueType;
+
+    Aux::BucketPriorityQueue<KeyType, ValueType> prioQ(6, KeyType{-2}, KeyType{2});
+
+    prioQ.insert(KeyType{1}, ValueType{0});
+    prioQ.insert(KeyType{1}, ValueType{1});
+    prioQ.insert(KeyType{1}, ValueType{2});
+    prioQ.insert(KeyType{-1}, ValueType{3});
+
+    prioQ.remove(ValueType{1});
+    EXPECT_FALSE(prioQ.contains(ValueType{1}));
+    EXPECT_TRUE(prioQ.contains(ValueType{0}));
+    EXPECT_TRUE(prioQ.contains(ValueType{2}));
+
+    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{-1}, ValueType{3}}));
+
+    prioQ.remove(ValueType{2});
+    EXPECT_FALSE(prioQ.contains(ValueType{2}));
+    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{1}, ValueType{0}}));
+    EXPECT_THAT(prioQ, IsEmpty());
+}
+
 TYPED_TEST_P(BucketPriorityQueueGTest, testEmptySentinelsUseTemplateTypes) {
     using KeyType = typename TestFixture::KeyType;
     using ValueType = typename TestFixture::ValueType;
@@ -92,7 +116,8 @@ TYPED_TEST_P(BucketPriorityQueueGTest, testEmptySentinelsUseTemplateTypes) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(BucketPriorityQueueGTest, testConstructFromKeysSkipsNone,
-                            testChangeKeyAndRemove, testEmptySentinelsUseTemplateTypes);
+                            testChangeKeyAndRemove, testRemoveElementsWithSameKey,
+                            testEmptySentinelsUseTemplateTypes);
 
 using BucketPriorityQueueTestTypes =
     ::testing::Types<BucketPQConfig<int64_t, index>, BucketPQConfig<int32_t, uint32_t>,


### PR DESCRIPTION
## Summary

This PR improves `BucketPriorityQueue` performance by replacing per-bucket `std::list` storage with an array-backed  representation. In local benchmarks, this reduces CPU time by **3.7x to 6.7x** on the 100k workloads and by **4.8x to 5.3x** on the 10k workloads. 

The new representation uses:

- `head[bucket]`
- `next[value]`
- `prev[value]`

Values are already bounded by the queue capacity, so this avoids per-element list-node allocations while preserving constant-time insertion, removal, and key changes.

## Performance

I benchmarked master against this branch with 20 repetitions using release build compiled with GCC 11.4.0 (`-O3 -DNDEBUG`, C++20). CPU scaling was enabled.

| Workload | Size | Implementation | Median CPU time | Mean CPU time | Stddev | Speedup |
|---|---:|---|---:|---:|---:|---:|
| InsertExtract | 10k | Current master | 0.455 ms | 0.455 ms | 0.001 ms | 1.0x |
| InsertExtract | 10k | This branch | 0.094 ms | 0.094 ms | 0.001 ms | 4.84x |
| InsertExtract | 100k | Current master | 5.841 ms | 5.851 ms | 0.034 ms | 1.0x |
| InsertExtract | 100k | This branch | 1.591 ms | 1.587 ms | 0.051 ms | 3.67x |
| ChangeRemove | 10k | Current master | 0.531 ms | 0.531 ms | 0.002 ms | 1.0x |
| ChangeRemove | 10k | This branch | 0.109 ms | 0.109 ms | 0.001 ms | 4.87x |
| ChangeRemove | 100k | Current master | 5.635 ms | 5.648 ms | 0.079 ms | 1.0x |
| ChangeRemove | 100k | This branch | 0.838 ms | 0.839 ms | 0.003 ms | 6.72x |
| ConstructExtract | 10k | Current master | 0.473 ms | 0.472 ms | 0.004 ms | 1.0x |
| ConstructExtract | 10k | This branch | 0.089 ms | 0.089 ms | 0.001 ms | 5.33x |
| ConstructExtract | 100k | Current master | 6.030 ms | 6.048 ms | 0.066 ms | 1.0x |
| ConstructExtract | 100k | This branch | 1.515 ms | 1.523 ms | 0.052 ms | 3.98x |

For the 100k `ChangeRemove` workload, callgrind reports:

| Implementation | Instruction references |
|---|---:|
| Current master | 91,657,530 |
| This branch | 25,393,970 |

This is a reduction of about **72.3%**.

## Tests

I added a regression test for multiple values with the same key. This covered a gap found while debugging the new bucket representation.
```