### PR TITLE
Remove `Graph.hpp` deprecation message

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1,9 +1,6 @@
 #ifndef NETWORKIT_GRAPH_GRAPH_HPP_
 #define NETWORKIT_GRAPH_GRAPH_HPP_
 
-#pragma message( \
-    "warning: Graph.hpp is deprecated. Include a graph implementation like AdjListGraph.hpp instead.")
-
 #include <networkit/graph/AdjListGraph.hpp>
 
 #endif // NETWORKIT_GRAPH_GRAPH_HPP_


### PR DESCRIPTION
Removes the compile-time deprecation message from `Graph.hpp`.
`Graph.hpp` is included transitively in many places, so the #pragma message emits the same warning
hundreds of times during normal builds and makes compiler output noisy. 