### PR TITLE
Add tests for `LocalCommunity`

### DIFF
--- a/include/networkit/structures/LocalCommunity.hpp
+++ b/include/networkit/structures/LocalCommunity.hpp
@@ -146,7 +146,7 @@ public:
         OptionalValue<node, MaintainBoundary && AllowRemoval> exclusiveOutsideNeighbor;
 
         /**
-         * The number of neighbors that have no internal neighbors.
+         * The number of neighboring community nodes that have no external neighbors.
          */
         OptionalValue<count, MaintainBoundary && AllowRemoval> numFullyInternalNeighbors;
 

--- a/networkit/cpp/structures/LocalCommunity.cpp
+++ b/networkit/cpp/structures/LocalCommunity.cpp
@@ -17,8 +17,8 @@ void LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::addNo
     std::tie(uIt, std::ignore) = community.insert({u, CommunityInfo()});
     shell.erase(u);
 
-    node boundaryNeighbor = none; // if u is in the boundary and has only one neighbor outside of
-                                  // the community, store it here.
+    // If u has exactly one shell neighbor, store it here for removal bookkeeping.
+    node exclusiveShellNeighbor = none;
     std::unordered_map<node, count>::iterator boundaryIt;
 
     if (MaintainBoundary) {
@@ -54,7 +54,7 @@ void LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::addNo
                             if (it != shell.end()) {
                                 it->second.numExclusiveBoundaryMembers += 1;
                                 if (AllowRemoval) {
-                                    *uIt->second.exclusiveOutsideNeighbor = it->first;
+                                    *vIt->second.exclusiveOutsideNeighbor = it->first;
                                 }
                             }
                         });
@@ -95,7 +95,7 @@ void LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::addNo
                 if (MaintainBoundary) {
                     if (boundaryIt == currentBoundary->end()) {
                         std::tie(boundaryIt, std::ignore) = currentBoundary->insert({u, 0});
-                        boundaryNeighbor = v;
+                        exclusiveShellNeighbor = v;
                     }
 
                     ++boundaryIt->second;
@@ -114,10 +114,14 @@ void LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::addNo
 #endif
             }
         });
-
+    // If the added node u has exactly one outside neighbor, that shell node gains
+    // u as an exclusive boundary member. Store the neighbor for future removals.
     if (MaintainBoundary && boundaryIt != currentBoundary->end() && boundaryIt->second == 1) {
-        assert(boundaryNeighbor != none);
-        shell[boundaryNeighbor].numExclusiveBoundaryMembers += 1;
+        assert(exclusiveShellNeighbor != none);
+        shell[exclusiveShellNeighbor].numExclusiveBoundaryMembers += 1;
+        if (AllowRemoval) {
+            *uIt->second.exclusiveOutsideNeighbor = exclusiveShellNeighbor;
+        }
     }
 
     if (MaintainBoundary && AllowRemoval && boundaryIt == currentBoundary->end()) {
@@ -197,13 +201,20 @@ void LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::remov
                             }
                         });
 
-                        // u has now a neighbor that is only in the boundary
-                        // becuase of u
+                        // v is now a boundary node whose only shell neighbor is u.
                         uIt->second.numExclusiveBoundaryMembers += 1;
                     } else if (it->second == 2) {
-                        *vIt->second.exclusiveOutsideNeighbor = none;
+                        if (AllowRemoval) {
+                            const auto exclusiveOutsideNeighbor =
+                                *vIt->second.exclusiveOutsideNeighbor;
+                            assert(exclusiveOutsideNeighbor != none);
 
-                        uIt->second.numExclusiveBoundaryMembers -= 1;
+                            auto shellIt = shell.find(exclusiveOutsideNeighbor);
+                            assert(shellIt != shell.end());
+                            shellIt->second.numExclusiveBoundaryMembers -= 1;
+
+                            *vIt->second.exclusiveOutsideNeighbor = none;
+                        }
                     }
                 }
 

--- a/networkit/cpp/structures/LocalCommunity.cpp
+++ b/networkit/cpp/structures/LocalCommunity.cpp
@@ -166,96 +166,95 @@ void LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>::remov
         }
     }
 
