### PR TITLE
Fix bugs in Dinic and EdmondKarp algorithms and add regression tests.

### DIFF
--- a/include/networkit/graph/AdjListGraphImpl.hpp
+++ b/include/networkit/graph/AdjListGraphImpl.hpp
@@ -1276,7 +1276,7 @@ void AdjListGraph<NodeT, EdgeWeightT>::removeEdge(NodeT u, NodeT v) {
             balancedParallelForNodes([&](NodeT w) {
                 for (index i = 0; i < inEdges[w].size(); ++i) {
                     NodeT vv = inEdges[w][i];
-                    if (vv != none) {
+                    if (vv != NullNodeId<NodeT>) {
                         index j = indexInOutEdgeArray(vv, w);
                         inEdgeIds[w][i] = outEdgeIds[vv][j];
                     }

--- a/networkit/cpp/flow/Dinic.cpp
+++ b/networkit/cpp/flow/Dinic.cpp
@@ -24,7 +24,13 @@ Dinic::Dinic(const Graph &G, node src, node dst) : graph(&G), source(src), targe
         throw std::runtime_error(
             "Dinic algorithm requires `source` and `target` node to be different!");
     }
-    parents.resize(graph->numberOfNodes());
+    if (!graph->hasNode(source)) {
+        throw std::runtime_error("Dinic: source node is not in the graph");
+    }
+    if (!graph->hasNode(target)) {
+        throw std::runtime_error("Dinic: target node is not in the graph");
+    }
+    parents.resize(graph->upperNodeIdBound());
 }
 
 void Dinic::initializeResidualGraph() {
@@ -48,7 +54,7 @@ void Dinic::initializeResidualGraph() {
 }
 
 bool Dinic::canReachTargetInLevelGraph() {
-    std::vector<int> level(residualGraph.numberOfNodes(), -1);
+    std::vector<int> level(residualGraph.upperNodeIdBound(), -1);
     for (auto &parentList : parents) {
         parentList.clear();
     }

--- a/networkit/cpp/flow/EdmondsKarp.cpp
+++ b/networkit/cpp/flow/EdmondsKarp.cpp
@@ -15,7 +15,14 @@
 namespace NetworKit {
 
 EdmondsKarp::EdmondsKarp(const Graph &graph, node source, node sink)
-    : graph(&graph), source(source), sink(sink) {}
+    : graph(&graph), source(source), sink(sink) {
+    if (!this->graph->hasNode(this->source)) {
+        throw std::runtime_error("EdmondsKarp: source node is not in the graph");
+    }
+    if (!this->graph->hasNode(this->sink)) {
+        throw std::runtime_error("EdmondsKarp: sink node is not in the graph");
+    }
+}
 
 edgeweight EdmondsKarp::BFS(std::vector<node> &pred) const {
     std::fill(pred.begin(), pred.end(), none);

--- a/networkit/cpp/flow/test/DinicGTest.cpp
+++ b/networkit/cpp/flow/test/DinicGTest.cpp
@@ -53,6 +53,24 @@ TEST_F(DinicGTest, testConstructorThrowsForSameSourceAndTarget) {
     }
 }
 
+TEST_F(DinicGTest, testConstructorThrowsForOutOfRangeSource) {
+    Graph graph(3, true, true);
+    EXPECT_THROW(Dinic test(graph, /* source */ 99, /* target */ 0), std::runtime_error);
+}
+
+TEST_F(DinicGTest, testConstructorThrowsForOutOfRangeTarget) {
+    Graph graph(3, true, true);
+    EXPECT_THROW(Dinic test(graph, /* source */ 0, /* target */ 99), std::runtime_error);
+}
+
+TEST_F(DinicGTest, testConstructorThrowsForDeletedEndpoint) {
+    Graph graph(4, true, true);
+    graph.removeNode(3);
+
+    EXPECT_THROW(Dinic deletedSource(graph, /* source */ 3, /* target */ 0), std::runtime_error);
+    EXPECT_THROW(Dinic deletedTarget(graph, /* source */ 0, /* target */ 3), std::runtime_error);
+}
+
 TEST_F(DinicGTest, testRunNotCalledThrows) {
     Graph graph(2, true, true);
     Dinic test(graph, /* source */ 0, /*target */ 1);
@@ -265,5 +283,17 @@ TEST_F(DinicGTest, testNumericalStabilityTinyScale) {
     Dinic algo(G, 0, 6);
     algo.run();
     EXPECT_NEAR(algo.getMaxFlow(), 1.0 * scale, 1e-15);
+}
+
+TEST_F(DinicGTest, testValidSparseNodeIds) {
+    Graph G(4, true, true);
+    G.removeNode(1);
+    G.addEdge(0, 2, 2.0);
+    G.addEdge(2, 3, 2.0);
+
+    Dinic algo(G, 0, 3);
+    algo.run();
+
+    EXPECT_DOUBLE_EQ(algo.getMaxFlow(), 2.0);
 }
 } // namespace NetworKit

--- a/networkit/cpp/flow/test/EdmondsKarpGTest.cpp
+++ b/networkit/cpp/flow/test/EdmondsKarpGTest.cpp
@@ -266,4 +266,24 @@ TEST_F(EdmondsKarpGTest, testEdmondsKarpUnconnected) {
     EXPECT_DOUBLE_EQ(0, edKa.getMaxFlow()) << "max flow is not correct";
 }
 
+TEST_F(EdmondsKarpGTest, testConstructorThrowsForOutOfRangeSource) {
+    Graph G(3, false, true);
+
+    EXPECT_THROW(EdmondsKarp(G, 99, 0), std::runtime_error);
+}
+
+TEST_F(EdmondsKarpGTest, testConstructorThrowsForOutOfRangeSink) {
+    Graph G(3, false, true);
+
+    EXPECT_THROW(EdmondsKarp(G, 0, 99), std::runtime_error);
+}
+
+TEST_F(EdmondsKarpGTest, testConstructorThrowsForDeletedEndpoint) {
+    Graph G(4, false, true);
+    G.removeNode(3);
+
+    EXPECT_THROW(EdmondsKarp(G, 3, 0), std::runtime_error);
+    EXPECT_THROW(EdmondsKarp(G, 0, 3), std::runtime_error);
+}
+
 } /* namespace NetworKit */


### PR DESCRIPTION
This PR adds endpoint validation for EdmondsKarp and Dinic so out-of-range or deleted source/sink/target nodes throw std::runtime_error instead of indexing scratch vectors out of bounds.
Also adds regression tests for invalid endpoints and verifies Dinic still handles valid sparse node ids after node deletion.
Fixes #1484.