### PR TITLE
Template `LeftRightPlanarityCheck`

### DIFF
--- a/include/networkit/planarity/LeftRightPlanarityCheck.hpp
+++ b/include/networkit/planarity/LeftRightPlanarityCheck.hpp
@@ -17,9 +17,13 @@
 
 namespace NetworKit {
 
-class LeftRightPlanarityCheck final : public Algorithm {
+template <typename GraphT>
+class GenericLeftRightPlanarityCheck final : public Algorithm {
 
 public:
+    using NodeT = typename GraphT::NodeT;
+    using EdgeWeightT = typename GraphT::EdgeWeightT;
+
     /**
      * Implements the left-right planarity test as described in
      * [citation](https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=7963e9feffe1c9362eb1a69010a5139d1da3661e).
@@ -33,7 +37,7 @@ public:
      * @param G The input graph to test for planarity. The graph should be undirected.
      * @throws std::runtime_error if graph is not an undirected graph
      */
-    LeftRightPlanarityCheck(const Graph &G);
+    GenericLeftRightPlanarityCheck(const GraphT &G);
 
     void run() override;
 
@@ -77,21 +81,21 @@ private:
 
     const ConflictPair NoneConflictPair{Interval{}, Interval{}};
 
-    const Graph *graph;
+    const GraphT *graph;
     bool isGraphPlanar{false};
 
-    void dfsOrientation(node startNode);
-    bool dfsTesting(node startNode);
+    void dfsOrientation(NodeT startNode);
+    bool dfsTesting(NodeT startNode);
 
     bool applyConstraints(edgeid edgeId, edgeid parentEdgeId);
-    void removeBackEdges(edgeid edgeId, node parentNode);
+    void removeBackEdges(edgeid edgeId, NodeT parentNode);
     void sortAdjacencyListByNestingDepth();
     bool conflicting(const Interval &interval, edgeid edgeId);
     count getLowestLowPoint(const ConflictPair &conflictPair);
 
     // DFS / lowpoint state
     std::vector<count> heights; // per node
-    std::vector<node> roots;    // roots of DFS forest
+    std::vector<NodeT> roots;   // roots of DFS forest
 
     std::vector<count> lowestPoint;
     std::vector<count> secondLowestPoint;
@@ -102,17 +106,21 @@ private:
 
     // Per-node parent edge + parent node in DFS tree
     std::vector<edgeid> parentEdgeIds; // parent edge for each node (noneEdgeId if root)
-    std::vector<node> parentNodes;     // parent node for each node (none if root)
+    std::vector<NodeT> parentNodes;    // parent node for each node (none if root)
 
     // For each *underlying* edge ID, remember the DFS orientation's head (v)
-    std::vector<node> edgeEndpoints; // edgeEndpoints[eid] = v in oriented DFS edge (u -> v)
+    std::vector<NodeT> edgeEndpoints; // edgeEndpoints[eid] = v in oriented DFS edge (u -> v)
 
     // Conflict stack
     std::stack<ConflictPair> stack;
     // DFS graph with tree/back orientation
-    Graph dfsGraph;
+    GraphT dfsGraph;
 };
 
+using LeftRightPlanarityCheck = GenericLeftRightPlanarityCheck<Graph>;
+
 } // namespace NetworKit
+
+#include <networkit/planarity/LeftRightPlanarityCheckImpl.hpp>
 
 #endif // NETWORKIT_PLANARITY_LEFT_RIGHT_PLANARITY_CHECK_HPP_

--- a/include/networkit/planarity/LeftRightPlanarityCheck.hpp
+++ b/include/networkit/planarity/LeftRightPlanarityCheck.hpp
@@ -49,16 +49,15 @@ public:
 private:
     count numberOfEdges;
     static constexpr count noneHeight{std::numeric_limits<count>::max()};
-    static constexpr edgeid noneEdgeId{std::numeric_limits<edgeid>::max()};
 
     struct Interval {
-        edgeid low{noneEdgeId};
-        edgeid high{noneEdgeId};
+        edgeid low{nullEdgeId};
+        edgeid high{nullEdgeId};
 
         Interval() = default;
         Interval(edgeid lowId, edgeid highId) : low(lowId), high(highId) {}
 
-        bool isEmpty() const { return low == noneEdgeId && high == noneEdgeId; }
+        bool isEmpty() const { return low == nullEdgeId && high == nullEdgeId; }
 
         friend bool operator==(const Interval &lhs, const Interval &rhs) {
             return lhs.low == rhs.low && lhs.high == rhs.high;
@@ -94,7 +93,7 @@ private:
     count getLowestLowPoint(const ConflictPair &conflictPair);
 
     // DFS / lowpoint state
-    std::vector<count> heights; // per node
+    std::vector<count> heights; // per vertex
     std::vector<NodeT> roots;   // roots of DFS forest
 
     std::vector<count> lowestPoint;
@@ -104,9 +103,9 @@ private:
     std::vector<count> nestingDepth;
     std::vector<ConflictPair> stackBottom;
 
-    // Per-node parent edge + parent node in DFS tree
-    std::vector<edgeid> parentEdgeIds; // parent edge for each node (noneEdgeId if root)
-    std::vector<NodeT> parentNodes;    // parent node for each node (none if root)
+    // Per-vertex parent edge + parent vertex in DFS tree
+    std::vector<edgeid> parentEdgeIds; // parent edge for each vertex (nullEdgeId if root)
+    std::vector<NodeT> parentNodes;    // parent vertex for each vertex (NullNodeId<NodeT> if root)
 
     // For each *underlying* edge ID, remember the DFS orientation's head (v)
     std::vector<NodeT> edgeEndpoints; // edgeEndpoints[eid] = v in oriented DFS edge (u -> v)

--- a/include/networkit/planarity/LeftRightPlanarityCheckImpl.hpp
+++ b/include/networkit/planarity/LeftRightPlanarityCheckImpl.hpp
@@ -26,9 +26,9 @@ GenericLeftRightPlanarityCheck<GraphT>::GenericLeftRightPlanarityCheck(const Gra
 
     numberOfEdges = graph->numberOfEdges();
     nestingDepth.resize(numberOfEdges, none);
-    lowestPointEdge.resize(numberOfEdges, noneEdgeId);
+    lowestPointEdge.resize(numberOfEdges, nullEdgeId);
     secondLowestPoint.resize(numberOfEdges, none);
-    ref.resize(numberOfEdges, noneEdgeId);
+    ref.resize(numberOfEdges, nullEdgeId);
     stackBottom.resize(numberOfEdges, {});
 
     lowestPoint.resize(numberOfEdges, none);
@@ -47,9 +47,9 @@ void GenericLeftRightPlanarityCheck<GraphT>::run() {
     }
 
     heights.assign(graph->upperNodeIdBound(), noneHeight);
-    parentEdgeIds.assign(graph->upperNodeIdBound(), noneEdgeId);
-    parentNodes.assign(graph->upperNodeIdBound(), none);
-    edgeEndpoints.assign(graph->upperEdgeIdBound(), none);
+    parentEdgeIds.assign(graph->upperNodeIdBound(), nullEdgeId);
+    parentNodes.assign(graph->upperNodeIdBound(), NullNodeId<NodeT>);
+    edgeEndpoints.assign(graph->upperEdgeIdBound(), NullNodeId<NodeT>);
 
     // DFS orientation
     graph->forNodes([&](NodeT currentNode) {
@@ -82,8 +82,7 @@ void GenericLeftRightPlanarityCheck<GraphT>::sortAdjacencyListByNestingDepth() {
 }
 
 template <typename GraphT>
-bool GenericLeftRightPlanarityCheck<GraphT>::conflicting(const Interval &interval,
-                                                        edgeid edgeId) {
+bool GenericLeftRightPlanarityCheck<GraphT>::conflicting(const Interval &interval, edgeid edgeId) {
     if (interval.isEmpty()) {
         return false;
     }
@@ -96,7 +95,7 @@ bool GenericLeftRightPlanarityCheck<GraphT>::conflicting(const Interval &interva
 
 template <typename GraphT>
 bool GenericLeftRightPlanarityCheck<GraphT>::applyConstraints(const edgeid edgeId,
-                                                             const edgeid parentEdgeId) {
+                                                              const edgeid parentEdgeId) {
     ConflictPair tmpConflictPair{};
 
     // First phase: pop until stackBottom[edgeId], merging intervals on the right side.
@@ -146,7 +145,7 @@ bool GenericLeftRightPlanarityCheck<GraphT>::applyConstraints(const edgeid edgeI
 
         ref[tmpConflictPair.right.low] = currentConflictPair.right.high;
 
-        if (currentConflictPair.right.low != noneEdgeId) {
+        if (currentConflictPair.right.low != nullEdgeId) {
             tmpConflictPair.right = currentConflictPair.right;
         }
 
@@ -166,8 +165,7 @@ bool GenericLeftRightPlanarityCheck<GraphT>::applyConstraints(const edgeid edgeI
 }
 
 template <typename GraphT>
-count GenericLeftRightPlanarityCheck<GraphT>::getLowestLowPoint(
-    const ConflictPair &conflictPair) {
+count GenericLeftRightPlanarityCheck<GraphT>::getLowestLowPoint(const ConflictPair &conflictPair) {
     if (conflictPair.left.isEmpty()) {
         return lowestPoint[conflictPair.right.low];
     }
@@ -179,7 +177,7 @@ count GenericLeftRightPlanarityCheck<GraphT>::getLowestLowPoint(
 
 template <typename GraphT>
 void GenericLeftRightPlanarityCheck<GraphT>::removeBackEdges(const edgeid edgeId,
-                                                            const NodeT parentNode) {
+                                                             const NodeT parentNode) {
     while (!stack.empty() && getLowestLowPoint(stack.top()) == heights[parentNode]) {
         stack.pop();
     }
@@ -189,25 +187,25 @@ void GenericLeftRightPlanarityCheck<GraphT>::removeBackEdges(const edgeid edgeId
         stack.pop();
 
         // Reduce left interval
-        while (conflictPair.left.high != noneEdgeId
+        while (conflictPair.left.high != nullEdgeId
                && edgeEndpoints[conflictPair.left.high] == parentNode) {
             auto tmpEdgeId = ref[conflictPair.left.high];
-            conflictPair.left.high = (tmpEdgeId != noneEdgeId) ? tmpEdgeId : noneEdgeId;
+            conflictPair.left.high = (tmpEdgeId != nullEdgeId) ? tmpEdgeId : nullEdgeId;
         }
-        if (conflictPair.left.high == noneEdgeId && conflictPair.left.low != noneEdgeId) {
+        if (conflictPair.left.high == nullEdgeId && conflictPair.left.low != nullEdgeId) {
             ref[conflictPair.left.low] = conflictPair.right.low;
-            conflictPair.left.low = noneEdgeId;
+            conflictPair.left.low = nullEdgeId;
         }
 
         // Reduce right interval
-        while (conflictPair.right.high != noneEdgeId
+        while (conflictPair.right.high != nullEdgeId
                && edgeEndpoints[conflictPair.right.high] == parentNode) {
             auto tmpEdgeId = ref[conflictPair.right.high];
-            conflictPair.right.high = (tmpEdgeId != noneEdgeId) ? tmpEdgeId : noneEdgeId;
+            conflictPair.right.high = (tmpEdgeId != nullEdgeId) ? tmpEdgeId : nullEdgeId;
         }
-        if (conflictPair.right.high == noneEdgeId && conflictPair.right.low != noneEdgeId) {
+        if (conflictPair.right.high == nullEdgeId && conflictPair.right.low != nullEdgeId) {
             ref[conflictPair.right.low] = conflictPair.left.low;
-            conflictPair.right.low = noneEdgeId;
+            conflictPair.right.low = nullEdgeId;
         }
 
         stack.push(conflictPair);
@@ -217,8 +215,8 @@ void GenericLeftRightPlanarityCheck<GraphT>::removeBackEdges(const edgeid edgeId
         const edgeid highestReturnEdgeLeft = stack.top().left.high;
         const edgeid highestReturnEdgeRight = stack.top().right.high;
 
-        if (highestReturnEdgeLeft != noneEdgeId
-            && (highestReturnEdgeRight == noneEdgeId
+        if (highestReturnEdgeLeft != nullEdgeId
+            && (highestReturnEdgeRight == nullEdgeId
                 || lowestPoint[highestReturnEdgeLeft] > lowestPoint[highestReturnEdgeRight])) {
             ref[edgeId] = highestReturnEdgeLeft;
         } else {
@@ -232,11 +230,11 @@ bool GenericLeftRightPlanarityCheck<GraphT>::dfsTesting(NodeT startNode) {
     std::stack<NodeT> dfsStack;
     dfsStack.push(startNode);
 
-    // Per-node neighbor iterators in DFS graph
+    // Per-vertex neighbor iterators in DFS graph
     using NeighborIterator = decltype(dfsGraph.neighborRange(static_cast<NodeT>(0)).begin());
     std::vector<NeighborIterator> neighborIterators(dfsGraph.upperNodeIdBound());
     std::vector<bool> neighborInitialized(dfsGraph.upperNodeIdBound(), false);
-    std::vector<edgeid> preprocessedEdges(numberOfEdges, noneEdgeId);
+    std::vector<edgeid> preprocessedEdges(numberOfEdges, nullEdgeId);
 
     auto processNeighborEdges = [&](NodeT currentNode, bool &callRemoveBackEdges) -> bool {
         auto range = dfsGraph.neighborRange(currentNode);
@@ -245,8 +243,8 @@ bool GenericLeftRightPlanarityCheck<GraphT>::dfsTesting(NodeT startNode) {
         while (neighborIterator != range.end()) {
             const NodeT neighbor = *neighborIterator;
             const edgeid currentEdgeId = graph->edgeId(currentNode, neighbor);
-            assert(currentEdgeId != noneEdgeId);
-            if (preprocessedEdges[currentEdgeId] == noneEdgeId) {
+            assert(currentEdgeId != nullEdgeId);
+            if (preprocessedEdges[currentEdgeId] == nullEdgeId) {
                 stackBottom[currentEdgeId] = stack.empty() ? NoneConflictPair : stack.top();
 
                 if (currentEdgeId == parentEdgeIds[neighbor]) {
@@ -296,7 +294,7 @@ bool GenericLeftRightPlanarityCheck<GraphT>::dfsTesting(NodeT startNode) {
             return false;
         }
 
-        if (callRemoveBackEdges && parentEid != noneEdgeId) {
+        if (callRemoveBackEdges && parentEid != nullEdgeId) {
             removeBackEdges(parentEid, parentNodes[currentNode]);
         }
 
@@ -310,7 +308,7 @@ void GenericLeftRightPlanarityCheck<GraphT>::dfsOrientation(NodeT startNode) {
     std::stack<NodeT> dfsStack;
     dfsStack.push(startNode);
 
-    std::vector<edgeid> preprocessedEdges(numberOfEdges, noneEdgeId);
+    std::vector<edgeid> preprocessedEdges(numberOfEdges, nullEdgeId);
     do {
         const NodeT currentNode = dfsStack.top();
         dfsStack.pop();
@@ -320,7 +318,7 @@ void GenericLeftRightPlanarityCheck<GraphT>::dfsOrientation(NodeT startNode) {
         for (NodeT neighbor : graph->neighborRange(currentNode)) {
             const edgeid edgeId = graph->edgeId(currentNode, neighbor);
 
-            if (preprocessedEdges[edgeId] == noneEdgeId) {
+            if (preprocessedEdges[edgeId] == nullEdgeId) {
                 if (dfsGraph.hasEdge(currentNode, neighbor)
                     || dfsGraph.hasEdge(neighbor, currentNode)) {
                     continue;
@@ -355,7 +353,7 @@ void GenericLeftRightPlanarityCheck<GraphT>::dfsOrientation(NodeT startNode) {
                 nestingDepth[edgeId] += 1;
             }
 
-            if (parentEdgeId != noneEdgeId) {
+            if (parentEdgeId != nullEdgeId) {
                 if (lowestPoint[edgeId] < lowestPoint[parentEdgeId]) {
                     secondLowestPoint[parentEdgeId] =
                         std::min(lowestPoint[parentEdgeId], secondLowestPoint[edgeId]);

--- a/include/networkit/planarity/LeftRightPlanarityCheckImpl.hpp
+++ b/include/networkit/planarity/LeftRightPlanarityCheckImpl.hpp
@@ -1,18 +1,22 @@
-/*  LeftRightPlanarityCheck.cpp
+/*  LeftRightPlanarityCheckImpl.hpp
  *
  *  Created on: 03.01.2025
  *  Authors: Andreas Scharf (andreas.b.scharf@gmail.com)
  *
  */
 
-#include "networkit/planarity/LeftRightPlanarityCheck.hpp"
+#ifndef NETWORKIT_PLANARITY_LEFT_RIGHT_PLANARITY_CHECK_IMPL_HPP_
+#define NETWORKIT_PLANARITY_LEFT_RIGHT_PLANARITY_CHECK_IMPL_HPP_
 
 #include <algorithm>
-#include <stack>
+#include <ranges>
+#include <stdexcept>
 
 namespace NetworKit {
 
-LeftRightPlanarityCheck::LeftRightPlanarityCheck(const Graph &G) : graph(&G) {
+template <typename GraphT>
+GenericLeftRightPlanarityCheck<GraphT>::GenericLeftRightPlanarityCheck(const GraphT &G)
+    : graph(&G) {
     if (G.isDirected()) {
         throw std::runtime_error("The graph is not an undirected graph.");
     }
@@ -30,10 +34,11 @@ LeftRightPlanarityCheck::LeftRightPlanarityCheck(const Graph &G) : graph(&G) {
     lowestPoint.resize(numberOfEdges, none);
 
     // dfsGraph: directed view of DFS tree + back edges
-    dfsGraph = Graph(graph->numberOfNodes(), false, true, false);
+    dfsGraph = GraphT(graph->numberOfNodes(), false, true, false);
 }
 
-void LeftRightPlanarityCheck::run() {
+template <typename GraphT>
+void GenericLeftRightPlanarityCheck<GraphT>::run() {
     // Euler-criterion: non-planar if m > 3n - 6 for n > 2
     if (graph->numberOfNodes() > 2 && graph->numberOfEdges() > 3 * graph->numberOfNodes() - 6) {
         hasRun = true;
@@ -47,7 +52,7 @@ void LeftRightPlanarityCheck::run() {
     edgeEndpoints.assign(graph->upperEdgeIdBound(), none);
 
     // DFS orientation
-    graph->forNodes([&](node currentNode) {
+    graph->forNodes([&](NodeT currentNode) {
         if (heights[currentNode] == noneHeight) {
             heights[currentNode] = 0;
             roots.push_back(currentNode);
@@ -60,14 +65,15 @@ void LeftRightPlanarityCheck::run() {
 
     // Planarity testing DFS
     isGraphPlanar =
-        std::ranges::all_of(roots, [this](node rootNode) { return dfsTesting(rootNode); });
+        std::ranges::all_of(roots, [this](NodeT rootNode) { return dfsTesting(rootNode); });
 
     hasRun = true;
 }
 
-void LeftRightPlanarityCheck::sortAdjacencyListByNestingDepth() {
-    dfsGraph.forNodes([&](node currentNode) {
-        dfsGraph.sortNeighbors(currentNode, [&](node neighbor1, node neighbor2) {
+template <typename GraphT>
+void GenericLeftRightPlanarityCheck<GraphT>::sortAdjacencyListByNestingDepth() {
+    dfsGraph.forNodes([&](NodeT currentNode) {
+        dfsGraph.sortNeighbors(currentNode, [&](NodeT neighbor1, NodeT neighbor2) {
             const edgeid e1 = graph->edgeId(currentNode, neighbor1);
             const edgeid e2 = graph->edgeId(currentNode, neighbor2);
             return nestingDepth[e1] < nestingDepth[e2];
@@ -75,7 +81,9 @@ void LeftRightPlanarityCheck::sortAdjacencyListByNestingDepth() {
     });
 }
 
-bool LeftRightPlanarityCheck::conflicting(const Interval &interval, edgeid edgeId) {
+template <typename GraphT>
+bool GenericLeftRightPlanarityCheck<GraphT>::conflicting(const Interval &interval,
+                                                        edgeid edgeId) {
     if (interval.isEmpty()) {
         return false;
     }
@@ -86,7 +94,9 @@ bool LeftRightPlanarityCheck::conflicting(const Interval &interval, edgeid edgeI
            && iteratorHigh > iteratorEdge;
 }
 
-bool LeftRightPlanarityCheck::applyConstraints(const edgeid edgeId, const edgeid parentEdgeId) {
+template <typename GraphT>
+bool GenericLeftRightPlanarityCheck<GraphT>::applyConstraints(const edgeid edgeId,
+                                                             const edgeid parentEdgeId) {
     ConflictPair tmpConflictPair{};
 
     // First phase: pop until stackBottom[edgeId], merging intervals on the right side.
@@ -103,7 +113,6 @@ bool LeftRightPlanarityCheck::applyConstraints(const edgeid edgeId, const edgeid
 
         auto rightLowIterator = lowestPoint[currentConflictPair.right.low];
         auto parentEdgeIterator = lowestPoint[parentEdgeId];
-        ;
 
         if (rightLowIterator != none && parentEdgeIterator != none
             && rightLowIterator > parentEdgeIterator) {
@@ -156,7 +165,9 @@ bool LeftRightPlanarityCheck::applyConstraints(const edgeid edgeId, const edgeid
     return true;
 }
 
-count LeftRightPlanarityCheck::getLowestLowPoint(const ConflictPair &conflictPair) {
+template <typename GraphT>
+count GenericLeftRightPlanarityCheck<GraphT>::getLowestLowPoint(
+    const ConflictPair &conflictPair) {
     if (conflictPair.left.isEmpty()) {
         return lowestPoint[conflictPair.right.low];
     }
@@ -166,7 +177,9 @@ count LeftRightPlanarityCheck::getLowestLowPoint(const ConflictPair &conflictPai
     return std::min(lowestPoint[conflictPair.right.low], lowestPoint[conflictPair.left.low]);
 }
 
-void LeftRightPlanarityCheck::removeBackEdges(const edgeid edgeId, const node parentNode) {
+template <typename GraphT>
+void GenericLeftRightPlanarityCheck<GraphT>::removeBackEdges(const edgeid edgeId,
+                                                            const NodeT parentNode) {
     while (!stack.empty() && getLowestLowPoint(stack.top()) == heights[parentNode]) {
         stack.pop();
     }
@@ -214,22 +227,23 @@ void LeftRightPlanarityCheck::removeBackEdges(const edgeid edgeId, const node pa
     }
 }
 
-bool LeftRightPlanarityCheck::dfsTesting(node startNode) {
-    std::stack<node> dfsStack;
+template <typename GraphT>
+bool GenericLeftRightPlanarityCheck<GraphT>::dfsTesting(NodeT startNode) {
+    std::stack<NodeT> dfsStack;
     dfsStack.push(startNode);
 
     // Per-node neighbor iterators in DFS graph
-    using NeighborIterator = decltype(dfsGraph.neighborRange(static_cast<node>(0)).begin());
+    using NeighborIterator = decltype(dfsGraph.neighborRange(static_cast<NodeT>(0)).begin());
     std::vector<NeighborIterator> neighborIterators(dfsGraph.upperNodeIdBound());
     std::vector<bool> neighborInitialized(dfsGraph.upperNodeIdBound(), false);
     std::vector<edgeid> preprocessedEdges(numberOfEdges, noneEdgeId);
 
-    auto processNeighborEdges = [&](node currentNode, bool &callRemoveBackEdges) -> bool {
+    auto processNeighborEdges = [&](NodeT currentNode, bool &callRemoveBackEdges) -> bool {
         auto range = dfsGraph.neighborRange(currentNode);
 
         auto &neighborIterator = neighborIterators[currentNode];
         while (neighborIterator != range.end()) {
-            const node neighbor = *neighborIterator;
+            const NodeT neighbor = *neighborIterator;
             const edgeid currentEdgeId = graph->edgeId(currentNode, neighbor);
             assert(currentEdgeId != noneEdgeId);
             if (preprocessedEdges[currentEdgeId] == noneEdgeId) {
@@ -267,7 +281,7 @@ bool LeftRightPlanarityCheck::dfsTesting(node startNode) {
 
     // Main DFS loop
     do {
-        const node currentNode = dfsStack.top();
+        const NodeT currentNode = dfsStack.top();
         dfsStack.pop();
 
         const edgeid parentEid = parentEdgeIds[currentNode];
@@ -291,18 +305,19 @@ bool LeftRightPlanarityCheck::dfsTesting(node startNode) {
     return true;
 }
 
-void LeftRightPlanarityCheck::dfsOrientation(node startNode) {
-    std::stack<node> dfsStack;
+template <typename GraphT>
+void GenericLeftRightPlanarityCheck<GraphT>::dfsOrientation(NodeT startNode) {
+    std::stack<NodeT> dfsStack;
     dfsStack.push(startNode);
 
     std::vector<edgeid> preprocessedEdges(numberOfEdges, noneEdgeId);
     do {
-        const node currentNode = dfsStack.top();
+        const NodeT currentNode = dfsStack.top();
         dfsStack.pop();
 
         const edgeid parentEdgeId = parentEdgeIds[currentNode];
 
-        for (node neighbor : graph->neighborRange(currentNode)) {
+        for (NodeT neighbor : graph->neighborRange(currentNode)) {
             const edgeid edgeId = graph->edgeId(currentNode, neighbor);
 
             if (preprocessedEdges[edgeId] == noneEdgeId) {
@@ -358,3 +373,5 @@ void LeftRightPlanarityCheck::dfsOrientation(node startNode) {
 }
 
 } // namespace NetworKit
+
+#endif // NETWORKIT_PLANARITY_LEFT_RIGHT_PLANARITY_CHECK_IMPL_HPP_

--- a/networkit/cpp/planarity/CMakeLists.txt
+++ b/networkit/cpp/planarity/CMakeLists.txt
@@ -1,4 +1,4 @@
-networkit_add_module(planarity LeftRightPlanarityCheck.cpp)
+networkit_add_module(planarity)
 
 networkit_module_link_modules(planarity graph)
 

--- a/networkit/cpp/planarity/test/LeftRightPlanarityCheckGTest.cpp
+++ b/networkit/cpp/planarity/test/LeftRightPlanarityCheckGTest.cpp
@@ -4,7 +4,6 @@
  *  Created on: 05.01.2025
  *      Author: Andreas Scharf (andreas.b.scharf@gmail.com)
  */
-#include <cmath>
 #include <stdexcept>
 
 #include <gtest/gtest.h>
@@ -33,120 +32,115 @@ public:
 
     static constexpr int maxNumberOfNodes{10};
 
-    GraphType graphWithNodes(count numNodes) {
+    GraphType graphWithNodes(NodeT numNodes) {
         return GraphType(numNodes, TestT::weighted, false, true);
     }
 
-    GraphType pathGraph(count numNodes) {
+    GraphType pathGraph(NodeT numNodes) {
         GraphType graph = graphWithNodes(numNodes);
-        for (count i = 0; i < numNodes - 1; ++i) {
-            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(i + 1));
+        for (NodeT i = 0; i < numNodes - 1; ++i) {
+            graph.addEdge(i, i + 1);
         }
         return graph;
     }
 
-    GraphType cycleGraph(count numNodes) {
+    GraphType cycleGraph(NodeT numNodes) {
         GraphType graph = graphWithNodes(numNodes);
-        for (count i = 0; i < numNodes - 1; ++i) {
-            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(i + 1));
-        }
-        if (numNodes > 2)
-            graph.addEdge(static_cast<NodeT>(numNodes - 2), NodeT{0});
-        return graph;
-    }
-
-    GraphType starGraph(count numNodes) {
-        GraphType graph = graphWithNodes(numNodes);
-        for (count i = 0; i < numNodes - 1; ++i) {
-            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(i + 1));
+        for (NodeT i = 0; i < numNodes - 1; ++i) {
+            graph.addEdge(i, i + 1);
         }
         if (numNodes > 2)
-            graph.addEdge(static_cast<NodeT>(numNodes - 2), NodeT{0});
+            graph.addEdge(numNodes - 2, NodeT{0});
         return graph;
     }
 
-    GraphType binaryTreeGraph(count numNodes) {
+    GraphType starGraph(NodeT numNodes) {
         GraphType graph = graphWithNodes(numNodes);
-        for (count i = 0; i < numNodes; ++i) {
-            count leftChild = 2 * i + 1;
-            count rightChild = 2 * i + 2;
+        for (NodeT i = 0; i < numNodes - 1; ++i) {
+            graph.addEdge(i, i + 1);
+        }
+        if (numNodes > 2)
+            graph.addEdge(numNodes - 2, NodeT{0});
+        return graph;
+    }
+
+    GraphType binaryTreeGraph(NodeT numNodes) {
+        GraphType graph = graphWithNodes(numNodes);
+        for (NodeT i = 0; i < numNodes; ++i) {
+            const NodeT leftChild = 2 * i + 1;
+            const NodeT rightChild = 2 * i + 2;
             if (leftChild < numNodes) {
-                graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(leftChild),
-                              static_cast<EdgeWeightT>(i));
+                graph.addEdge(i, leftChild, static_cast<EdgeWeightT>(i));
             }
             if (rightChild < numNodes) {
-                graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(rightChild),
-                              static_cast<EdgeWeightT>(i));
+                graph.addEdge(i, rightChild, static_cast<EdgeWeightT>(i));
             }
         }
         return graph;
     }
 
-    GraphType wheelGraph(count numNodes) {
+    GraphType wheelGraph(NodeT numNodes) {
         GraphType graph = graphWithNodes(numNodes);
         if (numNodes < 4) {
             throw std::invalid_argument("A wheel graph requires at least 4 nodes.");
         }
         // Form cycle
-        for (count i = 1; i < numNodes - 1; ++i) {
-            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(i + 1));
+        for (NodeT i = 1; i < numNodes - 1; ++i) {
+            graph.addEdge(i, i + 1);
         }
-        graph.addEdge(static_cast<NodeT>(numNodes - 1), NodeT{1}); // Close the cycle
+        graph.addEdge(numNodes - 1, NodeT{1}); // Close the cycle
 
         // Connect center to cycle
-        for (count i = 1; i < numNodes; ++i) {
-            graph.addEdge(NodeT{0}, static_cast<NodeT>(i));
+        for (NodeT i = 1; i < numNodes; ++i) {
+            graph.addEdge(NodeT{0}, i);
         }
         return graph;
     }
 
-    GraphType completeGraph(count numNodes) {
+    GraphType completeGraph(NodeT numNodes) {
         GraphType graph = graphWithNodes(numNodes);
 
-        for (count i = 0; i < numNodes; ++i) {
-            for (count j = i + 1; j < numNodes; ++j) {
-                graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(j),
-                              static_cast<EdgeWeightT>(j * (j + 1)));
+        for (NodeT i = 0; i < numNodes; ++i) {
+            for (NodeT j = i + 1; j < numNodes; ++j) {
+                graph.addEdge(i, j, static_cast<EdgeWeightT>(j * (j + 1)));
             }
         }
         return graph;
     }
 
-    GraphType gridGraph(count rows, count columns) {
+    GraphType gridGraph(NodeT rows, NodeT columns) {
         GraphType graph = graphWithNodes(rows * columns);
-        for (count row = 0; row < rows; ++row) {
-            for (count col = 0; col < columns; ++col) {
-                count currentNode = row * columns + col;
+        for (NodeT row = 0; row < rows; ++row) {
+            for (NodeT col = 0; col < columns; ++col) {
+                const NodeT currentNode = row * columns + col;
 
                 // Connect to the right neighbor
                 if (col + 1 < columns) {
-                    graph.addEdge(static_cast<NodeT>(currentNode),
-                                  static_cast<NodeT>(currentNode + 1));
+                    graph.addEdge(currentNode, currentNode + 1);
                 }
 
                 // Connect to the bottom neighbor
                 if (row + 1 < rows) {
-                    graph.addEdge(static_cast<NodeT>(currentNode),
-                                  static_cast<NodeT>(currentNode + columns));
+                    graph.addEdge(currentNode, currentNode + columns);
                 }
             }
         }
         return graph;
     }
 
-    GraphType petersenGraph(count n, count k) {
+    GraphType petersenGraph(NodeT n, NodeT k) {
         GraphType graph = graphWithNodes(2 * n);
 
-        for (count i = 0; i < n; ++i) {
-            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>((i + 1) % n));
+        for (NodeT i = 0; i < n; ++i) {
+            graph.addEdge(i, (i + 1) % n);
         }
 
-        for (count i = 0; i < n; ++i) {
-            graph.addEdge(static_cast<NodeT>(n + i), static_cast<NodeT>(n + (i + k) % n));
+        for (NodeT i = 0; i < n; ++i) {
+            graph.addEdge(n + i, n + (i + k) % n);
         }
 
-        for (count i = 0; i < n; ++i) {
-            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(n + i));
+        for (NodeT i = 0; i < n; ++i) {
+            graph.addEdge(i, n + i);
         }
         return graph;
     }
@@ -211,7 +205,9 @@ TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarSingleNode) {
 }
 
 TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarPathGraphs) {
-    for (count numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+    using NodeT = typename TestFixture::NodeT;
+
+    for (NodeT numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
         typename TestFixture::GraphType graph = this->pathGraph(numberOfNodes);
         typename TestFixture::PlanarityCheck test(graph);
         test.run();
@@ -220,7 +216,9 @@ TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarPathGraphs) {
 }
 
 TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarCycleGraphs) {
-    for (count numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+    using NodeT = typename TestFixture::NodeT;
+
+    for (NodeT numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
         typename TestFixture::GraphType graph = this->cycleGraph(numberOfNodes);
         typename TestFixture::PlanarityCheck test(graph);
         test.run();
@@ -229,7 +227,9 @@ TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarCycleGraphs) {
 }
 
 TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarStarGraphs) {
-    for (count numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+    using NodeT = typename TestFixture::NodeT;
+
+    for (NodeT numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
         typename TestFixture::GraphType graph = this->starGraph(numberOfNodes);
         typename TestFixture::PlanarityCheck test(graph);
         test.run();
@@ -238,7 +238,9 @@ TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarStarGraphs) {
 }
 
 TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarTreeGraphs) {
-    for (count numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+    using NodeT = typename TestFixture::NodeT;
+
+    for (NodeT numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
         typename TestFixture::GraphType graph = this->binaryTreeGraph(numberOfNodes);
         typename TestFixture::PlanarityCheck test(graph);
         test.run();
@@ -247,7 +249,9 @@ TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarTreeGraphs) {
 }
 
 TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarWheelGraphs) {
-    for (count numberOfNodes = 4; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+    using NodeT = typename TestFixture::NodeT;
+
+    for (NodeT numberOfNodes = 4; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
         typename TestFixture::GraphType graph = this->wheelGraph(numberOfNodes);
         typename TestFixture::PlanarityCheck test(graph);
         test.run();
@@ -256,8 +260,10 @@ TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarWheelGraphs) {
 }
 
 TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarCompleteGraphs) {
-    constexpr count maxNumberPlanar{5};
-    for (count numberOfNodes = 2; numberOfNodes < maxNumberPlanar; ++numberOfNodes) {
+    using NodeT = typename TestFixture::NodeT;
+
+    constexpr NodeT maxNumberPlanar{5};
+    for (NodeT numberOfNodes = 2; numberOfNodes < maxNumberPlanar; ++numberOfNodes) {
         typename TestFixture::GraphType graph = this->completeGraph(numberOfNodes);
         typename TestFixture::PlanarityCheck test(graph);
         test.run();
@@ -266,7 +272,9 @@ TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarCompleteGraphs) {
 }
 
 TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testNonPlanarCompleteGraphsEulerCriterium) {
-    for (count numberOfNodes = 5; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+    using NodeT = typename TestFixture::NodeT;
+
+    for (NodeT numberOfNodes = 5; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
         typename TestFixture::GraphType graph = this->completeGraph(numberOfNodes);
         typename TestFixture::PlanarityCheck test(graph);
         test.run();
@@ -275,8 +283,10 @@ TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testNonPlanarCompleteGraphsEuler
 }
 
 TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarGridGraphs) {
-    for (count numberOfRows = 2; numberOfRows < TestFixture::maxNumberOfNodes / 2; ++numberOfRows) {
-        for (count numberOfColumns = 2; numberOfColumns < TestFixture::maxNumberOfNodes / 2;
+    using NodeT = typename TestFixture::NodeT;
+
+    for (NodeT numberOfRows = 2; numberOfRows < TestFixture::maxNumberOfNodes / 2; ++numberOfRows) {
+        for (NodeT numberOfColumns = 2; numberOfColumns < TestFixture::maxNumberOfNodes / 2;
              ++numberOfColumns) {
             typename TestFixture::GraphType graph = this->gridGraph(numberOfRows, numberOfColumns);
             typename TestFixture::PlanarityCheck test(graph);
@@ -370,8 +380,10 @@ TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testOnePlanarOneNonPlanarSubGrap
 }
 
 TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarPetersenGraphs) {
-    for (count n = 3; n < TestFixture::maxNumberOfNodes; ++n) {
-        for (count k = 1; k <= std::floor(n / 2); ++k) {
+    using NodeT = typename TestFixture::NodeT;
+
+    for (NodeT n = 3; n < TestFixture::maxNumberOfNodes; ++n) {
+        for (NodeT k = 1; k <= n / 2; ++k) {
             const bool isPlanarPetersenGraph = k == 1 || (k == 2 && !(n & 1));
             if (isPlanarPetersenGraph) {
                 typename TestFixture::GraphType graph = this->petersenGraph(n, k);
@@ -384,8 +396,10 @@ TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarPetersenGraphs) {
 }
 
 TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testNonPlanarPetersenGraphs) {
-    for (count n = 3; n < TestFixture::maxNumberOfNodes; ++n) {
-        for (count k = 1; k <= std::floor(n / 2); ++k) {
+    using NodeT = typename TestFixture::NodeT;
+
+    for (NodeT n = 3; n < TestFixture::maxNumberOfNodes; ++n) {
+        for (NodeT k = 1; k <= n / 2; ++k) {
             const bool isNonPlanarPetersenGraph = !(k == 1 || (k == 2 && !(n & 1)));
             if (isNonPlanarPetersenGraph) {
                 typename TestFixture::GraphType graph = this->petersenGraph(n, k);

--- a/networkit/cpp/planarity/test/LeftRightPlanarityCheckGTest.cpp
+++ b/networkit/cpp/planarity/test/LeftRightPlanarityCheckGTest.cpp
@@ -4,163 +4,164 @@
  *  Created on: 05.01.2025
  *      Author: Andreas Scharf (andreas.b.scharf@gmail.com)
  */
+#include <cmath>
+#include <stdexcept>
+
 #include <gtest/gtest.h>
+
+#include <networkit/graph/AdjListGraph.hpp>
 #include <networkit/io/METISGraphReader.hpp>
 #include <networkit/planarity/LeftRightPlanarityCheck.hpp>
 
 namespace NetworKit {
-class LeftRightPlanarityCheckGTest : public testing::Test {
+namespace {
+
+template <class NodeT_, class EdgeWeightT_, bool Weighted>
+struct PlanarityGraphConfig {
+    using NodeT = NodeT_;
+    using EdgeWeightT = EdgeWeightT_;
+    static constexpr bool weighted = Weighted;
+};
+
+template <class TestT>
+class GenericLeftRightPlanarityCheckGTest : public testing::Test {
 public:
-    LeftRightPlanarityCheckGTest() = default;
+    using NodeT = typename TestT::NodeT;
+    using EdgeWeightT = typename TestT::EdgeWeightT;
+    using GraphType = AdjListGraph<NodeT, EdgeWeightT>;
+    using PlanarityCheck = GenericLeftRightPlanarityCheck<GraphType>;
+
     static constexpr int maxNumberOfNodes{10};
-    Graph pathGraph(count numNodes) {
-        Graph graph;
-        graph.addNodes(numNodes);
+
+    GraphType graphWithNodes(count numNodes) {
+        return GraphType(numNodes, TestT::weighted, false, true);
+    }
+
+    GraphType pathGraph(count numNodes) {
+        GraphType graph = graphWithNodes(numNodes);
         for (count i = 0; i < numNodes - 1; ++i) {
-            graph.addEdge(i, i + 1);
+            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(i + 1));
         }
-        graph.indexEdges();
         return graph;
     }
 
-    Graph cycleGraph(count numNodes) {
-        Graph graph;
-        graph.addNodes(numNodes);
+    GraphType cycleGraph(count numNodes) {
+        GraphType graph = graphWithNodes(numNodes);
         for (count i = 0; i < numNodes - 1; ++i) {
-            graph.addEdge(i, i + 1);
-        }
-        if (numNodes > 2)
-            graph.addEdge(numNodes - 2, 0);
-        graph.indexEdges();
-        return graph;
-    }
-
-    Graph starGraph(count numNodes) {
-        Graph graph;
-        graph.addNodes(numNodes);
-        for (count i = 0; i < numNodes - 1; ++i) {
-            graph.addEdge(i, i + 1);
+            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(i + 1));
         }
         if (numNodes > 2)
-            graph.addEdge(numNodes - 2, 0);
-        graph.indexEdges();
+            graph.addEdge(static_cast<NodeT>(numNodes - 2), NodeT{0});
         return graph;
     }
 
-    Graph binaryTreeGraph(count numNodes) {
-        Graph graph(numNodes, true, false);
+    GraphType starGraph(count numNodes) {
+        GraphType graph = graphWithNodes(numNodes);
+        for (count i = 0; i < numNodes - 1; ++i) {
+            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(i + 1));
+        }
+        if (numNodes > 2)
+            graph.addEdge(static_cast<NodeT>(numNodes - 2), NodeT{0});
+        return graph;
+    }
+
+    GraphType binaryTreeGraph(count numNodes) {
+        GraphType graph = graphWithNodes(numNodes);
         for (count i = 0; i < numNodes; ++i) {
             count leftChild = 2 * i + 1;
             count rightChild = 2 * i + 2;
             if (leftChild < numNodes) {
-                graph.addEdge(i, leftChild, static_cast<double>(i));
+                graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(leftChild),
+                              static_cast<EdgeWeightT>(i));
             }
             if (rightChild < numNodes) {
-                graph.addEdge(i, rightChild, static_cast<double>(i));
+                graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(rightChild),
+                              static_cast<EdgeWeightT>(i));
             }
         }
-        graph.indexEdges();
         return graph;
     }
 
-    Graph wheelGraph(count numNodes) {
-        Graph graph(numNodes, false, false);
+    GraphType wheelGraph(count numNodes) {
+        GraphType graph = graphWithNodes(numNodes);
         if (numNodes < 4) {
             throw std::invalid_argument("A wheel graph requires at least 4 nodes.");
         }
         // Form cycle
         for (count i = 1; i < numNodes - 1; ++i) {
-            graph.addEdge(i, i + 1);
+            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(i + 1));
         }
-        graph.addEdge(numNodes - 1, 1); // Close the cycle
+        graph.addEdge(static_cast<NodeT>(numNodes - 1), NodeT{1}); // Close the cycle
 
         // Connect center to cycle
         for (count i = 1; i < numNodes; ++i) {
-            graph.addEdge(0, i);
+            graph.addEdge(NodeT{0}, static_cast<NodeT>(i));
         }
-        graph.indexEdges();
         return graph;
     }
 
-    Graph completeGraph(count numNodes) {
-        Graph graph(numNodes, true);
+    GraphType completeGraph(count numNodes) {
+        GraphType graph = graphWithNodes(numNodes);
 
         for (count i = 0; i < numNodes; ++i) {
             for (count j = i + 1; j < numNodes; ++j) {
-                graph.addEdge(i, j, static_cast<double>(j * (j + 1)));
+                graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(j),
+                              static_cast<EdgeWeightT>(j * (j + 1)));
             }
         }
-        graph.indexEdges();
         return graph;
     }
 
-    Graph gridGraph(count rows, count columns) {
-        Graph graph(rows * columns);
+    GraphType gridGraph(count rows, count columns) {
+        GraphType graph = graphWithNodes(rows * columns);
         for (count row = 0; row < rows; ++row) {
             for (count col = 0; col < columns; ++col) {
                 count currentNode = row * columns + col;
 
                 // Connect to the right neighbor
                 if (col + 1 < columns) {
-                    graph.addEdge(currentNode, currentNode + 1);
+                    graph.addEdge(static_cast<NodeT>(currentNode),
+                                  static_cast<NodeT>(currentNode + 1));
                 }
 
                 // Connect to the bottom neighbor
                 if (row + 1 < rows) {
-                    graph.addEdge(currentNode, currentNode + columns);
+                    graph.addEdge(static_cast<NodeT>(currentNode),
+                                  static_cast<NodeT>(currentNode + columns));
                 }
             }
         }
-        graph.indexEdges();
         return graph;
     }
 
-    Graph petersenGraph(count n, count k) {
-        Graph graph(2 * n);
+    GraphType petersenGraph(count n, count k) {
+        GraphType graph = graphWithNodes(2 * n);
 
         for (count i = 0; i < n; ++i) {
-            graph.addEdge(i, (i + 1) % n);
+            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>((i + 1) % n));
         }
 
         for (count i = 0; i < n; ++i) {
-            graph.addEdge(n + i, n + (i + k) % n);
+            graph.addEdge(static_cast<NodeT>(n + i), static_cast<NodeT>(n + (i + k) % n));
         }
 
         for (count i = 0; i < n; ++i) {
-            graph.addEdge(i, n + i);
+            graph.addEdge(static_cast<NodeT>(i), static_cast<NodeT>(n + i));
         }
-        graph.indexEdges();
         return graph;
     }
 };
 
-TEST_F(LeftRightPlanarityCheckGTest, testNoEdgesIndexedGraphThrows) {
-    Graph graph(0);
-    try {
-        LeftRightPlanarityCheck test(graph);
-        FAIL() << "Expected std::runtime_error";
-    } catch (const std::runtime_error &e) {
-        EXPECT_STREQ(e.what(), "The graph has no edge IDs.");
-    } catch (...) {
-        FAIL() << "Expected std::runtime_error but got a different exception.";
-    }
-}
+using PlanarityTestTypes = ::testing::Types<
+    PlanarityGraphConfig<node, edgeweight, false>, PlanarityGraphConfig<node, edgeweight, true>,
+    PlanarityGraphConfig<int, float, false>, PlanarityGraphConfig<int, float, true>,
+    PlanarityGraphConfig<int, int, false>, PlanarityGraphConfig<int, int, true>>;
 
-TEST_F(LeftRightPlanarityCheckGTest, testDirectedGraphThrows) {
-    Graph graph(0, false, true, false);
-    try {
-        LeftRightPlanarityCheck test(graph);
-        FAIL() << "Expected std::runtime_error";
-    } catch (const std::runtime_error &e) {
-        EXPECT_STREQ(e.what(), "The graph is not an undirected graph.");
-    } catch (...) {
-        FAIL() << "Expected std::runtime_error but got a different exception.";
-    }
-}
+TYPED_TEST_SUITE(GenericLeftRightPlanarityCheckGTest, PlanarityTestTypes, );
 
-TEST_F(LeftRightPlanarityCheckGTest, testIsPlanarThrowsIfRunIsNotCalled) {
-    Graph graph(0, false, false, true);
-    LeftRightPlanarityCheck test(graph);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testIsPlanarThrowsIfRunIsNotCalled) {
+    typename TestFixture::GraphType graph = this->graphWithNodes(0);
+    typename TestFixture::PlanarityCheck test(graph);
     try {
         test.isPlanar();
         FAIL() << "Expected std::runtime_error";
@@ -171,181 +172,210 @@ TEST_F(LeftRightPlanarityCheckGTest, testIsPlanarThrowsIfRunIsNotCalled) {
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarEmptyGraph) {
-    Graph graph(0, false, false, true);
-    LeftRightPlanarityCheck test(graph);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testNoEdgesIndexedGraphThrows) {
+    typename TestFixture::GraphType graph(0, TypeParam::weighted, false, false);
+    try {
+        typename TestFixture::PlanarityCheck test(graph);
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_STREQ(e.what(), "The graph has no edge IDs.");
+    } catch (...) {
+        FAIL() << "Expected std::runtime_error but got a different exception.";
+    }
+}
+
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testDirectedGraphThrows) {
+    typename TestFixture::GraphType graph(0, TypeParam::weighted, true, true);
+    try {
+        typename TestFixture::PlanarityCheck test(graph);
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_STREQ(e.what(), "The graph is not an undirected graph.");
+    } catch (...) {
+        FAIL() << "Expected std::runtime_error but got a different exception.";
+    }
+}
+
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarEmptyGraph) {
+    typename TestFixture::GraphType graph = this->graphWithNodes(0);
+    typename TestFixture::PlanarityCheck test(graph);
     test.run();
     EXPECT_TRUE(test.isPlanar());
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarSingleNode) {
-    Graph graph{1, false, false, true};
-    LeftRightPlanarityCheck test(graph);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarSingleNode) {
+    typename TestFixture::GraphType graph = this->graphWithNodes(1);
+    typename TestFixture::PlanarityCheck test(graph);
     test.run();
     EXPECT_TRUE(test.isPlanar());
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarPathGraphs) {
-    for (count numberOfNodes = 2; numberOfNodes <= maxNumberOfNodes; ++numberOfNodes) {
-        Graph graph = pathGraph(numberOfNodes);
-        LeftRightPlanarityCheck test(graph);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarPathGraphs) {
+    for (count numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+        typename TestFixture::GraphType graph = this->pathGraph(numberOfNodes);
+        typename TestFixture::PlanarityCheck test(graph);
         test.run();
         EXPECT_TRUE(test.isPlanar());
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarCycleGraphs) {
-    for (count numberOfNodes = 2; numberOfNodes <= maxNumberOfNodes; ++numberOfNodes) {
-        Graph graph = cycleGraph(numberOfNodes);
-        LeftRightPlanarityCheck test(graph);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarCycleGraphs) {
+    for (count numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+        typename TestFixture::GraphType graph = this->cycleGraph(numberOfNodes);
+        typename TestFixture::PlanarityCheck test(graph);
         test.run();
         EXPECT_TRUE(test.isPlanar());
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarStarGraphs) {
-    for (count numberOfNodes = 2; numberOfNodes <= maxNumberOfNodes; ++numberOfNodes) {
-        Graph graph = starGraph(numberOfNodes);
-        LeftRightPlanarityCheck test(graph);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarStarGraphs) {
+    for (count numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+        typename TestFixture::GraphType graph = this->starGraph(numberOfNodes);
+        typename TestFixture::PlanarityCheck test(graph);
         test.run();
         EXPECT_TRUE(test.isPlanar());
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarTreeGraphs) {
-    for (count numberOfNodes = 2; numberOfNodes <= maxNumberOfNodes; ++numberOfNodes) {
-        Graph graph = binaryTreeGraph(numberOfNodes);
-        LeftRightPlanarityCheck test(graph);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarTreeGraphs) {
+    for (count numberOfNodes = 2; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+        typename TestFixture::GraphType graph = this->binaryTreeGraph(numberOfNodes);
+        typename TestFixture::PlanarityCheck test(graph);
         test.run();
         EXPECT_TRUE(test.isPlanar());
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarWheelGraphs) {
-    for (count numberOfNodes = 4; numberOfNodes <= maxNumberOfNodes; ++numberOfNodes) {
-        Graph graph = wheelGraph(numberOfNodes);
-        LeftRightPlanarityCheck test(graph);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarWheelGraphs) {
+    for (count numberOfNodes = 4; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+        typename TestFixture::GraphType graph = this->wheelGraph(numberOfNodes);
+        typename TestFixture::PlanarityCheck test(graph);
         test.run();
         EXPECT_TRUE(test.isPlanar());
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarCompleteGraphs) {
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarCompleteGraphs) {
     constexpr count maxNumberPlanar{5};
     for (count numberOfNodes = 2; numberOfNodes < maxNumberPlanar; ++numberOfNodes) {
-        Graph graph = completeGraph(numberOfNodes);
-        LeftRightPlanarityCheck test(graph);
+        typename TestFixture::GraphType graph = this->completeGraph(numberOfNodes);
+        typename TestFixture::PlanarityCheck test(graph);
         test.run();
         EXPECT_TRUE(test.isPlanar());
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testNonPlanarCompleteGraphsEulerCriterium) {
-    for (count numberOfNodes = 5; numberOfNodes <= maxNumberOfNodes; ++numberOfNodes) {
-        Graph graph = completeGraph(numberOfNodes);
-        LeftRightPlanarityCheck test(graph);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testNonPlanarCompleteGraphsEulerCriterium) {
+    for (count numberOfNodes = 5; numberOfNodes <= TestFixture::maxNumberOfNodes; ++numberOfNodes) {
+        typename TestFixture::GraphType graph = this->completeGraph(numberOfNodes);
+        typename TestFixture::PlanarityCheck test(graph);
         test.run();
         EXPECT_FALSE(test.isPlanar());
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarGridGraphs) {
-    for (count numberOfRows = 2; numberOfRows < maxNumberOfNodes / 2; ++numberOfRows) {
-        for (count numberOfColumns = 2; numberOfColumns < maxNumberOfNodes / 2; ++numberOfColumns) {
-            Graph graph = gridGraph(numberOfRows, numberOfColumns);
-            LeftRightPlanarityCheck test(graph);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarGridGraphs) {
+    for (count numberOfRows = 2; numberOfRows < TestFixture::maxNumberOfNodes / 2; ++numberOfRows) {
+        for (count numberOfColumns = 2; numberOfColumns < TestFixture::maxNumberOfNodes / 2;
+             ++numberOfColumns) {
+            typename TestFixture::GraphType graph = this->gridGraph(numberOfRows, numberOfColumns);
+            typename TestFixture::PlanarityCheck test(graph);
             test.run();
             EXPECT_TRUE(test.isPlanar());
         }
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testNonPlanarCompleteBipartiteGraphK3_3) {
-    Graph graph(6);
-    graph.addEdge(0, 3);
-    graph.addEdge(0, 4);
-    graph.addEdge(0, 5);
-    graph.addEdge(1, 3);
-    graph.addEdge(1, 4);
-    graph.addEdge(1, 5);
-    graph.addEdge(2, 3);
-    graph.addEdge(2, 4);
-    graph.addEdge(2, 5);
-    graph.indexEdges();
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testNonPlanarCompleteBipartiteGraphK3_3) {
+    using NodeT = typename TestFixture::NodeT;
 
-    LeftRightPlanarityCheck test(graph);
+    typename TestFixture::GraphType graph = this->graphWithNodes(6);
+    graph.addEdge(NodeT{0}, NodeT{3});
+    graph.addEdge(NodeT{0}, NodeT{4});
+    graph.addEdge(NodeT{0}, NodeT{5});
+    graph.addEdge(NodeT{1}, NodeT{3});
+    graph.addEdge(NodeT{1}, NodeT{4});
+    graph.addEdge(NodeT{1}, NodeT{5});
+    graph.addEdge(NodeT{2}, NodeT{3});
+    graph.addEdge(NodeT{2}, NodeT{4});
+    graph.addEdge(NodeT{2}, NodeT{5});
+
+    typename TestFixture::PlanarityCheck test(graph);
     test.run();
     EXPECT_FALSE(test.isPlanar());
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testNonPlanarCompleteTripartiteGraphK3_3_3) {
-    Graph graph(9);
-    graph.addEdge(0, 3);
-    graph.addEdge(0, 4);
-    graph.addEdge(0, 5);
-    graph.addEdge(1, 3);
-    graph.addEdge(1, 4);
-    graph.addEdge(1, 5);
-    graph.addEdge(2, 3);
-    graph.addEdge(2, 4);
-    graph.addEdge(2, 5);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testNonPlanarCompleteTripartiteGraphK3_3_3) {
+    using NodeT = typename TestFixture::NodeT;
 
-    graph.addEdge(0, 6);
-    graph.addEdge(0, 7);
-    graph.addEdge(0, 8);
-    graph.addEdge(1, 6);
-    graph.addEdge(1, 7);
-    graph.addEdge(1, 8);
-    graph.addEdge(2, 6);
-    graph.addEdge(2, 7);
-    graph.addEdge(2, 8);
+    typename TestFixture::GraphType graph = this->graphWithNodes(9);
+    graph.addEdge(NodeT{0}, NodeT{3});
+    graph.addEdge(NodeT{0}, NodeT{4});
+    graph.addEdge(NodeT{0}, NodeT{5});
+    graph.addEdge(NodeT{1}, NodeT{3});
+    graph.addEdge(NodeT{1}, NodeT{4});
+    graph.addEdge(NodeT{1}, NodeT{5});
+    graph.addEdge(NodeT{2}, NodeT{3});
+    graph.addEdge(NodeT{2}, NodeT{4});
+    graph.addEdge(NodeT{2}, NodeT{5});
 
-    graph.addEdge(3, 6);
-    graph.addEdge(3, 7);
-    graph.addEdge(3, 8);
-    graph.addEdge(4, 6);
-    graph.addEdge(4, 7);
-    graph.addEdge(4, 8);
-    graph.addEdge(5, 6);
-    graph.addEdge(5, 7);
-    graph.addEdge(5, 8);
-    graph.indexEdges();
-    LeftRightPlanarityCheck test(graph);
+    graph.addEdge(NodeT{0}, NodeT{6});
+    graph.addEdge(NodeT{0}, NodeT{7});
+    graph.addEdge(NodeT{0}, NodeT{8});
+    graph.addEdge(NodeT{1}, NodeT{6});
+    graph.addEdge(NodeT{1}, NodeT{7});
+    graph.addEdge(NodeT{1}, NodeT{8});
+    graph.addEdge(NodeT{2}, NodeT{6});
+    graph.addEdge(NodeT{2}, NodeT{7});
+    graph.addEdge(NodeT{2}, NodeT{8});
+
+    graph.addEdge(NodeT{3}, NodeT{6});
+    graph.addEdge(NodeT{3}, NodeT{7});
+    graph.addEdge(NodeT{3}, NodeT{8});
+    graph.addEdge(NodeT{4}, NodeT{6});
+    graph.addEdge(NodeT{4}, NodeT{7});
+    graph.addEdge(NodeT{4}, NodeT{8});
+    graph.addEdge(NodeT{5}, NodeT{6});
+    graph.addEdge(NodeT{5}, NodeT{7});
+    graph.addEdge(NodeT{5}, NodeT{8});
+
+    typename TestFixture::PlanarityCheck test(graph);
     test.run();
     EXPECT_FALSE(test.isPlanar());
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testOnePlanarOneNonPlanarSubGraph) {
-    Graph graph(10);
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testOnePlanarOneNonPlanarSubGraph) {
+    using NodeT = typename TestFixture::NodeT;
+
+    typename TestFixture::GraphType graph = this->graphWithNodes(10);
     // complete bipartite graph K3,3 (non-planar)
-    graph.addEdge(0, 3);
-    graph.addEdge(0, 4);
-    graph.addEdge(0, 5);
-    graph.addEdge(1, 3);
-    graph.addEdge(1, 4);
-    graph.addEdge(1, 5);
-    graph.addEdge(2, 3);
-    graph.addEdge(2, 4);
-    graph.addEdge(2, 5);
+    graph.addEdge(NodeT{0}, NodeT{3});
+    graph.addEdge(NodeT{0}, NodeT{4});
+    graph.addEdge(NodeT{0}, NodeT{5});
+    graph.addEdge(NodeT{1}, NodeT{3});
+    graph.addEdge(NodeT{1}, NodeT{4});
+    graph.addEdge(NodeT{1}, NodeT{5});
+    graph.addEdge(NodeT{2}, NodeT{3});
+    graph.addEdge(NodeT{2}, NodeT{4});
+    graph.addEdge(NodeT{2}, NodeT{5});
     // Simple cycle graph (planar)
-    graph.addEdge(6, 7);
-    graph.addEdge(7, 8);
-    graph.addEdge(8, 9);
-    graph.addEdge(9, 6);
+    graph.addEdge(NodeT{6}, NodeT{7});
+    graph.addEdge(NodeT{7}, NodeT{8});
+    graph.addEdge(NodeT{8}, NodeT{9});
+    graph.addEdge(NodeT{9}, NodeT{6});
 
-    graph.indexEdges();
-    LeftRightPlanarityCheck test(graph);
+    typename TestFixture::PlanarityCheck test(graph);
     test.run();
     EXPECT_FALSE(test.isPlanar());
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarPetersenGraphs) {
-    for (count n = 3; n < maxNumberOfNodes; ++n) {
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testPlanarPetersenGraphs) {
+    for (count n = 3; n < TestFixture::maxNumberOfNodes; ++n) {
         for (count k = 1; k <= std::floor(n / 2); ++k) {
             const bool isPlanarPetersenGraph = k == 1 || (k == 2 && !(n & 1));
             if (isPlanarPetersenGraph) {
-                Graph graph = petersenGraph(n, k);
-                LeftRightPlanarityCheck test(graph);
+                typename TestFixture::GraphType graph = this->petersenGraph(n, k);
+                typename TestFixture::PlanarityCheck test(graph);
                 test.run();
                 EXPECT_TRUE(test.isPlanar());
             }
@@ -353,13 +383,13 @@ TEST_F(LeftRightPlanarityCheckGTest, testPlanarPetersenGraphs) {
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testNonPlanarPetersenGraphs) {
-    for (count n = 3; n < maxNumberOfNodes; ++n) {
+TYPED_TEST(GenericLeftRightPlanarityCheckGTest, testNonPlanarPetersenGraphs) {
+    for (count n = 3; n < TestFixture::maxNumberOfNodes; ++n) {
         for (count k = 1; k <= std::floor(n / 2); ++k) {
             const bool isNonPlanarPetersenGraph = !(k == 1 || (k == 2 && !(n & 1)));
             if (isNonPlanarPetersenGraph) {
-                Graph graph = petersenGraph(n, k);
-                LeftRightPlanarityCheck test(graph);
+                typename TestFixture::GraphType graph = this->petersenGraph(n, k);
+                typename TestFixture::PlanarityCheck test(graph);
                 test.run();
                 EXPECT_FALSE(test.isPlanar());
             }
@@ -367,7 +397,7 @@ TEST_F(LeftRightPlanarityCheckGTest, testNonPlanarPetersenGraphs) {
     }
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanar4eltGraph) {
+TEST(LeftRightPlanarityCheckGTest, testPlanar4eltGraph) {
     METISGraphReader reader;
     Graph graph = reader.read("input/4elt.graph");
     graph.indexEdges();
@@ -376,7 +406,7 @@ TEST_F(LeftRightPlanarityCheckGTest, testPlanar4eltGraph) {
     EXPECT_TRUE(test.isPlanar());
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testNonPlanarHepthGraph) {
+TEST(LeftRightPlanarityCheckGTest, testNonPlanarHepthGraph) {
     METISGraphReader reader;
     Graph graph = reader.read("input/hep-th.graph");
     graph.indexEdges();
@@ -385,7 +415,7 @@ TEST_F(LeftRightPlanarityCheckGTest, testNonPlanarHepthGraph) {
     EXPECT_FALSE(test.isPlanar());
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testPlanarAirfoil1Graph) {
+TEST(LeftRightPlanarityCheckGTest, testPlanarAirfoil1Graph) {
     METISGraphReader reader;
     Graph graph = reader.read("input/airfoil1.graph");
     graph.indexEdges();
@@ -394,7 +424,7 @@ TEST_F(LeftRightPlanarityCheckGTest, testPlanarAirfoil1Graph) {
     EXPECT_TRUE(test.isPlanar());
 }
 
-TEST_F(LeftRightPlanarityCheckGTest, testNonPlanarAstroPhGraph) {
+TEST(LeftRightPlanarityCheckGTest, testNonPlanarAstroPhGraph) {
     METISGraphReader reader;
     Graph graph = reader.read("input/astro-ph.graph");
     graph.indexEdges();
@@ -403,4 +433,5 @@ TEST_F(LeftRightPlanarityCheckGTest, testNonPlanarAstroPhGraph) {
     EXPECT_FALSE(test.isPlanar());
 }
 
+} // namespace
 } // namespace NetworKit


### PR DESCRIPTION
This PR generalizes `LeftRightPlanarityCheck` to work with `AdjListGraph<NodeT, EdgeWeightT>` as part of the templated graph work discussed in #1415.

The implementation was moved from the `.cpp` file to a new `LeftRightPlanarityCheckImpl.hpp`. The existing `LeftRightPlanarityCheck` name is kept as an alias for the default `Graph` type.

The tests for generated graphs are now typed tests covering different node and edge-weight types.