-    G->forNeighborsOf(
-        u, [&](node, node v, edgeweight ew) { // insert external neighbors of u into shell
-            auto vIt = community.find(v);
-            if (vIt != community.end()) {
-                if (MaintainBoundary) {
-                    if (wasFullyInternal) {
-                        vIt->second.numFullyInternalNeighbors -= 1;
-                    }
+    G->forNeighborsOf(u, [&](node, node v,
+                             edgeweight ew) { // insert external neighbors of u into shell
+        auto vIt = community.find(v);
+        if (vIt != community.end()) {
+            if (MaintainBoundary) {
+                if (wasFullyInternal) {
+                    vIt->second.numFullyInternalNeighbors -= 1;
+                }
 
-                    auto it = currentBoundary->find(v);
+                auto it = currentBoundary->find(v);
+                // v was a fully internal node
+                if (it == currentBoundary->end()) {
+                    std::tie(it, std::ignore) = currentBoundary->insert({v, 0});
+                }
+
+                assert(it != currentBoundary->end());
+
+                it->second += 1;
+
+                if (it->second == 1) {
                     // v was a fully internal node
-                    if (it == currentBoundary->end()) {
-                        std::tie(it, std::ignore) = currentBoundary->insert({v, 0});
-                    }
+                    // therefore, u is now the exclusive outside neighbor of v
+                    *vIt->second.exclusiveOutsideNeighbor = u;
 
-                    assert(it != currentBoundary->end());
-
-                    it->second += 1;
-
-                    if (it->second == 1) {
-                        // v was a fully internal node
-                        // therefore, u is now the exclusive outside neighbor of v
-                        *vIt->second.exclusiveOutsideNeighbor = u;
-
-                        // inform all neighbors of v that they now have one fully
-                        // internal neighbor less
-                        G->forNeighborsOf(v, [&](node x) {
-                            auto comIt = community.find(x);
-                            if (comIt != community.end()) {
-                                comIt->second.numFullyInternalNeighbors -= 1;
-                            } else {
-                                assert(x == u);
-                            }
-                        });
-
-                        // v is now a boundary node whose only shell neighbor is u.
-                        uIt->second.numExclusiveBoundaryMembers += 1;
-                    } else if (it->second == 2) {
-                        if (AllowRemoval) {
-                            const auto exclusiveOutsideNeighbor =
-                                *vIt->second.exclusiveOutsideNeighbor;
-                            assert(exclusiveOutsideNeighbor != none);
-
-                            auto shellIt = shell.find(exclusiveOutsideNeighbor);
-                            assert(shellIt != shell.end());
-                            shellIt->second.numExclusiveBoundaryMembers -= 1;
-
-                            *vIt->second.exclusiveOutsideNeighbor = none;
+                    // inform all neighbors of v that they now have one fully
+                    // internal neighbor less
+                    G->forNeighborsOf(v, [&](node x) {
+                        auto comIt = community.find(x);
+                        if (comIt != community.end()) {
+                            comIt->second.numFullyInternalNeighbors -= 1;
+                        } else {
+                            assert(x == u);
                         }
+                    });
+
+                    // v is now a boundary node whose only shell neighbor is u.
+                    uIt->second.numExclusiveBoundaryMembers += 1;
+                } else if (it->second == 2) {
+                    if (AllowRemoval) {
+                        const auto exclusiveOutsideNeighbor = *vIt->second.exclusiveOutsideNeighbor;
+                        assert(exclusiveOutsideNeighbor != none);
+
+                        auto shellIt = shell.find(exclusiveOutsideNeighbor);
+                        assert(shellIt != shell.end());
+                        shellIt->second.numExclusiveBoundaryMembers -= 1;
+
+                        *vIt->second.exclusiveOutsideNeighbor = none;
                     }
-                }
-
-                intWeight -= ew;
-                extWeight += ew;
-
-                vIt->second.intDeg -= ew;
-                uIt->second.intDeg += ew;
-
-                if (ShellMaintainsExtDeg) {
-                    vIt->second.extDeg += ew;
-                }
-            } else {
-                auto it = shell.find(v);
-                assert(it != shell.end());
-
-                it->second.intDeg -= ew;
-                if (ShellMaintainsExtDeg) {
-                    it->second.extDeg += ew;
-                    uIt->second.extDeg += ew;
-                }
-
-                extWeight -= ew;
-
-                if (*it->second.intDeg == 0) {
-                    shell.erase(it);
-                } else {
-#ifdef NETWORKIT_SANITY_CHECKS
-#ifndef NDEBUG
-                    {
-                        auto intExtDeg = calculateIntExtDeg(v);
-                        assert(*shell[v].intDeg == intExtDeg.first);
-                        if (ShellMaintainsExtDeg) {
-                            assert(*shell[v].extDeg == intExtDeg.second);
-                        }
-                    }
-#endif
-#endif
                 }
             }
-        });
+
+            intWeight -= ew;
+            extWeight += ew;
+
+            vIt->second.intDeg -= ew;
+            uIt->second.intDeg += ew;
+
+            if (ShellMaintainsExtDeg) {
+                vIt->second.extDeg += ew;
+            }
+        } else {
+            auto it = shell.find(v);
+            assert(it != shell.end());
+
+            it->second.intDeg -= ew;
+            if (ShellMaintainsExtDeg) {
+                it->second.extDeg += ew;
+                uIt->second.extDeg += ew;
+            }
+
+            extWeight -= ew;
+
+            if (*it->second.intDeg == 0) {
+                shell.erase(it);
+            } else {
+#ifdef NETWORKIT_SANITY_CHECKS
+#ifndef NDEBUG
+                {
+                    auto intExtDeg = calculateIntExtDeg(v);
+                    assert(*shell[v].intDeg == intExtDeg.first);
+                    if (ShellMaintainsExtDeg) {
+                        assert(*shell[v].extDeg == intExtDeg.second);
+                    }
+                }
+#endif
+#endif
+            }
+        }
+    });
 
 #ifdef NETWORKIT_SANITY_CHECKS
 #ifndef NDEBUG

--- a/networkit/cpp/structures/test/CMakeLists.txt
+++ b/networkit/cpp/structures/test/CMakeLists.txt
@@ -1,3 +1,4 @@
 networkit_add_test(structures CoverGTest auxiliary)
 networkit_add_test(structures GenericPartitionGTest)
+networkit_add_test(structures LocalCommunityGTest graph)
 networkit_add_test(structures UnionFindGTest)

--- a/networkit/cpp/structures/test/LocalCommunityGTest.cpp
+++ b/networkit/cpp/structures/test/LocalCommunityGTest.cpp
@@ -1,0 +1,196 @@
+#include <set>
+#include <unordered_map>
+#include <utility>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <networkit/Globals.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/structures/LocalCommunity.hpp>
+
+namespace NetworKit {
+namespace {
+
+using ::testing::Pair;
+using ::testing::UnorderedElementsAre;
+
+template <bool ShellMaintainsExtDeg, bool MaintainBoundary, bool AllowRemoval>
+struct LocalCommunityConfig {
+    static constexpr bool shellMaintainsExtDeg = ShellMaintainsExtDeg;
+    static constexpr bool maintainBoundary = MaintainBoundary;
+    static constexpr bool allowRemoval = AllowRemoval;
+
+    using Community = LocalCommunity<ShellMaintainsExtDeg, MaintainBoundary, AllowRemoval>;
+};
+
+struct DegSnapshot {
+    double intDeg;
+    double extDeg;
+};
+
+bool operator==(const DegSnapshot &lhs, const DegSnapshot &rhs) {
+    return lhs.intDeg == rhs.intDeg && lhs.extDeg == rhs.extDeg;
+}
+
+template <typename LocalCommunity, typename F>
+auto collectShell(LocalCommunity &community, F getValue) {
+    using Value = decltype(getValue(std::declval<const typename LocalCommunity::ShellInfo &>()));
+    std::unordered_map<node, Value> result;
+    community.forShellNodes([&](node u, const auto &info) { result.emplace(u, getValue(info)); });
+    return result;
+}
+
+template <typename LocalCommunity, typename F>
+auto collectCommunity(LocalCommunity &community, F getValue) {
+    using Value =
+        decltype(getValue(std::declval<const typename LocalCommunity::CommunityInfo &>()));
+    std::unordered_map<node, Value> result;
+    community.forCommunityNodes(
+        [&](node u, const auto &info) { result.emplace(u, getValue(info)); });
+    return result;
+}
+
+Graph weightedGraph() {
+    Graph G(6, true, false);
+    G.addEdge(0, 1, 2.0);
+    G.addEdge(1, 2, 3.0);
+    G.addEdge(1, 3, 5.0);
+    G.addEdge(2, 3, 7.0);
+    G.addEdge(3, 4, 11.0);
+    G.addEdge(0, 5, 13.0);
+    return G;
+}
+
+template <typename Config>
+class LocalCommunityGTest : public ::testing::Test {};
+
+using LocalCommunityConfigs = ::testing::Types<
+    LocalCommunityConfig<false, false, false>, LocalCommunityConfig<true, false, false>,
+    LocalCommunityConfig<true, true, false>, LocalCommunityConfig<false, false, true>,
+    LocalCommunityConfig<true, false, true>, LocalCommunityConfig<true, true, true>>;
+
+TYPED_TEST_SUITE(LocalCommunityGTest, LocalCommunityConfigs);
+
+TYPED_TEST(LocalCommunityGTest, testConstructorRejectsDirectedGraphs) {
+    Graph G(2, false, true);
+
+    EXPECT_THROW(
+        { [[maybe_unused]] typename TypeParam::Community community(G); }, std::runtime_error);
+}
+
+TYPED_TEST(LocalCommunityGTest, testAddNodeMaintainsCommunityShellAndCut) {
+    Graph G = weightedGraph();
+    typename TypeParam::Community community(G);
+
+    community.addNode(1);
+
+    EXPECT_TRUE(community.contains(1));
+    EXPECT_EQ(community.toSet(), std::set<node>({1}));
+    EXPECT_EQ(community.internalEdgeWeight(), 0.0);
+    EXPECT_EQ(community.cut(), 10.0);
+    EXPECT_THAT(collectShell(community, [](const auto &info) { return *info.intDeg; }),
+                UnorderedElementsAre(Pair(0, 2.0), Pair(2, 3.0), Pair(3, 5.0)));
+
+    if constexpr (TypeParam::shellMaintainsExtDeg) {
+        EXPECT_THAT(
+            collectShell(community,
+                         [](const auto &info) { return DegSnapshot{*info.intDeg, *info.extDeg}; }),
+            UnorderedElementsAre(Pair(0, DegSnapshot{2.0, 13.0}), Pair(2, DegSnapshot{3.0, 7.0}),
+                                 Pair(3, DegSnapshot{5.0, 18.0})));
+    }
+
+    if constexpr (TypeParam::maintainBoundary) {
+        EXPECT_EQ(community.boundarySize(), 1u);
+    }
+
+    community.addNode(2);
+    community.addNode(3);
+
+    EXPECT_EQ(community.toSet(), std::set<node>({1, 2, 3}));
+    EXPECT_EQ(community.internalEdgeWeight(), 15.0);
+    EXPECT_EQ(community.cut(), 13.0);
+    EXPECT_THAT(collectShell(community, [](const auto &info) { return *info.intDeg; }),
+                UnorderedElementsAre(Pair(0, 2.0), Pair(4, 11.0)));
+
+    if constexpr (TypeParam::shellMaintainsExtDeg) {
+        EXPECT_THAT(
+            collectShell(community,
+                         [](const auto &info) { return DegSnapshot{*info.intDeg, *info.extDeg}; }),
+            UnorderedElementsAre(Pair(0, DegSnapshot{2.0, 13.0}), Pair(4, DegSnapshot{11.0, 0.0})));
+    }
+
+    if constexpr (TypeParam::maintainBoundary) {
+        EXPECT_EQ(community.boundarySize(), 2u);
+        EXPECT_THAT(collectShell(community, [](const auto &info) { return info.boundaryChange(); }),
+                    UnorderedElementsAre(Pair(0, 0), Pair(4, -1)));
+    }
+}
+
+template <typename Config>
+class RemovableLocalCommunityGTest : public ::testing::Test {};
+
+using RemovableLocalCommunityConfigs = ::testing::Types<LocalCommunityConfig<false, false, true>,
+                                                        LocalCommunityConfig<true, false, true>,
+                                                        LocalCommunityConfig<true, true, true>>;
+
+TYPED_TEST_SUITE(RemovableLocalCommunityGTest, RemovableLocalCommunityConfigs);
+
+TYPED_TEST(RemovableLocalCommunityGTest, testRemoveNodeMaintainsCommunityShellAndCut) {
+    Graph G = weightedGraph();
+    typename TypeParam::Community community(G);
+
+    community.addNode(1);
+    community.addNode(2);
+    community.addNode(3);
+    community.removeNode(3);
+
+    EXPECT_EQ(community.toSet(), std::set<node>({1, 2}));
+    EXPECT_TRUE(!community.contains(3));
+    EXPECT_EQ(community.internalEdgeWeight(), 3.0);
+    EXPECT_EQ(community.cut(), 14.0);
+    EXPECT_THAT(collectShell(community, [](const auto &info) { return *info.intDeg; }),
+                UnorderedElementsAre(Pair(0, 2.0), Pair(3, 12.0)));
+
+    if constexpr (TypeParam::shellMaintainsExtDeg) {
+        EXPECT_THAT(
+            collectShell(community,
+                         [](const auto &info) { return DegSnapshot{*info.intDeg, *info.extDeg}; }),
+            UnorderedElementsAre(Pair(0, DegSnapshot{2.0, 13.0}),
+                                 Pair(3, DegSnapshot{12.0, 11.0})));
+    }
+
+    if constexpr (TypeParam::maintainBoundary) {
+        EXPECT_EQ(community.boundarySize(), 2u);
+    }
+}
+
+TYPED_TEST(RemovableLocalCommunityGTest, testCommunityNodeInfoSupportsRemovalScoring) {
+    Graph G = weightedGraph();
+    typename TypeParam::Community community(G);
+
+    community.addNode(1);
+    community.addNode(2);
+    community.addNode(3);
+
+    EXPECT_THAT(collectCommunity(community, [](const auto &info) { return *info.intDeg; }),
+                UnorderedElementsAre(Pair(1, 8.0), Pair(2, 10.0), Pair(3, 12.0)));
+
+    if constexpr (TypeParam::shellMaintainsExtDeg) {
+        EXPECT_THAT(collectCommunity(
+                        community,
+                        [](const auto &info) { return DegSnapshot{*info.intDeg, *info.extDeg}; }),
+                    UnorderedElementsAre(Pair(1, DegSnapshot{8.0, 2.0}),
+                                         Pair(2, DegSnapshot{10.0, 0.0}),
+                                         Pair(3, DegSnapshot{12.0, 11.0})));
+    }
+
+    if constexpr (TypeParam::maintainBoundary) {
+        EXPECT_THAT(
+            collectCommunity(community, [](const auto &info) { return info.boundaryChange(); }),
+            UnorderedElementsAre(Pair(1, 0), Pair(2, 0), Pair(3, 0)));
+    }
+}
+
+} // namespace
+} // namespace NetworKit

--- a/networkit/cpp/structures/test/LocalCommunityGTest.cpp
+++ b/networkit/cpp/structures/test/LocalCommunityGTest.cpp
@@ -70,7 +70,7 @@ using LocalCommunityConfigs = ::testing::Types<
     LocalCommunityConfig<true, true, false>, LocalCommunityConfig<false, false, true>,
     LocalCommunityConfig<true, false, true>, LocalCommunityConfig<true, true, true>>;
 
-TYPED_TEST_SUITE(LocalCommunityGTest, LocalCommunityConfigs);
+TYPED_TEST_SUITE(LocalCommunityGTest, LocalCommunityConfigs, /*Comma needed for variadic macro.*/);
 
 TYPED_TEST(LocalCommunityGTest, testConstructorRejectsDirectedGraphs) {
     Graph G(2, false, true);
@@ -134,7 +134,8 @@ using RemovableLocalCommunityConfigs = ::testing::Types<LocalCommunityConfig<fal
                                                         LocalCommunityConfig<true, false, true>,
                                                         LocalCommunityConfig<true, true, true>>;
 
-TYPED_TEST_SUITE(RemovableLocalCommunityGTest, RemovableLocalCommunityConfigs);
+TYPED_TEST_SUITE(RemovableLocalCommunityGTest, RemovableLocalCommunityConfigs,
+                 /*Comma needed for variadic macro.*/);
 
 TYPED_TEST(RemovableLocalCommunityGTest, testRemoveNodeMaintainsCommunityShellAndCut) {
     Graph G = weightedGraph();

--- a/networkit/cpp/structures/test/LocalCommunityGTest.cpp
+++ b/networkit/cpp/structures/test/LocalCommunityGTest.cpp
@@ -12,6 +12,7 @@
 namespace NetworKit {
 namespace {
 
+using ::testing::ElementsAre;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 
@@ -51,6 +52,17 @@ auto collectCommunity(LocalCommunity &community, F getValue) {
     return result;
 }
 
+//        (5)
+//         |  13
+//        (0)
+//         |  2
+//        (1)------ 3 ------(2)
+//         |                 |
+//         5                 7
+//         |                 |
+//         +------(3)--------+
+//                 |  11
+//                (4)
 Graph weightedGraph() {
     Graph G(6, true, false);
     G.addEdge(0, 1, 2.0);
@@ -80,13 +92,13 @@ TYPED_TEST(LocalCommunityGTest, testConstructorRejectsDirectedGraphs) {
 }
 
 TYPED_TEST(LocalCommunityGTest, testAddNodeMaintainsCommunityShellAndCut) {
-    Graph G = weightedGraph();
+    const Graph G = weightedGraph();
     typename TypeParam::Community community(G);
 
     community.addNode(1);
 
     EXPECT_TRUE(community.contains(1));
-    EXPECT_EQ(community.toSet(), std::set<node>({1}));
+    EXPECT_THAT(community.toSet(), ElementsAre(1));
     EXPECT_EQ(community.internalEdgeWeight(), 0.0);
     EXPECT_EQ(community.cut(), 10.0);
     EXPECT_THAT(collectShell(community, [](const auto &info) { return *info.intDeg; }),
@@ -107,7 +119,7 @@ TYPED_TEST(LocalCommunityGTest, testAddNodeMaintainsCommunityShellAndCut) {
     community.addNode(2);
     community.addNode(3);
 
-    EXPECT_EQ(community.toSet(), std::set<node>({1, 2, 3}));
+    EXPECT_THAT(community.toSet(), ElementsAre(1, 2, 3));
     EXPECT_EQ(community.internalEdgeWeight(), 15.0);
     EXPECT_EQ(community.cut(), 13.0);
     EXPECT_THAT(collectShell(community, [](const auto &info) { return *info.intDeg; }),
@@ -138,7 +150,7 @@ TYPED_TEST_SUITE(RemovableLocalCommunityGTest, RemovableLocalCommunityConfigs,
                  /*Comma needed for variadic macro.*/);
 
 TYPED_TEST(RemovableLocalCommunityGTest, testRemoveNodeMaintainsCommunityShellAndCut) {
-    Graph G = weightedGraph();
+    const Graph G = weightedGraph();
     typename TypeParam::Community community(G);
 
     community.addNode(1);
@@ -146,7 +158,7 @@ TYPED_TEST(RemovableLocalCommunityGTest, testRemoveNodeMaintainsCommunityShellAn
     community.addNode(3);
     community.removeNode(3);
 
-    EXPECT_EQ(community.toSet(), std::set<node>({1, 2}));
+    EXPECT_THAT(community.toSet(), ElementsAre(1, 2));
     EXPECT_TRUE(!community.contains(3));
     EXPECT_EQ(community.internalEdgeWeight(), 3.0);
     EXPECT_EQ(community.cut(), 14.0);
@@ -169,7 +181,7 @@ TYPED_TEST(RemovableLocalCommunityGTest, testRemoveNodeMaintainsCommunityShellAn
 }
 
 TYPED_TEST(RemovableLocalCommunityGTest, testCommunityNodeInfoSupportsRemovalScoring) {
-    Graph G = weightedGraph();
+    const Graph G = weightedGraph();
     typename TypeParam::Community community(G);
 
     community.addNode(1);

--- a/networkit/cpp/structures/test/LocalCommunityGTest.cpp
+++ b/networkit/cpp/structures/test/LocalCommunityGTest.cpp
@@ -163,6 +163,8 @@ TYPED_TEST(RemovableLocalCommunityGTest, testRemoveNodeMaintainsCommunityShellAn
 
     if constexpr (TypeParam::maintainBoundary) {
         EXPECT_EQ(community.boundarySize(), 2u);
+        EXPECT_THAT(collectShell(community, [](const auto &info) { return info.boundaryChange(); }),
+                    UnorderedElementsAre(Pair(0, 1), Pair(3, 0)));
     }
 }
 


### PR DESCRIPTION
This PR adds unit tests for the class template `LocalCommunity`.
The new tests cover the explicit template instantiations, including add/remove behavior, shell bookkeeping, cut/internal weight updates and boundary tracking.

While adding the tests, this also fixes a boundary bookkeeping bug. 

Fixes #1453