### PR TITLE
Fix SIGSEGV crashes in Diameter

### DIFF
--- a/networkit/cpp/distance/Diameter.cpp
+++ b/networkit/cpp/distance/Diameter.cpp
@@ -38,6 +38,12 @@ Diameter::Diameter(const Graph &G, DiameterAlgo algo, double error, count nSampl
 
 void Diameter::run() {
     diameterBounds = {0, 0};
+
+    if (G->isEmpty()) {
+        hasRun = true;
+        return;
+    }
+
     if (algo == DiameterAlgo::EXACT) {
         std::get<0>(diameterBounds) = this->exactDiameter(*G);
     } else if (algo == DiameterAlgo::ESTIMATED_RANGE) {

--- a/networkit/cpp/distance/test/DistanceGTest.cpp
+++ b/networkit/cpp/distance/test/DistanceGTest.cpp
@@ -481,6 +481,29 @@ TEST_F(DistanceGTest, testExactDiameter) {
     }
 }
 
+TEST_F(DistanceGTest, testDiameterEmptyGraph) {
+    Graph G(0);
+    const auto expectedDiameter = std::make_pair<count, count>(0, 0);
+
+    for (const auto algo :
+         {DiameterAlgo::AUTOMATIC, DiameterAlgo::EXACT, DiameterAlgo::ESTIMATED_PEDANTIC}) {
+        Diameter diam(G, algo);
+        diam.run();
+        EXPECT_TRUE(diam.hasFinished());
+        EXPECT_EQ(diam.getDiameter(), expectedDiameter);
+    }
+
+    Diameter estimatedRange(G, DiameterAlgo::ESTIMATED_RANGE, 0.1);
+    estimatedRange.run();
+    EXPECT_TRUE(estimatedRange.hasFinished());
+    EXPECT_EQ(estimatedRange.getDiameter(), expectedDiameter);
+
+    Diameter estimatedSamples(G, DiameterAlgo::ESTIMATED_SAMPLES, -1., 1);
+    estimatedSamples.run();
+    EXPECT_TRUE(estimatedSamples.hasFinished());
+    EXPECT_EQ(estimatedSamples.getDiameter(), expectedDiameter);
+}
+
 TEST_F(DistanceGTest, testEstimatedDiameterRange) {
     using namespace std;
 


### PR DESCRIPTION
This PR fixes Diameter(Graph(0)) by returning (0, 0) early from Diameter::run() instead of 
dispatching into algorithms that assume a non-empty graph.
Adds a C++ regression test covering empty graphs across all diameter modes.
Fixes #1480.