### PR TITLE
Template topo sort

### DIFF
--- a/include/networkit/graph/AdjListGraphImpl.hpp
+++ b/include/networkit/graph/AdjListGraphImpl.hpp
@@ -1276,7 +1276,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::removeEdge(NodeT u, NodeT v) {
             balancedParallelForNodes([&](NodeT w) {
                 for (index i = 0; i < inEdges[w].size(); ++i) {
                     NodeT vv = inEdges[w][i];
-                    if (vv != none) {
+                    if (vv != NullNodeId<NodeT>) {
                         index j = indexInOutEdgeArray(vv, w);
                         inEdgeIds[w][i] = outEdgeIds[vv][j];
                     }

--- a/include/networkit/graph/TopologicalSort.hpp
+++ b/include/networkit/graph/TopologicalSort.hpp
@@ -9,6 +9,8 @@
 
 #include <optional>
 #include <unordered_map>
+#include <vector>
+
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
 
@@ -19,14 +21,18 @@ namespace NetworKit {
  * Undirected graphs are not accepted as input, since a topology sort is a linear ordering of
  * vertices such that for every edge u -> v, node u comes before v in the ordering.
  */
-class TopologicalSort final : public Algorithm {
+template <typename GraphT>
+class GenericTopologicalSort final : public Algorithm {
 public:
+    using NodeT = typename GraphT::NodeT;
+    using NodeIdMapping = std::unordered_map<NodeT, index>;
+
     /**
      * Initialize the topological sort algorithm by passing an input graph.
      *
      * @param G The input graph.
      */
-    TopologicalSort(const Graph &G);
+    GenericTopologicalSort(const GraphT &G);
 
     /**
      * Initialize the topological sort algorithm by passing an input graph and an node id map.
@@ -37,8 +43,8 @@ public:
      * @param nodeIdMapping Node id mapping from non-continuous to continuous ids.
      * @param checkMapping Check whether the given node id map is continuous.
      */
-    TopologicalSort(const Graph &G, const std::unordered_map<node, node> &nodeIdMapping,
-                    bool checkMapping = false);
+    GenericTopologicalSort(const GraphT &G, const NodeIdMapping &nodeIdMapping,
+                           bool checkMapping = false);
 
     /**
      * Execute the algorithm. The algorithm is not parallel.
@@ -50,7 +56,7 @@ public:
      *
      * @return One valid topology. Order in topology is from 0 to number of nodes.
      */
-    const std::vector<node> &getResult() const {
+    const std::vector<NodeT> &getResult() const {
         assureFinished();
         return topology;
     }
@@ -58,30 +64,37 @@ public:
 private:
     enum class NodeMark : unsigned char { NONE, TEMP, PERM };
 
-    const Graph &G;
+    const GraphT &G;
 
-    std::optional<std::unordered_map<node, node>> computedNodeIdMap;
+    std::optional<NodeIdMapping> computedNodeIdMap;
 
-    const std::unordered_map<node, node> *nodeIdMap = nullptr;
+    const NodeIdMapping *nodeIdMap = nullptr;
 
     // Used to mark the status of each node, one vector per thread
     std::vector<NodeMark> topSortMark;
 
     // Contains information about the computed topology
-    std::vector<node> topology;
+    std::vector<NodeT> topology;
 
     // Helper structures
     count current;
+
+    static NodeIdMapping computeContinuousNodeIds(const GraphT &G);
 
     void checkDirected();
 
     void checkNodeIdMap();
 
-    node mapNode(node u);
+    index mapNode(NodeT u) const;
 
     // Reset algorithm data structure
     void reset();
 };
+
+using TopologicalSort = GenericTopologicalSort<Graph>;
+
 } // namespace NetworKit
+
+#include <networkit/graph/TopologicalSortImpl.hpp>
 
 #endif // NETWORKIT_GRAPH_TOPOLOGICAL_SORT_HPP_

--- a/include/networkit/graph/TopologicalSortImpl.hpp
+++ b/include/networkit/graph/TopologicalSortImpl.hpp
@@ -1,25 +1,29 @@
 /*
- * TopologicalSort.cpp
+ * TopologicalSortImpl.hpp
  *
- *  Created on: 22.11.2021
- *      Author: Fabian Brandt-Tumescheit
+ *  Created on: 10.09.2026
+ *      Author: NetworKit contributors
  */
+#ifndef NETWORKIT_GRAPH_TOPOLOGICAL_SORT_IMPL_HPP_
+#define NETWORKIT_GRAPH_TOPOLOGICAL_SORT_IMPL_HPP_
 
+#include <algorithm>
+#include <sstream>
 #include <stack>
 #include <stdexcept>
 
-#include <networkit/graph/GraphTools.hpp>
-#include <networkit/graph/TopologicalSort.hpp>
-
 namespace NetworKit {
 
-TopologicalSort::TopologicalSort(const Graph &G)
-    : G(G), computedNodeIdMap(GraphTools::getContinuousNodeIds(G)) {
+template <typename GraphT>
+GenericTopologicalSort<GraphT>::GenericTopologicalSort(const GraphT &G)
+    : G(G), computedNodeIdMap(computeContinuousNodeIds(G)) {
     checkDirected();
 }
 
-TopologicalSort::TopologicalSort(const Graph &G, const std::unordered_map<node, node> &nodeIdMap,
-                                 bool checkMapping)
+template <typename GraphT>
+GenericTopologicalSort<GraphT>::GenericTopologicalSort(const GraphT &G,
+                                                       const NodeIdMapping &nodeIdMap,
+                                                       bool checkMapping)
     : G(G), nodeIdMap(&nodeIdMap) {
     checkDirected();
     if (nodeIdMap.size() != G.numberOfNodes())
@@ -29,18 +33,33 @@ TopologicalSort::TopologicalSort(const Graph &G, const std::unordered_map<node, 
         checkNodeIdMap();
 }
 
-void TopologicalSort::checkDirected() {
+template <typename GraphT>
+typename GenericTopologicalSort<GraphT>::NodeIdMapping
+GenericTopologicalSort<GraphT>::computeContinuousNodeIds(const GraphT &G) {
+    NodeIdMapping nodeIdMap;
+    nodeIdMap.reserve(G.numberOfNodes());
+
+    index continuousId = 0;
+    G.forNodes([&](NodeT u) { nodeIdMap.emplace(u, continuousId++); });
+
+    return nodeIdMap;
+}
+
+template <typename GraphT>
+void GenericTopologicalSort<GraphT>::checkDirected() {
     if (!G.isDirected())
         throw std::runtime_error("Topological sort is defined for directed graphs only.");
 }
 
-void TopologicalSort::checkNodeIdMap() {
+template <typename GraphT>
+void GenericTopologicalSort<GraphT>::checkNodeIdMap() {
     if (!nodeIdMap)
         return;
 
-    size_t numberOfNodes = G.numberOfNodes();
+    const count numberOfNodes = G.numberOfNodes();
     std::vector<bool> checkTable(numberOfNodes);
-    for (auto &[origNode, mappedNode] : *nodeIdMap) {
+    for (const auto &entry : *nodeIdMap) {
+        const index mappedNode = entry.second;
         if (mappedNode < numberOfNodes && !checkTable[mappedNode])
             checkTable[mappedNode] = true;
         else
@@ -48,20 +67,21 @@ void TopologicalSort::checkNodeIdMap() {
     }
 }
 
-void TopologicalSort::run() {
+template <typename GraphT>
+void GenericTopologicalSort<GraphT>::run() {
     reset();
 
-    std::stack<node> nodeStack;
+    std::stack<NodeT> nodeStack;
 
-    G.forNodes([&](node u) {
-        node mappedU = mapNode(u);
+    G.forNodes([&](NodeT u) {
+        const index mappedU = mapNode(u);
         if (topSortMark[mappedU] == NodeMark::PERM)
             return;
 
         nodeStack.push(u);
         do {
-            node v = nodeStack.top();
-            node mappedV = mapNode(v);
+            const NodeT v = nodeStack.top();
+            const index mappedV = mapNode(v);
 
             if (topSortMark[mappedV] != NodeMark::NONE) {
                 nodeStack.pop();
@@ -72,8 +92,8 @@ void TopologicalSort::run() {
                 }
             } else {
                 topSortMark[mappedV] = NodeMark::TEMP;
-                G.forNeighborsOf(v, [&](node w) {
-                    node mappedW = mapNode(w);
+                G.forNeighborsOf(v, [&](NodeT w) {
+                    const index mappedW = mapNode(w);
 
                     if (topSortMark[mappedW] == NodeMark::NONE)
                         nodeStack.push(w);
@@ -87,24 +107,26 @@ void TopologicalSort::run() {
     hasRun = true;
 }
 
-node TopologicalSort::mapNode(node u) {
+template <typename GraphT>
+index GenericTopologicalSort<GraphT>::mapNode(NodeT u) const {
     if (nodeIdMap) {
-        auto it = nodeIdMap->find(u);
+        const auto it = nodeIdMap->find(u);
         if (it == nodeIdMap->cend()) {
             std::stringstream errorMsg;
             errorMsg << "Node id mapping does not contain node " << u;
             throw std::runtime_error(errorMsg.str());
         }
         return it->second;
-    } else if (computedNodeIdMap.has_value())
+    } else if (computedNodeIdMap.has_value()) {
         return computedNodeIdMap.value().at(u);
-    else
-        return u;
+    } else {
+        return static_cast<index>(u);
+    }
 }
 
-void TopologicalSort::reset() {
-    // Reset node marks
-    count n = G.numberOfNodes();
+template <typename GraphT>
+void GenericTopologicalSort<GraphT>::reset() {
+    const count n = G.numberOfNodes();
     if (n == 0)
         throw std::runtime_error("Graph should contain at least one node.");
 
@@ -113,9 +135,10 @@ void TopologicalSort::reset() {
         topology.resize(n);
     }
     std::fill(topSortMark.begin(), topSortMark.end(), NodeMark::NONE);
-    std::fill(topology.begin(), topology.end(), 0);
-    // Reset current
+    std::fill(topology.begin(), topology.end(), NodeT{0});
     current = n - 1;
 }
 
 } // namespace NetworKit
+
+#endif // NETWORKIT_GRAPH_TOPOLOGICAL_SORT_IMPL_HPP_

--- a/include/networkit/graph/TopologicalSortImpl.hpp
+++ b/include/networkit/graph/TopologicalSortImpl.hpp
@@ -1,8 +1,8 @@
 /*
  * TopologicalSortImpl.hpp
  *
- *  Created on: 10.09.2026
- *      Author: NetworKit contributors
+ *  Created on: 22.11.2021
+ *      Author: Fabian Brandt-Tumescheit
  */
 #ifndef NETWORKIT_GRAPH_TOPOLOGICAL_SORT_IMPL_HPP_
 #define NETWORKIT_GRAPH_TOPOLOGICAL_SORT_IMPL_HPP_

--- a/networkit/cpp/graph/CMakeLists.txt
+++ b/networkit/cpp/graph/CMakeLists.txt
@@ -5,7 +5,6 @@ networkit_add_module(graph
     PrimMSF.cpp
     RandomMaximumSpanningForest.cpp
     SpanningForest.cpp
-    TopologicalSort.cpp
     UnionMaximumSpanningForest.cpp
     DHBGraph.cpp
     )

--- a/networkit/cpp/graph/test/TopologicalSortGTest.cpp
+++ b/networkit/cpp/graph/test/TopologicalSortGTest.cpp
@@ -5,169 +5,204 @@
  *      Author: Fabian Brandt-Tumescheit
  */
 
-#include <networkit/graph/TopologicalSort.hpp>
-
+#include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 #include <unordered_map>
+#include <vector>
+
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-namespace NetworKit {
+#include <networkit/graph/AdjListGraph.hpp>
+#include <networkit/graph/TopologicalSort.hpp>
 
-class TopologicalSortGTest : public testing::Test {
-protected:
-    Graph inputGraph(bool directed) const noexcept;
-    std::unordered_map<node, node> makeMapping() const noexcept;
-    void assertTopological(Graph &G, std::vector<node> &sort);
+namespace NetworKit {
+namespace {
+
+template <class NodeT_, class EdgeWeightT_>
+struct TopologicalSortConfig {
+    using NodeT = NodeT_;
+    using EdgeWeightT = EdgeWeightT_;
 };
 
-Graph TopologicalSortGTest::inputGraph(bool directed) const noexcept {
-    auto G = Graph(5, false, directed);
+template <class TestT>
+class TopologicalSortGTest : public testing::Test {
+public:
+    using NodeT = typename TestT::NodeT;
+    using EdgeWeightT = typename TestT::EdgeWeightT;
+    using GraphT = AdjListGraph<NodeT, EdgeWeightT>;
+    using TopologicalSortT = GenericTopologicalSort<GraphT>;
+    using NodeIdMapping = typename TopologicalSortT::NodeIdMapping;
 
-    /**
-     * /--> 1 --> 3
-     * |    ^
-     * 0    |
-     * |    |
-     * \--> 2 <-- 4
-     */
+    GraphT inputGraph(bool directed) const {
+        GraphT G(5, false, directed);
 
-    G.addEdge(0, 1);
-    G.addEdge(0, 2);
-    G.addEdge(2, 1);
-    G.addEdge(1, 3);
-    G.addEdge(4, 2);
+        /**
+         * /--> 1 --> 3
+         * |    ^
+         * 0    |
+         * |    |
+         * \--> 2 <-- 4
+         */
 
-    return G;
-}
+        G.addEdge(NodeT{0}, NodeT{1});
+        G.addEdge(NodeT{0}, NodeT{2});
+        G.addEdge(NodeT{2}, NodeT{1});
+        G.addEdge(NodeT{1}, NodeT{3});
+        G.addEdge(NodeT{4}, NodeT{2});
 
-std::unordered_map<node, node> TopologicalSortGTest::makeMapping() const noexcept {
-    std::unordered_map<node, node> mapping;
-    mapping[0] = 0;
-    mapping[1] = 1;
-    mapping[2] = 2;
-    mapping[4] = 3;
+        return G;
+    }
 
-    return mapping;
-}
+    NodeIdMapping makeMapping() const {
+        NodeIdMapping mapping;
+        mapping[NodeT{0}] = 0;
+        mapping[NodeT{1}] = 1;
+        mapping[NodeT{2}] = 2;
+        mapping[NodeT{4}] = 3;
 
-void TopologicalSortGTest::assertTopological(Graph &G, std::vector<node> &sort) {
-    std::unordered_map<node, node> indices;
-    EXPECT_EQ(sort.size(), G.numberOfNodes());
-    G.forNodes([&](node u) {
-        indices[u] = std::distance(sort.begin(), std::find(sort.begin(), sort.end(), u));
-    });
-    G.forNodes([&](node u) {
-        G.forNeighborsOf(u, [&](node v) { EXPECT_TRUE(indices[u] < indices[v]); });
-    });
-}
+        return mapping;
+    }
 
-TEST_F(TopologicalSortGTest, testTopologicalSort) {
-    auto G = inputGraph(true);
+    void assertTopological(const GraphT &G, const std::vector<NodeT> &sort) const {
+        std::vector<NodeT> nodes;
+        nodes.reserve(G.numberOfNodes());
+        G.forNodes([&](NodeT u) { nodes.push_back(u); });
 
-    TopologicalSort topSort = TopologicalSort(G);
-    topSort.run();
-    std::vector<node> res = topSort.getResult();
+        std::unordered_map<NodeT, index> indices;
+        EXPECT_EQ(sort.size(), G.numberOfNodes());
+        EXPECT_THAT(sort, testing::UnorderedElementsAreArray(nodes));
+        G.forNodes([&](NodeT u) {
+            const auto it = std::find(sort.begin(), sort.end(), u);
+            EXPECT_NE(it, sort.end());
+            indices[u] = std::distance(sort.begin(), it);
+        });
+        G.forNodes([&](NodeT u) {
+            G.forNeighborsOf(u, [&](NodeT v) { EXPECT_LT(indices[u], indices[v]); });
+        });
+    }
+};
 
-    assertTopological(G, res);
-}
+TYPED_TEST_SUITE_P(TopologicalSortGTest);
 
-TEST_F(TopologicalSortGTest, testRepeatedRuns) {
-    auto G = inputGraph(true);
-    TopologicalSort topSort = TopologicalSort(G);
-    topSort.run();
-    std::vector<node> res = topSort.getResult();
-    topSort.run();
-    std::vector<node> res2 = topSort.getResult();
-    EXPECT_TRUE(res == res2);
-}
+TYPED_TEST_P(TopologicalSortGTest, testTopologicalSort) {
+    auto G = this->inputGraph(true);
 
-TEST_F(TopologicalSortGTest, testRejectGraphWithCycles) {
-    auto G = inputGraph(true);
-    G.addEdge(3, 4);
-    TopologicalSort topSort = TopologicalSort(G);
-    EXPECT_THROW(topSort.run(), std::runtime_error);
-}
-
-TEST_F(TopologicalSortGTest, testRejectUndirectedGraph) {
-    EXPECT_THROW(TopologicalSort(inputGraph(false)), std::runtime_error);
-}
-
-TEST_F(TopologicalSortGTest, testNonContinuousNodeIds) {
-    auto G = inputGraph(true);
-    G.removeNode(3);
-
-    TopologicalSort topSort = TopologicalSort(G);
-    topSort.run();
-    std::vector<node> res = topSort.getResult();
-
-    assertTopological(G, res);
-}
-
-TEST_F(TopologicalSortGTest, testCustomNodeIdMapping) {
-    auto G = inputGraph(true);
-    G.removeNode(3);
-    std::unordered_map<node, node> mapping = makeMapping();
-    TopologicalSort topSort = TopologicalSort(G, mapping);
-    topSort.run();
-    std::vector<node> res = topSort.getResult();
-
-    assertTopological(G, res);
-}
-
-TEST_F(TopologicalSortGTest, testWrongSizeOfNodeIdMapping) {
-    auto G = inputGraph(true);
-    G.removeNode(3);
-    std::unordered_map<node, node> mapping = makeMapping();
-    mapping[5] = 4;
-    EXPECT_THROW(TopologicalSort(G, mapping), std::runtime_error);
-}
-
-TEST_F(TopologicalSortGTest, testNonContinuousNodeIdMapping) {
-    auto G = inputGraph(true);
-    G.removeNode(3);
-    std::unordered_map<node, node> mapping = makeMapping();
-    mapping[1] = 4;
-    EXPECT_THROW(TopologicalSort(G, mapping, true), std::runtime_error);
-
-    mapping = makeMapping();
-    mapping.erase(1);
-    // to get correct size
-    mapping[5] = 5;
-    EXPECT_THROW(TopologicalSort(G, mapping, true), std::runtime_error);
-    TopologicalSort topSort = TopologicalSort(G, mapping);
-    EXPECT_THROW(topSort.run(), std::runtime_error);
-}
-
-TEST_F(TopologicalSortGTest, testNonInjectiveNodeIdMapping) {
-    auto G = inputGraph(true);
-    G.removeNode(3);
-    std::unordered_map<node, node> mapping = makeMapping();
-    mapping[2] = 1;
-    EXPECT_THROW(TopologicalSort(G, mapping, true), std::runtime_error);
-}
-
-TEST_F(TopologicalSortGTest, testGenericTopologicalSort) {
-    using NodeT = uint32_t;
-    using WeightT = float;
-    using GraphT = AdjListGraph<NodeT, WeightT>;
-
-    GraphT G(5, false, true);
-    G.addEdge(NodeT{0}, NodeT{1});
-    G.addEdge(NodeT{0}, NodeT{2});
-    G.addEdge(NodeT{2}, NodeT{1});
-    G.addEdge(NodeT{1}, NodeT{3});
-    G.addEdge(NodeT{4}, NodeT{2});
-
-    GenericTopologicalSort<GraphT> topSort(G);
+    typename TestFixture::TopologicalSortT topSort(G);
     topSort.run();
     const auto &res = topSort.getResult();
 
-    std::unordered_map<NodeT, index> indices;
-    EXPECT_EQ(res.size(), G.numberOfNodes());
-    G.forNodes([&](NodeT u) {
-        indices[u] = std::distance(res.begin(), std::find(res.begin(), res.end(), u));
-    });
-    G.forNodes(
-        [&](NodeT u) { G.forNeighborsOf(u, [&](NodeT v) { EXPECT_LT(indices[u], indices[v]); }); });
+    this->assertTopological(G, res);
 }
+
+TYPED_TEST_P(TopologicalSortGTest, testRepeatedRuns) {
+    auto G = this->inputGraph(true);
+
+    typename TestFixture::TopologicalSortT topSort(G);
+    topSort.run();
+    const auto res = topSort.getResult();
+    topSort.run();
+    const auto res2 = topSort.getResult();
+
+    EXPECT_THAT(res2, testing::ElementsAreArray(res));
+}
+
+TYPED_TEST_P(TopologicalSortGTest, testRejectGraphWithCycles) {
+    using NodeT = typename TestFixture::NodeT;
+
+    auto G = this->inputGraph(true);
+    G.addEdge(NodeT{3}, NodeT{4});
+
+    typename TestFixture::TopologicalSortT topSort(G);
+    EXPECT_THROW(topSort.run(), std::runtime_error);
+}
+
+TYPED_TEST_P(TopologicalSortGTest, testRejectUndirectedGraph) {
+    EXPECT_THROW(typename TestFixture::TopologicalSortT(this->inputGraph(false)),
+                 std::runtime_error);
+}
+
+TYPED_TEST_P(TopologicalSortGTest, testNonContinuousNodeIds) {
+    using NodeT = typename TestFixture::NodeT;
+
+    auto G = this->inputGraph(true);
+    G.removeNode(NodeT{3});
+
+    typename TestFixture::TopologicalSortT topSort(G);
+    topSort.run();
+    const auto &res = topSort.getResult();
+
+    this->assertTopological(G, res);
+}
+
+TYPED_TEST_P(TopologicalSortGTest, testCustomNodeIdMapping) {
+    using NodeT = typename TestFixture::NodeT;
+
+    auto G = this->inputGraph(true);
+    G.removeNode(NodeT{3});
+    auto mapping = this->makeMapping();
+
+    typename TestFixture::TopologicalSortT topSort(G, mapping);
+    topSort.run();
+    const auto &res = topSort.getResult();
+
+    this->assertTopological(G, res);
+}
+
+TYPED_TEST_P(TopologicalSortGTest, testWrongSizeOfNodeIdMapping) {
+    using NodeT = typename TestFixture::NodeT;
+
+    auto G = this->inputGraph(true);
+    G.removeNode(NodeT{3});
+    auto mapping = this->makeMapping();
+    mapping[NodeT{5}] = 4;
+
+    EXPECT_THROW(typename TestFixture::TopologicalSortT(G, mapping), std::runtime_error);
+}
+
+TYPED_TEST_P(TopologicalSortGTest, testNonContinuousNodeIdMapping) {
+    using NodeT = typename TestFixture::NodeT;
+
+    auto G = this->inputGraph(true);
+    G.removeNode(NodeT{3});
+    auto mapping = this->makeMapping();
+    mapping[NodeT{1}] = 4;
+    EXPECT_THROW(typename TestFixture::TopologicalSortT(G, mapping, true), std::runtime_error);
+
+    mapping = this->makeMapping();
+    mapping.erase(NodeT{1});
+    // to get correct size
+    mapping[NodeT{5}] = 5;
+    EXPECT_THROW(typename TestFixture::TopologicalSortT(G, mapping, true), std::runtime_error);
+
+    typename TestFixture::TopologicalSortT topSort(G, mapping);
+    EXPECT_THROW(topSort.run(), std::runtime_error);
+}
+
+TYPED_TEST_P(TopologicalSortGTest, testNonInjectiveNodeIdMapping) {
+    using NodeT = typename TestFixture::NodeT;
+
+    auto G = this->inputGraph(true);
+    G.removeNode(NodeT{3});
+    auto mapping = this->makeMapping();
+    mapping[NodeT{2}] = 1;
+
+    EXPECT_THROW(typename TestFixture::TopologicalSortT(G, mapping, true), std::runtime_error);
+}
+
+REGISTER_TYPED_TEST_SUITE_P(TopologicalSortGTest, testTopologicalSort, testRepeatedRuns,
+                            testRejectGraphWithCycles, testRejectUndirectedGraph,
+                            testNonContinuousNodeIds, testCustomNodeIdMapping,
+                            testWrongSizeOfNodeIdMapping, testNonContinuousNodeIdMapping,
+                            testNonInjectiveNodeIdMapping);
+
+using TopologicalSortTestTypes =
+    ::testing::Types<TopologicalSortConfig<node, edgeweight>,
+                     TopologicalSortConfig<uint32_t, float>, TopologicalSortConfig<int, int>>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(TestTopologicalSort, TopologicalSortGTest,
+                               TopologicalSortTestTypes, );
+
+} // namespace
 } // namespace NetworKit

--- a/networkit/cpp/graph/test/TopologicalSortGTest.cpp
+++ b/networkit/cpp/graph/test/TopologicalSortGTest.cpp
@@ -145,4 +145,29 @@ TEST_F(TopologicalSortGTest, testNonInjectiveNodeIdMapping) {
     mapping[2] = 1;
     EXPECT_THROW(TopologicalSort(G, mapping, true), std::runtime_error);
 }
+
+TEST_F(TopologicalSortGTest, testGenericTopologicalSort) {
+    using NodeT = uint32_t;
+    using WeightT = float;
+    using GraphT = AdjListGraph<NodeT, WeightT>;
+
+    GraphT G(5, false, true);
+    G.addEdge(NodeT{0}, NodeT{1});
+    G.addEdge(NodeT{0}, NodeT{2});
+    G.addEdge(NodeT{2}, NodeT{1});
+    G.addEdge(NodeT{1}, NodeT{3});
+    G.addEdge(NodeT{4}, NodeT{2});
+
+    GenericTopologicalSort<GraphT> topSort(G);
+    topSort.run();
+    const auto &res = topSort.getResult();
+
+    std::unordered_map<NodeT, index> indices;
+    EXPECT_EQ(res.size(), G.numberOfNodes());
+    G.forNodes([&](NodeT u) {
+        indices[u] = std::distance(res.begin(), std::find(res.begin(), res.end(), u));
+    });
+    G.forNodes(
+        [&](NodeT u) { G.forNeighborsOf(u, [&](NodeT v) { EXPECT_LT(indices[u], indices[v]); }); });
+}
 } // namespace NetworKit


### PR DESCRIPTION
This PR generalizes `TopologicalSort` as part of the templated graph work discussed in #1415.
The implementation is available through `GenericTopologicalSort<GraphT>`, while the existing `TopologicalSort` name is kept as an alias for the default Graph type.
The `TopologicalSort` tests are generalized as typed tests.