### PR TITLE
Fix issue #1458

### DIFF
--- a/include/networkit/algebraic/Vector.hpp
+++ b/include/networkit/algebraic/Vector.hpp
@@ -42,7 +42,7 @@ public:
      * @param transpose Indicates whether this vector is transposed (row vector) or not (column
      * vector).
      */
-    Vector(count dimension, double initialValue = 0, bool transpose = false);
+    explicit Vector(count dimension, double initialValue = 0, bool transpose = false);
 
     /**
      * Constructs the Vector with the contents of @a values.

--- a/include/networkit/numerics/LAMG/SolverLamg.hpp
+++ b/include/networkit/numerics/LAMG/SolverLamg.hpp
@@ -109,7 +109,7 @@ void SolverLamg<Matrix>::solve(Vector &x, const Vector &b, LAMGSolverStatus &sta
         if (hierarchy.getType(1) == ELIMINATION) {
             hierarchy.at(1).restrict(b, bc, bStages[1]);
             if (hierarchy.at(1).getLaplacian().numberOfRows() == 1) {
-                x = 0.0;
+                x.fill(0.0);
                 return;
             } else {
                 hierarchy.at(1).coarseType(x, xc);

--- a/networkit/cpp/numerics/test/SolverLamgGTest.cpp
+++ b/networkit/cpp/numerics/test/SolverLamgGTest.cpp
@@ -102,7 +102,9 @@ TEST_F(SolverLamgGTest, testSolveWithSingletonEliminationLevelSetsZeroResult) {
 
     solver.solve(x, b, status);
 
-    EXPECT_THAT(my_vector, AllOf(SizeIs(2), Each(DoubleEq(0.0))));
+    EXPECT_EQ(x.getDimension(), 2);
+    EXPECT_DOUBLE_EQ(x[0], 0.0);
+    EXPECT_DOUBLE_EQ(x[1], 0.0);
 }
 
 Vector SolverLamgGTest::randVector(count dimension) const {

--- a/networkit/cpp/numerics/test/SolverLamgGTest.cpp
+++ b/networkit/cpp/numerics/test/SolverLamgGTest.cpp
@@ -102,9 +102,7 @@ TEST_F(SolverLamgGTest, testSolveWithSingletonEliminationLevelSetsZeroResult) {
 
     solver.solve(x, b, status);
 
-    EXPECT_EQ(x.getDimension(), 2);
-    EXPECT_DOUBLE_EQ(x[0], 0.0);
-    EXPECT_DOUBLE_EQ(x[1], 0.0);
+    EXPECT_THAT(my_vector, AllOf(SizeIs(2), Each(DoubleEq(0.0))));
 }
 
 Vector SolverLamgGTest::randVector(count dimension) const {

--- a/networkit/cpp/numerics/test/SolverLamgGTest.cpp
+++ b/networkit/cpp/numerics/test/SolverLamgGTest.cpp
@@ -17,6 +17,7 @@
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/io/METISGraphWriter.hpp>
 #include <networkit/numerics/GaussSeidelRelaxation.hpp>
+#include <networkit/numerics/LAMG/Level/EliminationStage.hpp>
 #include <networkit/numerics/LAMG/Lamg.hpp>
 #include <networkit/numerics/LAMG/MultiLevelSetup.hpp>
 #include <networkit/numerics/LAMG/SolverLamg.hpp>
@@ -78,6 +79,33 @@ TEST_F(SolverLamgGTest, testSmallGraphs) {
         DEBUG("numIters = ", status.numIters);
         DEBUG("DONE");
     }
+}
+
+TEST_F(SolverLamgGTest, testSolveWithSingletonEliminationLevelSetsZeroResult) {
+    const CSRMatrix finestLaplacian(
+        2, 2, std::vector<Triplet>{{0, 0, 1.0}, {0, 1, -1.0}, {1, 0, -1.0}, {1, 1, 1.0}});
+    const CSRMatrix coarseLaplacian(1, 1, std::vector<Triplet>{{0, 0, 0.0}});
+    const CSRMatrix interpolation(1, 1, std::vector<Triplet>{{0, 0, 1.0}});
+    const Vector q(1, 0.0);
+
+    LevelHierarchy<CSRMatrix> hierarchy;
+    hierarchy.addFinestLevel(finestLaplacian);
+    hierarchy.addEliminationLevel(
+        coarseLaplacian,
+        {EliminationStage<CSRMatrix>(interpolation, q, std::vector<index>{0},
+                                     std::vector<index>{1})});
+
+    GaussSeidelRelaxation<CSRMatrix> smoother;
+    SolverLamg<CSRMatrix> solver(hierarchy, smoother);
+    Vector x(2, 1.0);
+    const Vector b(2, 0.0);
+    LAMGSolverStatus status;
+
+    solver.solve(x, b, status);
+
+    EXPECT_EQ(x.getDimension(), 2);
+    EXPECT_DOUBLE_EQ(x[0], 0.0);
+    EXPECT_DOUBLE_EQ(x[1], 0.0);
 }
 
 Vector SolverLamgGTest::randVector(count dimension) const {

--- a/networkit/cpp/numerics/test/SolverLamgGTest.cpp
+++ b/networkit/cpp/numerics/test/SolverLamgGTest.cpp
@@ -17,8 +17,8 @@
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/io/METISGraphWriter.hpp>
 #include <networkit/numerics/GaussSeidelRelaxation.hpp>
-#include <networkit/numerics/LAMG/Level/EliminationStage.hpp>
 #include <networkit/numerics/LAMG/Lamg.hpp>
+#include <networkit/numerics/LAMG/Level/EliminationStage.hpp>
 #include <networkit/numerics/LAMG/MultiLevelSetup.hpp>
 #include <networkit/numerics/LAMG/SolverLamg.hpp>
 #include <networkit/structures/Partition.hpp>
@@ -91,9 +91,8 @@ TEST_F(SolverLamgGTest, testSolveWithSingletonEliminationLevelSetsZeroResult) {
     LevelHierarchy<CSRMatrix> hierarchy;
     hierarchy.addFinestLevel(finestLaplacian);
     hierarchy.addEliminationLevel(
-        coarseLaplacian,
-        {EliminationStage<CSRMatrix>(interpolation, q, std::vector<index>{0},
-                                     std::vector<index>{1})});
+        coarseLaplacian, {EliminationStage<CSRMatrix>(interpolation, q, std::vector<index>{0},
+                                                      std::vector<index>{1})});
 
     GaussSeidelRelaxation<CSRMatrix> smoother;
     SolverLamg<CSRMatrix> solver(hierarchy, smoother);


### PR DESCRIPTION
This PR fixes the bug by:
- Replacing an unintended `Vector` assignment from `0.0` with `fill(0.0)`.
- The old assignment was only accepted because `Vector` had a non-explicit size constructor, so that constructor is now explicit. 

A regression test was added for this case.

Fixes:  #1458

