### PR TITLE
Fix BucketPriorityQueue clear state reset

### DIFF
--- a/include/networkit/auxiliary/BucketPriorityQueue.hpp
+++ b/include/networkit/auxiliary/BucketPriorityQueue.hpp
@@ -8,6 +8,7 @@
 #ifndef NETWORKIT_AUXILIARY_BUCKET_PRIORITY_QUEUE_HPP_
 #define NETWORKIT_AUXILIARY_BUCKET_PRIORITY_QUEUE_HPP_
 
+#include <algorithm>
 #include <concepts>
 #include <cstdint>
 #include <limits>
@@ -147,6 +148,11 @@ public:
      * Removes key-value pair given by value @a val.
      */
     void remove(const ValueType &value) override;
+
+    /**
+     * Removes all elements from the priority queue.
+     */
+    void clear() override;
 
     /**
      * @return key to given value @val.

--- a/include/networkit/auxiliary/BucketPriorityQueue.hpp
+++ b/include/networkit/auxiliary/BucketPriorityQueue.hpp
@@ -12,6 +12,7 @@
 #include <concepts>
 #include <cstdint>
 #include <limits>
+#include <ranges>
 #include <span>
 #include <stdexcept>
 #include <type_traits>
@@ -41,6 +42,7 @@ concept IntegralValue = std::integral<T> && !std::same_as<std::remove_cvref_t<T>
 template <SignedIntegral KeyType = int64_t, IntegralValue ValueType = index>
 class BucketPriorityQueue : public PrioQueue<KeyType, ValueType> {
 private:
+    using Bucket = std::list<ValueType>;
     using BucketIndex = index;
 
     static constexpr KeyType noneKey = std::numeric_limits<KeyType>::max();

--- a/include/networkit/auxiliary/BucketPriorityQueue.hpp
+++ b/include/networkit/auxiliary/BucketPriorityQueue.hpp
@@ -42,7 +42,6 @@ concept IntegralValue = std::integral<T> && !std::same_as<std::remove_cvref_t<T>
 template <SignedIntegral KeyType = int64_t, IntegralValue ValueType = index>
 class BucketPriorityQueue : public PrioQueue<KeyType, ValueType> {
 private:
-    using Bucket = std::list<ValueType>;
     using BucketIndex = index;
 
     static constexpr KeyType noneKey = std::numeric_limits<KeyType>::max();

--- a/include/networkit/auxiliary/BucketPriorityQueueImpl.hpp
+++ b/include/networkit/auxiliary/BucketPriorityQueueImpl.hpp
@@ -184,13 +184,10 @@ void BucketPriorityQueue<KeyType, ValueType>::remove(const ValueType &value) {
 
 template <SignedIntegral KeyType, IntegralValue ValueType>
 void BucketPriorityQueue<KeyType, ValueType>::clear() {
-    for (std::list<ValueType> &bucket : buckets) {
-        bucket.clear();
-    }
-    for (OptionalIterator &ptr : nodePtr) {
-        ptr.reset();
-    }
-    std::ranges::fill(myBucket.begin(), myBucket.end(), noneBucket);
+    std::ranges::fill(bucketHead, noneValue);
+    std::ranges::fill(previous, noneValue);
+    std::ranges::fill(next, noneValue);
+    std::ranges::fill(myBucket, noneBucket);
     currentMinKey = noneKey;
     currentMaxKey = std::numeric_limits<KeyType>::min();
     numElems = 0;

--- a/include/networkit/auxiliary/BucketPriorityQueueImpl.hpp
+++ b/include/networkit/auxiliary/BucketPriorityQueueImpl.hpp
@@ -183,6 +183,20 @@ void BucketPriorityQueue<KeyType, ValueType>::remove(const ValueType &value) {
 }
 
 template <SignedIntegral KeyType, IntegralValue ValueType>
+void BucketPriorityQueue<KeyType, ValueType>::clear() {
+    for (auto &bucket : buckets) {
+        bucket.clear();
+    }
+    for (auto &ptr : nodePtr) {
+        ptr.reset();
+    }
+    std::fill(myBucket.begin(), myBucket.end(), noneBucket);
+    currentMinKey = noneKey;
+    currentMaxKey = std::numeric_limits<KeyType>::min();
+    numElems = 0;
+}
+
+template <SignedIntegral KeyType, IntegralValue ValueType>
 KeyType BucketPriorityQueue<KeyType, ValueType>::getKey(const ValueType &val) {
     const auto valueIdx = static_cast<index>(val);
     if constexpr (std::is_signed_v<ValueType>) {

--- a/include/networkit/auxiliary/BucketPriorityQueueImpl.hpp
+++ b/include/networkit/auxiliary/BucketPriorityQueueImpl.hpp
@@ -184,13 +184,13 @@ void BucketPriorityQueue<KeyType, ValueType>::remove(const ValueType &value) {
 
 template <SignedIntegral KeyType, IntegralValue ValueType>
 void BucketPriorityQueue<KeyType, ValueType>::clear() {
-    for (auto &bucket : buckets) {
+    for (std::list<ValueType> &bucket : buckets) {
         bucket.clear();
     }
-    for (auto &ptr : nodePtr) {
+    for (OptionalIterator &ptr : nodePtr) {
         ptr.reset();
     }
-    std::fill(myBucket.begin(), myBucket.end(), noneBucket);
+    std::ranges::fill(myBucket.begin(), myBucket.end(), noneBucket);
     currentMinKey = noneKey;
     currentMaxKey = std::numeric_limits<KeyType>::min();
     numElems = 0;

--- a/networkit/cpp/auxiliary/test/BucketPriorityQueueGTest.cpp
+++ b/networkit/cpp/auxiliary/test/BucketPriorityQueueGTest.cpp
@@ -115,9 +115,32 @@ TYPED_TEST_P(BucketPriorityQueueGTest, testEmptySentinelsUseTemplateTypes) {
     EXPECT_EQ(prioQ.extractMin(), emptySentinel);
 }
 
+TYPED_TEST_P(BucketPriorityQueueGTest, testClearResetsBucketState) {
+    using KeyType = typename TestFixture::KeyType;
+    using ValueType = typename TestFixture::ValueType;
+
+    Aux::BucketPriorityQueue<KeyType, ValueType> prioQ(5, KeyType{-2}, KeyType{4});
+
+    prioQ.insert(KeyType{0}, ValueType{0});
+    prioQ.insert(KeyType{2}, ValueType{1});
+    prioQ.insert(KeyType{-1}, ValueType{2});
+
+    prioQ.clear();
+
+    EXPECT_THAT(prioQ, IsEmpty());
+    EXPECT_FALSE(prioQ.contains(ValueType{0}));
+    EXPECT_EQ(prioQ.getMin(),
+              (std::pair<KeyType, ValueType>{std::numeric_limits<KeyType>::max(),
+                                             std::numeric_limits<ValueType>::max()}));
+
+    prioQ.insert(KeyType{4}, ValueType{3});
+    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{4}, ValueType{3}}));
+    EXPECT_THAT(prioQ, IsEmpty());
+}
+
 REGISTER_TYPED_TEST_SUITE_P(BucketPriorityQueueGTest, testConstructFromKeysSkipsNone,
-                            testChangeKeyAndRemove, testRemoveElementsWithSameKey,
-                            testEmptySentinelsUseTemplateTypes);
+                            testChangeKeyAndRemove, testEmptySentinelsUseTemplateTypes,
+                            testClearResetsBucketState, testRemoveElementsWithSameKey);
 
 using BucketPriorityQueueTestTypes =
     ::testing::Types<BucketPQConfig<int64_t, index>, BucketPQConfig<int32_t, uint32_t>,

--- a/networkit/cpp/auxiliary/test/BucketPriorityQueueGTest.cpp
+++ b/networkit/cpp/auxiliary/test/BucketPriorityQueueGTest.cpp
@@ -3,7 +3,6 @@
 
 #include <cstdint>
 #include <limits>
-#include <utility>
 #include <vector>
 
 #include <networkit/auxiliary/BucketPriorityQueue.hpp>
@@ -48,9 +47,9 @@ TYPED_TEST_P(BucketPriorityQueueGTest, testConstructFromKeysSkipsNone) {
     EXPECT_EQ(prioQ.getKey(ValueType{2}), KeyType{-2});
     EXPECT_EQ(prioQ.getKey(ValueType{3}), KeyType{1});
 
-    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{-2}, ValueType{2}}));
-    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{1}, ValueType{3}}));
-    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{3}, ValueType{0}}));
+    EXPECT_THAT(prioQ.extractMin(), Pair(KeyType{-2}, ValueType{2}));
+    EXPECT_THAT(prioQ.extractMin(), Pair(KeyType{1}, ValueType{3}));
+    EXPECT_THAT(prioQ.extractMin(), Pair(KeyType{3}, ValueType{0}));
     EXPECT_THAT(prioQ, IsEmpty());
 }
 
@@ -67,15 +66,15 @@ TYPED_TEST_P(BucketPriorityQueueGTest, testChangeKeyAndRemove) {
     EXPECT_TRUE(prioQ.contains(ValueType{0}));
     EXPECT_TRUE(prioQ.contains(ValueType{1}));
     EXPECT_TRUE(prioQ.contains(ValueType{2}));
-    EXPECT_EQ(prioQ.getMin(), (std::pair<KeyType, ValueType>{KeyType{-3}, ValueType{1}}));
+    EXPECT_THAT(prioQ.getMin(), Pair(KeyType{-3}, ValueType{1}));
 
     prioQ.changeKey(KeyType{-5}, ValueType{2});
     EXPECT_EQ(prioQ.getKey(ValueType{2}), KeyType{-5});
-    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{-5}, ValueType{2}}));
+    EXPECT_THAT(prioQ.extractMin(), Pair(KeyType{-5}, ValueType{2}));
 
     prioQ.remove(ValueType{1});
     EXPECT_FALSE(prioQ.contains(ValueType{1}));
-    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{4}, ValueType{0}}));
+    EXPECT_THAT(prioQ.extractMin(), Pair(KeyType{4}, ValueType{0}));
     EXPECT_THAT(prioQ, IsEmpty());
 }
 
@@ -95,11 +94,11 @@ TYPED_TEST_P(BucketPriorityQueueGTest, testRemoveElementsWithSameKey) {
     EXPECT_TRUE(prioQ.contains(ValueType{0}));
     EXPECT_TRUE(prioQ.contains(ValueType{2}));
 
-    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{-1}, ValueType{3}}));
+    EXPECT_THAT(prioQ.extractMin(), Pair(KeyType{-1}, ValueType{3}));
 
     prioQ.remove(ValueType{2});
     EXPECT_FALSE(prioQ.contains(ValueType{2}));
-    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{1}, ValueType{0}}));
+    EXPECT_THAT(prioQ.extractMin(), Pair(KeyType{1}, ValueType{0}));
     EXPECT_THAT(prioQ, IsEmpty());
 }
 
@@ -109,11 +108,11 @@ TYPED_TEST_P(BucketPriorityQueueGTest, testEmptySentinelsUseTemplateTypes) {
 
     Aux::BucketPriorityQueue<KeyType, ValueType> prioQ(4, KeyType{-2}, KeyType{2});
 
-    const std::pair<KeyType, ValueType> emptySentinel{std::numeric_limits<KeyType>::max(),
-                                                      std::numeric_limits<ValueType>::max()};
     EXPECT_THAT(prioQ, IsEmpty());
-    EXPECT_EQ(prioQ.getMin(), emptySentinel);
-    EXPECT_EQ(prioQ.extractMin(), emptySentinel);
+    EXPECT_THAT(prioQ.getMin(),
+                Pair(std::numeric_limits<KeyType>::max(), std::numeric_limits<ValueType>::max()));
+    EXPECT_THAT(prioQ.extractMin(),
+                Pair(std::numeric_limits<KeyType>::max(), std::numeric_limits<ValueType>::max()));
 }
 
 TYPED_TEST_P(BucketPriorityQueueGTest, testClearResetsBucketState) {

--- a/networkit/cpp/auxiliary/test/BucketPriorityQueueGTest.cpp
+++ b/networkit/cpp/auxiliary/test/BucketPriorityQueueGTest.cpp
@@ -12,6 +12,7 @@ namespace NetworKit {
 namespace {
 
 using ::testing::IsEmpty;
+using ::testing::Pair;
 using ::testing::SizeIs;
 
 template <typename KeyT, typename ValueT>
@@ -129,12 +130,11 @@ TYPED_TEST_P(BucketPriorityQueueGTest, testClearResetsBucketState) {
 
     EXPECT_THAT(prioQ, IsEmpty());
     EXPECT_FALSE(prioQ.contains(ValueType{0}));
-    EXPECT_EQ(prioQ.getMin(),
-              (std::pair<KeyType, ValueType>{std::numeric_limits<KeyType>::max(),
-                                             std::numeric_limits<ValueType>::max()}));
+    EXPECT_THAT(prioQ.getMin(),
+                Pair(std::numeric_limits<KeyType>::max(), std::numeric_limits<ValueType>::max()));
 
     prioQ.insert(KeyType{4}, ValueType{3});
-    EXPECT_EQ(prioQ.extractMin(), (std::pair<KeyType, ValueType>{KeyType{4}, ValueType{3}}));
+    EXPECT_THAT(prioQ.extractMin(), Pair(KeyType{4}, ValueType{3}));
     EXPECT_THAT(prioQ, IsEmpty());
 }
 


### PR DESCRIPTION
This PR adds a `clear()` override to `BucketPriorityQueue`.

Previously, `BucketPriorityQueue` inherited `clear()` from `PrioQueue`, which only reset the base-class state. The new override resets the bucket queue state and adds a regression test.

Fixes #1442