### PR TITLE
Fix #1460: Ensure all Lamg setup functions work for disconnected graphs

### DIFF
--- a/include/networkit/numerics/LAMG/Lamg.hpp
+++ b/include/networkit/numerics/LAMG/Lamg.hpp
@@ -302,12 +302,18 @@ void Lamg<Matrix>::initializeMultipleComponents(const Graph &G,
         // construct new objects
         compHierarchies[compIdx] = LevelHierarchy<Matrix>();
 
-        // construct block matrix via neighborsOf in G
+        // Construct the component's Laplacian block
         std::vector<Triplet> triplets;
         for (node u : component) {
+            double weightedDegree = 0.0;
             G.forNeighborsOf(u, [&](node v, edgeweight w) {
-                triplets.push_back({graph2Components[u], graph2Components[v], w});
+                if (u != v) {
+                    weightedDegree += w;
+                    triplets.push_back({graph2Components[u], graph2Components[v], -w});
+                }
             });
+            if (weightedDegree != 0.0)
+                triplets.push_back({graph2Components[u], graph2Components[u], weightedDegree});
         }
         Matrix compMatrix(component.size(), component.size(), triplets);
         lamgSetup.setup(compMatrix, compHierarchies[compIdx]);
@@ -362,7 +368,7 @@ void Lamg<Matrix>::setup(const Matrix &laplacianMatrix, const Graph &G) {
 
 template <class Matrix>
 void Lamg<Matrix>::setup(const Matrix &laplacianMatrix) {
-    Graph G = MatrixTools::matrixToGraph(laplacianMatrix);
+    Graph G = MatrixTools::laplacianToGraph(laplacianMatrix);
     setup(laplacianMatrix, G);
 }
 

--- a/networkit/cpp/numerics/test/LAMGGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGGTest.cpp
@@ -44,6 +44,8 @@ inline bool vector_almost_equal(const Vector &lhs, const Vector &rhs) {
     if (lhs.getDimension() != rhs.getDimension())
         return false;
     for (size_t i = 0; i < lhs.getDimension(); ++i) {
+        if (std::isnan(lhs[i]) || std::isnan(rhs[i]))
+            return false;
         if (std::abs(lhs[i] - rhs[i]) > 1e-4)
             return false;
     }


### PR DESCRIPTION
Fixes #1460, details in issue