### PR TITLE
Only require cmake/make at build time, not for metadata generation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ import numpy as np
 
 cmakeCompiler = None
 buildDirectory = "build/build_python"
-ninja_available = False
 enable_osx_crossbuild = False
 build_tests = False
 
@@ -30,14 +29,6 @@ if "NETWORKIT_OSX_CROSSBUILD" in os.environ:
 if "NETWORKIT_BUILD_TESTS" in os.environ:
     build_tests = True
 
-if shutil.which("cmake") is None:
-    print("ERROR: NetworKit compilation requires cmake.")
-    sys.exit(1)
-
-ninja_available = shutil.which("ninja") is not None
-if not (ninja_available or shutil.which("make")):
-    print("ERROR: NetworKit compilation requires Make or Ninja.")
-    sys.exit(1)
 try:
     from setuptools import setup  # to ensure setuptools is installed
 except ImportError:
@@ -83,6 +74,18 @@ sys.argv = [__file__] + args
 def buildNetworKit(
     install_prefix, externalCore=False, externalTlx=None, withTests=False, rpath=None
 ):
+    # cmake and a generator (make or ninja) are only needed to *compile*
+    # NetworKit. Check for them here, at build time, instead of at import time
+    # so that PEP 517 metadata hooks (e.g. get_requires_for_build_wheel) can run
+    # without a C++ build toolchain installed. See issue #1450.
+    if shutil.which("cmake") is None:
+        print("ERROR: NetworKit compilation requires cmake.")
+        sys.exit(1)
+    ninja_available = shutil.which("ninja") is not None
+    if not (ninja_available or shutil.which("make")):
+        print("ERROR: NetworKit compilation requires Make or Ninja.")
+        sys.exit(1)
+
     try:
         os.makedirs(buildDirectory)
     except FileExistsError:


### PR DESCRIPTION
## Summary

Fixes #1450.

`setup.py` checks for `cmake` (and `make`/`ninja`) at **module scope**, so they run on
*every* execution of `setup.py` — including the PEP 517 metadata-only hooks
`get_requires_for_build_wheel` and `prepare_metadata_for_build_wheel`. On a machine
without a C++ toolchain those hooks abort with `ERROR: NetworKit compilation requires
cmake`, even though NetworKit's metadata is fully static (declared in
`pyproject.toml [project]`).

As a result, resolvers / lockfile generators (pip, Poetry, PDM, pex/Pants, …) cannot read
NetworKit's metadata from the sdist unless cmake is installed — which breaks dependency
resolution and lockfile generation in CI images and other toolchain-less environments,
even when a suitable wheel is available.

## Change

Move the `cmake` / `make` / `ninja` availability checks out of module scope and into
`buildNetworKit()`, which runs only from the `build_ext` command (i.e. an actual compile).
Metadata hooks then succeed without a toolchain, while real builds keep the identical error
messages.

No runtime, API, or ABI change (so nothing in `CHANGES.md` applies); `install_requires` and
the declared build requirements are unchanged.

## Verification

On a machine **without cmake on `PATH`**:

- `get_requires_for_build_wheel()` (the hook from the report) now succeeds and returns `[]`
  instead of aborting.
- `python setup.py build_ext` still fails fast with `ERROR: NetworKit compilation requires
  cmake.` — the guard is preserved, only relocated to build time.

With cmake present, behaviour is unchanged.
